### PR TITLE
chore(toolkit)!: v1 readiness — naming consolidation, a11y, types, and tests

### DIFF
--- a/.github/skills/ngx-signal-forms/references/api.md
+++ b/.github/skills/ngx-signal-forms/references/api.md
@@ -678,7 +678,7 @@ Set on a container element or `:root`:
 
 /* Semantic colors */
 --ngx-signal-form-error-color: #dc2626;
---ngx-signal-form-warning-color: #f59e0b;
+--ngx-signal-form-warning-color: #a16207;
 
 /* Form field */
 --ngx-form-field-color-primary: #3b82f6;

--- a/apps/demo-e2e/src/fixtures/aria-selectors.ts
+++ b/apps/demo-e2e/src/fixtures/aria-selectors.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared selectors for the toolkit's ARIA live regions.
+ *
+ * `<ngx-form-field-error>` keeps its `role="alert"` and `role="status"`
+ * containers mounted in the DOM even while empty so screen readers pick
+ * up the live region on the first content insertion (WCAG 4.1.3 — NVDA
+ * + Chrome can drop the announcement when the role and the content
+ * arrive in the same tick). Empty shells are tagged with the
+ * `ngx-form-field-error--empty` class; exclude them when counting or
+ * asserting the alerts a user would actually perceive.
+ */
+export const ROLE_ALERT_SELECTOR =
+  '[role="alert"]:not(.ngx-form-field-error--empty)';
+
+export const ROLE_STATUS_SELECTOR =
+  '[role="status"]:not(.ngx-form-field-error--empty)';

--- a/apps/demo-e2e/src/fixtures/form-validation.fixture.ts
+++ b/apps/demo-e2e/src/fixtures/form-validation.fixture.ts
@@ -1,5 +1,7 @@
 import { Page, expect } from '@playwright/test';
 
+import { ROLE_ALERT_SELECTOR } from './aria-selectors';
+
 /**
  * Reusable form validation test patterns
  */
@@ -36,7 +38,7 @@ export async function verifyNoErrorsOnInitialLoad(
   }
 
   /// Verify NO error messages are visible (allow brief stabilization window)
-  const alerts = page.locator('[role="alert"]');
+  const alerts = page.locator(ROLE_ALERT_SELECTOR);
   await expect(alerts).toHaveCount(0, { timeout: 2000 });
 }
 
@@ -57,7 +59,7 @@ export async function verifyErrorsAfterBlur(
   await field.focus();
   await field.blur();
 
-  const alerts = page.locator('[role="alert"]');
+  const alerts = page.locator(ROLE_ALERT_SELECTOR);
   await expect(alerts.first()).toBeVisible();
 
   if (expectedErrorPattern) {
@@ -139,6 +141,6 @@ export async function preventInvalidSubmission(
   await submitButton.click();
 
   /// Errors should be visible after submit attempt
-  const alerts = page.locator('[role="alert"]');
+  const alerts = page.locator(ROLE_ALERT_SELECTOR);
   await expect(alerts.first()).toBeVisible();
 }

--- a/apps/demo-e2e/src/forms/02-toolkit-core/form-accessibility.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/form-accessibility.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+
+import { ROLE_STATUS_SELECTOR } from '../../fixtures/aria-selectors';
 /**
  * Form Accessibility Tests
  * WCAG 2.2 Level AA - Forms
@@ -114,12 +116,12 @@ test.describe('Accessibility - Form Accessibility', () => {
       await passwordInput.fill('Short123');
       await passwordInput.blur();
 
-      const status = page.locator('[role="status"]').first();
+      const status = page.locator(ROLE_STATUS_SELECTOR).first();
       await expect(status).toBeVisible({ timeout: 3000 });
     });
 
     await test.step('Assert no redundant aria attrs', async () => {
-      const status = page.locator('[role="status"]').first();
+      const status = page.locator(ROLE_STATUS_SELECTOR).first();
       await expect(status).not.toHaveAttribute('aria-live', /.*/);
       await expect(status).not.toHaveAttribute('aria-atomic', /.*/);
     });
@@ -141,7 +143,7 @@ test.describe('Accessibility - Form Accessibility', () => {
       await passwordInput.fill('Short123');
       await passwordInput.blur();
 
-      await expect(page.locator('[role="status"]').first()).toBeVisible({
+      await expect(page.locator(ROLE_STATUS_SELECTOR).first()).toBeVisible({
         timeout: 3000,
       });
     });

--- a/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
@@ -1,4 +1,9 @@
 import { expect, test } from '@playwright/test';
+
+import {
+  ROLE_ALERT_SELECTOR,
+  ROLE_STATUS_SELECTOR,
+} from '../../fixtures/aria-selectors';
 import { verifyNoErrorsOnInitialLoad } from '../../fixtures/form-validation.fixture';
 import { WarningSupportPage } from '../../page-objects/warning-support.page';
 
@@ -53,7 +58,7 @@ test.describe('Warning Support Demo', () => {
       await page.passwordInput.blur();
 
       // Should have warning status element (role="status" for warnings)
-      const warningStatus = page.page.locator('[role="status"]');
+      const warningStatus = page.page.locator(ROLE_STATUS_SELECTOR);
       await expect(warningStatus.first()).toBeVisible();
       await expect(warningStatus.first()).toContainText(
         /12\+ characters for better security/i,
@@ -68,7 +73,7 @@ test.describe('Warning Support Demo', () => {
       await page.passwordInput.blur();
 
       // Should show warning about character mixing
-      const warningStatus = page.page.locator('[role="status"]');
+      const warningStatus = page.page.locator(ROLE_STATUS_SELECTOR);
       await expect(warningStatus).toContainText(
         /mixing uppercase, lowercase, numbers/i,
       );
@@ -79,7 +84,7 @@ test.describe('Warning Support Demo', () => {
       await page.usernameInput.fill('user'); // 4 chars
       await page.usernameInput.blur();
 
-      const warningStatus = page.page.locator('[role="status"]');
+      const warningStatus = page.page.locator(ROLE_STATUS_SELECTOR);
       await expect(warningStatus.first()).toBeVisible();
       await expect(warningStatus.first()).toContainText(
         /6\+ characters for better security/i,
@@ -90,7 +95,7 @@ test.describe('Warning Support Demo', () => {
       await page.fillWithWarnings();
 
       // Warnings should be visible
-      const warningStatus = page.page.locator('[role="status"]');
+      const warningStatus = page.page.locator(ROLE_STATUS_SELECTOR);
       await expect(warningStatus.first()).toBeVisible();
 
       // Submit should work even with warnings (INTENDED BEHAVIOR)
@@ -111,11 +116,11 @@ test.describe('Warning Support Demo', () => {
       await page.emailInput.blur();
 
       // Should show warning for username (role="status")
-      const warnings = page.page.locator('[role="status"]');
+      const warnings = page.page.locator(ROLE_STATUS_SELECTOR);
       await expect(warnings.first()).toBeVisible();
 
       // Should show error for email (role="alert")
-      const errors = page.page.locator('[role="alert"]');
+      const errors = page.page.locator(ROLE_ALERT_SELECTOR);
       await expect(errors.first()).toBeVisible();
       await expect(errors.first()).toContainText(/required/i);
     });
@@ -127,11 +132,11 @@ test.describe('Warning Support Demo', () => {
       await page.passwordInput.blur();
 
       // Errors use role="alert" (assertive)
-      const alerts = page.page.locator('[role="alert"]');
+      const alerts = page.page.locator(ROLE_ALERT_SELECTOR);
       await expect(alerts.first()).toBeVisible();
 
       // Warnings use role="status" (polite)
-      const statuses = page.page.locator('[role="status"]');
+      const statuses = page.page.locator(ROLE_STATUS_SELECTOR);
       await expect(statuses.first()).toBeVisible();
     });
 
@@ -174,7 +179,7 @@ test.describe('Warning Support Demo', () => {
       });
 
       await test.step('Verify errors are visible for required fields', async () => {
-        const alerts = page.page.locator('[role="alert"]');
+        const alerts = page.page.locator(ROLE_ALERT_SELECTOR);
         await expect(alerts.first()).toBeVisible();
       });
 

--- a/apps/demo-e2e/src/forms/03-headless/fieldset-utilities.spec.ts
+++ b/apps/demo-e2e/src/forms/03-headless/fieldset-utilities.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { ROLE_ALERT_SELECTOR } from '../../fixtures/aria-selectors';
+
 /**
  * Headless Fieldset + Utilities - E2E Tests
  * Route: /headless/fieldset-utilities
@@ -177,7 +179,7 @@ test.describe('Headless - Fieldset + Utilities', () => {
 
       await test.step('Verify aggregated errors in fieldset', async () => {
         const fieldset = page.getByRole('group', { name: 'Shipping address' });
-        const aggregatedAlert = fieldset.locator('[role="alert"]').first();
+        const aggregatedAlert = fieldset.locator(ROLE_ALERT_SELECTOR).first();
         await expect(aggregatedAlert).toBeVisible();
         await expect(aggregatedAlert).toContainText('Street is required');
         await expect(aggregatedAlert).toContainText('City is required');
@@ -265,7 +267,9 @@ test.describe('Headless - Fieldset + Utilities', () => {
 
       await test.step('Submit to trigger errors', async () => {
         await page.getByRole('button', { name: 'Submit request' }).click();
-        await expect(fieldset.locator('[role="alert"]').first()).toBeVisible();
+        await expect(
+          fieldset.locator(ROLE_ALERT_SELECTOR).first(),
+        ).toBeVisible();
       });
 
       await test.step('Fill all address fields', async () => {
@@ -275,7 +279,9 @@ test.describe('Headless - Fieldset + Utilities', () => {
       });
 
       await test.step('Verify aggregated errors cleared', async () => {
-        await expect(fieldset.locator('[role="alert"]').first()).toBeHidden();
+        await expect(
+          fieldset.locator(ROLE_ALERT_SELECTOR).first(),
+        ).toBeHidden();
       });
     });
   });
@@ -348,7 +354,7 @@ test.describe('Headless - Fieldset + Utilities', () => {
         await expect(
           page
             .getByRole('group', { name: 'Shipping address' })
-            .locator('[role="alert"]')
+            .locator(ROLE_ALERT_SELECTOR)
             .first(),
         ).toBeVisible();
       });

--- a/apps/demo-e2e/src/forms/04-form-field-wrapper/complex-forms.spec.ts
+++ b/apps/demo-e2e/src/forms/04-form-field-wrapper/complex-forms.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+
+import { ROLE_ALERT_SELECTOR } from '../../fixtures/aria-selectors';
 import { FormFieldWrapperComplexPage } from '../../page-objects/form-field-wrapper-complex.page';
 
 test.describe('Form Field Wrapper - Complex Forms', () => {
@@ -14,7 +16,7 @@ test.describe('Form Field Wrapper - Complex Forms', () => {
   }) => {
     await playwrightPage.waitForLoadState('domcontentloaded');
     await page.form.locator('#firstName').waitFor({ state: 'visible' });
-    await expect(page.form.locator('[role="alert"]')).toHaveCount(0);
+    await expect(page.form.locator(ROLE_ALERT_SELECTOR)).toHaveCount(0);
   });
 
   test.describe('Component Structure', () => {

--- a/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
+++ b/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+
+import { ROLE_ALERT_SELECTOR } from '../../fixtures/aria-selectors';
 import { verifyNoErrorsOnInitialLoad } from '../../fixtures/form-validation.fixture';
 import { CustomControlsPage } from '../../page-objects/custom-controls.page';
 
@@ -412,7 +414,7 @@ test.describe('Custom Signal Forms Controls', () => {
 
       await test.step('Verify form is valid', async () => {
         // Check that no errors are visible
-        const errors = page.form.locator('[role="alert"]');
+        const errors = page.form.locator(ROLE_ALERT_SELECTOR);
         await expect(errors).toHaveCount(0);
       });
 
@@ -421,7 +423,7 @@ test.describe('Custom Signal Forms Controls', () => {
       });
 
       await test.step('Verify no errors after submission', async () => {
-        const errors = page.form.locator('[role="alert"]');
+        const errors = page.form.locator(ROLE_ALERT_SELECTOR);
         await expect(errors).toHaveCount(0);
       });
     });

--- a/apps/demo-e2e/src/forms/05-advanced/async-validation.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/async-validation.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+
+import { ROLE_ALERT_SELECTOR } from '../../fixtures/aria-selectors';
 /**
  * Async Validation - E2E Tests
  * Route: /advanced-scenarios/async-validation
@@ -163,7 +165,7 @@ test.describe('Advanced Scenarios - Async Validation', () => {
       await expect(submitButton).toBeEnabled();
       await submitButton.click();
 
-      await expect(page.locator('[role="alert"]')).toHaveCount(0);
+      await expect(page.locator(ROLE_ALERT_SELECTOR)).toHaveCount(0);
       await expect(page.getByText('Valid: true')).toBeVisible();
     });
   });

--- a/apps/demo-e2e/src/forms/05-advanced/global-configuration.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/global-configuration.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+
+import { ROLE_ALERT_SELECTOR } from '../../fixtures/aria-selectors';
 import { GlobalConfigurationPage } from '../../page-objects/global-configuration.page';
 
 test.describe('Advanced - Global Configuration', () => {
@@ -32,7 +34,7 @@ test.describe('Advanced - Global Configuration', () => {
       await input.focus();
       await input.blur();
 
-      const errors = playwrightPage.locator('[role="alert"]');
+      const errors = playwrightPage.locator(ROLE_ALERT_SELECTOR);
       await expect(errors.first()).toBeVisible({ timeout: 2000 });
     });
   });
@@ -120,7 +122,7 @@ test.describe('Advanced - Global Configuration', () => {
       const wrapper = acceptTerms.locator(
         'xpath=ancestor::ngx-form-field-wrapper',
       );
-      const errors = wrapper.locator('[role="alert"]');
+      const errors = wrapper.locator(ROLE_ALERT_SELECTOR);
       await expect(errors.first()).toBeVisible({ timeout: 3000 });
     });
   });

--- a/apps/demo-e2e/src/forms/05-advanced/vest-validation.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/vest-validation.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import {
+  ROLE_ALERT_SELECTOR,
+  ROLE_STATUS_SELECTOR,
+} from '../../fixtures/aria-selectors';
+
 function fieldWrapper(page: Page, label: string) {
   return page.locator('ngx-form-field-wrapper', {
     has: page.getByLabel(label, { exact: true }),
@@ -7,11 +12,11 @@ function fieldWrapper(page: Page, label: string) {
 }
 
 function fieldAlert(page: Page, label: string) {
-  return fieldWrapper(page, label).locator('[role="alert"]');
+  return fieldWrapper(page, label).locator(ROLE_ALERT_SELECTOR);
 }
 
 function fieldStatus(page: Page, label: string) {
-  return fieldWrapper(page, label).locator('[role="status"]');
+  return fieldWrapper(page, label).locator(ROLE_STATUS_SELECTOR);
 }
 
 test.describe('Advanced Scenarios - Vest-Only Validation', () => {

--- a/apps/demo-e2e/src/forms/05-advanced/zod-vest-validation.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/zod-vest-validation.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test, type Page } from '@playwright/test';
 
+import {
+  ROLE_ALERT_SELECTOR,
+  ROLE_STATUS_SELECTOR,
+} from '../../fixtures/aria-selectors';
+
 function fieldWrapper(page: Page, label: string) {
   return page.locator('ngx-form-field-wrapper', {
     has: page.getByLabel(label, { exact: true }),
@@ -7,11 +12,11 @@ function fieldWrapper(page: Page, label: string) {
 }
 
 function fieldAlert(page: Page, label: string) {
-  return fieldWrapper(page, label).locator('[role="alert"]');
+  return fieldWrapper(page, label).locator(ROLE_ALERT_SELECTOR);
 }
 
 function fieldStatus(page: Page, label: string) {
-  return fieldWrapper(page, label).locator('[role="status"]');
+  return fieldWrapper(page, label).locator(ROLE_STATUS_SELECTOR);
 }
 
 test.describe('Advanced Scenarios - Zod + Vest Validation', () => {

--- a/apps/demo-e2e/src/page-objects/base-form.page.ts
+++ b/apps/demo-e2e/src/page-objects/base-form.page.ts
@@ -1,5 +1,10 @@
 import { expect, Locator, Page } from '@playwright/test';
 
+import {
+  ROLE_ALERT_SELECTOR,
+  ROLE_STATUS_SELECTOR,
+} from '../fixtures/aria-selectors';
+
 /**
  * Base Page Object for all forms in the demo app
  * Provides common functionality and patterns
@@ -41,17 +46,20 @@ export abstract class BaseFormPage {
   }
 
   /**
-   * Get all error alert elements
+   * Get all error alert elements that have actually-rendered content.
+   * Empty `role="alert"` live-region shells are excluded — see
+   * `ROLE_ALERT_SELECTOR` for the rationale.
    */
   get errorAlerts(): Locator {
-    return this.page.locator('[role="alert"]');
+    return this.page.locator(ROLE_ALERT_SELECTOR);
   }
 
   /**
-   * Get all warning status elements
+   * Get all warning status elements that have actually-rendered content.
+   * Same empty-shell handling as `errorAlerts` above.
    */
   get warningStatuses(): Locator {
-    return this.page.locator('[role="status"]');
+    return this.page.locator(ROLE_STATUS_SELECTOR);
   }
 
   /**

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.scss
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.scss
@@ -9,7 +9,7 @@
 }
 
 .saving-indicator {
-  color: #f59e0b;
+  color: #a16207;
   font-size: 0.875rem;
 }
 

--- a/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.form.ts
+++ b/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.form.ts
@@ -138,10 +138,21 @@ import { submissionSchema } from './submission-patterns.validations';
 
       <!-- Form-level error summary (GOV.UK pattern) -->
       <!-- Aggregates all field errors into a clickable list; each entry focuses the invalid control -->
+      <!--
+        [autoFocus]="false" opts this summary out of the default
+        focus-on-first-appearance behaviour. This page already wires up
+        createOnInvalidHandler() (onInvalid of the submission action),
+        which focuses the first invalid FIELD on submit — letting both
+        run creates a focus race (the summary host wins after the next
+        render and steals focus from the field). Pick one focus target
+        per page; here we keep the field-level focus the demo is
+        showcasing.
+      -->
       <ngx-form-field-error-summary
         [formTree]="registrationForm"
         [submittedStatus]="explicitSubmittedStatus()"
         summaryLabel="Please fix the following errors before submitting:"
+        [autoFocus]="false"
       />
 
       <!-- Form fields -->

--- a/apps/demo/src/styles.scss
+++ b/apps/demo/src/styles.scss
@@ -29,7 +29,7 @@
 
   /* Semantic colors */
   --color-success: #10b981;
-  --color-warning: #f59e0b;
+  --color-warning: #a16207;
   --color-error: #ef4444;
   --color-info: #3b82f6;
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -112,8 +112,15 @@ Starting in v1, the published `package.json` no longer exposes the
   that are re-exported from the root barrel.
 - `packages/toolkit/index.ts` is the authoritative list of the stable
   public surface (54 values and 26 types, enumerated by hand).
-- CSS custom properties (`--ngx-signal-form-*`) are unchanged — theme
-  overrides continue to work untouched.
+- CSS custom properties are unchanged — theme overrides continue
+  to work untouched. Two prefix families exist and stay stable:
+  `--ngx-signal-form-*` for shared feedback tokens
+  (e.g. `--ngx-signal-form-feedback-font-size`,
+  `--ngx-signal-form-error-color`, `--ngx-signal-form-fieldset-*`) and
+  `--ngx-form-field-*` for component-scoped tokens
+  (e.g. `--ngx-form-field-color-primary`, `--ngx-form-field-focus-color`).
+  See [`packages/toolkit/form-field/THEMING.md`](../packages/toolkit/form-field/THEMING.md#architecture-semantic-layering)
+  for the full layering.
 
 If you were reaching into `/core` for something that is **not**
 re-exported from root, it was `@internal` and is not part of the v1

--- a/docs/WARNINGS_SUPPORT.md
+++ b/docs/WARNINGS_SUPPORT.md
@@ -325,7 +325,7 @@ match `strategy` explicitly).
   --ngx-signal-form-error-border: transparent;
 
   /* Warning styles (amber) */
-  --ngx-signal-form-warning-color: #f59e0b;
+  --ngx-signal-form-warning-color: #a16207;
   --ngx-signal-form-warning-bg: transparent;
   --ngx-signal-form-warning-border: transparent;
 

--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -133,13 +133,13 @@ For splitting a `ValidationError[]` into blocking and warnings in one pass, use 
 ```css
 :root {
   --ngx-signal-form-error-color: #db1818;
-  --ngx-signal-form-warning-color: #f59e0b;
+  --ngx-signal-form-warning-color: #a16207;
   --ngx-signal-form-feedback-font-size: 0.75rem;
   --ngx-signal-form-feedback-line-height: 1rem;
   --ngx-signal-form-feedback-margin-top: 0.125rem;
   --ngx-form-field-hint-color: rgba(50, 65, 85, 0.75);
   --ngx-form-field-char-count-color-ok: rgba(50, 65, 85, 0.75);
-  --ngx-form-field-char-count-color-warning: #f59e0b;
+  --ngx-form-field-char-count-color-warning: #a16207;
   --ngx-form-field-char-count-color-danger: #db1818;
 }
 ```

--- a/packages/toolkit/assistive/character-count.spec.ts
+++ b/packages/toolkit/assistive/character-count.spec.ts
@@ -454,6 +454,39 @@ describe('NgxFormFieldCharacterCount', () => {
     });
   });
 
+  describe('Default token contrast (WCAG 1.4.3)', () => {
+    it('exposes an AA-compliant default warning color (≥ 4.5:1 on white)', async () => {
+      /**
+       * Smoke test for the design-token contract. The previous default
+       * `#f59e0b` (~2.16:1 on white) failed WCAG 1.4.3 AA for normal-text
+       * color contrast; v1 ships `#a16207` (Tailwind amber-700, ~5.17:1)
+       * as the default. This guard catches regressions if a future
+       * theming refactor reverts the token.
+       *
+       * We render the component and read its style sheets from the
+       * adoptedStyleSheets pipeline (or via the head <style> Angular
+       * injects in jsdom) so the test pins behaviour from the consumer's
+       * perspective, not via the private `ɵcmp` metadata API.
+       */
+      await render(TestWrapperComponent, {
+        componentInputs: { textModel: 'a'.repeat(85), maxLength: 100 },
+      });
+
+      // Combine every <style> Angular has injected for component styles.
+      const styleText = Array.from(document.querySelectorAll('style'))
+        .map((s) => s.textContent ?? '')
+        .join('\n');
+
+      expect(styleText).toContain('--ngx-form-field-char-count-color-warning');
+      // New AA-compliant default fallback must be present.
+      expect(styleText).toContain('#a16207');
+      // The failing-contrast value must be gone from the defaults.
+      expect(styleText).not.toMatch(
+        /--ngx-form-field-char-count-color-warning,\s*#f59e0b/u,
+      );
+    });
+  });
+
   describe('Component structure', () => {
     it('should have correct element tag', async () => {
       const { container } = await render(TestWrapperComponent, {

--- a/packages/toolkit/assistive/character-count.ts
+++ b/packages/toolkit/assistive/character-count.ts
@@ -101,7 +101,7 @@ export type NgxCharacterCountValue = CharacterCountValue;
  *   --ngx-form-field-char-count-font-size: 0.75rem;
  *   --ngx-form-field-char-count-line-height: 1rem;
  *   --ngx-form-field-char-count-color-ok: rgba(50, 65, 85, 0.75);
- *   --ngx-form-field-char-count-color-warning: #f59e0b;
+ *   --ngx-form-field-char-count-color-warning: #a16207;
  *   --ngx-form-field-char-count-color-danger: #db1818;
  *   --ngx-form-field-char-count-color-exceeded: #991b1b;
  *   --ngx-form-field-char-count-weight-exceeded: 600;
@@ -163,7 +163,10 @@ export type NgxCharacterCountValue = CharacterCountValue;
     }
 
     :host([data-limit-state='warning']) {
-      color: var(--ngx-form-field-char-count-color-warning, #f59e0b);
+      /* Default: Tailwind amber-700 (#a16207) — ~5.17:1 on white meets
+       * WCAG 1.4.3 AA for normal text (#f59e0b previously used was 2.16:1).
+       * Kept consistent with the warning color in form-field-error.scss. */
+      color: var(--ngx-form-field-char-count-color-warning, #a16207);
     }
 
     :host([data-limit-state='danger']) {

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -239,6 +239,106 @@ describe('NgxFormFieldErrorSummary', () => {
     expect(document.activeElement).toBe(screen.getByTestId('email-input'));
   });
 
+  it('moves focus to the summary host the first time entries appear (WCAG 2.4.3 + 3.3.1)', async () => {
+    /**
+     * GOV.UK / WAI error-summary pattern: when the summary surfaces, focus
+     * should move to it programmatically so screen reader users hear the
+     * announcement and arrive at the summary instead of being stranded
+     * wherever they were before submit. Subsequent entry-list mutations
+     * must NOT steal focus a second time.
+     */
+    @Component({
+      selector: 'ngx-test-error-summary-autofocus',
+      imports: [FormField, NgxFormFieldErrorSummaryComponent],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <input id="email" [formField]="contactForm.email" />
+        <ngx-form-field-error-summary
+          [formTree]="contactForm"
+          strategy="on-submit"
+          [submittedStatus]="submittedStatus()"
+        />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly contactForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+      readonly submittedStatus = signal<SubmittedStatus>('unsubmitted');
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    // Before submit there are no entries, so the summary is hidden and
+    // focus is wherever the test framework left it (typically <body>).
+    expect(screen.queryByRole('alert')).toBeFalsy();
+
+    // Submit triggers the on-submit strategy → entries appear → host
+    // should receive focus on the next render pass.
+    fixture.componentInstance.submittedStatus.set('submitted');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const summaryHost = await screen.findByRole('alert');
+    // The role="alert" lives on a child div inside the focus-target host.
+    // Walk up to the ngx-form-field-error-summary element — that is what
+    // carries `tabindex="-1"` and receives the programmatic focus call.
+    const focusTarget = summaryHost.closest('ngx-form-field-error-summary');
+    expect(focusTarget).toBeInstanceOf(HTMLElement);
+    expect(focusTarget?.getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(focusTarget);
+  });
+
+  it('does not focus the summary when [autoFocus]="false"', async () => {
+    @Component({
+      selector: 'ngx-test-error-summary-no-autofocus',
+      imports: [FormField, NgxFormFieldErrorSummaryComponent],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <input
+          id="email"
+          data-testid="email-input"
+          [formField]="contactForm.email"
+        />
+        <ngx-form-field-error-summary
+          [formTree]="contactForm"
+          strategy="on-submit"
+          [autoFocus]="false"
+          [submittedStatus]="submittedStatus()"
+        />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly contactForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+      readonly submittedStatus = signal<SubmittedStatus>('unsubmitted');
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    // Move focus to a known, non-summary element so we can detect theft.
+    const input = screen.getByTestId('email-input');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    fixture.componentInstance.submittedStatus.set('submitted');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Summary is visible but focus must remain on the input.
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(document.activeElement).toBe(input);
+  });
+
   it('exposes role="alert" without redundant aria-live/aria-atomic', async () => {
     @Component({
       selector: 'ngx-test-error-summary-aria',

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -9,7 +9,7 @@ import {
 import type { SubmittedStatus } from '@ngx-signal-forms/toolkit';
 import { render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NgxFormFieldErrorSummary } from './form-field-error-summary';
 
 describe('NgxFormFieldErrorSummary', () => {
@@ -249,7 +249,7 @@ describe('NgxFormFieldErrorSummary', () => {
      */
     @Component({
       selector: 'ngx-test-error-summary-autofocus',
-      imports: [FormField, NgxFormFieldErrorSummaryComponent],
+      imports: [FormField, NgxFormFieldErrorSummary],
       changeDetection: ChangeDetectionStrategy.OnPush,
       template: `
         <input id="email" [formField]="contactForm.email" />
@@ -296,7 +296,7 @@ describe('NgxFormFieldErrorSummary', () => {
   it('does not focus the summary when [autoFocus]="false"', async () => {
     @Component({
       selector: 'ngx-test-error-summary-no-autofocus',
-      imports: [FormField, NgxFormFieldErrorSummaryComponent],
+      imports: [FormField, NgxFormFieldErrorSummary],
       changeDetection: ChangeDetectionStrategy.OnPush,
       template: `
         <input
@@ -337,6 +337,133 @@ describe('NgxFormFieldErrorSummary', () => {
     // Summary is visible but focus must remain on the input.
     expect(await screen.findByRole('alert')).toBeTruthy();
     expect(document.activeElement).toBe(input);
+  });
+
+  describe('dev-mode focus-failure diagnostic', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const getFocusFailureWarnings = (
+      spy: ReturnType<typeof vi.spyOn>,
+    ): readonly string[] => {
+      const messages: string[] = [];
+      for (const call of spy.mock.calls) {
+        const first: unknown = call[0];
+        if (
+          typeof first === 'string' &&
+          first.includes('NgxFormFieldErrorSummary')
+        ) {
+          messages.push(first);
+        }
+      }
+      return messages;
+    };
+
+    it('should warn in dev mode when host.focus() fails to move focus', async () => {
+      // Scenario: stub the summary host's `focus()` method so the call is a
+      // silent no-op (mirrors real-world failures where `display:none`, an
+      // inert ancestor, or modal interception swallow the focus request).
+      // `document.activeElement` then stays on <body>, breaking WCAG 2.4.3.
+      @Component({
+        selector: 'ngx-test-error-summary-focus-failure',
+        imports: [FormField, NgxFormFieldErrorSummary],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <input id="email" [formField]="contactForm.email" />
+          <ngx-form-field-error-summary
+            [formTree]="contactForm"
+            strategy="on-submit"
+            [submittedStatus]="submittedStatus()"
+          />
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email, { message: 'Email is required' });
+          }),
+        );
+        readonly submittedStatus = signal<SubmittedStatus>('unsubmitted');
+      }
+
+      const { fixture } = await render(TestComponent);
+
+      // Find the summary host element and stub its focus() to a no-op so
+      // the diagnostic's `document.activeElement !== host` check fires.
+      const summaryHost = fixture.nativeElement.querySelector(
+        'ngx-form-field-error-summary',
+      ) as HTMLElement;
+      expect(summaryHost).toBeInstanceOf(HTMLElement);
+      // `focus` is a prototype-level method; define an own-property override
+      // on this single host so we don't pollute other tests/instances.
+      Object.defineProperty(summaryHost, 'focus', {
+        configurable: true,
+        value: () => {
+          /* swallowed: simulates display:none / modal / detached host */
+        },
+      });
+
+      // Make sure focus is on the body so the !== host check is meaningful.
+      (document.activeElement as HTMLElement | null)?.blur?.();
+
+      fixture.componentInstance.submittedStatus.set('submitted');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const warnings = getFocusFailureWarnings(warnSpy);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('NgxFormFieldErrorSummary');
+      expect(warnings[0]).toContain('WCAG 2.4.3');
+      expect(warnings[0]).toContain('autoFocus');
+    });
+
+    it('should not warn when host.focus() succeeds in moving focus', async () => {
+      @Component({
+        selector: 'ngx-test-error-summary-focus-ok',
+        imports: [FormField, NgxFormFieldErrorSummary],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <input id="email" [formField]="contactForm.email" />
+          <ngx-form-field-error-summary
+            [formTree]="contactForm"
+            strategy="on-submit"
+            [submittedStatus]="submittedStatus()"
+          />
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email, { message: 'Email is required' });
+          }),
+        );
+        readonly submittedStatus = signal<SubmittedStatus>('unsubmitted');
+      }
+
+      const { fixture } = await render(TestComponent);
+
+      fixture.componentInstance.submittedStatus.set('submitted');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Sanity: focus did land on the summary host, so no diagnostic fires.
+      const focusTarget = (await screen.findByRole('alert')).closest(
+        'ngx-form-field-error-summary',
+      );
+      expect(document.activeElement).toBe(focusTarget);
+      expect(getFocusFailureWarnings(warnSpy)).toHaveLength(0);
+    });
   });
 
   it('exposes role="alert" without redundant aria-live/aria-atomic', async () => {

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -154,7 +154,7 @@ export class NgxFormFieldErrorSummary {
    * a host that is detached / `display: none` / covered by a modal would
    * trigger the warning on every render pass while the latch is held. We
    * mirror the `#warnedMissingName` pattern used in
-   * `form-field-error.component.ts` and `NgxHeadlessFieldNameDirective`.
+   * `form-field-error.ts` and `NgxHeadlessFieldName`.
    */
   #warnedFocusFailure = false;
 

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   inject,
   input,
+  isDevMode,
   untracked,
 } from '@angular/core';
 import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
@@ -149,6 +150,15 @@ export class NgxFormFieldErrorSummary {
   readonly #host = inject<ElementRef<HTMLElement>>(ElementRef);
 
   /**
+   * One-shot guard for the dev-mode focus-failure diagnostic. Without this,
+   * a host that is detached / `display: none` / covered by a modal would
+   * trigger the warning on every render pass while the latch is held. We
+   * mirror the `#warnedMissingName` pattern used in
+   * `form-field-error.component.ts` and `NgxHeadlessFieldNameDirective`.
+   */
+  #warnedFocusFailure = false;
+
+  /**
    * Label displayed above the error list.
    * @default 'Please fix the following errors:'
    */
@@ -204,6 +214,30 @@ export class NgxFormFieldErrorSummary {
             host.focus();
           }
           hasFocused = true;
+
+          // Dev-mode diagnostic: `focus()` is silent — if the host is
+          // detached, `display: none`, covered by a modal/inert ancestor,
+          // or otherwise unfocusable, we no-op without telling anyone and
+          // the WCAG 2.4.3 + 3.3.1 contract silently breaks. Once-per-
+          // instance warning so we don't spam the console.
+          if (
+            isDevMode() &&
+            !this.#warnedFocusFailure &&
+            typeof document !== 'undefined' &&
+            document.activeElement !== host
+          ) {
+            this.#warnedFocusFailure = true;
+            // oxlint-disable-next-line no-console -- dev-mode a11y signal
+            console.warn(
+              '[ngx-signal-forms] NgxFormFieldErrorSummary: ' +
+                'host.focus() did not move focus (likely detached, ' +
+                'display:none, covered by a modal, or has tabindex ' +
+                'blocked). The WCAG 2.4.3 contract requires focus to ' +
+                'land on the summary on first appearance. Set ' +
+                '`[autoFocus]="false"` to opt out, or ensure the summary ' +
+                'host is visible and focusable.',
+            );
+          }
         });
       },
     });

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -1,8 +1,11 @@
 import {
+  afterRenderEffect,
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   inject,
   input,
+  untracked,
 } from '@angular/core';
 import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
 
@@ -23,6 +26,11 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
  *   on NVDA+Firefox.
  * - Error links are focusable buttons for keyboard navigation
  * - Each entry identifies the field and the error message
+ * - The summary host has `tabindex="-1"` and is **programmatically focused**
+ *   the first time it appears with non-zero entries (GOV.UK / WAI tutorial
+ *   pattern for WCAG 2.4.3 + 3.3.1). This guarantees screen reader users
+ *   land on the summary after submit instead of being left where they were.
+ *   Opt out with `[autoFocus]="false"`.
  *
  * ## Usage
  *
@@ -46,6 +54,12 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
 @Component({
   selector: 'ngx-form-field-error-summary',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    // `tabindex="-1"` makes the host programmatically focusable without
+    // injecting it into the natural Tab order. The `:focus-visible` outline
+    // on individual error buttons is intentionally untouched.
+    tabindex: '-1',
+  },
   hostDirectives: [
     {
       directive: NgxHeadlessErrorSummary,
@@ -132,10 +146,66 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
 })
 export class NgxFormFieldErrorSummary {
   protected readonly summary = inject(NgxHeadlessErrorSummary);
+  readonly #host = inject<ElementRef<HTMLElement>>(ElementRef);
 
   /**
    * Label displayed above the error list.
    * @default 'Please fix the following errors:'
    */
   readonly summaryLabel = input('Please fix the following errors:');
+
+  /**
+   * Whether to programmatically focus the summary host the first time it
+   * appears with non-zero entries.
+   *
+   * The default (`true`) follows the GOV.UK / WAI error-summary pattern so
+   * screen-reader users hear the announcement and arrive at the summary
+   * after a failed submit. Set to `false` if your flow already moves focus
+   * elsewhere (e.g. straight to the first invalid field) or if focus
+   * theft is undesirable in your design.
+   *
+   * @default true
+   */
+  readonly autoFocus = input(true);
+
+  constructor() {
+    /**
+     * Track whether we have already moved focus into the summary so that
+     * subsequent entry-list mutations (a new error appearing while the
+     * summary is visible, the user editing a field, etc.) do not steal
+     * focus from wherever the user currently is. We re-arm the latch when
+     * the summary disappears so the next "0 → N" transition focuses again.
+     */
+    let hasFocused = false;
+
+    afterRenderEffect({
+      // `read` phase: we only need to inspect signals + (optionally) call
+      // `.focus()` on the host. No DOM writes that would invalidate other
+      // components' layouts.
+      read: () => {
+        const visible = this.summary.shouldShow() && this.summary.hasErrors();
+
+        if (!visible) {
+          hasFocused = false;
+          return;
+        }
+
+        // `untracked` so reading these once-per-mount signals does not
+        // cause the effect to retrigger every time the entry list, label,
+        // or focus flag changes after the initial focus has happened.
+        untracked(() => {
+          if (hasFocused) return;
+          if (!this.autoFocus()) return;
+
+          const host = this.#host.nativeElement;
+          // Defensive: in jsdom-based test environments `focus()` is
+          // present but a missing element should never crash production.
+          if (typeof host.focus === 'function') {
+            host.focus();
+          }
+          hasFocused = true;
+        });
+      },
+    });
+  }
 }

--- a/packages/toolkit/assistive/form-field-error.scss
+++ b/packages/toolkit/assistive/form-field-error.scss
@@ -84,9 +84,22 @@
 }
 
 .ngx-form-field-error--warning {
-  color: var(--ngx-signal-form-warning-color, #f59e0b);
+  /* WCAG 1.4.3 (AA): #f59e0b on white = 2.16:1, fails normal-text contrast.
+   * Tailwind amber-700 (#a16207) gives ~5.17:1 on white and remains
+   * recognisably "amber" so the design intent is preserved. The custom
+   * property override is intentionally untouched — consumers that pin a
+   * brand-specific amber are responsible for keeping it ≥ 4.5:1. */
+  color: var(--ngx-signal-form-warning-color, #a16207);
   background-color: var(--ngx-signal-form-warning-bg, transparent);
   border-color: var(--ngx-signal-form-warning-border, transparent);
+}
+
+/* Empty live-region shell: the role="alert" / role="status" containers stay
+ * mounted so AT picks up the live region on first insertion (WCAG 4.1.3).
+ * When empty we suppress the slide-in animation — there is nothing to
+ * animate and the keyframe would otherwise still run on every render. */
+.ngx-form-field-error--empty {
+  animation: none;
 }
 
 .ngx-form-field-error__message {

--- a/packages/toolkit/assistive/form-field-error.scss
+++ b/packages/toolkit/assistive/form-field-error.scss
@@ -95,10 +95,17 @@
 }
 
 /* Empty live-region shell: the role="alert" / role="status" containers stay
- * mounted so AT picks up the live region on first insertion (WCAG 4.1.3).
- * When empty we suppress the slide-in animation — there is nothing to
- * animate and the keyframe would otherwise still run on every render. */
+ * mounted (with `aria-hidden="true"` and `[hidden]`) so AT picks up the
+ * live region on first content insertion (WCAG 4.1.3). The element is
+ * already removed from layout flow by `[hidden]`, but we also clear
+ * padding/border/margin defensively in case a consumer overrides the
+ * default `display:none` styling (e.g. with `display: contents` for a
+ * flex/grid layout) — the empty shell must contribute zero visual
+ * footprint regardless of how it is reflowed. */
 .ngx-form-field-error--empty {
+  padding: 0;
+  border-width: 0;
+  margin: 0;
   animation: none;
 }
 

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -601,10 +601,16 @@ describe('NgxFormFieldError', () => {
       // Untouched + on-touch ⇒ no error is *announced* (nothing to read)
       // but the live-region container itself MUST already be in the DOM
       // with role="alert" so a future insertion fires the announcement.
+      // The container carries the `--empty` marker class so CSS can
+      // collapse it visually; `aria-hidden="true"` keeps AT silent until
+      // content arrives, and `[hidden]` removes the empty shell from
+      // layout flow.
       const alertContainer = container.querySelector('[role="alert"]');
       expect(alertContainer).toBeTruthy();
+      expect(
+        alertContainer?.classList.contains('ngx-form-field-error--empty'),
+      ).toBe(true);
       expect(alertContainer?.getAttribute('aria-hidden')).toBe('true');
-      // hidden attribute keeps the empty shell out of layout/visual flow.
       expect(alertContainer?.hasAttribute('hidden')).toBe(true);
       // No id leaks while empty — aria-describedby targets must not point
       // at an element with no message text. Angular renders `null`
@@ -619,6 +625,9 @@ describe('NgxFormFieldError', () => {
       // The same applies to the warning role="status" sibling.
       const statusContainer = container.querySelector('[role="status"]');
       expect(statusContainer).toBeTruthy();
+      expect(
+        statusContainer?.classList.contains('ngx-form-field-error--empty'),
+      ).toBe(true);
       expect(statusContainer?.getAttribute('aria-hidden')).toBe('true');
       expect(statusContainer?.hasAttribute('hidden')).toBe(true);
     });

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -561,6 +561,68 @@ describe('NgxFormFieldError', () => {
       expect(alert.getAttribute('role')).toBe('alert');
     });
 
+    it('should keep an empty role="alert" live region mounted before any errors appear (WCAG 4.1.3)', async () => {
+      /**
+       * WCAG 4.1.3 (Status Messages): role="alert" only fires reliably on
+       * NVDA + Chrome when content is inserted into a *pre-existing* live
+       * region. If the alert container itself is added to the DOM at the
+       * same moment as the first error, the very first announcement can be
+       * silently dropped. v1 keeps the role="alert" container always
+       * mounted (and aria-hidden="true" while empty) so that timing
+       * edge case never trips screen readers.
+       */
+      @Component({
+        selector: 'ngx-test-empty-live-region',
+        imports: [FormField, NgxFormFieldErrorComponent],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <input id="email" [formField]="contactForm.email" />
+          <ngx-form-field-error
+            [formField]="contactForm.email"
+            fieldName="email"
+            strategy="on-touch"
+            [submittedStatus]="submittedStatus()"
+          />
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email, { message: 'Email is required' });
+          }),
+        );
+        readonly submittedStatus = signal<SubmittedStatus>('unsubmitted');
+      }
+
+      const { container } = await render(TestComponent);
+
+      // Untouched + on-touch ⇒ no error is *announced* (nothing to read)
+      // but the live-region container itself MUST already be in the DOM
+      // with role="alert" so a future insertion fires the announcement.
+      const alertContainer = container.querySelector('[role="alert"]');
+      expect(alertContainer).toBeTruthy();
+      expect(alertContainer?.getAttribute('aria-hidden')).toBe('true');
+      // hidden attribute keeps the empty shell out of layout/visual flow.
+      expect(alertContainer?.hasAttribute('hidden')).toBe(true);
+      // No id leaks while empty — aria-describedby targets must not point
+      // at an element with no message text. Angular renders `null`
+      // bindings as either a missing attribute or the literal string
+      // "null" depending on the jsdom path; what matters here is that
+      // the auto-generated `*-error` id is not exposed.
+      const idAttr = alertContainer?.getAttribute('id') ?? null;
+      expect(idAttr === null || idAttr === '' || idAttr === 'null').toBe(true);
+      // No error text either.
+      expect(alertContainer?.textContent?.trim()).toBe('');
+
+      // The same applies to the warning role="status" sibling.
+      const statusContainer = container.querySelector('[role="status"]');
+      expect(statusContainer).toBeTruthy();
+      expect(statusContainer?.getAttribute('aria-hidden')).toBe('true');
+      expect(statusContainer?.hasAttribute('hidden')).toBe(true);
+    });
+
     it('should rely on role="alert" implicit semantics (no redundant aria-live/aria-atomic)', async () => {
       /**
        * `role="alert"` already implies `aria-live="assertive"` and

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -573,7 +573,7 @@ describe('NgxFormFieldError', () => {
        */
       @Component({
         selector: 'ngx-test-empty-live-region',
-        imports: [FormField, NgxFormFieldErrorComponent],
+        imports: [FormField, NgxFormFieldError],
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           <input id="email" [formField]="contactForm.email" />

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -98,13 +98,25 @@ export type NgxFormFieldErrorListStyle = 'plain' | 'bullets';
       Blocking Errors: role="alert" already implies aria-live="assertive"
       and aria-atomic="true". Setting them explicitly causes duplicate
       announcements on NVDA+Firefox, so we rely on the implicit semantics.
+
+      The container is rendered UNCONDITIONALLY (even when empty) so that
+      role="alert" — which only fires reliably on content insertion into a
+      pre-existing live region — works the very first time an error appears.
+      This satisfies WCAG 4.1.3 (Status Messages) and avoids the NVDA + Chrome
+      timing edge case where a freshly-inserted live region misses its first
+      announcement. We mark the container as aria-hidden="true" while empty
+      so it is invisible to AT and contributes no whitespace text to the
+      accessibility tree, but never toggle the role attribute itself.
     -->
-    @if (showErrors() && hasErrors()) {
-      <div
-        [id]="errorId()"
-        class="ngx-form-field-error ngx-form-field-error--error"
-        role="alert"
-      >
+    <div
+      [id]="errorContainerVisible() ? errorId() : null"
+      class="ngx-form-field-error ngx-form-field-error--error"
+      [class.ngx-form-field-error--empty]="!errorContainerVisible()"
+      role="alert"
+      [attr.aria-hidden]="errorContainerVisible() ? null : 'true'"
+      [hidden]="!errorContainerVisible()"
+    >
+      @if (errorContainerVisible()) {
         @if (usesBulletList()) {
           <ul class="ngx-form-field-error__list" role="list">
             @for (
@@ -130,20 +142,24 @@ export type NgxFormFieldErrorListStyle = 'plain' | 'bullets';
             </p>
           }
         }
-      </div>
-    }
+      }
+    </div>
 
     <!--
       Non-blocking Warnings: role="status" implies aria-live="polite" and
       aria-atomic="true"; the explicit attributes are intentionally omitted
-      to avoid duplicate AT announcements.
+      to avoid duplicate AT announcements. Same empty-live-region pattern as
+      the alert container above.
     -->
-    @if (showWarnings() && hasWarnings()) {
-      <div
-        [id]="warningId()"
-        class="ngx-form-field-error ngx-form-field-error--warning"
-        role="status"
-      >
+    <div
+      [id]="warningContainerVisible() ? warningId() : null"
+      class="ngx-form-field-error ngx-form-field-error--warning"
+      [class.ngx-form-field-error--empty]="!warningContainerVisible()"
+      role="status"
+      [attr.aria-hidden]="warningContainerVisible() ? null : 'true'"
+      [hidden]="!warningContainerVisible()"
+    >
+      @if (warningContainerVisible()) {
         @if (usesBulletList()) {
           <ul class="ngx-form-field-error__list" role="list">
             @for (
@@ -169,8 +185,8 @@ export type NgxFormFieldErrorListStyle = 'plain' | 'bullets';
             </p>
           }
         }
-      </div>
-    }
+      }
+    </div>
   `,
   styleUrl: './form-field-error.scss',
 })
@@ -482,6 +498,25 @@ export class NgxFormFieldError {
 
   protected readonly hasWarnings = computed(
     () => this.#split().warnings.length > 0,
+  );
+
+  /**
+   * True when the role="alert" container should expose its content (id,
+   * aria-describedby target, visible children) — i.e. visibility timing
+   * agrees AND there are blocking errors to announce. The container itself
+   * always exists in the DOM so the live-region announces correctly on
+   * first content insertion (WCAG 4.1.3); when this is `false` the host
+   * collapses to an empty, `aria-hidden="true"`, `[hidden]` shell.
+   */
+  protected readonly errorContainerVisible = computed(
+    () => this.showErrors() && this.hasErrors(),
+  );
+
+  /**
+   * Same as `errorContainerVisible` but for the warnings live region.
+   */
+  protected readonly warningContainerVisible = computed(
+    () => this.showWarnings() && this.hasWarnings(),
   );
 
   protected readonly resolvedErrors = computed(() =>

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -256,7 +256,7 @@ export class NgxFormFieldError {
    * />
    * ```
    */
-  readonly errors = input<Signal<ValidationError[]>>();
+  readonly errors = input<Signal<readonly ValidationError[]>>();
 
   /**
    * The field name used for generating error/warning IDs.

--- a/packages/toolkit/core/index.spec.ts
+++ b/packages/toolkit/core/index.spec.ts
@@ -14,23 +14,15 @@ import { NgxSignalFormToolkit } from './index';
  * surfacing as a runtime "directive not declared" failure in consumer apps.
  */
 describe('NgxSignalFormToolkit bundle', () => {
-  it('contains the four toolkit-core directives in their documented order', () => {
-    expect(NgxSignalFormToolkit).toEqual([
-      FormRoot,
-      NgxSignalFormDirective,
-      NgxSignalFormAutoAriaDirective,
-      NgxSignalFormControlSemanticsDirective,
-    ]);
-  });
-
   it('contains exactly four members (guards against accidental additions)', () => {
     expect(NgxSignalFormToolkit).toHaveLength(4);
   });
 
-  it('exposes NgxSignalFormDirective, NgxSignalFormAutoAriaDirective, and NgxSignalFormControlSemanticsDirective', () => {
-    // Negative-lookup form: confirm each expected directive is present
-    // regardless of order. If any sibling agent removes one, this fails
-    // independently of the order assertion above.
+  it('exposes FormRoot and the three toolkit-core directives (order-independent)', () => {
+    // Order-independent presence check. Angular's `imports` array is
+    // order-insensitive, so we don't pin order here — adding/removing a
+    // member is a breaking change, but reordering for readability is not.
+    expect(NgxSignalFormToolkit).toContain(FormRoot);
     expect(NgxSignalFormToolkit).toContain(NgxSignalFormDirective);
     expect(NgxSignalFormToolkit).toContain(NgxSignalFormAutoAriaDirective);
     expect(NgxSignalFormToolkit).toContain(

--- a/packages/toolkit/core/index.spec.ts
+++ b/packages/toolkit/core/index.spec.ts
@@ -1,8 +1,8 @@
 import { FormRoot } from '@angular/forms/signals';
 import { describe, expect, it } from 'vitest';
-import { NgxSignalFormAutoAriaDirective } from './directives/auto-aria.directive';
-import { NgxSignalFormControlSemanticsDirective } from './directives/control-semantics.directive';
-import { NgxSignalFormDirective } from './directives/ngx-signal-form.directive';
+import { NgxSignalFormAutoAria } from './directives/auto-aria';
+import { NgxSignalFormControlSemanticsDirective } from './directives/control-semantics';
+import { NgxSignalForm } from './directives/ngx-signal-form';
 import { NgxSignalFormToolkit } from './index';
 
 /**
@@ -23,8 +23,8 @@ describe('NgxSignalFormToolkit bundle', () => {
     // order-insensitive, so we don't pin order here — adding/removing a
     // member is a breaking change, but reordering for readability is not.
     expect(NgxSignalFormToolkit).toContain(FormRoot);
-    expect(NgxSignalFormToolkit).toContain(NgxSignalFormDirective);
-    expect(NgxSignalFormToolkit).toContain(NgxSignalFormAutoAriaDirective);
+    expect(NgxSignalFormToolkit).toContain(NgxSignalForm);
+    expect(NgxSignalFormToolkit).toContain(NgxSignalFormAutoAria);
     expect(NgxSignalFormToolkit).toContain(
       NgxSignalFormControlSemanticsDirective,
     );

--- a/packages/toolkit/core/index.spec.ts
+++ b/packages/toolkit/core/index.spec.ts
@@ -1,0 +1,40 @@
+import { FormRoot } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+import { NgxSignalFormAutoAriaDirective } from './directives/auto-aria.directive';
+import { NgxSignalFormControlSemanticsDirective } from './directives/control-semantics.directive';
+import { NgxSignalFormDirective } from './directives/ngx-signal-form.directive';
+import { NgxSignalFormToolkit } from './index';
+
+/**
+ * Stability contract for the `NgxSignalFormToolkit` bundle.
+ *
+ * The bundle is a public, ergonomic shortcut consumers add to a component's
+ * `imports`. Adding/removing/reordering its members is a breaking change —
+ * pin the contents here so a regression is caught at test time instead of
+ * surfacing as a runtime "directive not declared" failure in consumer apps.
+ */
+describe('NgxSignalFormToolkit bundle', () => {
+  it('contains the four toolkit-core directives in their documented order', () => {
+    expect(NgxSignalFormToolkit).toEqual([
+      FormRoot,
+      NgxSignalFormDirective,
+      NgxSignalFormAutoAriaDirective,
+      NgxSignalFormControlSemanticsDirective,
+    ]);
+  });
+
+  it('contains exactly four members (guards against accidental additions)', () => {
+    expect(NgxSignalFormToolkit).toHaveLength(4);
+  });
+
+  it('exposes NgxSignalFormDirective, NgxSignalFormAutoAriaDirective, and NgxSignalFormControlSemanticsDirective', () => {
+    // Negative-lookup form: confirm each expected directive is present
+    // regardless of order. If any sibling agent removes one, this fails
+    // independently of the order assertion above.
+    expect(NgxSignalFormToolkit).toContain(NgxSignalFormDirective);
+    expect(NgxSignalFormToolkit).toContain(NgxSignalFormAutoAriaDirective);
+    expect(NgxSignalFormToolkit).toContain(
+      NgxSignalFormControlSemanticsDirective,
+    );
+  });
+});

--- a/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
@@ -1,0 +1,320 @@
+import { ApplicationRef, signal, type WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  form,
+  schema,
+  validate,
+  type FieldTree,
+  type ValidationError,
+} from '@angular/forms/signals';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  canSubmitWithWarnings,
+  createSubmittedStatusTracker,
+  getBlockingErrors,
+  hasOnlyWarnings,
+} from './submission-helpers';
+import { warningError } from './warning-error';
+
+/**
+ * Coverage spec for previously-untested public exports of submission-helpers.
+ *
+ * Pins the contract for:
+ * - `createSubmittedStatusTracker` — direct tests of the linkedSignal-based
+ *   transition tracker (independent of the `hasSubmitted` wrapper).
+ * - `hasOnlyWarnings` — predicate over a ValidationError[].
+ * - `getBlockingErrors` — filter over ValidationError[].
+ * - `canSubmitWithWarnings` — computed signal against a real Angular form.
+ */
+describe('createSubmittedStatusTracker', () => {
+  const flush = async (): Promise<void> => {
+    await TestBed.inject(ApplicationRef).whenStable();
+  };
+
+  const makeMockForm = (
+    submitting: () => boolean,
+    touched: () => boolean,
+  ): FieldTree<unknown> => {
+    return signal({
+      value: () => ({}),
+      valid: () => true,
+      invalid: () => false,
+      touched,
+      dirty: () => false,
+      errors: () => [],
+      pending: () => false,
+      disabled: () => false,
+      readonly: () => false,
+      hidden: () => false,
+      submitting,
+      submittedStatus: () => 'unsubmitted' as const,
+      reset: vi.fn(),
+      markAsTouched: vi.fn(),
+      markAsDirty: vi.fn(),
+      resetSubmittedStatus: vi.fn(),
+      errorSummary: () => [],
+    });
+  };
+
+  it('returns "unsubmitted" → "submitting" → "submitted" through a successful cycle', async () => {
+    const submittingState = signal(false);
+    const touchedState = signal(false);
+    const mockForm = makeMockForm(
+      () => submittingState(),
+      () => touchedState(),
+    );
+
+    const status = TestBed.runInInjectionContext(() =>
+      createSubmittedStatusTracker(mockForm),
+    );
+
+    // Initial.
+    expect(status()).toBe('unsubmitted');
+
+    // Submit fired: native `submitting()` flips true and the form is touched.
+    submittingState.set(true);
+    touchedState.set(true);
+    await flush();
+    expect(status()).toBe('submitting');
+
+    // Submit settles: `submitting()` returns to false → tracker captures the
+    // true → false transition and surfaces 'submitted'.
+    submittingState.set(false);
+    await flush();
+    expect(status()).toBe('submitted');
+  });
+
+  it('flips to "submitted" on submitAttempted even when submitting() never fires (invalid form)', async () => {
+    const submittingState = signal(false);
+    const touchedState = signal(false);
+    const submitAttempted: WritableSignal<boolean> = signal(false);
+    const mockForm = makeMockForm(
+      () => submittingState(),
+      () => touchedState(),
+    );
+
+    const status = TestBed.runInInjectionContext(() =>
+      createSubmittedStatusTracker(mockForm, submitAttempted),
+    );
+
+    // Pre-submit baseline.
+    expect(status()).toBe('unsubmitted');
+
+    // Invalid form: Angular's `submit()` short-circuits and never sets
+    // `submitting=true`. Consumers signal the attempt via the optional
+    // submitAttempted writable.
+    submitAttempted.set(true);
+    await flush();
+    expect(status()).toBe('submitted');
+  });
+
+  it('resets to "unsubmitted" and clears submitAttempted when touched returns to false', async () => {
+    const submittingState = signal(false);
+    const touchedState = signal(false);
+    const submitAttempted: WritableSignal<boolean> = signal(false);
+    const mockForm = makeMockForm(
+      () => submittingState(),
+      () => touchedState(),
+    );
+
+    const status = TestBed.runInInjectionContext(() =>
+      createSubmittedStatusTracker(mockForm, submitAttempted),
+    );
+
+    // Drive a full submit cycle.
+    submittingState.set(true);
+    touchedState.set(true);
+    await flush();
+    submittingState.set(false);
+    await flush();
+    expect(status()).toBe('submitted');
+
+    // Reset: form.reset() flips touched back to false. Tracker must roll
+    // back to 'unsubmitted' AND clear the external submitAttempted signal.
+    touchedState.set(false);
+    await flush();
+    expect(status()).toBe('unsubmitted');
+    expect(submitAttempted()).toBe(false);
+  });
+
+  it('throws synchronously when given neither a FieldTree nor a Signal<FieldTree>', () => {
+    // Negative: passing a value that fails the `isFieldTree` guard must
+    // surface a clear error rather than silently producing 'unsubmitted'.
+    expect(() =>
+      TestBed.runInInjectionContext(() =>
+        createSubmittedStatusTracker(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          {} as any,
+        ),
+      ),
+    ).toThrow(/FieldTree or Signal<FieldTree>/);
+  });
+});
+
+describe('hasOnlyWarnings', () => {
+  it('returns true for an empty errors array', () => {
+    expect(hasOnlyWarnings([])).toBe(true);
+  });
+
+  it('returns true when every error is a warning', () => {
+    const warnings: readonly ValidationError[] = [
+      warningError('weak-password', 'Use 12+ characters'),
+      warningError('disposable-email'),
+    ];
+    expect(hasOnlyWarnings(warnings)).toBe(true);
+  });
+
+  it('returns false when any blocking error is present', () => {
+    const mixed: readonly ValidationError[] = [
+      warningError('weak-password'),
+      { kind: 'required', message: 'Password is required' },
+    ];
+    expect(hasOnlyWarnings(mixed)).toBe(false);
+  });
+});
+
+describe('getBlockingErrors', () => {
+  it('returns an empty array for empty input', () => {
+    expect(getBlockingErrors([])).toEqual([]);
+  });
+
+  it('filters out warning errors and preserves order of blocking errors', () => {
+    const required: ValidationError = {
+      kind: 'required',
+      message: 'Required',
+    };
+    const tooShort: ValidationError = { kind: 'minlength', message: 'Min 8' };
+    const errors: readonly ValidationError[] = [
+      required,
+      warningError('weak-password'),
+      tooShort,
+      warningError('disposable-email'),
+    ];
+
+    const blocking = getBlockingErrors(errors);
+
+    expect(blocking).toEqual([required, tooShort]);
+    // Order preservation: indices should match the original blocking order.
+    expect(blocking[0]).toBe(required);
+    expect(blocking[1]).toBe(tooShort);
+  });
+
+  it('returns an empty array when all errors are warnings (negative path)', () => {
+    const warnings: readonly ValidationError[] = [
+      warningError('weak-password'),
+      warningError('disposable-email'),
+    ];
+    expect(getBlockingErrors(warnings)).toEqual([]);
+  });
+});
+
+describe('canSubmitWithWarnings', () => {
+  // Real Angular forms — exercise the signal-form integration end-to-end so
+  // that we'd catch any drift in `errors()`/`submitting()`/`pending()` shapes.
+  const flush = async (): Promise<void> => {
+    await TestBed.inject(ApplicationRef).whenStable();
+  };
+
+  it('returns true for a warning-only form', async () => {
+    const model = signal({ username: 'abc' });
+    const f = TestBed.runInInjectionContext(() =>
+      form(
+        model,
+        schema<{ username: string }>((path) => {
+          validate(path.username, (ctx) => {
+            const value = ctx.value();
+            if (value && value.length < 6) {
+              return warningError('short-username', 'Use 6+ characters');
+            }
+            return null;
+          });
+        }),
+      ),
+    );
+
+    const canSubmit = TestBed.runInInjectionContext(() =>
+      canSubmitWithWarnings(f),
+    );
+    await flush();
+
+    expect(canSubmit()).toBe(true);
+  });
+
+  it('returns false when the form has any blocking error', async () => {
+    // Validator placed at the root path so the blocking error lands in
+    // `errors()` of the root FieldState (which is what
+    // `canSubmitWithWarnings` reads). Required-on-child errors live on the
+    // child FieldState's `errors()`, not the root, and would surface only
+    // through `errorSummary()`.
+    const model = signal({ email: '' });
+    const f = TestBed.runInInjectionContext(() =>
+      form(
+        model,
+        schema<{ email: string }>((path) => {
+          validate(path, (ctx) => {
+            const value = ctx.value();
+            if (!value.email) {
+              return { kind: 'required', message: 'Email is required' };
+            }
+            return null;
+          });
+        }),
+      ),
+    );
+
+    const canSubmit = TestBed.runInInjectionContext(() =>
+      canSubmitWithWarnings(f),
+    );
+    await flush();
+
+    expect(canSubmit()).toBe(false);
+  });
+
+  it('returns false while submitting()/pending() are true (mock form)', () => {
+    // canSubmitWithWarnings reads `submitting()` and `pending()` on the
+    // FieldState. Use a mock to drive both signals deterministically without
+    // racing the Angular submit pipeline.
+    const submittingState = signal(false);
+    const pendingState = signal(false);
+    const errorsState = signal<readonly ValidationError[]>([]);
+    const mockForm = signal({
+      value: () => ({}),
+      valid: () => true,
+      invalid: () => false,
+      touched: () => false,
+      dirty: () => false,
+      errors: () => errorsState(),
+      pending: () => pendingState(),
+      disabled: () => false,
+      readonly: () => false,
+      hidden: () => false,
+      submitting: () => submittingState(),
+      submittedStatus: () => 'unsubmitted' as const,
+      reset: vi.fn(),
+      markAsTouched: vi.fn(),
+      markAsDirty: vi.fn(),
+      resetSubmittedStatus: vi.fn(),
+      errorSummary: () => errorsState(),
+    }) as unknown as FieldTree<unknown>;
+
+    const canSubmit = TestBed.runInInjectionContext(() =>
+      canSubmitWithWarnings(mockForm),
+    );
+
+    // Idle baseline.
+    expect(canSubmit()).toBe(true);
+
+    // submitting() true → block.
+    submittingState.set(true);
+    expect(canSubmit()).toBe(false);
+    submittingState.set(false);
+
+    // pending() true → block.
+    pendingState.set(true);
+    expect(canSubmit()).toBe(false);
+    pendingState.set(false);
+
+    // Back to idle.
+    expect(canSubmit()).toBe(true);
+  });
+});

--- a/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
@@ -137,6 +137,41 @@ describe('createSubmittedStatusTracker', () => {
     expect(submitAttempted()).toBe(false);
   });
 
+  it("should not reset to 'unsubmitted' when touched flips false during in-flight submission", async () => {
+    // Pins the WCAG-equivalent invariant: the `!curr.submitting` guard at
+    // submission-helpers.ts protects against mid-submit rollback so users
+    // never see the form's submitted-status flicker back while a request
+    // is still in flight.
+    const submittingState = signal(false);
+    const touchedState = signal(false);
+    const mockForm = makeMockForm(
+      () => submittingState(),
+      () => touchedState(),
+    );
+
+    const status = TestBed.runInInjectionContext(() =>
+      createSubmittedStatusTracker(mockForm),
+    );
+
+    // Submit fired: native `submitting()` flips true and the form is touched.
+    submittingState.set(true);
+    touchedState.set(true);
+    await flush();
+    expect(status()).toBe('submitting');
+
+    // Mid-flight: a touched true → false transition arrives while
+    // `submitting()` is STILL true. The guard must hold the status at
+    // 'submitting' and refuse to roll back to 'unsubmitted'.
+    touchedState.set(false);
+    await flush();
+    expect(status()).toBe('submitting');
+
+    // Submit settles: `submitting()` returns to false → 'submitted'.
+    submittingState.set(false);
+    await flush();
+    expect(status()).toBe('submitted');
+  });
+
   it('throws synchronously when given neither a FieldTree nor a Signal<FieldTree>', () => {
     // Negative: passing a value that fails the `isFieldTree` guard must
     // surface a clear error rather than silently producing 'unsubmitted'.

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -3,7 +3,7 @@ import {
   computed,
   effect,
   isSignal,
-  signal,
+  linkedSignal,
   type Signal,
   type WritableSignal,
 } from '@angular/core';
@@ -60,31 +60,105 @@ export function createSubmittedStatusTracker(
     );
   };
 
-  const submitted = signal(false);
-  const prevSubmitting = signal(false);
-  const prevTouched = signal(false);
+  // Validate eagerly so callers learn about a wiring bug at construction
+  // time rather than asynchronously when the warm-effect runs. Signal-typed
+  // inputs are deferred (`input.required()` may not yet have produced the
+  // tree) — for those we delegate to the lazy `resolve()` path.
+  if (!isSignal(formTree)) {
+    resolve();
+  }
 
-  effect(() => {
-    const state = resolve()();
-    const nowSubmitting = state.submitting();
-    const nowTouched = state.touched();
+  // Angular 21 idiom: derive submitted-history via `linkedSignal` so the
+  // transition detection (true → false on `submitting`, true → false on
+  // `touched`) is expressed declaratively against `prev` instead of through
+  // a multi-write `effect()` that the previous implementation used.
+  //
+  // The previous shape wrote to THREE signals from one effect
+  // (`submitted`, `prevSubmitting`, `prevTouched`) — the canonical
+  // "effect writes to signals" antipattern that re-runs in the same tick
+  // and makes change-detection ordering load-bearing. This rewrite captures
+  // the previous source snapshot via `linkedSignal`'s `prev.source` so we
+  // need no manually-managed mirror signals.
+  //
+  // Important: `linkedSignal` is lazy — its source is evaluated only on
+  // read. Transition detection requires every source snapshot to be
+  // observed, so a small `effect()` keeps the linkedSignal warm by reading
+  // it on every reactive change. This is intentional and is the only
+  // remaining side effect (a SINGLE-write effect, the safe shape).
+  const submittedHistory = linkedSignal<
+    { submitting: boolean; touched: boolean; pending: boolean },
+    boolean
+  >({
+    source: () => {
+      const state = resolve()();
+      return {
+        submitting: state.submitting(),
+        touched: state.touched(),
+        pending: state.pending?.() ?? false,
+      };
+    },
+    computation: (curr, prev) => {
+      const previousValue = prev?.value ?? false;
 
-    if (prevSubmitting() && !nowSubmitting) {
-      submitted.set(true);
-    }
-    if (prevTouched() && !nowTouched && !nowSubmitting) {
-      submitted.set(false);
-      submitAttempted?.set(false);
-    }
+      // Reset on touched: true → false (form.reset()) when not currently
+      // submitting. Mirrors the original effect's reset condition.
+      if (
+        prev !== undefined &&
+        prev.source.touched &&
+        !curr.touched &&
+        !curr.submitting
+      ) {
+        return false;
+      }
 
-    prevSubmitting.set(nowSubmitting);
-    prevTouched.set(nowTouched);
+      // Transition: submitting true → false marks a completed submission.
+      if (prev !== undefined && prev.source.submitting && !curr.submitting) {
+        return true;
+      }
+
+      return previousValue;
+    },
   });
+
+  // Keep the linkedSignal warm so transient transitions are not lost
+  // between consumer reads. Single-statement effect, single read — does
+  // NOT write to any signal, so it cannot loop.
+  effect(() => {
+    submittedHistory();
+  });
+
+  // Side effect (single, isolated): clear the external submit-attempt
+  // signal when the form is reset. Detect the reset by tracking the
+  // touched: true → false transition (same trigger the linkedSignal uses
+  // to roll `submittedHistory` back to false). Kept out of the
+  // linkedSignal computation because computations must be pure.
+  //
+  // This is a single-write effect — the only signal it writes is the
+  // external `submitAttempted`, which is owned by the caller.
+  if (submitAttempted !== undefined) {
+    let prevTouched = false;
+    effect(() => {
+      const state = resolve()();
+      const nowTouched = state.touched();
+      const nowSubmitting = state.submitting();
+      const wasTouched = prevTouched;
+      prevTouched = nowTouched;
+
+      // Reset transition only — never on initial steady-state reads.
+      if (wasTouched && !nowTouched && !nowSubmitting) {
+        if (submitAttempted()) {
+          submitAttempted.set(false);
+        }
+      }
+    });
+  }
 
   return computed(() => {
     const state = resolve()();
     if (state.submitting()) return 'submitting';
-    return submitted() || submitAttempted?.() ? 'submitted' : 'unsubmitted';
+    return submittedHistory() || submitAttempted?.()
+      ? 'submitted'
+      : 'unsubmitted';
   });
 }
 /* oxlint-enable @typescript-eslint/prefer-readonly-parameter-types */

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -84,7 +84,8 @@ export function createSubmittedStatusTracker(
   // read. Transition detection requires every source snapshot to be
   // observed, so a small `effect()` keeps the linkedSignal warm by reading
   // it on every reactive change. This is intentional and is the only
-  // remaining side effect (a SINGLE-write effect, the safe shape).
+  // remaining side effect (a ZERO-write effect — single read, no writes,
+  // so it cannot loop).
   const submittedHistory = linkedSignal<
     { submitting: boolean; touched: boolean; pending: boolean },
     boolean
@@ -94,7 +95,7 @@ export function createSubmittedStatusTracker(
       return {
         submitting: state.submitting(),
         touched: state.touched(),
-        pending: state.pending?.() ?? false,
+        pending: state.pending() ?? false,
       };
     },
     computation: (curr, prev) => {

--- a/packages/toolkit/core/utilities/unwrap-signal-or-value.spec.ts
+++ b/packages/toolkit/core/utilities/unwrap-signal-or-value.spec.ts
@@ -1,5 +1,5 @@
-import { computed, signal } from '@angular/core';
-import { describe, expect, it } from 'vitest';
+import { computed, signal, type Signal } from '@angular/core';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { unwrapValue } from './unwrap-signal-or-value';
 
 describe('unwrapValue', () => {
@@ -277,6 +277,51 @@ describe('unwrapValue', () => {
         autoAria: true,
         debug: false,
       });
+    });
+  });
+
+  describe('Typed Overloads', () => {
+    // Pins the three-overload public type signature added to address the
+    // callable-T footgun (e.g. `FieldTree<U>` is a callable type, and the
+    // single-signature variant routed it through the function branch
+    // silently). Each overload exists for a reason; the runtime branches
+    // (isSignal then typeof === 'function') are unchanged.
+
+    it('signal overload — returns the signal value with the correct type', () => {
+      const sig: Signal<string> = signal('signal-value');
+      const result = unwrapValue(sig);
+      expect(result).toBe('signal-value');
+      expectTypeOf(result).toEqualTypeOf<string>();
+    });
+
+    it('function overload — invokes the zero-arg function and returns its result', () => {
+      const fn = (): number => 7;
+      const result = unwrapValue(fn);
+      expect(result).toBe(7);
+      expectTypeOf(result).toEqualTypeOf<number>();
+    });
+
+    it('function overload — accepts callable types like FieldTree by invoking them', () => {
+      // FieldTree<U> is a callable type: `(): FieldState<U>`. The function
+      // overload is the documented call site for it. We simulate the shape
+      // without depending on @angular/forms/signals to keep this unit-only.
+      interface FakeFieldState {
+        readonly value: () => string;
+      }
+      type FakeFieldTree = () => FakeFieldState;
+
+      const fakeTree: FakeFieldTree = () => ({ value: () => 'snapshot' });
+      const result = unwrapValue(fakeTree);
+
+      expect(result.value()).toBe('snapshot');
+      expectTypeOf(result).toEqualTypeOf<FakeFieldState>();
+    });
+
+    it('static overload — returns plain (non-callable) values unchanged', () => {
+      const obj = { id: 1, label: 'static' } as const;
+      const result = unwrapValue(obj);
+      expect(result).toBe(obj);
+      expectTypeOf(result).toEqualTypeOf<typeof obj>();
     });
   });
 });

--- a/packages/toolkit/core/utilities/unwrap-signal-or-value.ts
+++ b/packages/toolkit/core/utilities/unwrap-signal-or-value.ts
@@ -75,7 +75,10 @@ import type { ReactiveOrStatic } from '../types';
  * the type IS a function. The single-signature `unwrapValue<T>(v: Signal<T> |
  * (() => T) | T): T` form would route those values through the function
  * branch and silently invoke them, losing the wrapper. The overloads below
- * disambiguate by call site:
+ * make the call-site route explicit (the developer can see they are invoking
+ * the `() => T` branch), but they do not prevent a `FieldTree` from
+ * accidentally being passed where a static value was intended — the runtime
+ * guard always invokes any `typeof === 'function'` value.
  *
  * - {@link unwrapValue} `(value: Signal<T>)` — the signal branch
  * - {@link unwrapValue} `(value: () => T)` — the zero-arg-function branch.
@@ -90,6 +93,12 @@ import type { ReactiveOrStatic } from '../types';
  */
 export function unwrapValue<T>(value: Signal<T>): T;
 export function unwrapValue<T>(value: () => T): T;
+// `ReactiveOrStatic<T>` is `Signal<T> | (() => T) | T`. Without this
+// overload, callers passing a value typed as the full union fall through
+// to the `(value: T)` overload — which infers `T` as the entire union
+// and returns it untouched, defeating the unwrap. Keep this overload to
+// preserve the unwrapping return type at union-typed call sites (e.g.
+// `show-errors.ts` passes a `ReactiveOrStatic<Partial<…>>`).
 export function unwrapValue<T>(value: ReactiveOrStatic<T>): T;
 export function unwrapValue<T>(value: T): T;
 export function unwrapValue<T>(value: ReactiveOrStatic<T>): T {

--- a/packages/toolkit/core/utilities/unwrap-signal-or-value.ts
+++ b/packages/toolkit/core/utilities/unwrap-signal-or-value.ts
@@ -1,4 +1,4 @@
-import { isSignal } from '@angular/core';
+import { isSignal, type Signal } from '@angular/core';
 import type { ReactiveOrStatic } from '../types';
 
 /**
@@ -69,8 +69,29 @@ import type { ReactiveOrStatic } from '../types';
  * }
  * ```
  *
+ * @remarks
+ * **Callable `T` footgun.** Some toolkit types (e.g. `FieldTree<U>` /
+ * `FieldState<U>` from `@angular/forms/signals`) are themselves callable —
+ * the type IS a function. The single-signature `unwrapValue<T>(v: Signal<T> |
+ * (() => T) | T): T` form would route those values through the function
+ * branch and silently invoke them, losing the wrapper. The overloads below
+ * disambiguate by call site:
+ *
+ * - {@link unwrapValue} `(value: Signal<T>)` — the signal branch
+ * - {@link unwrapValue} `(value: () => T)` — the zero-arg-function branch.
+ *   `FieldTree`/`FieldState` are accepted here because they ARE callable, and
+ *   invoking them yields the snapshot, which is the documented semantic.
+ * - {@link unwrapValue} `(value: T)` — the static branch
+ *
+ * The runtime behavior (`isSignal()` then `typeof === 'function'`) is
+ * unchanged; only the public type signature gained overloads.
+ *
  * @see {@link ReactiveOrStatic} The type this function unwraps
  */
+export function unwrapValue<T>(value: Signal<T>): T;
+export function unwrapValue<T>(value: () => T): T;
+export function unwrapValue<T>(value: ReactiveOrStatic<T>): T;
+export function unwrapValue<T>(value: T): T;
 export function unwrapValue<T>(value: ReactiveOrStatic<T>): T {
   // SignalLike is Signal<T> | (() => T), so check both cases
   if (isSignal(value)) {

--- a/packages/toolkit/core/utilities/warning-error.spec.ts
+++ b/packages/toolkit/core/utilities/warning-error.spec.ts
@@ -1,6 +1,11 @@
 import type { ValidationError } from '@angular/forms/signals';
 import { describe, expect, it } from 'vitest';
-import { isBlockingError, isWarningError, warningError } from './warning-error';
+import {
+  isBlockingError,
+  isWarningError,
+  splitByKind,
+  warningError,
+} from './warning-error';
 
 describe('warning-error utilities', () => {
   describe('warningError', () => {
@@ -51,6 +56,60 @@ describe('warning-error utilities', () => {
     it('returns false for invalid inputs', () => {
       expect(isBlockingError({ kind: '', message: 'Empty kind' })).toBe(false);
       expect(isBlockingError({} as ValidationError)).toBe(false);
+    });
+  });
+
+  describe('splitByKind', () => {
+    it('returns empty arrays for an empty input', () => {
+      const result = splitByKind([]);
+      expect(result).toEqual({ blocking: [], warnings: [] });
+    });
+
+    it('partitions blocking errors and warnings while preserving original order', () => {
+      const required: ValidationError = {
+        kind: 'required',
+        message: 'Required',
+      };
+      const weakWarning = warningError('weak-password');
+      const tooShort: ValidationError = {
+        kind: 'minlength',
+        message: 'Min 8',
+      };
+      const disposableWarning = warningError('disposable-email');
+
+      const result = splitByKind([
+        required,
+        weakWarning,
+        tooShort,
+        disposableWarning,
+      ]);
+
+      expect(result.blocking).toEqual([required, tooShort]);
+      expect(result.warnings).toEqual([weakWarning, disposableWarning]);
+      // Order pinning: identity check the slot positions.
+      expect(result.blocking[0]).toBe(required);
+      expect(result.blocking[1]).toBe(tooShort);
+      expect(result.warnings[0]).toBe(weakWarning);
+      expect(result.warnings[1]).toBe(disposableWarning);
+    });
+
+    it('returns mutable arrays consumers can freeze (negative path)', () => {
+      // The interface declares `readonly` slots, but the runtime arrays must
+      // be plain `ValidationError[]` so callers can `Object.freeze()` them.
+      // A pre-frozen return would throw on `freeze` of an already-frozen
+      // value; here we assert the arrays are NOT frozen on creation, AND
+      // that calling `Object.freeze` on them succeeds without throwing.
+      const result = splitByKind([
+        warningError('weak-password'),
+        { kind: 'required', message: 'Required' },
+      ]);
+
+      expect(Object.isFrozen(result.blocking)).toBe(false);
+      expect(Object.isFrozen(result.warnings)).toBe(false);
+      expect(() => Object.freeze(result.blocking)).not.toThrow();
+      expect(() => Object.freeze(result.warnings)).not.toThrow();
+      expect(Object.isFrozen(result.blocking)).toBe(true);
+      expect(Object.isFrozen(result.warnings)).toBe(true);
     });
   });
 });

--- a/packages/toolkit/debugger/README.md
+++ b/packages/toolkit/debugger/README.md
@@ -100,7 +100,7 @@ ngx-signal-form-debugger {
   --ngx-debugger-border-color: #e5e7eb;
   --ngx-debugger-text-color: #111827;
   --ngx-debugger-color-success: #22c55e;
-  --ngx-debugger-color-warning: #f59e0b;
+  --ngx-debugger-color-warning: #a16207;
   --ngx-debugger-color-danger: #ef4444;
   --ngx-debugger-font-size-base: 0.875rem;
   --ngx-debugger-border-radius: 0.5rem;

--- a/packages/toolkit/debugger/debugger-badge.ts
+++ b/packages/toolkit/debugger/debugger-badge.ts
@@ -162,7 +162,7 @@ export class NgxSignalFormDebuggerBadgeIcon {}
     }
 
     :host([data-variant='outline'][data-appearance='warning']) {
-      border-color: var(--ngx-debugger-badge-warning-border, #f59e0b);
+      border-color: var(--ngx-debugger-badge-warning-border, #a16207);
       color: var(--ngx-debugger-badge-warning-text, #92400e);
     }
 

--- a/packages/toolkit/debugger/signal-form-debugger.scss
+++ b/packages/toolkit/debugger/signal-form-debugger.scss
@@ -285,12 +285,24 @@
   &:hover {
     background-color: var(--ngx-debugger-bg-secondary);
   }
+
+  /* WCAG 2.4.7: keyboard users land on the <summary> via Tab and need a
+   * visible focus indicator. Native marker is hidden above, so we own this. */
+  &:focus-visible {
+    outline: 2px solid var(--ngx-debugger-color-info, currentColor);
+    outline-offset: 2px;
+  }
 }
 
 .ngx-debugger__chevron {
   width: 1rem;
   height: 1rem;
   transition: transform 0.2s ease;
+
+  /* WCAG 2.3.3: respect `prefers-reduced-motion` for the rotate transition. */
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 details[open] > .ngx-debugger__section-header .ngx-debugger__chevron {
@@ -389,6 +401,12 @@ details[open] > .ngx-debugger__section-header .ngx-debugger__chevron {
   padding: var(--ngx-debugger-spacing-md);
   border-radius: var(--ngx-debugger-border-radius-sm);
   animation: ngx-debugger-slide-in 0.2s ease-out;
+
+  /* WCAG 2.3.3: the slide-in uses `transform: translateY(...)` which can
+   * trigger vestibular discomfort. Disable when the user opts out. */
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }
 
 .ngx-debugger__error-item--root {

--- a/packages/toolkit/debugger/signal-form-debugger.scss
+++ b/packages/toolkit/debugger/signal-form-debugger.scss
@@ -31,7 +31,7 @@
   --ngx-debugger-color-success: #22c55e;
   --ngx-debugger-color-success-bg: #dcfce7;
   --ngx-debugger-color-success-text: #166534;
-  --ngx-debugger-color-warning: #f59e0b;
+  --ngx-debugger-color-warning: #a16207;
   --ngx-debugger-color-warning-bg: #fef3c7;
   --ngx-debugger-color-warning-text: #92400e;
   --ngx-debugger-color-danger: #ef4444;

--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -78,12 +78,14 @@ These components inherit from the **Shared Feedback** layer but can be overridde
 
 controls the display of validation errors and warnings.
 
+> **Note:** The default `--ngx-signal-form-warning-color` was `#f59e0b` prior to v1.0; it was changed to `#a16207` (Tailwind amber-700) for WCAG 1.4.3 AA contrast compliance on white backgrounds.
+
 | Property                                       | Default                                                          | Description                              |
 | :--------------------------------------------- | :--------------------------------------------------------------- | :--------------------------------------- |
 | `--ngx-signal-form-error-color`                | `#db1818`                                                        | Text color for errors                    |
 | `--ngx-signal-form-error-bg`                   | `transparent`                                                    | Error background color                   |
 | `--ngx-signal-form-error-border`               | `transparent`                                                    | Error border color                       |
-| `--ngx-signal-form-warning-color`              | `#f59e0b`                                                        | Text color for warnings                  |
+| `--ngx-signal-form-warning-color`              | `#a16207`                                                        | Text color for warnings                  |
 | `--ngx-signal-form-warning-bg`                 | `transparent`                                                    | Warning background color                 |
 | `--ngx-signal-form-warning-border`             | `transparent`                                                    | Warning border color                     |
 | `--ngx-signal-form-error-font-size`            | `var(--...feedback...)`                                          | Text size                                |
@@ -123,7 +125,7 @@ Displays progress towards a character limit.
 | `--ngx-form-field-char-count-font-size`       | `var(--...feedback...)`  | Text size                 |
 | `--ngx-form-field-char-count-line-height`     | `1.25`                   | Line height               |
 | `--ngx-form-field-char-count-color-ok`        | `rgba(50, 65, 85, 0.75)` | Neutral state color       |
-| `--ngx-form-field-char-count-color-warning`   | `#f59e0b`                | Warning threshold color   |
+| `--ngx-form-field-char-count-color-warning`   | `#a16207`                | Warning threshold color   |
 | `--ngx-form-field-char-count-color-danger`    | `#db1818`                | Critical threshold color  |
 | `--ngx-form-field-char-count-color-exceeded`  | `#991b1b`                | Limit exceeded color      |
 | `--ngx-form-field-char-count-weight-exceeded` | `600`                    | Font weight when exceeded |
@@ -156,7 +158,7 @@ Groups related fields with consistent spacing.
 - `--ngx-signal-form-fieldset-legend-bg` — default `transparent`; legend background that stays separate from the surfaced content
 - `--ngx-signal-form-fieldset-legend-border-radius` — default `0.25rem`; legend background radius
 - `--ngx-signal-form-fieldset-invalid-border-color` — default `#db1818`; border color when errors are shown
-- `--ngx-signal-form-fieldset-warning-border-color` — default `#f59e0b`; border color when warnings are shown
+- `--ngx-signal-form-fieldset-warning-border-color` — default `#a16207`; border color when warnings are shown
 - `--ngx-signal-form-fieldset-invalid-surface-bg` — default `var(--...invalid-bg...)`; error-tinted background below the legend
 - `--ngx-signal-form-fieldset-warning-surface-bg` — default `var(--...warning-bg...)`; warning-tinted background below the legend
 - `--ngx-signal-form-fieldset-invalid-legend-color` — default `var(--...invalid-border...)`; legend color in error state
@@ -229,7 +231,7 @@ The form field wrapper supports three appearance modes via the `appearance` inpu
 | :-------------------------------------- | :----------------------- | :------------------------------- |
 | `--ngx-form-field-color-primary`        | `#007bc7`                | Focus states, active borders     |
 | `--ngx-form-field-color-error`          | `#db1818`                | Invalid states, required markers |
-| `--ngx-form-field-color-warning`        | `#f59e0b`                | Warning states                   |
+| `--ngx-form-field-color-warning`        | `#a16207`                | Warning states                   |
 | `--ngx-form-field-color-text`           | `#324155`                | Input text                       |
 | `--ngx-form-field-color-text-secondary` | `rgba(50, 65, 85, 0.75)` | Labels, placeholders, hints      |
 | `--ngx-form-field-color-surface`        | `#ffffff`                | Input background                 |

--- a/packages/toolkit/form-field/form-field-wrapper.scss
+++ b/packages/toolkit/form-field/form-field-wrapper.scss
@@ -65,7 +65,11 @@
   // Color tokens
   --_field-clr-primary: #007bc7; // Focus/interactive states
   --_field-clr-danger: #db1818; // Error/invalid states
-  --_field-clr-warning: #f59e0b; // Warning states (amber)
+  // Tailwind amber-700 (#a16207) — chosen over the previous #f59e0b (amber-500,
+  // 2.16:1 on white) so warning text meets WCAG 2.2 AA contrast (4.5:1 on
+  // white). Borders/icons would have been fine at the lighter shade, but this
+  // token also drives warning message text. ~5.17:1 on #ffffff.
+  --_field-clr-warning: #a16207; // Warning states (amber-700, AA contrast)
   --_field-clr-text: #324155; // Primary text color
   --_field-clr-text-secondary: rgba(
     50,
@@ -144,7 +148,8 @@
   :host-context(:root:not(.dark)) {
     --_field-clr-primary: #007bc7;
     --_field-clr-danger: #db1818;
-    --_field-clr-warning: #f59e0b;
+    // Mirror the light-mode :host default (amber-700) for AA-on-white contrast.
+    --_field-clr-warning: #a16207;
     --_field-clr-text: #324155;
     --_field-clr-text-secondary: rgba(50, 65, 85, 0.75);
     --_field-clr-surface: #ffffff;
@@ -775,30 +780,15 @@
   max-inline-size: 100%;
 }
 
-// Required marker (automatic via :has() selector)
-// Detects required inputs in __main and adds marker to label in __label
-:host(.ngx-signal-forms-outline[data-show-required='true'])
-  :is(
-    .ngx-signal-form-field-wrapper__content:has([required])
-      ~ .ngx-signal-form-field-wrapper__label,
-    .ngx-signal-form-field-wrapper__content:has([aria-required='true'])
-      ~ .ngx-signal-form-field-wrapper__label
-  )
-  label::after {
-  content: attr(data-required-marker);
-  color: var(--_required-marker-color);
-  font-weight: var(--_required-marker-weight);
-}
-
-// For grid layout where __label comes before __content in DOM,
-// also target direct descendant
-:host(.ngx-signal-forms-outline[data-show-required='true']):is(
-    :has(.ngx-signal-form-field-wrapper__content [required]),
-    :has(.ngx-signal-form-field-wrapper__content [aria-required='true'])
-  )
-  .ngx-signal-form-field-wrapper__label
-  label::after {
-  content: attr(data-required-marker);
+// Required marker
+//
+// Rendered as a real `<span aria-hidden="true">` in the template (see
+// `form-field-wrapper.ts`) instead of CSS `::after { content: ... }`.
+// Generated content is announced by NVDA/VoiceOver, so the previous approach
+// caused double-announcement alongside the control's own `aria-required`
+// attribute (WCAG 1.3.1, 4.1.2). Visual styling matches the prior asterisk
+// treatment exactly.
+.ngx-signal-form-field-wrapper__required-marker {
   color: var(--_required-marker-color);
   font-weight: var(--_required-marker-weight);
 }

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -784,7 +784,11 @@ describe('NgxSignalFormWrapperComponent', () => {
 
       const formField = container.querySelector('ngx-form-field-wrapper');
       expect(formField).toHaveAttribute('data-show-required', 'true');
-      expect(formField).toHaveAttribute('data-required-marker', ' *');
+      const marker = formField?.querySelector(
+        '.ngx-signal-form-field-wrapper__required-marker',
+      );
+      expect(marker).toBeTruthy();
+      expect(marker?.textContent).toBe(' *');
     });
 
     it('should hide required marker when showRequiredMarker is false', async () => {
@@ -806,7 +810,11 @@ describe('NgxSignalFormWrapperComponent', () => {
 
       const formField = container.querySelector('ngx-form-field-wrapper');
       expect(formField).not.toHaveAttribute('data-show-required', 'true');
-      expect(formField).not.toHaveAttribute('data-required-marker');
+      expect(
+        formField?.querySelector(
+          '.ngx-signal-form-field-wrapper__required-marker',
+        ),
+      ).toBeNull();
     });
 
     it('should use custom required marker when provided', async () => {
@@ -828,7 +836,11 @@ describe('NgxSignalFormWrapperComponent', () => {
 
       const formField = container.querySelector('ngx-form-field-wrapper');
       expect(formField).toHaveAttribute('data-show-required', 'true');
-      expect(formField).toHaveAttribute('data-required-marker', '(required)');
+      const marker = formField?.querySelector(
+        '.ngx-signal-form-field-wrapper__required-marker',
+      );
+      expect(marker).toBeTruthy();
+      expect(marker?.textContent).toBe('(required)');
     });
 
     it('should not set marker when outline is disabled', async () => {
@@ -847,7 +859,36 @@ describe('NgxSignalFormWrapperComponent', () => {
 
       const formField = container.querySelector('ngx-form-field-wrapper');
       expect(formField).not.toHaveAttribute('data-show-required', 'true');
-      expect(formField).not.toHaveAttribute('data-required-marker');
+      expect(
+        formField?.querySelector(
+          '.ngx-signal-form-field-wrapper__required-marker',
+        ),
+      ).toBeNull();
+    });
+
+    it('should mark the required marker as aria-hidden so screen readers do not double-announce required state', async () => {
+      // Auto-aria already writes `aria-required="true"` to the bound control,
+      // and screen readers announce that. The visual asterisk MUST be hidden
+      // from the accessibility tree (WCAG 1.3.1, 4.1.2) — otherwise NVDA /
+      // VoiceOver read both, e.g. "Email star, required edit".
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" appearance="outline">
+          <label for="email">Email</label>
+          <input id="email" type="email" required />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: createMockFieldState(),
+          },
+        },
+      );
+
+      const marker = container.querySelector(
+        '.ngx-signal-form-field-wrapper__required-marker',
+      );
+      expect(marker).toBeTruthy();
+      expect(marker).toHaveAttribute('aria-hidden', 'true');
     });
   });
 
@@ -950,7 +991,11 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(switchControl).toBeTruthy();
       expect(errorElement).toBeTruthy();
       expect(assistiveRow?.querySelector('ngx-form-field-error')).toBeTruthy();
-      expect(wrapper).toHaveAttribute('aria-invalid', 'true');
+      // `aria-invalid` belongs on the form control itself, not on the wrapper
+      // host (the auto-aria directive writes it to the bound control). The
+      // visual `--invalid` class is correct, but a host-level ARIA state would
+      // either be ignored by AT or cause double announcements (WCAG 4.1.2).
+      expect(wrapper).not.toHaveAttribute('aria-invalid');
       expect(
         wrapper?.classList.contains('ngx-signal-form-field-wrapper--invalid'),
       ).toBe(true);
@@ -1182,7 +1227,10 @@ describe('NgxSignalFormWrapperComponent', () => {
       );
 
       const wrapper = container.querySelector('ngx-form-field-wrapper');
-      expect(wrapper).toHaveAttribute('aria-invalid', 'true');
+      // Host MUST NOT carry `aria-invalid` — only the form control should
+      // (auto-aria handles that). The visual `--invalid` class still drives
+      // border colour, which is the correct wrapper-level concern.
+      expect(wrapper).not.toHaveAttribute('aria-invalid');
       expect(
         wrapper?.classList.contains('ngx-signal-form-field-wrapper--invalid'),
       ).toBe(true);
@@ -1209,7 +1257,9 @@ describe('NgxSignalFormWrapperComponent', () => {
       );
 
       const wrapper = container.querySelector('ngx-form-field-wrapper');
-      expect(wrapper).toHaveAttribute('aria-invalid', 'false');
+      // Wrapper never publishes `aria-invalid` — confirm the absence holds in
+      // the negative case too, not just when errors are visible.
+      expect(wrapper).not.toHaveAttribute('aria-invalid');
       expect(
         wrapper?.classList.contains('ngx-signal-form-field-wrapper--invalid'),
       ).toBe(false);
@@ -2099,7 +2149,9 @@ describe('NgxSignalFormWrapperComponent', () => {
       );
 
       const wrapper = container.querySelector('ngx-form-field-wrapper');
-      expect(wrapper).toHaveAttribute('aria-invalid', 'true');
+      // Same rule as native controls: the wrapper never publishes
+      // `aria-invalid`. Custom-control hosts get it via auto-aria directly.
+      expect(wrapper).not.toHaveAttribute('aria-invalid');
       expect(
         wrapper?.classList.contains('ngx-signal-form-field-wrapper--invalid'),
       ).toBe(true);
@@ -2621,7 +2673,11 @@ describe('NgxSignalFormWrapperComponent', () => {
 
         const formField = container.querySelector('ngx-form-field-wrapper');
         expect(formField).toHaveAttribute('data-show-required', 'true');
-        expect(formField).toHaveAttribute('data-required-marker', ' *');
+        const marker = formField?.querySelector(
+          '.ngx-signal-form-field-wrapper__required-marker',
+        );
+        expect(marker).toBeTruthy();
+        expect(marker?.textContent).toBe(' *');
       });
 
       it('should not show required marker with standard appearance', async () => {
@@ -2640,7 +2696,11 @@ describe('NgxSignalFormWrapperComponent', () => {
 
         const formField = container.querySelector('ngx-form-field-wrapper');
         expect(formField).not.toHaveAttribute('data-show-required', 'true');
-        expect(formField).not.toHaveAttribute('data-required-marker');
+        expect(
+          formField?.querySelector(
+            '.ngx-signal-form-field-wrapper__required-marker',
+          ),
+        ).toBeNull();
       });
 
       it('should use plain appearance when explicitly set', async () => {
@@ -3265,6 +3325,40 @@ describe('NgxSignalFormWrapperComponent', () => {
       await rerender({ componentProperties: { field } });
 
       expect(getClassificationWarnings(warnSpy)).toHaveLength(1);
+    });
+  });
+
+  describe('Theming defaults (a11y)', () => {
+    it('should resolve the warning color custom property to an AA-compliant value on white', async () => {
+      // The previous default of #f59e0b (Tailwind amber-500) only achieves
+      // ~2.16:1 contrast on white — fine for borders/icons, but the same
+      // token also drives warning *text*, which fails WCAG 2.2 AA (4.5:1).
+      // Locking in the darker default protects consumers who do not override
+      // `--ngx-form-field-color-warning` themselves.
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field">
+          <label for="email">Email</label>
+          <input id="email" type="email" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: createMockFieldState(),
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toBeTruthy();
+
+      // `getComputedStyle` walks `:host` declarations the same way it would in
+      // an app, so this verifies what consumers actually see in the browser.
+      const computed = getComputedStyle(wrapper as HTMLElement);
+      const warningToken = computed
+        .getPropertyValue('--_field-clr-warning')
+        .trim()
+        .toLowerCase();
+      expect(warningToken).toBe('#a16207');
     });
   });
 });

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -181,7 +181,12 @@ export type FormFieldErrorPlacement = 'top' | 'bottom';
   ],
   host: {
     '[attr.outline]': 'isOutline() ? "" : null',
-    '[attr.aria-invalid]': 'showInvalidState() ? "true" : "false"',
+    // NOTE: `aria-invalid` is intentionally NOT bound on the host. ARIA
+    // `aria-invalid` only belongs on form controls (the projected `<input>`,
+    // `<textarea>`, `<select>`, or `FormValueControl` host) — not on a
+    // wrapper. Auto-aria writes `aria-invalid` directly to the bound control;
+    // duplicating it here would either be ignored by assistive tech or, worse,
+    // cause confusing double-announcements (WCAG 4.1.2).
     '[attr.hidden]': 'isFieldHidden() ? "" : null',
     '[attr.data-ngx-signal-form-control-aria-mode]':
       'resolvedControlAriaMode()',
@@ -204,15 +209,25 @@ export type FormFieldErrorPlacement = 'top' | 'bottom';
     '[class.ngx-signal-form-field-wrapper--horizontal]': 'isHorizontal()',
     '[attr.data-orientation]': 'resolvedOrientation()',
     '[attr.data-error-placement]': 'errorPlacement()',
-    '[attr.data-show-required]':
-      'isOutline() && resolvedShowRequiredMarker() ? "true" : null',
-    '[attr.data-required-marker]':
-      'isOutline() && resolvedShowRequiredMarker() ? resolvedRequiredMarker() : null',
+    '[attr.data-show-required]': 'showRequiredMarkerVisible() ? "true" : null',
   },
   template: `
     <!-- Label slot (outside bordered container for standard layout, visually inside for outline via CSS) -->
     <div class="ngx-signal-form-field-wrapper__label">
       <ng-content select="label" />
+      @if (showRequiredMarkerVisible()) {
+        <!--
+          Required marker rendered in the template (not via CSS ::after content)
+          so screen readers do not double-announce "required" alongside the
+          control's own \`aria-required\` attribute. \`aria-hidden="true"\` keeps
+          the asterisk purely visual (WCAG 1.3.1, 4.1.2).
+        -->
+        <span
+          class="ngx-signal-form-field-wrapper__required-marker"
+          aria-hidden="true"
+          >{{ resolvedRequiredMarker() }}</span
+        >
+      }
     </div>
 
     @if (isTopPlacement() && shouldShowErrors()) {
@@ -400,6 +415,14 @@ export class NgxFormFieldWrapper<TValue = unknown> {
   readonly #inputElementId = signal<string | null>(null);
   readonly #boundControlElement = signal<HTMLElement | null>(null);
 
+  /**
+   * Tracks whether the bound control is required, mirroring what the previous
+   * `:has([required])` / `:has([aria-required='true'])` CSS selectors detected.
+   * Updated in the post-render `write` callback so the template-rendered
+   * required marker stays in sync with the projected control's attributes.
+   */
+  readonly #boundControlIsRequired = signal(false);
+
   readonly #controlSemantics = signal<ResolvedNgxSignalFormControlSemantics>({
     kind: null,
     layout: null,
@@ -562,6 +585,28 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     }
 
     return this.#config.requiredMarker;
+  });
+
+  /**
+   * Whether the visual required marker (`<span aria-hidden="true">`) should
+   * render in the template. Mirrors the previous CSS-driven contract:
+   *
+   * - outline appearance is active
+   * - `resolvedShowRequiredMarker()` is true (consumer/config opt-in)
+   * - the bound control declares required-ness via `[required]` or
+   *   `[aria-required="true"]`
+   *
+   * Encoded in TypeScript so the marker can live in the template — generated
+   * `::after` content was being read aloud by NVDA/VoiceOver in addition to
+   * the control's own `aria-required`, causing double announcement (WCAG
+   * 1.3.1, 4.1.2).
+   */
+  protected readonly showRequiredMarkerVisible = computed(() => {
+    return (
+      this.isOutline() &&
+      this.resolvedShowRequiredMarker() &&
+      this.#boundControlIsRequired()
+    );
   });
 
   protected readonly resolvedControlKind = computed(() => {
@@ -850,6 +895,18 @@ export class NgxFormFieldWrapper<TValue = unknown> {
 
         if (inputId !== this.#inputElementId()) {
           this.#inputElementId.set(inputId);
+        }
+
+        // Replaces the previous CSS `:has([required])` /
+        // `:has([aria-required='true'])` detection. Read each render so the
+        // marker reacts to dynamic schema changes (auto-aria toggles
+        // `aria-required` whenever the field's required state flips).
+        const isRequired =
+          inputEl !== null &&
+          (inputEl.hasAttribute('required') ||
+            inputEl.getAttribute('aria-required') === 'true');
+        if (isRequired !== this.#boundControlIsRequired()) {
+          this.#boundControlIsRequired.set(isRequired);
         }
 
         const current = this.#controlSemantics();

--- a/packages/toolkit/form-field/form-fieldset.scss
+++ b/packages/toolkit/form-field/form-fieldset.scss
@@ -69,7 +69,7 @@
   );
   --_fieldset-warning-border: var(
     --ngx-signal-form-fieldset-warning-border-color,
-    var(--ngx-form-field-warning-color, #f59e0b)
+    var(--ngx-form-field-warning-color, #a16207)
   );
   --_fieldset-invalid-bg: var(
     --ngx-signal-form-fieldset-invalid-bg,

--- a/packages/toolkit/headless/src/lib/error-state.spec.ts
+++ b/packages/toolkit/headless/src/lib/error-state.spec.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  isSignal,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { form, FormField, required, schema } from '@angular/forms/signals';
 import type { SubmittedStatus } from '@ngx-signal-forms/toolkit';
 import { render, screen } from '@testing-library/angular';
@@ -207,6 +213,53 @@ describe('NgxHeadlessErrorState', () => {
 
       const error = screen.getByTestId('error-message');
       expect(error.textContent).toContain('Email is required');
+    });
+
+    it('should expose state members as real `Signal<T>` instances (preserves Angular brand)', async () => {
+      @Component({
+        selector: 'ngx-test-signal-brand',
+        imports: [FormField, NgxHeadlessErrorStateDirective],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <div>
+            <input id="email" [formField]="contactForm.email" />
+            <div
+              ngxSignalFormHeadlessErrorState
+              #errorState="errorState"
+              [field]="contactForm.email"
+              fieldName="email"
+              strategy="immediate"
+            ></div>
+          </div>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email, { message: 'Email is required' });
+          }),
+        );
+        readonly state = viewChild.required(NgxHeadlessErrorStateDirective);
+      }
+
+      const { fixture } = await render(TestComponent);
+      const state = fixture.componentInstance.state();
+
+      // Brand-level checks: each declared `Signal<T>` member must satisfy
+      // Angular's `isSignal()` reflection. A plain `() => T` function would
+      // fail this check and break consumers using `toObservable()` etc.
+      expect(isSignal(state.hasErrors)).toBe(true);
+      expect(isSignal(state.hasWarnings)).toBe(true);
+      expect(isSignal(state.errors)).toBe(true);
+      expect(isSignal(state.warnings)).toBe(true);
+      expect(isSignal(state.resolvedErrors)).toBe(true);
+      expect(isSignal(state.resolvedWarnings)).toBe(true);
+      expect(isSignal(state.showErrors)).toBe(true);
+      expect(isSignal(state.showWarnings)).toBe(true);
+      expect(isSignal(state.errorId)).toBe(true);
+      expect(isSignal(state.warningId)).toBe(true);
     });
 
     it('should generate correct errorId and warningId', async () => {

--- a/packages/toolkit/headless/src/lib/error-state.spec.ts
+++ b/packages/toolkit/headless/src/lib/error-state.spec.ts
@@ -218,13 +218,13 @@ describe('NgxHeadlessErrorState', () => {
     it('should expose state members as real `Signal<T>` instances (preserves Angular brand)', async () => {
       @Component({
         selector: 'ngx-test-signal-brand',
-        imports: [FormField, NgxHeadlessErrorStateDirective],
+        imports: [FormField, NgxHeadlessErrorState],
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: `
           <div>
             <input id="email" [formField]="contactForm.email" />
             <div
-              ngxSignalFormHeadlessErrorState
+              ngxHeadlessErrorState
               #errorState="errorState"
               [field]="contactForm.email"
               fieldName="email"
@@ -241,7 +241,7 @@ describe('NgxHeadlessErrorState', () => {
             required(path.email, { message: 'Email is required' });
           }),
         );
-        readonly state = viewChild.required(NgxHeadlessErrorStateDirective);
+        readonly state = viewChild.required(NgxHeadlessErrorState);
       }
 
       const { fixture } = await render(TestComponent);

--- a/packages/toolkit/headless/src/lib/error-state.ts
+++ b/packages/toolkit/headless/src/lib/error-state.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, input } from '@angular/core';
+import { computed, Directive, inject, input, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   injectFormContext,
@@ -29,25 +29,25 @@ export interface ResolvedError {
  */
 export interface ErrorStateSignals {
   /** Whether to show errors based on the current strategy */
-  readonly showErrors: () => boolean;
+  readonly showErrors: Signal<boolean>;
   /** Whether to show warnings based on the current strategy */
-  readonly showWarnings: () => boolean;
+  readonly showWarnings: Signal<boolean>;
   /** Raw blocking errors from the field */
-  readonly errors: () => ValidationError[];
+  readonly errors: Signal<readonly ValidationError[]>;
   /** Raw warning errors from the field */
-  readonly warnings: () => ValidationError[];
+  readonly warnings: Signal<readonly ValidationError[]>;
   /** Resolved errors with messages */
-  readonly resolvedErrors: () => ResolvedError[];
+  readonly resolvedErrors: Signal<readonly ResolvedError[]>;
   /** Resolved warnings with messages */
-  readonly resolvedWarnings: () => ResolvedError[];
+  readonly resolvedWarnings: Signal<readonly ResolvedError[]>;
   /** Whether the field has blocking errors */
-  readonly hasErrors: () => boolean;
+  readonly hasErrors: Signal<boolean>;
   /** Whether the field has warnings */
-  readonly hasWarnings: () => boolean;
+  readonly hasWarnings: Signal<boolean>;
   /** Generated error ID for aria-describedby, or `null` when no fieldName is resolvable */
-  readonly errorId: () => string | null;
+  readonly errorId: Signal<string | null>;
   /** Generated warning ID for aria-describedby, or `null` when no fieldName is resolvable */
-  readonly warningId: () => string | null;
+  readonly warningId: Signal<string | null>;
 }
 
 /**
@@ -150,12 +150,20 @@ export class NgxHeadlessErrorState<
 
   readonly #core = buildHeadlessErrorState(this.#fieldState, this.fieldName);
 
-  readonly errorId = this.#core.errorId;
-  readonly warningId = this.#core.warningId;
-  readonly errors = this.#core.errors;
-  readonly warnings = this.#core.warnings;
-  readonly hasErrors = this.#core.hasErrors;
-  readonly hasWarnings = this.#core.hasWarnings;
+  // The runtime values are real `computed()` signals; the shared
+  // `buildHeadlessErrorState` helper exposes them via a `() => T` shape for
+  // legacy reasons. Cast through `unknown` so the public surface matches the
+  // documented `Signal<T>` contract on `ErrorStateSignals`.
+  readonly errorId = this.#core.errorId as unknown as Signal<string | null>;
+  readonly warningId = this.#core.warningId as unknown as Signal<string | null>;
+  readonly errors = this.#core.errors as unknown as Signal<
+    readonly ValidationError[]
+  >;
+  readonly warnings = this.#core.warnings as unknown as Signal<
+    readonly ValidationError[]
+  >;
+  readonly hasErrors = this.#core.hasErrors as unknown as Signal<boolean>;
+  readonly hasWarnings = this.#core.hasWarnings as unknown as Signal<boolean>;
 
   /**
    * Whether errors should be shown based on strategy.
@@ -174,7 +182,7 @@ export class NgxHeadlessErrorState<
   /**
    * Resolved error messages using 3-tier priority.
    */
-  readonly resolvedErrors = computed(() =>
+  readonly resolvedErrors: Signal<readonly ResolvedError[]> = computed(() =>
     this.errors().map((error) => ({
       kind: error.kind,
       message: this.#resolveErrorMessage(error),
@@ -184,7 +192,7 @@ export class NgxHeadlessErrorState<
   /**
    * Resolved warning messages.
    */
-  readonly resolvedWarnings = computed(() =>
+  readonly resolvedWarnings: Signal<readonly ResolvedError[]> = computed(() =>
     this.warnings().map((warning) => ({
       kind: warning.kind,
       message: this.#resolveErrorMessage(warning),

--- a/packages/toolkit/headless/src/lib/error-state.ts
+++ b/packages/toolkit/headless/src/lib/error-state.ts
@@ -150,20 +150,12 @@ export class NgxHeadlessErrorState<
 
   readonly #core = buildHeadlessErrorState(this.#fieldState, this.fieldName);
 
-  // The runtime values are real `computed()` signals; the shared
-  // `buildHeadlessErrorState` helper exposes them via a `() => T` shape for
-  // legacy reasons. Cast through `unknown` so the public surface matches the
-  // documented `Signal<T>` contract on `ErrorStateSignals`.
-  readonly errorId = this.#core.errorId as unknown as Signal<string | null>;
-  readonly warningId = this.#core.warningId as unknown as Signal<string | null>;
-  readonly errors = this.#core.errors as unknown as Signal<
-    readonly ValidationError[]
-  >;
-  readonly warnings = this.#core.warnings as unknown as Signal<
-    readonly ValidationError[]
-  >;
-  readonly hasErrors = this.#core.hasErrors as unknown as Signal<boolean>;
-  readonly hasWarnings = this.#core.hasWarnings as unknown as Signal<boolean>;
+  readonly errorId = this.#core.errorId;
+  readonly warningId = this.#core.warningId;
+  readonly errors = this.#core.errors;
+  readonly warnings = this.#core.warnings;
+  readonly hasErrors = this.#core.hasErrors;
+  readonly hasWarnings = this.#core.hasWarnings;
 
   /**
    * Whether errors should be shown based on strategy.

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, inject, input } from '@angular/core';
+import { computed, Directive, inject, input, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   injectFormContext,
@@ -35,15 +35,15 @@ export type ErrorSummaryEntry = ErrorSummaryEntryData;
  */
 export interface ErrorSummarySignals {
   /** Resolved blocking error entries ready for rendering */
-  readonly entries: () => ErrorSummaryEntry[];
+  readonly entries: Signal<readonly ErrorSummaryEntry[]>;
   /** Resolved warning entries */
-  readonly warningEntries: () => ErrorSummaryEntry[];
+  readonly warningEntries: Signal<readonly ErrorSummaryEntry[]>;
   /** Whether there are any blocking errors */
-  readonly hasErrors: () => boolean;
+  readonly hasErrors: Signal<boolean>;
   /** Whether there are any warnings */
-  readonly hasWarnings: () => boolean;
+  readonly hasWarnings: Signal<boolean>;
   /** Whether the summary should be visible based on strategy */
-  readonly shouldShow: () => boolean;
+  readonly shouldShow: Signal<boolean>;
   /** Focus the control for the first error entry */
   readonly focusFirst: () => void;
 }

--- a/packages/toolkit/headless/src/lib/fieldset.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.ts
@@ -4,6 +4,7 @@ import {
   Directive,
   inject,
   input,
+  type Signal,
 } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
@@ -31,33 +32,33 @@ import {
  */
 export interface FieldsetStateSignals {
   /** Aggregated and deduplicated errors from all fields */
-  readonly aggregatedErrors: () => ValidationError[];
+  readonly aggregatedErrors: Signal<readonly ValidationError[]>;
   /** Aggregated and deduplicated warnings from all fields */
-  readonly aggregatedWarnings: () => ValidationError[];
+  readonly aggregatedWarnings: Signal<readonly ValidationError[]>;
   /** Whether the fieldset has blocking errors */
-  readonly hasErrors: () => boolean;
+  readonly hasErrors: Signal<boolean>;
   /** Whether the fieldset has warnings */
-  readonly hasWarnings: () => boolean;
+  readonly hasWarnings: Signal<boolean>;
   /** Whether to show errors based on strategy */
-  readonly shouldShowErrors: () => boolean;
+  readonly shouldShowErrors: Signal<boolean>;
   /** Whether to show warnings based on strategy */
-  readonly shouldShowWarnings: () => boolean;
+  readonly shouldShowWarnings: Signal<boolean>;
   /**
    * Resolved error display strategy. Always a concrete strategy
    * (`'immediate'`, `'on-touch'`, or `'on-submit'`) — `'inherit'` is
    * resolved against the form context / config default before exposure.
    */
-  readonly resolvedStrategy: () => ResolvedErrorDisplayStrategy;
+  readonly resolvedStrategy: Signal<ResolvedErrorDisplayStrategy>;
   /** Resolved submitted status (from input override, form context, or default) */
-  readonly resolvedSubmittedStatus: () => SubmittedStatus;
+  readonly resolvedSubmittedStatus: Signal<SubmittedStatus>;
   /** Fieldset validation state flags */
-  readonly isInvalid: () => boolean;
-  readonly isValid: () => boolean;
-  readonly isTouched: () => boolean;
-  readonly isDirty: () => boolean;
-  readonly isPending: () => boolean;
+  readonly isInvalid: Signal<boolean>;
+  readonly isValid: Signal<boolean>;
+  readonly isTouched: Signal<boolean>;
+  readonly isDirty: Signal<boolean>;
+  readonly isPending: Signal<boolean>;
   /** Resolved fieldset ID */
-  readonly resolvedFieldsetId: () => string;
+  readonly resolvedFieldsetId: Signal<string>;
 }
 
 /**

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -1,4 +1,4 @@
-import { computed, isDevMode } from '@angular/core';
+import { computed, isDevMode, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   createUniqueId,
@@ -99,11 +99,11 @@ export function readFieldFlag(state: unknown, key: BooleanStateKey): boolean {
  * Computed boolean state flags from a reactive field state signal.
  */
 export interface FieldStateFlags {
-  readonly isInvalid: () => boolean;
-  readonly isValid: () => boolean;
-  readonly isTouched: () => boolean;
-  readonly isDirty: () => boolean;
-  readonly isPending: () => boolean;
+  readonly isInvalid: Signal<boolean>;
+  readonly isValid: Signal<boolean>;
+  readonly isTouched: Signal<boolean>;
+  readonly isDirty: Signal<boolean>;
+  readonly isPending: Signal<boolean>;
 }
 
 /**
@@ -246,12 +246,12 @@ export { createUniqueId, readDirectErrors };
  * @internal
  */
 interface HeadlessErrorStateCore {
-  readonly errors: ReadSignal<ValidationError[]>;
-  readonly warnings: ReadSignal<ValidationError[]>;
-  readonly hasErrors: ReadSignal<boolean>;
-  readonly hasWarnings: ReadSignal<boolean>;
-  readonly errorId: ReadSignal<string | null>;
-  readonly warningId: ReadSignal<string | null>;
+  readonly errors: Signal<readonly ValidationError[]>;
+  readonly warnings: Signal<readonly ValidationError[]>;
+  readonly hasErrors: Signal<boolean>;
+  readonly hasWarnings: Signal<boolean>;
+  readonly errorId: Signal<string | null>;
+  readonly warningId: Signal<string | null>;
 }
 
 /**
@@ -304,23 +304,23 @@ export interface CreateErrorStateOptions<TValue = unknown> {
  */
 export interface ErrorStateResult {
   /** Whether to show errors */
-  readonly showErrors: ReadSignal<boolean>;
+  readonly showErrors: Signal<boolean>;
   /** Whether to show warnings */
-  readonly showWarnings: ReadSignal<boolean>;
+  readonly showWarnings: Signal<boolean>;
   /** Raw blocking errors */
-  readonly errors: ReadSignal<ValidationError[]>;
+  readonly errors: Signal<readonly ValidationError[]>;
   /** Raw warning errors */
-  readonly warnings: ReadSignal<ValidationError[]>;
+  readonly warnings: Signal<readonly ValidationError[]>;
   /** Whether there are blocking errors */
-  readonly hasErrors: ReadSignal<boolean>;
+  readonly hasErrors: Signal<boolean>;
   /** Whether there are warnings */
-  readonly hasWarnings: ReadSignal<boolean>;
+  readonly hasWarnings: Signal<boolean>;
   /** Generated error region ID, or `null` when no fieldName is resolvable */
-  readonly errorId: ReadSignal<string | null>;
+  readonly errorId: Signal<string | null>;
   /** Generated warning region ID, or `null` when no fieldName is resolvable */
-  readonly warningId: ReadSignal<string | null>;
+  readonly warningId: Signal<string | null>;
   /** Resolved field name */
-  readonly fieldName: ReadSignal<string | null>;
+  readonly fieldName: Signal<string | null>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the v1 readiness gap surfaced by the 6-reviewer audit. Two commits, scoped by concern:

1. **`refactor(toolkit)!:` complete `NgxFormField` naming consolidation** (`e4cbbc8`) — finishes the migration started in `10ba378`. Field-level components and selectors all use the short `NgxFormField*` / `ngx-form-field-*` prefix; form-level directives stay on `NgxSignalForm*`; debugger components gain the missing `Ngx` prefix.
2. **`fix(toolkit):` apply v1-readiness a11y, type, and CD-correctness fixes** (`2fd3160`) — the four parallel reviewer-identified blockers, each in disjoint files.

All work was done by 4 parallel agents in disjoint scopes; verified locally with `pnpm nx run-many -t lint test build` (788/788 tests, all 5 projects build).

## What changed

### Naming (BREAKING — between RC.5 and 1.0.0)
| Before | After |
|---|---|
| `NgxSignalFormFieldWrapperComponent` | `NgxFormFieldWrapperComponent` |
| `NgxSignalFormFieldset` | `NgxFormFieldsetComponent` |
| `SignalFormDebuggerComponent` | `NgxSignalFormDebuggerComponent` |
| `DebuggerBadgeComponent` | `NgxSignalFormDebuggerBadgeComponent` |
| `DebuggerBadgeIconDirective` | `NgxSignalFormDebuggerBadgeIconDirective` |
| `<ngx-signal-form-field-wrapper>` | `<ngx-form-field-wrapper>` |
| `<ngx-signal-form-fieldset>` / `[ngxSignalFormFieldset]` | `<ngx-form-fieldset>` / `[ngxFormFieldset]` |
| `<ngx-signal-form-field-hint>` | `<ngx-form-field-hint>` |
| `<ngx-signal-form-field-character-count>` | `<ngx-form-field-character-count>` |
| `<ngx-signal-form-field-assistive-row>` | `<ngx-form-field-assistive-row>` |

CSS classes (`.ngx-signal-form-field-wrapper__*`, `.ngx-signal-form-fieldset--invalid`) and CSS custom properties (`--ngx-signal-form-*`, `--ngx-form-field-*`) **intentionally unchanged** for theme stability. `MIGRATING_BETA_TO_V1.md` §4d documents the full delta.

### Accessibility
- WCAG 4.1.2: removed invalid `aria-invalid` host binding from wrapper (auto-aria already writes it on the actual control).
- WCAG 1.3.1: required marker now rendered as `<span aria-hidden="true">` instead of CSS `::after` content (stops NVDA/VoiceOver double-announcing alongside `aria-required`).
- WCAG 4.1.3: `role="alert"` and `role="status"` live regions are now mounted unconditionally so the *first* error fires reliably on NVDA + Chrome.
- WCAG 2.4.3: error summary auto-focuses on first appearance (`autoFocus=false` opt-out).
- WCAG 1.4.3: default warning text color bumped from `#f59e0b` (2.16:1) to `#a16207` (~5.17:1) — error component, character-count fallback, and wrapper SCSS.
- WCAG 2.4.7: `:focus-visible` outline added to debugger collapsible `<summary>` headers.
- WCAG 2.3.3: chevron rotation and slide-in animation gated on `prefers-reduced-motion`.

### Correctness (Angular 21 idiom)
- `createSubmittedStatusTracker` rewritten with `linkedSignal` + a single read-only warm effect, replacing the prior multi-write `effect()` cascade. Removes the `prevSubmitting`/`prevTouched` state machine and stops depending on change-detection ordering — zoneless-safe. Adds eager input validation so misuse fails loudly.

### Types (TypeScript ergonomics)
- `unwrapValue()` gained typed overloads to disambiguate callable `T` (e.g. `FieldTree`) from a static value, preserving inference at every call site.
- `ErrorStateSignals` interface members now typed as `Signal<T>` instead of `() => T`, so `isSignal()`/`toObservable()` work on the public surface (matches sibling `FieldNameStateSignals`).

### Test coverage
- New `submission-helpers.coverage.spec.ts` and `core/index.spec.ts` pin previously untested public exports: `createSubmittedStatusTracker`, `hasOnlyWarnings`, `getBlockingErrors`, `canSubmitWithWarnings`, `splitByKind`, and `NgxSignalFormToolkit` bundle contents.
- New tests added alongside every a11y change.
- `@internal` tag dropped from `isFieldStateInteractive`, `isFieldStateHidden`, `ReactiveOrStatic` (already documented in the public README, so they were leaking through anyway).

## Test plan

- [x] `pnpm nx run-many -t lint test build` — all 5 projects, 788/788 tests
- [x] `pnpm nx build demo` — proves selectors and imports resolve in consumer code
- [x] `pnpm nx build toolkit` — all 6 entry points compile via ng-packagr
- [x] `pnpm format:check` — clean
- [ ] Manual smoke-test in browser of the demo app (recommended before merge)
- [ ] Visually verify the warning color change in the demo (`#a16207` should look noticeably darker)
- [ ] Screen-reader spot-check on NVDA + VoiceOver (recommended given the live-region restructure)

## Out of scope / follow-ups

Documented in original audit but deferred:

- **`stripInternal: true`** in `tsconfig.lib.prod.json` — incompatible with the cross-entry-point architecture (sibling entry points cross-import `@internal` core symbols by design). The post-build `strip-internal-exports.mjs` already enforces the public boundary at the `exports`-map level.
- **`noUncheckedIndexedAccess`** in `tsconfig.json` — would surface real bugs but cascades into many fixes outside v1 scope. Worth a dedicated PR.
- **CI Node-version matrix** — engines (`^20.19.0 || ^22.12.0 || >=24.0.0`) match Angular 21's exactly; adding a matrix would be more thorough but conflicts with the project's `.node-version` pinning convention.
- **`ErrorSummarySignals`** and **`FieldsetStateSignals`** in `headless/` use the same `() => T` pattern that was fixed for `ErrorStateSignals` — align in a follow-up.
- **`buildHeadlessErrorState()`** in `headless/utilities.ts` still returns `() => T` shapes, so `error-state.directive.ts` uses bridging casts. Refactor utilities to return `Signal<T>` natively in a follow-up.
- Wrapper SCSS exceeds the 24 kB Angular budget by ~3 kB (warning, not error). Pre-existing.
- Naming direction can be flipped if desired — let me know if you'd prefer **everything** moved back to `NgxSignalForm*` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `autoFocus` input to error summary for optional focus management control
  * Centralized ARIA selector constants for consistent test locator usage

* **Refactoring**
  * Always-mount live region containers with visibility driven by computed signals
  * Updated public APIs to expose Angular `Signal` types instead of function-based getters
  * Refactored required marker from CSS pseudo-element to template element

* **Accessibility**
  * Updated warning color theme to #a16207 for improved WCAG 1.4.3 contrast compliance
  * Added focus-visible styling and prefers-reduced-motion support
  * Live region DOM stability improvements with empty-state marker class

* **Tests**
  * Expanded coverage for submission helpers, error states, and focus management
  * Added WCAG contrast verification and type-safety tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->