### PR TITLE
feat(headless): extract createHintIdsSignal pure-signal factory

### DIFF
--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -18,6 +18,7 @@ import {
   resolveFieldName,
 } from '../utilities/field-resolution';
 import { createErrorVisibility } from '../utilities/create-error-visibility';
+import { createHintIdsSignal } from '../utilities/aria/create-hint-ids-signal';
 import { isBlockingError, isWarningError } from '../utilities/warning-error';
 import { NgxFieldIdentity } from '../services/field-identity';
 
@@ -160,22 +161,15 @@ export class NgxSignalFormAutoAria {
 
   /**
    * Hint IDs from the identity service when available, falling back to the
-   * hint registry snapshot when the identity service is absent.
+   * hint registry snapshot when the identity service is absent. Delegates
+   * to the pure `createHintIdsSignal` factory so consumers building bespoke
+   * wrappers can reuse the same resolution order without inheriting this
+   * directive.
    */
-  readonly #hintIds = computed((): readonly string[] => {
-    // Identity service provides pre-filtered hint IDs for this field.
-    if (this.#fieldIdentity) {
-      return this.#fieldIdentity.hintIds();
-    }
-
-    const registry = this.#hintRegistry;
-    if (!registry) return [];
-
-    const fieldName = this.#domSnapshot().fieldName;
-    return registry
-      .hints()
-      .filter((hint) => !hint.fieldName || hint.fieldName === fieldName)
-      .map((hint) => hint.id);
+  readonly #hintIds = createHintIdsSignal({
+    identity: this.#fieldIdentity,
+    registry: this.#hintRegistry,
+    fieldName: () => this.#domSnapshot().fieldName,
   });
 
   /** Delegates to `#visibilityByStrategy` after filtering to blocking errors. */

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -30,6 +30,8 @@ export {
   createHintIdsSignal,
   type CreateHintIdsSignalOptions,
   type HintIdsFieldNameReader,
+  type HintIdsIdentityLike,
+  type HintIdsRegistryLike,
   type HintIdsSignal,
 } from './utilities/aria/create-hint-ids-signal';
 export * from './utilities/cascading-resolver';

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -26,6 +26,12 @@ export {
 } from './directives/ngx-signal-form';
 
 // Utilities
+export {
+  createHintIdsSignal,
+  type CreateHintIdsSignalOptions,
+  type HintIdsFieldNameReader,
+  type HintIdsSignal,
+} from './utilities/aria/create-hint-ids-signal';
 export * from './utilities/cascading-resolver';
 export * from './utilities/create-error-visibility';
 export * from './utilities/create-unique-id';

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.spec.ts
@@ -155,6 +155,30 @@ describe('createHintIdsSignal – registry-with-fieldName-filter path', () => {
 
     expect(result()).toEqual(['second', 'first', 'third']);
   });
+
+  it('treats an empty-string fieldName as scoped, not unscoped', () => {
+    const hints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'unscoped', fieldName: null },
+      { id: 'empty-scoped', fieldName: '' },
+      { id: 'email-scoped', fieldName: 'email' },
+    ]);
+
+    // For a non-empty current field name, the empty-string-scoped hint must
+    // NOT be matched as unscoped.
+    const emailResult = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+      fieldName: () => 'email',
+    });
+    expect(emailResult()).toEqual(['unscoped', 'email-scoped']);
+
+    // The empty-string-scoped hint only matches when the current field name
+    // is itself the empty string.
+    const emptyResult = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+      fieldName: () => '',
+    });
+    expect(emptyResult()).toEqual(['unscoped', 'empty-scoped']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.spec.ts
@@ -1,0 +1,179 @@
+import { signal, type Signal } from '@angular/core';
+import { describe, expect, it } from 'vitest';
+import type { NgxSignalFormHintDescriptor } from '../../tokens';
+import type { NgxFieldIdentity } from '../../services/field-identity';
+import { createHintIdsSignal } from './create-hint-ids-signal';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a stub identity service exposing only the `hintIds` reactive surface
+ * the factory consumes. Cast through `NgxFieldIdentity` so the call site
+ * matches the production signature without spinning up a TestBed.
+ */
+function createStubIdentity(
+  hintIds: Signal<readonly string[]>,
+): NgxFieldIdentity {
+  return { hintIds } as unknown as NgxFieldIdentity;
+}
+
+function createStubRegistry(
+  hints: Signal<readonly NgxSignalFormHintDescriptor[]>,
+) {
+  return { hints };
+}
+
+// ---------------------------------------------------------------------------
+// Identity service path
+// ---------------------------------------------------------------------------
+
+describe('createHintIdsSignal – identity-service path', () => {
+  it("returns the identity service's pre-filtered hint IDs verbatim", () => {
+    const identityHintIds = signal<readonly string[]>(['email-hint']);
+    const identity = createStubIdentity(identityHintIds);
+
+    const result = createHintIdsSignal({ identity });
+
+    expect(result()).toEqual(['email-hint']);
+  });
+
+  it('reacts to the identity service updating its hint IDs', () => {
+    const identityHintIds = signal<readonly string[]>([]);
+    const identity = createStubIdentity(identityHintIds);
+
+    const result = createHintIdsSignal({ identity });
+    expect(result()).toEqual([]);
+
+    identityHintIds.set(['hint-a', 'hint-b']);
+    expect(result()).toEqual(['hint-a', 'hint-b']);
+  });
+
+  it('ignores a registry when both identity and registry are provided', () => {
+    const identityHintIds = signal<readonly string[]>(['from-identity']);
+    const registryHints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'from-registry', fieldName: null },
+    ]);
+
+    const result = createHintIdsSignal({
+      identity: createStubIdentity(identityHintIds),
+      registry: createStubRegistry(registryHints),
+      fieldName: () => 'email',
+    });
+
+    expect(result()).toEqual(['from-identity']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry fallback path (no field-name filter)
+// ---------------------------------------------------------------------------
+
+describe('createHintIdsSignal – registry fallback path', () => {
+  it('returns IDs of hints whose fieldName is null when no fieldName reader is supplied', () => {
+    const hints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'global-hint', fieldName: null },
+      { id: 'scoped-hint', fieldName: 'email' },
+    ]);
+
+    const result = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+    });
+
+    expect(result()).toEqual(['global-hint']);
+  });
+
+  it('reacts to registry hints changing', () => {
+    const hints = signal<readonly NgxSignalFormHintDescriptor[]>([]);
+
+    const result = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+    });
+    expect(result()).toEqual([]);
+
+    hints.set([
+      { id: 'first', fieldName: null },
+      { id: 'second', fieldName: null },
+    ]);
+    expect(result()).toEqual(['first', 'second']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry + fieldName filter path
+// ---------------------------------------------------------------------------
+
+describe('createHintIdsSignal – registry-with-fieldName-filter path', () => {
+  it('keeps unscoped hints and hints whose fieldName matches the current field', () => {
+    const hints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'global', fieldName: null },
+      { id: 'email-only', fieldName: 'email' },
+      { id: 'username-only', fieldName: 'username' },
+    ]);
+
+    const result = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+      fieldName: () => 'email',
+    });
+
+    expect(result()).toEqual(['global', 'email-only']);
+  });
+
+  it('reacts to the field name reader changing', () => {
+    const hints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'email-hint', fieldName: 'email' },
+      { id: 'username-hint', fieldName: 'username' },
+    ]);
+    const fieldName = signal<string | null>('email');
+
+    const result = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+      fieldName: () => fieldName(),
+    });
+
+    expect(result()).toEqual(['email-hint']);
+
+    fieldName.set('username');
+    expect(result()).toEqual(['username-hint']);
+
+    fieldName.set(null);
+    expect(result()).toEqual([]);
+  });
+
+  it('preserves the registry order when filtering', () => {
+    const hints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'second', fieldName: 'email' },
+      { id: 'first', fieldName: null },
+      { id: 'third', fieldName: 'email' },
+    ]);
+
+    const result = createHintIdsSignal({
+      registry: createStubRegistry(hints),
+      fieldName: () => 'email',
+    });
+
+    expect(result()).toEqual(['second', 'first', 'third']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Both-absent path
+// ---------------------------------------------------------------------------
+
+describe('createHintIdsSignal – both-absent path', () => {
+  it('returns an empty list when no identity and no registry are provided', () => {
+    const result = createHintIdsSignal();
+    expect(result()).toEqual([]);
+  });
+
+  it('returns an empty list when identity is null and registry is null', () => {
+    const result = createHintIdsSignal({ identity: null, registry: null });
+    expect(result()).toEqual([]);
+  });
+
+  it('returns an empty list when only a fieldName reader is supplied', () => {
+    const result = createHintIdsSignal({ fieldName: () => 'email' });
+    expect(result()).toEqual([]);
+  });
+});

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
@@ -1,6 +1,4 @@
 import { computed, type Signal } from '@angular/core';
-import type { NgxSignalFormHintRegistry } from '../../tokens';
-import type { NgxFieldIdentity } from '../../services/field-identity';
 
 /**
  * Reactive reader for the current field's name. Accepts a plain getter or a
@@ -18,6 +16,39 @@ export type HintIdsFieldNameReader = () => string | null;
 export type HintIdsSignal = Signal<readonly string[]>;
 
 /**
+ * Minimal structural surface the factory needs from a field-identity
+ * service: a reactive, pre-filtered list of hint IDs for the current field.
+ *
+ * Exposed as a public option type so consumers building bespoke wrappers can
+ * type-import the factory's inputs without crossing into `@internal`
+ * territory. Production code passes its `NgxFieldIdentity` instance in
+ * directly via structural assignability.
+ */
+export interface HintIdsIdentityLike {
+  readonly hintIds: Signal<readonly string[]>;
+}
+
+/**
+ * Minimal structural surface the factory needs from a hint registry: a
+ * reactive list of `{ id, fieldName }` descriptors.
+ *
+ * `fieldName` is `string | null`. `null` means the hint is unscoped and
+ * applies to any field; a non-null value scopes the hint to the field whose
+ * resolved name matches exactly (empty string included — empty string is
+ * **not** treated as unscoped).
+ *
+ * Exposed as a public option type so consumers building bespoke wrappers can
+ * type-import the factory's inputs without crossing into `@internal`
+ * territory. Production code passes its `NgxSignalFormHintRegistry` instance
+ * in directly via structural assignability.
+ */
+export interface HintIdsRegistryLike {
+  readonly hints: Signal<
+    readonly { readonly id: string; readonly fieldName: string | null }[]
+  >;
+}
+
+/**
  * Inputs for {@link createHintIdsSignal}.
  *
  * All three properties are optional — the factory must produce a stable
@@ -26,26 +57,27 @@ export type HintIdsSignal = Signal<readonly string[]>;
  */
 export interface CreateHintIdsSignalOptions {
   /**
-   * Optional shared field-identity service (typically provided by a form
-   * field wrapper). When present, its pre-filtered `hintIds()` signal is
-   * used as-is and no registry filtering is performed.
+   * Optional shared field-identity-like service (typically provided by a
+   * form field wrapper). When present, its pre-filtered `hintIds()` signal
+   * is used as-is and no registry filtering is performed.
    */
-  readonly identity?: NgxFieldIdentity | null;
+  readonly identity?: HintIdsIdentityLike | null;
 
   /**
-   * Optional hint registry exposing the un-filtered hint descriptors. Used
-   * as a fallback when {@link CreateHintIdsSignalOptions.identity} is
-   * absent. Hints are filtered to those that either have no `fieldName`
-   * (treated as "applies to any field") or whose `fieldName` matches the
-   * resolved field name from {@link CreateHintIdsSignalOptions.fieldName}.
+   * Optional hint-registry-like source exposing the un-filtered hint
+   * descriptors. Used as a fallback when
+   * {@link CreateHintIdsSignalOptions.identity} is absent. Hints are
+   * filtered to those whose `fieldName` is `null` (unscoped — applies to
+   * any field) or matches the resolved field name from
+   * {@link CreateHintIdsSignalOptions.fieldName}.
    */
-  readonly registry?: NgxSignalFormHintRegistry | null;
+  readonly registry?: HintIdsRegistryLike | null;
 
   /**
    * Optional reader for the resolved field name. Only consulted on the
    * registry-fallback path; ignored when an identity service is present.
    * When omitted, the registry is read with a `null` field name, so only
-   * hints without an own `fieldName` are kept.
+   * hints whose own `fieldName` is `null` are kept.
    */
   readonly fieldName?: HintIdsFieldNameReader;
 }
@@ -62,7 +94,9 @@ export interface CreateHintIdsSignalOptions {
  *    hints to this field.
  * 2. Otherwise, if a registry is provided, return the registry's hints
  *    filtered to those whose `fieldName` is `null` (unscoped) or matches
- *    the reader-supplied current field name.
+ *    the reader-supplied current field name. Empty-string `fieldName` is
+ *    treated as a real, scoped value — it only matches when the current
+ *    field name is also the empty string.
  * 3. Otherwise, return an empty list.
  *
  * No DI is performed inside the factory; consumers thread DI-resolved
@@ -89,7 +123,10 @@ export function createHintIdsSignal(
 
     return registry
       .hints()
-      .filter((hint) => !hint.fieldName || hint.fieldName === currentFieldName)
+      .filter(
+        (hint) =>
+          hint.fieldName === null || hint.fieldName === currentFieldName,
+      )
       .map((hint) => hint.id);
   });
 }

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
@@ -1,0 +1,95 @@
+import { computed, type Signal } from '@angular/core';
+import type { NgxSignalFormHintRegistry } from '../../tokens';
+import type { NgxFieldIdentity } from '../../services/field-identity';
+
+/**
+ * Reactive reader for the current field's name. Accepts a plain getter or a
+ * `Signal<string | null>`; both are invoked inside the resulting computed so
+ * signal-based readers stay tracked.
+ */
+export type HintIdsFieldNameReader = () => string | null;
+
+/**
+ * Public alias for the signal returned by {@link createHintIdsSignal}.
+ *
+ * Exposed so consumers composing custom wrappers can type their own
+ * `aria-describedby` aggregators without re-deriving the shape.
+ */
+export type HintIdsSignal = Signal<readonly string[]>;
+
+/**
+ * Inputs for {@link createHintIdsSignal}.
+ *
+ * All three properties are optional — the factory must produce a stable
+ * signal even when neither an identity service nor a registry is available,
+ * matching the directive shell's "no wrapper context" branch.
+ */
+export interface CreateHintIdsSignalOptions {
+  /**
+   * Optional shared field-identity service (typically provided by a form
+   * field wrapper). When present, its pre-filtered `hintIds()` signal is
+   * used as-is and no registry filtering is performed.
+   */
+  readonly identity?: NgxFieldIdentity | null;
+
+  /**
+   * Optional hint registry exposing the un-filtered hint descriptors. Used
+   * as a fallback when {@link CreateHintIdsSignalOptions.identity} is
+   * absent. Hints are filtered to those that either have no `fieldName`
+   * (treated as "applies to any field") or whose `fieldName` matches the
+   * resolved field name from {@link CreateHintIdsSignalOptions.fieldName}.
+   */
+  readonly registry?: NgxSignalFormHintRegistry | null;
+
+  /**
+   * Optional reader for the resolved field name. Only consulted on the
+   * registry-fallback path; ignored when an identity service is present.
+   * When omitted, the registry is read with a `null` field name, so only
+   * hints without an own `fieldName` are kept.
+   */
+  readonly fieldName?: HintIdsFieldNameReader;
+}
+
+/**
+ * Pure-signal factory that produces the `aria-describedby` hint-ID list for
+ * a single field.
+ *
+ * Mirrors the resolution order previously inlined in
+ * `NgxSignalFormAutoAria.#hintIds`:
+ *
+ * 1. If an identity service is provided, return its pre-filtered
+ *    `hintIds()` signal verbatim — the wrapper has already correlated
+ *    hints to this field.
+ * 2. Otherwise, if a registry is provided, return the registry's hints
+ *    filtered to those whose `fieldName` is `null` (unscoped) or matches
+ *    the reader-supplied current field name.
+ * 3. Otherwise, return an empty list.
+ *
+ * No DI is performed inside the factory; consumers thread DI-resolved
+ * values in via {@link CreateHintIdsSignalOptions}. This keeps the factory
+ * testable without `TestBed` and reusable from any injection context.
+ *
+ * @public
+ */
+export function createHintIdsSignal(
+  options: CreateHintIdsSignalOptions = {},
+): HintIdsSignal {
+  const { identity, registry, fieldName } = options;
+
+  return computed((): readonly string[] => {
+    if (identity) {
+      return identity.hintIds();
+    }
+
+    if (!registry) {
+      return [];
+    }
+
+    const currentFieldName = fieldName ? fieldName() : null;
+
+    return registry
+      .hints()
+      .filter((hint) => !hint.fieldName || hint.fieldName === currentFieldName)
+      .map((hint) => hint.id);
+  });
+}

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -58,6 +58,8 @@ export {
   createHintIdsSignal,
   type CreateHintIdsSignalOptions,
   type HintIdsFieldNameReader,
+  type HintIdsIdentityLike,
+  type HintIdsRegistryLike,
   type HintIdsSignal,
 } from '@ngx-signal-forms/toolkit/core';
 

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -52,6 +52,15 @@ export {
   type ResolvedNotificationMessage,
 } from './lib/notification';
 
+// ARIA primitives — sourced from `/core` to keep the directive shell and
+// the headless re-export in lockstep without duplicating implementation.
+export {
+  createHintIdsSignal,
+  type CreateHintIdsSignalOptions,
+  type HintIdsFieldNameReader,
+  type HintIdsSignal,
+} from '@ngx-signal-forms/toolkit/core';
+
 // Utility functions
 export {
   createCharacterCount,


### PR DESCRIPTION
## Summary

Tracer-bullet slice of #38. Extracts hint-ID resolution from `NgxSignalFormAutoAria` into a pure signal factory so wrapper authors composing on top of Material, PrimeNG, Spartan, etc. can reuse the toolkit's `aria-describedby` ID list without inheriting the directive shell.

- New `createHintIdsSignal({ identity?, registry?, fieldName? })` factory mirroring the directive's existing resolution order (identity service > registry-with-fieldName-filter > empty).
- `NgxSignalFormAutoAria.#hintIds` now delegates to the factory — no logic duplication.
- Public types `HintIdsSignal`, `HintIdsFieldNameReader`, and `CreateHintIdsSignalOptions` exported alongside the factory.
- Source lives in `/core/utilities/aria/` to avoid a secondary-entry-point cycle (the directive imports it relatively); re-exported from `@ngx-signal-forms/toolkit/headless` per PRD #38's placement decision.

## Acceptance criteria

- [x] `createHintIdsSignal(...)` exists in `packages/toolkit` and is exported from the headless barrel
- [x] Unit spec covers: identity-service path, registry fallback path, registry-with-fieldName-filter path, both-absent path
- [x] `NgxSignalFormAutoAria.#hintIds` delegates to the factory (no logic duplication)
- [x] Existing `auto-aria.spec.ts` and downstream `form-field-wrapper.*.spec.ts` pass unchanged
- [x] Public type `HintIdsSignal` exported alongside the factory
- [x] `pnpm nx test toolkit` green (997 jsdom + 16 browser)
- [x] `pnpm nx build toolkit` green across all secondary entry points (core, assistive, debugger, form-field, headless, vest)

## Test plan

- [x] `pnpm nx test toolkit` — 997/997 passing including 11 new specs for `createHintIdsSignal`
- [x] `pnpm nx test-browser toolkit` — 16/16 passing including the existing `auto-aria.browser.spec.ts`
- [x] `pnpm nx lint toolkit` — 0 errors (pre-existing warnings unchanged)
- [x] `pnpm nx build toolkit` — all secondary entry points built
- [x] `pnpm format` — clean

Closes #41
Refs #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `createHintIdsSignal` utility function and supporting types for generating aria-describedby hint IDs, now available from both core and headless packages in the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->