### PR TITLE
fix(toolkit): field-labels map resolver falls back to humanizeFieldPath

### DIFF
--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -33,6 +33,10 @@ export {
 export * from './utilities/field-resolution';
 export type * from './utilities/field-state-types';
 export * from './utilities/focus-first-invalid';
+export {
+  humanizeFieldPath,
+  stripAngularFormPrefix,
+} from './utilities/humanize-field-path';
 export { updateAt, updateNested } from './utilities/immutable-array';
 export * from './utilities/inject-field-control';
 export * from './utilities/inject-form-context';

--- a/packages/toolkit/core/providers/field-labels.provider.spec.ts
+++ b/packages/toolkit/core/providers/field-labels.provider.spec.ts
@@ -23,7 +23,7 @@ describe('Field Label Provider', () => {
       expect(resolver('address.postalCode')).toBe('Postcode');
     });
 
-    it('should fall back to raw path for unmapped fields', () => {
+    it('should fall back to humanizeFieldPath for unmapped fields', () => {
       TestBed.configureTestingModule({
         providers: [
           provideFieldLabels({
@@ -33,7 +33,22 @@ describe('Field Label Provider', () => {
       });
 
       const resolver = TestBed.inject(NGX_FIELD_LABEL_RESOLVER);
-      expect(resolver('address.street')).toBe('address.street');
+      expect(resolver('address.street')).toBe('Address / Street');
+      expect(resolver('address.postalCode')).toBe('Address / Postal code');
+      expect(resolver('ng.form0.email')).toBe('Email');
+    });
+
+    it('should prefer mapped labels over humanized fallback', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideFieldLabels({
+            'address.postalCode': 'Postcode',
+          }),
+        ],
+      });
+
+      const resolver = TestBed.inject(NGX_FIELD_LABEL_RESOLVER);
+      expect(resolver('address.postalCode')).toBe('Postcode');
     });
   });
 

--- a/packages/toolkit/core/providers/field-labels.provider.ts
+++ b/packages/toolkit/core/providers/field-labels.provider.ts
@@ -1,5 +1,7 @@
 import { InjectionToken, type Provider } from '@angular/core';
 
+import { humanizeFieldPath } from '../utilities/humanize-field-path';
+
 /**
  * A function that resolves a raw field path (e.g. `'address.postalCode'`)
  * into a human-readable display label (e.g. `'Postcode'`).
@@ -100,5 +102,5 @@ export function provideFieldLabels(
 }
 
 function createMapResolver(map: FieldLabelMap): FieldLabelResolver {
-  return (fieldPath) => map[fieldPath] ?? fieldPath;
+  return (fieldPath) => map[fieldPath] ?? humanizeFieldPath(fieldPath);
 }

--- a/packages/toolkit/core/utilities/humanize-field-path.ts
+++ b/packages/toolkit/core/utilities/humanize-field-path.ts
@@ -1,0 +1,56 @@
+const ANGULAR_FORM_NAME_PREFIX = /^ng\.form\d+\./u;
+
+/**
+ * Strips the Angular internal form prefix (`ng.form0.`) from a field path,
+ * splits camelCase, capitalizes each segment, and joins nested paths with
+ * ` / `.
+ *
+ * This is the default field-label resolver used by error summaries. Override
+ * it globally via `provideFieldLabels()` or `NGX_FIELD_LABEL_RESOLVER`.
+ *
+ * @example
+ * ```typescript
+ * humanizeFieldPath('address.postalCode'); // 'Address / Postal code'
+ * humanizeFieldPath('ng.form0.email');     // 'Email'
+ * ```
+ *
+ * @public
+ */
+export function humanizeFieldPath(fieldName: string): string {
+  const strippedFieldName = fieldName
+    .trim()
+    .replace(ANGULAR_FORM_NAME_PREFIX, '');
+
+  const segments = strippedFieldName
+    .split('.')
+    .map((segment) =>
+      segment
+        .replaceAll(/[_-]+/gu, ' ')
+        .replaceAll(/([a-z\d])([A-Z])/gu, '$1 $2')
+        .replaceAll(/\s+/gu, ' ')
+        .trim(),
+    )
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length === 0) {
+    return fieldName;
+  }
+
+  return segments
+    .map(
+      (segment) =>
+        `${segment.charAt(0).toUpperCase()}${segment.slice(1).toLowerCase()}`,
+    )
+    .join(' / ');
+}
+
+/**
+ * Strips the Angular internal form prefix from a raw field name.
+ *
+ * Resolver functions receive the stripped path, not the raw `ng.form0.*` name.
+ *
+ * @internal
+ */
+export function stripAngularFormPrefix(rawName: string): string {
+  return rawName.trim().replace(ANGULAR_FORM_NAME_PREFIX, '');
+}

--- a/packages/toolkit/core/utilities/humanize-field-path.ts
+++ b/packages/toolkit/core/utilities/humanize-field-path.ts
@@ -14,6 +14,9 @@ const ANGULAR_FORM_NAME_PREFIX = /^ng\.form\d+\./u;
  * humanizeFieldPath('ng.form0.email');     // 'Email'
  * ```
  *
+ * @param fieldName - Raw field path, optionally prefixed with `ng.form{n}.`
+ * @returns Human-readable label; nested segments are joined with ` / `
+ *
  * @public
  */
 export function humanizeFieldPath(fieldName: string): string {
@@ -48,6 +51,9 @@ export function humanizeFieldPath(fieldName: string): string {
  * Strips the Angular internal form prefix from a raw field name.
  *
  * Resolver functions receive the stripped path, not the raw `ng.form0.*` name.
+ *
+ * @param rawName - Raw field name that may include Angular's `ng.form{n}.` prefix
+ * @returns Field name with the Angular internal form prefix removed
  *
  * @internal
  */

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -14,10 +14,14 @@ import {
   type ErrorReadableState,
   type SubmittedStatus,
 } from '@ngx-signal-forms/toolkit';
-import type {
-  ErrorMessageRegistry,
-  FieldLabelResolver,
+import {
+  humanizeFieldPath,
+  stripAngularFormPrefix,
+  type ErrorMessageRegistry,
+  type FieldLabelResolver,
 } from '@ngx-signal-forms/toolkit/core';
+
+export { humanizeFieldPath } from '@ngx-signal-forms/toolkit/core';
 
 import type { CharacterCountLimitState } from './character-count.directive';
 import {
@@ -541,63 +545,6 @@ type ValidationErrorWithFieldTree = ValidationError & {
     | undefined;
 };
 
-const ANGULAR_FORM_NAME_PREFIX = /^ng\.form\d+\./u;
-
-/**
- * Strips the Angular internal form prefix (`ng.form0.`) from a field path,
- * splits camelCase, capitalizes each segment, and joins nested paths with
- * ` / `.
- *
- * This is the default field-label resolver used by error summaries. Override
- * it globally via `provideFieldLabels()` or `NGX_FIELD_LABEL_RESOLVER`.
- *
- * @example
- * ```typescript
- * humanizeFieldPath('address.postalCode'); // 'Address / Postal code'
- * humanizeFieldPath('ng.form0.email');     // 'Email'
- * ```
- *
- * @public
- */
-export function humanizeFieldPath(fieldName: string): string {
-  const strippedFieldName = fieldName
-    .trim()
-    .replace(ANGULAR_FORM_NAME_PREFIX, '');
-
-  const segments = strippedFieldName
-    .split('.')
-    .map((segment) =>
-      segment
-        .replaceAll(/[_-]+/gu, ' ')
-        .replaceAll(/([a-z\d])([A-Z])/gu, '$1 $2')
-        .replaceAll(/\s+/gu, ' ')
-        .trim(),
-    )
-    .filter((segment) => segment.length > 0);
-
-  if (segments.length === 0) {
-    return fieldName;
-  }
-
-  return segments
-    .map(
-      (segment) =>
-        `${segment.charAt(0).toUpperCase()}${segment.slice(1).toLowerCase()}`,
-    )
-    .join(' / ');
-}
-
-/**
- * Strips the Angular internal form prefix from a raw field name.
- *
- * Resolver functions receive the stripped path, not the raw `ng.form0.*` name.
- *
- * @internal
- */
-function stripAngularPrefix(rawName: string): string {
-  return rawName.trim().replace(ANGULAR_FORM_NAME_PREFIX, '');
-}
-
 /**
  * Resolve the field name from a `ValidationError` via duck-typed access
  * to `error.fieldTree().name()`.
@@ -621,7 +568,7 @@ export function resolveFieldNameFromError(
   if (typeof e.fieldTree === 'function') {
     const fieldState = e.fieldTree();
     if (fieldState && typeof fieldState.name === 'function') {
-      const stripped = stripAngularPrefix(fieldState.name());
+      const stripped = stripAngularFormPrefix(fieldState.name());
       return resolve(stripped);
     }
   }

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -21,9 +21,9 @@ import {
   type FieldLabelResolver,
 } from '@ngx-signal-forms/toolkit/core';
 
-export { humanizeFieldPath } from '@ngx-signal-forms/toolkit/core';
-
 import type { CharacterCountLimitState } from './character-count.directive';
+
+export { humanizeFieldPath };
 import {
   DEFAULT_DANGER_THRESHOLD,
   DEFAULT_WARNING_THRESHOLD,


### PR DESCRIPTION
## Summary

The JSDoc on `provideFieldLabels` promised that unmapped keys fall back to
`humanizeFieldPath`, matching the behavior already documented in
[`docs/COMPLEX_NESTED_FORMS.md`](docs/COMPLEX_NESTED_FORMS.md) and
[`docs/WARNINGS_SUPPORT.md`](docs/WARNINGS_SUPPORT.md). The implementation
instead returned the raw field path, so users got `address.postalCode`
instead of `Address / Postal code` for any key they didn't explicitly map.

## The bug

Before, in `packages/toolkit/core/providers/field-labels.provider.ts`:

```typescript
function createMapResolver(map: FieldLabelMap): FieldLabelResolver {
  return (fieldPath) => map[fieldPath] ?? fieldPath;
}
```

The `?? fieldPath` branch returned the raw dot-path rather than the
humanized form, silently breaking the documented contract for the (very
common) case of partial maps.

## The fix

```typescript
function createMapResolver(map: FieldLabelMap): FieldLabelResolver {
  return (fieldPath) => map[fieldPath] ?? humanizeFieldPath(fieldPath);
}
```

### Before / after

With `provideFieldLabels({ contactEmail: 'E-mailadres' })` and an unmapped
field `address.postalCode`:

| | Resolved label |
|---|---|
| Before | `address.postalCode` |
| After  | `Address / Postal code` |

## Why the move of `humanizeFieldPath`

`humanizeFieldPath` lived in `packages/toolkit/headless/src/lib/utilities.ts`,
but `headless` already depends on `@ngx-signal-forms/toolkit/core`, so
importing it from core would create a cycle. The function (and its
internal `stripAngularFormPrefix` helper) now lives in
`packages/toolkit/core/utilities/humanize-field-path.ts`. The public
`@ngx-signal-forms/toolkit/headless` barrel still re-exports
`humanizeFieldPath`, so the public API is unchanged.

## Test changes

`packages/toolkit/core/providers/field-labels.provider.spec.ts`:

- Replaced the `'should fall back to raw path for unmapped fields'` test
  (which pinned the buggy behavior) with one asserting humanized output
  for unmapped keys, including the `ng.form0.` prefix-strip path.
- Added a regression test confirming mapped labels still take priority
  over the humanized fallback.

All 707 toolkit unit tests pass (`pnpm nx test toolkit`), and
`pnpm nx build toolkit` and `pnpm nx lint toolkit` are both green.

## Test plan

- [x] `pnpm nx test toolkit`
- [x] `pnpm nx build toolkit`
- [x] `pnpm nx lint toolkit`
- [x] Verified no `provideFieldLabels` usage in `apps/demo/` or elsewhere in `packages/` depends on the old raw-path behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Field paths now automatically display in humanized format when no label mapping is defined, converting formats like "address.street" to "Address / Street" for improved readability.

* **Bug Fixes**
  * Updated field label resolution fallback behavior to return humanized field paths instead of raw paths, providing better user-facing labels.

* **Refactor**
  * Consolidated field path humanization utilities into the core toolkit, improving code organization and reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->