### PR TITLE
feat(headless): extract createAriaRequiredSignal pure-signal factory

### DIFF
--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -8,6 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { FORM_FIELD, type FieldState } from '@angular/forms/signals';
+import { createAriaRequiredSignal } from '../utilities/aria/create-aria-required-signal';
 import {
   NGX_SIGNAL_FORM_ARIA_MODE,
   NGX_SIGNAL_FORM_HINT_REGISTRY,
@@ -215,22 +216,24 @@ export class NgxSignalFormAutoAria {
     return this.#factoryAriaInvalid();
   });
 
+  readonly #ariaRequiredFromFactory = createAriaRequiredSignal(
+    this.#fieldStateSignal,
+  );
+
   /**
    * Computed ARIA required state.
    * Returns 'true' | null based on the field's `required()` signal.
+   *
+   * Delegates to {@link createAriaRequiredSignal} for the actual resolution.
+   * The directive shell only owns the manual-mode opt-out branch — when
+   * `ngxSignalFormControlAria='manual'`, the consumer's DOM value wins.
    */
   protected readonly ariaRequired = computed(() => {
     if (this.#isManualAriaMode()) {
       return this.#domSnapshot().ariaRequired;
     }
 
-    const fieldState = this.#resolveFieldState();
-
-    if (!fieldState) {
-      return null;
-    }
-
-    return fieldState.required() ? 'true' : null;
+    return this.#ariaRequiredFromFactory();
   });
 
   /**

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -29,6 +29,10 @@ export {
 // Utilities
 export { createAriaInvalidSignal } from './utilities/aria/create-aria-invalid-signal';
 export {
+  type AriaRequiredFieldState,
+  createAriaRequiredSignal,
+} from './utilities/aria/create-aria-required-signal';
+export {
   createHintIdsSignal,
   type CreateHintIdsSignalOptions,
   type HintIdsFieldNameReader,

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -29,8 +29,8 @@ export {
 // Utilities
 export { createAriaInvalidSignal } from './utilities/aria/create-aria-invalid-signal';
 export {
-  type AriaRequiredFieldState,
   createAriaRequiredSignal,
+  type AriaRequiredFieldState,
 } from './utilities/aria/create-aria-required-signal';
 export {
   createHintIdsSignal,

--- a/packages/toolkit/core/utilities/aria/create-aria-required-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-required-signal.spec.ts
@@ -1,0 +1,91 @@
+import { signal, type Signal } from '@angular/core';
+import { describe, expect, it } from 'vitest';
+import {
+  createAriaRequiredSignal,
+  type AriaRequiredFieldState,
+} from './create-aria-required-signal';
+
+function createMockFieldState(required: boolean): {
+  fieldState: AriaRequiredFieldState;
+  setRequired: (value: boolean) => void;
+} {
+  const requiredSignal = signal(required);
+  return {
+    fieldState: { required: requiredSignal },
+    setRequired: (value) => {
+      requiredSignal.set(value);
+    },
+  };
+}
+
+describe('createAriaRequiredSignal', () => {
+  it("returns 'true' when the field is required", () => {
+    const { fieldState } = createMockFieldState(true);
+    const fieldStateSignal: Signal<AriaRequiredFieldState | null> =
+      signal(fieldState);
+
+    const ariaRequired = createAriaRequiredSignal(fieldStateSignal);
+
+    expect(ariaRequired()).toBe('true');
+  });
+
+  it('returns null when the field is not required', () => {
+    const { fieldState } = createMockFieldState(false);
+    const fieldStateSignal: Signal<AriaRequiredFieldState | null> =
+      signal(fieldState);
+
+    const ariaRequired = createAriaRequiredSignal(fieldStateSignal);
+
+    expect(ariaRequired()).toBeNull();
+  });
+
+  it('returns null when no field state is available', () => {
+    const fieldStateSignal: Signal<AriaRequiredFieldState | null> =
+      signal(null);
+
+    const ariaRequired = createAriaRequiredSignal(fieldStateSignal);
+
+    expect(ariaRequired()).toBeNull();
+  });
+
+  it("transitions from null to 'true' when required() flips on", () => {
+    const { fieldState, setRequired } = createMockFieldState(false);
+    const fieldStateSignal: Signal<AriaRequiredFieldState | null> =
+      signal(fieldState);
+
+    const ariaRequired = createAriaRequiredSignal(fieldStateSignal);
+
+    expect(ariaRequired()).toBeNull();
+
+    setRequired(true);
+    expect(ariaRequired()).toBe('true');
+  });
+
+  it("transitions from 'true' to null when required() flips off", () => {
+    const { fieldState, setRequired } = createMockFieldState(true);
+    const fieldStateSignal: Signal<AriaRequiredFieldState | null> =
+      signal(fieldState);
+
+    const ariaRequired = createAriaRequiredSignal(fieldStateSignal);
+
+    expect(ariaRequired()).toBe('true');
+
+    setRequired(false);
+    expect(ariaRequired()).toBeNull();
+  });
+
+  it('reacts when the field state itself swaps from null to a real state', () => {
+    const fieldStateSignal = signal<AriaRequiredFieldState | null>(null);
+
+    const ariaRequired = createAriaRequiredSignal(fieldStateSignal);
+
+    expect(ariaRequired()).toBeNull();
+
+    const { fieldState } = createMockFieldState(true);
+    fieldStateSignal.set(fieldState);
+    expect(ariaRequired()).toBe('true');
+
+    fieldStateSignal.set(null);
+    expect(ariaRequired()).toBeNull();
+  });
+});

--- a/packages/toolkit/core/utilities/aria/create-aria-required-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-required-signal.ts
@@ -25,7 +25,7 @@ export type AriaRequiredFieldState = Pick<FieldState<unknown>, 'required'>;
  * @example Compose inside a custom wrapper
  * ```typescript
  * const ariaRequired = createAriaRequiredSignal(
- *   computed(() => this.formField()()),
+ *   computed(() => this.formField()?.()),
  * );
  * // ariaRequired() → 'true' | null
  * ```

--- a/packages/toolkit/core/utilities/aria/create-aria-required-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-required-signal.ts
@@ -1,0 +1,47 @@
+import { computed, type Signal } from '@angular/core';
+import type { FieldState } from '@angular/forms/signals';
+
+/**
+ * Minimal FieldState contract required for aria-required resolution.
+ */
+export type AriaRequiredFieldState = Pick<FieldState<unknown>, 'required'>;
+
+/**
+ * Pure signal factory that resolves the `aria-required` attribute value from
+ * a reactive `FieldState`.
+ *
+ * Returns `'true'` when the field's `required()` signal is `true`, and `null`
+ * otherwise (so the caller can drop the attribute entirely rather than
+ * emitting `aria-required="false"`).
+ *
+ * The factory is unconditional — manual-mode opt-out lives in the directive
+ * shell that consumes this factory, not here. That keeps the contract clean:
+ * `fieldState in → ARIA out`.
+ *
+ * @param fieldState Reactive field state. `null` short-circuits to `null` so
+ *   consumers don't have to inline the null branch at every call site.
+ * @returns A computed `Signal<'true' | null>` driven by `fieldState().required()`.
+ *
+ * @example Compose inside a custom wrapper
+ * ```typescript
+ * const ariaRequired = createAriaRequiredSignal(
+ *   computed(() => this.formField()()),
+ * );
+ * // ariaRequired() → 'true' | null
+ * ```
+ *
+ * @public
+ */
+export function createAriaRequiredSignal(
+  fieldState: Signal<AriaRequiredFieldState | null>,
+): Signal<'true' | null> {
+  return computed(() => {
+    const state = fieldState();
+
+    if (!state) {
+      return null;
+    }
+
+    return state.required() ? 'true' : null;
+  });
+}

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -52,11 +52,14 @@ export {
   type ResolvedNotificationMessage,
 } from './lib/notification';
 
-// ARIA primitives — sourced from `/core` to keep the directive shell and
-// the headless re-export in lockstep without duplicating implementation.
+// ARIA primitives — sourced from `/core` to keep the directive shell
+// (`NgxSignalFormAutoAria`) and the headless re-export in lockstep without
+// duplicating implementation or forming a cycle through this barrel.
 export {
   createAriaInvalidSignal,
+  createAriaRequiredSignal,
   createHintIdsSignal,
+  type AriaRequiredFieldState,
   type CreateHintIdsSignalOptions,
   type HintIdsFieldNameReader,
   type HintIdsIdentityLike,

--- a/packages/toolkit/index.ts
+++ b/packages/toolkit/index.ts
@@ -29,7 +29,6 @@ export {
   buildAriaDescribedBy,
   canSubmitWithWarnings,
   combineShowErrors,
-  createAriaRequiredSignal,
   createErrorVisibility,
   createOnInvalidHandler,
   createShowErrorsComputed,
@@ -89,7 +88,6 @@ export {
 
 export type {
   AriaDescribedByChainOptions,
-  AriaRequiredFieldState,
   CreateErrorVisibilityOptions,
   ErrorDisplayStrategy,
   ErrorReadableState,

--- a/packages/toolkit/index.ts
+++ b/packages/toolkit/index.ts
@@ -29,6 +29,7 @@ export {
   buildAriaDescribedBy,
   canSubmitWithWarnings,
   combineShowErrors,
+  createAriaRequiredSignal,
   createErrorVisibility,
   createOnInvalidHandler,
   createShowErrorsComputed,
@@ -88,6 +89,7 @@ export {
 
 export type {
   AriaDescribedByChainOptions,
+  AriaRequiredFieldState,
   CreateErrorVisibilityOptions,
   ErrorDisplayStrategy,
   ErrorReadableState,


### PR DESCRIPTION
## Summary

First tracer-bullet slice of #38 (Auto-ARIA composition refactor). Extracts the `aria-required` resolution out of `NgxSignalFormAutoAria` into a pure signal factory that consumers can compose without inheriting the directive shell.

- `createAriaRequiredSignal(fieldState: Signal<FieldState | null>) -> Signal<'true' | null>` — unconditional pure factory, no DI inside the factory itself
- `NgxSignalFormAutoAria.ariaRequired` now delegates to the factory; manual-mode opt-out stays in the directive shell
- Source lives in `core/utilities/aria/` so the directive can import without forming a cycle through the headless barrel; re-exported from `@ngx-signal-forms/toolkit/headless` (and the root) to match the PRD's public-surface contract

Closes #43
Refs #38

## Acceptance criteria

- [x] `createAriaRequiredSignal(fieldState)` exists and is exported from `@ngx-signal-forms/toolkit/headless`
- [x] Unit spec covers: required-true -> 'true', required-false -> null, no-field-state -> null, transitions through `required` signal mutations, and field-state swaps
- [x] Manual-mode opt-out stays in the directive shell
- [x] `NgxSignalFormAutoAria.ariaRequired` computed delegates to the factory
- [x] Existing auto-aria specs pass unchanged (jsdom + browser)
- [x] `pnpm nx test toolkit` green (992 tests)
- [x] `pnpm nx build toolkit` green
- [x] `pnpm nx lint toolkit` green (0 errors)
- [x] `pnpm format` clean

## Test plan

- [ ] CI green on this branch
- [ ] Reviewer skims the new factory + spec for the unconditional contract
- [ ] Reviewer confirms the directive shell still owns manual-mode (line ~241 in `auto-aria.ts`)

## Coordination note

Sibling slices #41 (`createHintIdsSignal`) and #42 (`createAriaInvalidSignal`) are landing in parallel. This PR's edits to the shared `auto-aria.ts` and `headless/src/index.ts` are the minimum needed to delegate one computed and add one re-export line.