### PR TITLE
feat(headless): extract createAriaInvalidSignal pure-signal factory

### DIFF
--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -12,6 +12,7 @@ import {
   NGX_SIGNAL_FORM_ARIA_MODE,
   NGX_SIGNAL_FORM_HINT_REGISTRY,
 } from '../tokens';
+import { createAriaInvalidSignal } from '../utilities/aria/create-aria-invalid-signal';
 import {
   generateErrorId,
   generateWarningId,
@@ -92,10 +93,6 @@ export class NgxSignalFormAutoAria {
       typeof field === 'function' ? field() : this.#formField.state();
 
     return fieldState ?? null;
-  }
-
-  #hasUsableFieldState(): boolean {
-    return this.#resolveFieldState() !== null;
   }
 
   #shouldShowBy(errorType: 'blocking' | 'warning'): boolean {
@@ -183,6 +180,20 @@ export class NgxSignalFormAutoAria {
   });
 
   /**
+   * Reactive view of the resolved field state, exposed as a `Signal` so it
+   * can be threaded into pure-signal ARIA factories (e.g.
+   * `createAriaInvalidSignal`) without giving them access to the directive's
+   * private resolver.
+   */
+  readonly #fieldStateSignal = computed(() => this.#resolveFieldState());
+
+  readonly #factoryAriaInvalid = createAriaInvalidSignal(
+    this.#fieldStateSignal,
+    this.#visibilityByStrategy,
+    this.#fieldIdentity?.isControlVisible,
+  );
+
+  /**
    * Computed ARIA invalid state.
    * Returns 'true' | 'false' | null based on field validity and error display strategy.
    *
@@ -194,25 +205,14 @@ export class NgxSignalFormAutoAria {
    * removed from the hidden control rather than going stale.
    */
   protected readonly ariaInvalid = computed(() => {
+    // Manual-mode opt-out lives in the directive shell — the factory is
+    // unconditional, so the pass-through to the DOM snapshot has to be gated
+    // here, before delegating.
     if (this.#isManualAriaMode()) {
       return this.#domSnapshot().ariaInvalid;
     }
 
-    if (!this.#hasUsableFieldState()) {
-      return null;
-    }
-
-    // When the wrapper's identity service is present and the control has
-    // no layout box (collapsed `<details>`, `hidden` attribute,
-    // `display: none`), remove aria-invalid so it cannot go stale on
-    // collapsed/hidden fieldsets. Visibility is pushed from the wrapper
-    // via `checkVisibility()` polling in `afterEveryRender`, so this does
-    // not trigger merely because the control is scrolled off-screen.
-    if (this.#fieldIdentity && !this.#fieldIdentity.isControlVisible()) {
-      return null;
-    }
-
-    return this.#shouldShowErrors() ? 'true' : 'false';
+    return this.#factoryAriaInvalid();
   });
 
   /**

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -27,6 +27,7 @@ export {
 } from './directives/ngx-signal-form';
 
 // Utilities
+export { createAriaInvalidSignal } from './utilities/aria/create-aria-invalid-signal';
 export {
   createHintIdsSignal,
   type CreateHintIdsSignalOptions,

--- a/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.spec.ts
@@ -1,0 +1,161 @@
+import { signal, type Signal } from '@angular/core';
+import type { FieldState, ValidationError } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+import { warningError } from '../warning-error';
+import { createAriaInvalidSignal } from './create-aria-invalid-signal';
+
+type FieldStateStub = Pick<FieldState<unknown>, 'errors'>;
+
+function fieldStateSignal(
+  errors: readonly ValidationError[],
+): Signal<FieldState<unknown> | null> {
+  const stub: FieldStateStub = { errors: signal(errors) };
+  return signal(stub as FieldState<unknown>);
+}
+
+describe('createAriaInvalidSignal', () => {
+  it('returns "true" when visible and the field has a blocking error', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const visibility = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('returns "false" when visible but the field has no blocking errors', () => {
+    const fieldState = fieldStateSignal([]);
+    const visibility = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+
+    expect(ariaInvalid()).toBe('false');
+  });
+
+  it('returns "false" when visible and the field has only warning-kind errors', () => {
+    const fieldState = fieldStateSignal([warningError('weak-password')]);
+    const visibility = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+
+    expect(ariaInvalid()).toBe('false');
+  });
+
+  it('returns "false" when visibility is false even with blocking errors', () => {
+    // The strategy says "do not show errors yet" (e.g. on-touch + untouched),
+    // so aria-invalid must not announce the error.
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const visibility = signal(false);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+
+    expect(ariaInvalid()).toBe('false');
+  });
+
+  it('returns null when the control is not laid out (isControlVisible=false)', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const visibility = signal(true);
+    const isControlVisible = signal(false);
+
+    const ariaInvalid = createAriaInvalidSignal(
+      fieldState,
+      visibility,
+      isControlVisible,
+    );
+
+    expect(ariaInvalid()).toBeNull();
+  });
+
+  it('returns the resolved value when the control is laid out (isControlVisible=true)', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const visibility = signal(true);
+    const isControlVisible = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(
+      fieldState,
+      visibility,
+      isControlVisible,
+    );
+
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('returns null when no field state is bound', () => {
+    const fieldState = signal<FieldState<unknown> | null>(null);
+    const visibility = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+
+    expect(ariaInvalid()).toBeNull();
+  });
+
+  it('reacts to errors becoming present', () => {
+    const errors = signal<readonly ValidationError[]>([]);
+    const stub = signal<FieldState<unknown> | null>({
+      errors,
+    } as FieldState<unknown>);
+    const visibility = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(stub, visibility);
+    expect(ariaInvalid()).toBe('false');
+
+    errors.set([{ kind: 'required', message: 'Required' }]);
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('reacts to visibility flipping on', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const visibility = signal(false);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+    expect(ariaInvalid()).toBe('false');
+
+    visibility.set(true);
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('reacts to isControlVisible toggling', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const visibility = signal(true);
+    const isControlVisible = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(
+      fieldState,
+      visibility,
+      isControlVisible,
+    );
+    expect(ariaInvalid()).toBe('true');
+
+    isControlVisible.set(false);
+    expect(ariaInvalid()).toBeNull();
+
+    isControlVisible.set(true);
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('reacts to the bound field state going from null to populated', () => {
+    const populated = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ])();
+    const fieldState = signal<FieldState<unknown> | null>(null);
+    const visibility = signal(true);
+
+    const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+    expect(ariaInvalid()).toBeNull();
+
+    fieldState.set(populated);
+    expect(ariaInvalid()).toBe('true');
+  });
+});

--- a/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.ts
@@ -9,8 +9,9 @@ import { isBlockingError } from '../warning-error';
  * Returns one of:
  * - `'true'` — the control has at least one blocking error AND error
  *   visibility evaluates to `true` (per the configured display strategy).
- * - `'false'` — the control is reachable and visible, but has no blocking
- *   errors that should be announced.
+ * - `'false'` — the control is reachable and visible, but is not currently
+ *   announcing blocking errors, either because none exist or because error
+ *   visibility currently evaluates to `false`.
  * - `null` — the field state is missing, OR the control is not currently
  *   laid out (collapsed `<details>`, `hidden`, `display: none`). Consumers
  *   should remove `aria-invalid` from the host element in this case so the

--- a/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.ts
@@ -1,0 +1,63 @@
+import { computed, type Signal } from '@angular/core';
+import type { FieldState } from '@angular/forms/signals';
+import { isBlockingError } from '../warning-error';
+
+/**
+ * Pure-signal factory that derives the `aria-invalid` ARIA attribute value
+ * for a Signal Forms control.
+ *
+ * Returns one of:
+ * - `'true'` — the control has at least one blocking error AND error
+ *   visibility evaluates to `true` (per the configured display strategy).
+ * - `'false'` — the control is reachable and visible, but has no blocking
+ *   errors that should be announced.
+ * - `null` — the field state is missing, OR the control is not currently
+ *   laid out (collapsed `<details>`, `hidden`, `display: none`). Consumers
+ *   should remove `aria-invalid` from the host element in this case so the
+ *   attribute does not go stale on a hidden control.
+ *
+ * The factory is unconditional and contains no DI: callers thread DI-resolved
+ * values (the visibility computed from `createErrorVisibility`, and an
+ * optional `isControlVisible` predicate, typically from `NgxFieldIdentity`)
+ * in as inputs. The `'manual'` ARIA-mode opt-out lives in the directive
+ * shell that wires this factory, not here.
+ *
+ * @param fieldState A signal returning the bound `FieldState`, or `null`
+ *   when no field is bound yet.
+ * @param visibility A signal that is `true` when errors should be visible
+ *   under the active display strategy. Typically the result of
+ *   `createErrorVisibility(fieldState)`.
+ * @param isControlVisible Optional signal that is `false` when the control
+ *   is collapsed/hidden from layout. When omitted, visibility is assumed.
+ * @returns A computed signal with the resolved `aria-invalid` value.
+ *
+ * @example
+ * ```typescript
+ * const fieldState = computed(() => formField.state());
+ * const visibility = createErrorVisibility(fieldState);
+ * const ariaInvalid = createAriaInvalidSignal(fieldState, visibility);
+ * ```
+ *
+ * @public
+ */
+export function createAriaInvalidSignal(
+  fieldState: Signal<FieldState<unknown> | null>,
+  visibility: Signal<boolean>,
+  isControlVisible?: Signal<boolean>,
+): Signal<'true' | 'false' | null> {
+  return computed(() => {
+    const state = fieldState();
+
+    if (!state) {
+      return null;
+    }
+
+    if (isControlVisible && !isControlVisible()) {
+      return null;
+    }
+
+    const hasBlockingError = state.errors().some(isBlockingError);
+
+    return hasBlockingError && visibility() ? 'true' : 'false';
+  });
+}

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -55,6 +55,7 @@ export {
 // ARIA primitives — sourced from `/core` to keep the directive shell and
 // the headless re-export in lockstep without duplicating implementation.
 export {
+  createAriaInvalidSignal,
   createHintIdsSignal,
   type CreateHintIdsSignalOptions,
   type HintIdsFieldNameReader,


### PR DESCRIPTION
## Summary

Tracer-bullet slice of #38: extract `aria-invalid` resolution out of `NgxSignalFormAutoAria` into a pure signal factory that consumers can compose without inheriting the directive shell.

- `createAriaInvalidSignal(fieldState, visibility, isControlVisible?)` returns `Signal<'true' | 'false' | null>` and lives next to the existing `createErrorVisibility` building block (re-exported from `@ngx-signal-forms/toolkit/headless` as the documented public surface).
- `NgxSignalFormAutoAria.ariaInvalid` now delegates to the factory; the `'manual'` ARIA-mode opt-out stays in the directive shell so the factory's contract remains "fieldState in -> ARIA out" with no DI of its own.
- 11 new factory specs cover visible-with-blocking-errors, visible-no-errors, warning-only, visibility false, collapsed/hidden, no-field-state, plus reactive transitions. Existing `auto-aria.spec.ts` and `auto-aria.browser.spec.ts` pass unchanged (16/16 browser, 997/997 jsdom).

The factory source lives in `packages/toolkit/core/utilities/aria/` (not directly in `/headless/`) to avoid a circular entry-point dependency: `headless` already imports from `core`, so locating the source in `core` and re-exporting from the headless barrel keeps both build graphs acyclic. The PRD's "public surface lives in `/headless`" requirement is satisfied via the re-export.

Closes #42
Refs #38

## Acceptance criteria

- [x] `createAriaInvalidSignal(fieldState, visibility, isControlVisible?)` exists and is exported from the headless barrel
- [x] Unit spec covers: visible-with-blocking-errors -> 'true', visible-no-errors -> 'false', collapsed/hidden -> null, no-field-state -> null
- [x] Manual-mode opt-out stays in the directive shell (factory is unconditional)
- [x] `NgxSignalFormAutoAria.ariaInvalid` computed delegates to the factory
- [x] Existing auto-aria specs pass unchanged
- [x] `pnpm nx test toolkit` green (997 passed)
- [x] `pnpm nx build toolkit` green (all secondary entry points)
- [x] `pnpm nx lint toolkit` green (no new warnings)

## Test plan

- [x] `pnpm nx test toolkit` — 997 passed
- [x] `pnpm nx test-browser toolkit` — 16 passed (pre-existing `fieldState.errors is not a function` stderr in the visibility test exists on `main` and is unrelated to this change)
- [x] `pnpm nx build toolkit` — all 7 entry points built (root, core, headless, assistive, debugger, form-field, vest)
- [x] `pnpm nx lint toolkit` — clean (333 pre-existing warnings, 0 errors)
- [x] `pnpm format` — applied via lint-staged