### PR TITLE
chore(workspace): nx guardrails for design-system demo apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,46 @@ jobs:
       - run: pnpm exec nx fix-ci --outputStyle=static
         if: ${{ always() && !inputs.skip_cloud && steps.nx_cloud.outputs.enabled == 'true' }}
         continue-on-error: true
+
+  # Proves the published toolkit stays design-system-free as the reference
+  # demo apps (#40 - Material/PrimeNG/Spartan) land. Two assertions:
+  #   1. Static: toolkit's own package.json declares no design-system deps.
+  #   2. Runtime: `nx build toolkit` succeeds in a workspace pruned to
+  #      toolkit + its transitive deps via `pnpm install --filter`, so even
+  #      if a future demo app pulls in @angular/material et al., none of
+  #      those packages are present in node_modules during the toolkit build.
+  toolkit-isolation:
+    name: Toolkit isolation (design-system-free build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NX_NO_CLOUD: 'true'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - name: Assert toolkit declares no design-system deps
+        run: pnpm check:toolkit-peer-deps
+
+      - name: Install only toolkit + its dependencies
+        # `--filter "@ngx-signal-forms/toolkit..."` includes the toolkit and
+        # its transitive workspace deps but excludes apps/demo* and any
+        # future demo apps that depend on the toolkit. Demo design-system
+        # deps therefore never enter node_modules in this job.
+        run: pnpm install --frozen-lockfile --filter "@ngx-signal-forms/toolkit..."
+
+      - name: Build toolkit
+        run: pnpm exec nx build toolkit

--- a/apps/demo-e2e/project.json
+++ b/apps/demo-e2e/project.json
@@ -4,6 +4,7 @@
   "projectType": "application",
   "sourceRoot": "apps/demo-e2e/src",
   "implicitDependencies": ["demo"],
+  "tags": ["scope:demo", "type:app"],
   "targets": {
     "lint": {
       "executor": "nx:run-commands",

--- a/apps/demo/project.json
+++ b/apps/demo/project.json
@@ -4,7 +4,7 @@
   "projectType": "application",
   "prefix": "ngx",
   "sourceRoot": "apps/demo/src",
-  "tags": [],
+  "tags": ["scope:demo", "type:app"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing
+
+This document captures workspace-level conventions every contributor (and AI
+agent) must follow when changing project layout, adding apps, or wiring CI.
+For code-level conventions, see [`AGENTS.md`](../AGENTS.md), the per-package
+READMEs, and ADRs in [`docs/decisions/`](./decisions).
+
+## Project tags & module boundaries
+
+Every Nx project declares a `tags` array in its `project.json`. Tags drive the
+`@nx/enforce-module-boundaries` lint rule defined in
+[`oxlint.config.ts`](../oxlint.config.ts) and protect the published toolkit
+bundle from accidental contamination by demo-only code.
+
+### Tag vocabulary
+
+| Tag          | Meaning                                                |
+| ------------ | ------------------------------------------------------ |
+| `scope:lib`  | Publishable library code. Toolkit and any future libs. |
+| `scope:demo` | Demo apps and demo-only support libs.                  |
+| `type:lib`   | Library project (`projectType: "library"`).            |
+| `type:app`   | Application project (`projectType: "application"`).    |
+
+Each project carries one `scope:*` tag and one `type:*` tag.
+
+### Constraints
+
+- `scope:lib` may only depend on other `scope:lib` projects.
+- `scope:demo` may depend on both `scope:lib` and `scope:demo` projects.
+- `type:lib` may only depend on other `type:lib` projects.
+- `type:app` may depend on both `type:lib` and `type:app` projects.
+
+The constraint that bites hardest:
+
+> **`scope:lib` cannot depend on `scope:demo`.** A demo import inside the
+> toolkit fails lint, which fails CI. This guardrail exists because the
+> reference demo apps (Material, PrimeNG, Spartan — see #40) will pull in
+> design-system packages the toolkit must never ship with.
+
+### Adding a new project
+
+1. Create the project (Nx generator or manual).
+2. Edit its `project.json` and add the appropriate `scope:*` + `type:*` tags.
+3. Run `pnpm nx run-many -t lint` to confirm boundaries hold.
+
+## Demo app budgets
+
+> **The toolkit's own size budget lives in `packages/toolkit/ng-package.json`
+> and `packages/toolkit/tsconfig.lib.prod.json`. Do not change it when adding
+> a demo app.** Each demo app gets its own `budgets` block.
+
+When adding a new demo app under `apps/demo-*` (e.g. `apps/demo-material`,
+`apps/demo-primeng`, `apps/demo-spartan` per #40), declare its budgets in the
+app's own configuration so the demo's design-system bundle size doesn't
+distort the toolkit's perf signal. Use this template inside the app's build
+target configuration in `apps/demo-<name>/project.json`:
+
+```jsonc
+{
+  "targets": {
+    "build": {
+      "configurations": {
+        "production": {
+          // ...other production options...
+          "budgets": [
+            {
+              "type": "initial",
+              "maximumWarning": "1mb",
+              "maximumError": "2mb",
+            },
+            {
+              "type": "anyComponentStyle",
+              "maximumWarning": "8kb",
+              "maximumError": "16kb",
+            },
+          ],
+        },
+      },
+    },
+  },
+}
+```
+
+Tune the thresholds per design system. Material apps will run hotter than
+Spartan apps; that's expected. Set the warning at the steady-state size and
+the error 30-50% higher to leave room for new examples.
+
+## Toolkit isolation guarantees
+
+Two CI mechanisms keep the toolkit publishable and design-system-free:
+
+1. **Static check** — `pnpm check:toolkit-peer-deps` (script at
+   [`tools/scripts/check-toolkit-peer-deps.mjs`](../tools/scripts/check-toolkit-peer-deps.mjs))
+   asserts `packages/toolkit/package.json` declares no `@angular/material`,
+   `primeng`, `primeicons`, or `@spartan-ng/*` entries in `dependencies` or
+   `peerDependencies`.
+2. **Pruned build** — the `toolkit-isolation` job in
+   [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs
+   `pnpm install --frozen-lockfile --filter "@ngx-signal-forms/toolkit..."`
+   followed by `pnpm nx build toolkit`. The filter excludes demo apps from
+   the install graph, so even if a demo declares a design-system dep, the
+   toolkit build proves it can compile without that dep present.
+
+If either check fails, the right fix is almost never to relax the check —
+move the offending dep into the demo app that needs it.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -222,9 +222,24 @@ export default defineConfig({
             enforceBuildableLibDependency: true,
             allow: ['^@ngx-signal-forms/toolkit/.*$'],
             depConstraints: [
+              // The published toolkit must never reach into demo-only code.
+              // This is what keeps the design-system reference apps (#40)
+              // from contaminating the toolkit bundle.
               {
-                sourceTag: '*',
-                onlyDependOnLibsWithTags: ['*'],
+                sourceTag: 'scope:lib',
+                onlyDependOnLibsWithTags: ['scope:lib'],
+              },
+              {
+                sourceTag: 'scope:demo',
+                onlyDependOnLibsWithTags: ['scope:lib', 'scope:demo'],
+              },
+              {
+                sourceTag: 'type:lib',
+                onlyDependOnLibsWithTags: ['type:lib'],
+              },
+              {
+                sourceTag: 'type:app',
+                onlyDependOnLibsWithTags: ['type:lib', 'type:app'],
               },
             ],
           },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "format:check": "nx run workspace:format-check",
     "test:all": "nx run-many --target=test --all",
     "test:browser": "nx run toolkit:test-browser",
+    "check:toolkit-peer-deps": "node tools/scripts/check-toolkit-peer-deps.mjs",
     "prepare": "node tools/simple-git-hooks-worktree.cjs"
   },
   "private": true,

--- a/packages/demo-shared/project.json
+++ b/packages/demo-shared/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/demo-shared/src",
   "projectType": "library",
-  "tags": [],
+  "tags": ["scope:demo", "type:lib"],
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",

--- a/packages/toolkit/project.json
+++ b/packages/toolkit/project.json
@@ -10,7 +10,7 @@
       "fallbackCurrentVersionResolver": "disk"
     }
   },
-  "tags": ["scope:toolkit", "type:package"],
+  "tags": ["scope:lib", "type:lib"],
   "targets": {
     "build": {
       "executor": "@nx/angular:package",

--- a/tools/scripts/check-toolkit-peer-deps.mjs
+++ b/tools/scripts/check-toolkit-peer-deps.mjs
@@ -10,8 +10,7 @@
 // breach, not a build break.
 
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 const here = import.meta.dirname;
 const pkgPath = resolve(here, '../../packages/toolkit/package.json');

--- a/tools/scripts/check-toolkit-peer-deps.mjs
+++ b/tools/scripts/check-toolkit-peer-deps.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Asserts the published toolkit (`packages/toolkit/package.json`) declares no
+// design-system runtime dependencies. The toolkit is consumed alongside any
+// design system the user chooses; pulling Material/PrimeNG/Spartan into its
+// `dependencies` or `peerDependencies` would force every consumer to install
+// them, defeating the point of the seam.
+//
+// Wired as `pnpm check:toolkit-peer-deps`, runs in CI as a separate step from
+// the build so the failure mode is unambiguous: a violation is a guardrail
+// breach, not a build break.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = import.meta.dirname;
+const pkgPath = resolve(here, '../../packages/toolkit/package.json');
+
+const FORBIDDEN_PATTERNS = [
+  /^@angular\/material(\/.*)?$/,
+  /^@angular\/material-.*/,
+  /^primeng(\/.*)?$/,
+  /^primeicons(\/.*)?$/,
+  /^@spartan-ng\/.+/,
+];
+
+const FORBIDDEN_FIELDS = ['dependencies', 'peerDependencies'];
+
+function findViolations(pkg) {
+  const violations = [];
+  for (const field of FORBIDDEN_FIELDS) {
+    const block = pkg[field];
+    if (!block) continue;
+    for (const name of Object.keys(block)) {
+      const matched = FORBIDDEN_PATTERNS.find((re) => re.test(name));
+      if (matched) {
+        violations.push({ field, name, pattern: matched.source });
+      }
+    }
+  }
+  return violations;
+}
+
+const raw = readFileSync(pkgPath, 'utf8');
+const pkg = JSON.parse(raw);
+const violations = findViolations(pkg);
+
+if (violations.length > 0) {
+  console.error(`\n${pkgPath} declares forbidden design-system dependencies:`);
+  for (const { field, name, pattern } of violations) {
+    console.error(`  - ${field}.${name}  (matches /${pattern}/)`);
+  }
+  console.error(
+    '\nThe toolkit must stay design-system-free. Move such deps into',
+  );
+  console.error(
+    'the demo app(s) that wrap the toolkit, not the toolkit itself.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `${pkg.name}@${pkg.version}: no design-system deps found in ${FORBIDDEN_FIELDS.join(' or ')}.`,
+);


### PR DESCRIPTION
## Summary

Foundation slice for #40 (reference Material/PrimeNG/Spartan demos). Lands the Nx isolation safeguards before any demo app exists, so #8/#9/#10 inherit the guardrails on day one and the published toolkit bundle is provably uncontaminated.

This is pure workspace plumbing — no new app, no demo code.

## What changed

- **Project tags.** `packages/toolkit/project.json` is tagged `scope:lib` + `type:lib`. `apps/demo`, `apps/demo-e2e`, and `packages/demo-shared` are tagged `scope:demo` (with appropriate `type:app` / `type:lib`).
- **Module boundaries.** `oxlint.config.ts` replaces the wildcard `depConstraints` with explicit constraints. `scope:lib` cannot depend on `scope:demo`; `type:lib` cannot depend on `type:app`. The constraint that bites hardest: a demo import inside the toolkit fails lint, which fails CI.
- **Peer-dep assertion.** New `tools/scripts/check-toolkit-peer-deps.mjs` (wired as `pnpm check:toolkit-peer-deps`) fails if `packages/toolkit/package.json` declares any `@angular/material`, `primeng`, `primeicons`, or `@spartan-ng/*` entry in `dependencies` or `peerDependencies`.
- **CI smoke job.** New `toolkit-isolation` job runs `pnpm install --frozen-lockfile --filter "@ngx-signal-forms/toolkit..."` followed by `pnpm exec nx build toolkit`. The pnpm filter excludes demo apps from the install graph, so even when future demos pull in design-system deps, none of them enter `node_modules` for this job. Verified locally with an isolated checkout — the build succeeds and `node_modules` contains zero design-system packages.
- **Docs.** New `docs/CONTRIBUTING.md` documents the tag vocabulary, boundary constraints, demo-app budget template (each demo gets its own `budgets` block; toolkit's budget is untouched), and the isolation guarantees.

## Manual violation test (proof the boundary rule bites)

Injected this into `packages/toolkit/index.ts`:

```ts
import { DEMO_PATHS } from '@ngx-signal-forms/demo-shared';
console.log(DEMO_PATHS);
```

Ran `pnpm exec oxlint packages/toolkit/index.ts --type-aware`:

```
× @nx(enforce-module-boundaries): A project tagged with "scope:lib" can only depend on libs tagged with "scope:lib"
   ,-[packages/toolkit/index.ts:2:1]
 2 | import { DEMO_PATHS } from '@ngx-signal-forms/demo-shared';
   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Found 0 warnings and 1 error.
```

Reverted before commit.

## Acceptance criteria

- [x] `packages/toolkit/project.json` tagged `["scope:lib", "type:lib"]`
- [x] `apps/demo/project.json` (and `apps/demo-e2e`, `packages/demo-shared`) tagged with `scope:demo` + appropriate `type:*`
- [x] `enforce-module-boundaries` configured so `scope:lib` cannot depend on `scope:demo`; lint fails on violation (verified — see above)
- [x] CI smoke job (`toolkit-isolation`) builds `toolkit` in an environment where no design-system packages are installed
- [x] Budget template documented in `docs/CONTRIBUTING.md`
- [x] Peer-dep assertion script wired as `pnpm check:toolkit-peer-deps` and called in the smoke job
- [x] `pnpm nx run-many -t lint,test,build` green

## Test plan

- [ ] CI green on the new `toolkit-isolation` job
- [ ] Existing `main` job still passes
- [ ] Reviewer can locally inject a `scope:lib → scope:demo` import and confirm lint fails

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented module boundary enforcement to strengthen code organization.
  * Added CI guardrails to verify toolkit independence from design-system packages.
  * Updated project metadata and linting rules to enforce architectural constraints.

* **Documentation**
  * Added contributing guidelines covering module boundaries, project setup procedures, and build isolation guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->