### PR TITLE
feat(headless): extract createAriaDescribedBySignal pure-signal factory

### DIFF
--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -20,6 +20,7 @@ import {
   resolveFieldName,
 } from '../utilities/field-resolution';
 import { createErrorVisibility } from '../utilities/create-error-visibility';
+import { createAriaDescribedBySignal } from '../utilities/aria/create-aria-described-by-signal';
 import { createHintIdsSignal } from '../utilities/aria/create-hint-ids-signal';
 import { isBlockingError, isWarningError } from '../utilities/warning-error';
 import { NgxFieldIdentity } from '../services/field-identity';
@@ -170,6 +171,14 @@ export class NgxSignalFormAutoAria {
     fieldName: () => this.#domSnapshot().fieldName,
   });
 
+  /**
+   * Reactive view of the resolved field state, exposed as a `Signal` so it
+   * can be threaded into pure-signal ARIA factories (e.g.
+   * `createAriaInvalidSignal`) without giving them access to the directive's
+   * private resolver.
+   */
+  readonly #fieldStateSignal = computed(() => this.#resolveFieldState());
+
   /** Delegates to `#visibilityByStrategy` after filtering to blocking errors. */
   readonly #shouldShowErrors = computed(() => {
     return this.#shouldShowBy('blocking');
@@ -180,19 +189,26 @@ export class NgxSignalFormAutoAria {
     return this.#shouldShowBy('warning');
   });
 
-  /**
-   * Reactive view of the resolved field state, exposed as a `Signal` so it
-   * can be threaded into pure-signal ARIA factories (e.g.
-   * `createAriaInvalidSignal`) without giving them access to the directive's
-   * private resolver.
-   */
-  readonly #fieldStateSignal = computed(() => this.#resolveFieldState());
-
   readonly #factoryAriaInvalid = createAriaInvalidSignal(
     this.#fieldStateSignal,
     this.#visibilityByStrategy,
     this.#fieldIdentity?.isControlVisible,
   );
+
+  /**
+   * Pure-signal `aria-describedby` composer. Mirrors the directive's
+   * historical preserved-IDs + hints + error/warning composition, but lives
+   * in the headless surface so wrapper authors can reuse it without
+   * inheriting the directive shell. Manual-mode opt-out is still owned by
+   * this directive — the factory itself is unconditional.
+   */
+  readonly #factoryAriaDescribedBy = createAriaDescribedBySignal({
+    fieldState: this.#fieldStateSignal,
+    hintIds: this.#hintIds,
+    visibility: this.#visibilityByStrategy,
+    preservedIds: () => this.#domSnapshot().describedBy,
+    fieldName: () => this.#domSnapshot().fieldName,
+  });
 
   /**
    * Computed ARIA invalid state.
@@ -241,43 +257,17 @@ export class NgxSignalFormAutoAria {
    * Links to error/warning message elements for screen readers.
    *
    * Preserves existing aria-describedby values (hints, descriptions) and
-   * appends error/warning IDs when they should be shown.
+   * appends error/warning IDs when they should be shown. Delegates to the
+   * pure `createAriaDescribedBySignal` factory; the manual-mode opt-out
+   * stays in this directive shell so the factory contract stays
+   * unconditional.
    */
   protected readonly ariaDescribedBy = computed(() => {
     if (this.#isManualAriaMode()) {
       return this.#domSnapshot().describedBy;
     }
 
-    const snapshot = this.#domSnapshot();
-    const fieldName = snapshot.fieldName;
-    if (!fieldName) return snapshot.describedBy;
-
-    const existing = snapshot.describedBy;
-    const parts: string[] = existing ? existing.split(' ').filter(Boolean) : [];
-
-    for (const hintId of this.#hintIds()) {
-      if (!parts.includes(hintId)) {
-        parts.push(hintId);
-      }
-    }
-
-    // Add error ID if showing errors
-    if (this.#shouldShowErrors()) {
-      const errorId = generateErrorId(fieldName);
-      if (!parts.includes(errorId)) {
-        parts.push(errorId);
-      }
-    }
-
-    // Add warning ID if showing warnings
-    if (this.#shouldShowWarnings()) {
-      const warningId = generateWarningId(fieldName);
-      if (!parts.includes(warningId)) {
-        parts.push(warningId);
-      }
-    }
-
-    return parts.length > 0 ? parts.join(' ') : null;
+    return this.#factoryAriaDescribedBy();
   });
 
   #haveSameIds(current: readonly string[], next: readonly string[]): boolean {

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -27,6 +27,12 @@ export {
 } from './directives/ngx-signal-form';
 
 // Utilities
+export {
+  createAriaDescribedBySignal,
+  type AriaDescribedByFieldNameReader,
+  type AriaDescribedByPreservedIdsReader,
+  type CreateAriaDescribedBySignalOptions,
+} from './utilities/aria/create-aria-described-by-signal';
 export { createAriaInvalidSignal } from './utilities/aria/create-aria-invalid-signal';
 export {
   createAriaRequiredSignal,

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.spec.ts
@@ -1,0 +1,368 @@
+import { signal, type Signal } from '@angular/core';
+import type { FieldState, ValidationError } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+import { warningError } from '../warning-error';
+import { createAriaDescribedBySignal } from './create-aria-described-by-signal';
+
+type FieldStateStub = Pick<FieldState<unknown>, 'errors'>;
+
+function fieldStateSignal(
+  errors: readonly ValidationError[] = [],
+): Signal<FieldState<unknown> | null> {
+  const stub: FieldStateStub = { errors: signal(errors) };
+  return signal(stub as FieldState<unknown>);
+}
+
+describe('createAriaDescribedBySignal', () => {
+  it('preserves non-managed IDs verbatim when no hints, errors, or warnings apply', () => {
+    const fieldState = fieldStateSignal([]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => 'email-description',
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBe('email-description');
+  });
+
+  it('returns the preserved list verbatim when no field name is resolved', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const hintIds = signal<readonly string[]>(['ignored-hint']);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => 'email-description',
+      fieldName: () => null,
+    });
+
+    expect(ariaDescribedBy()).toBe('email-description');
+  });
+
+  it('appends hint IDs after the preserved list', () => {
+    const fieldState = fieldStateSignal([]);
+    const hintIds = signal<readonly string[]>(['email-hint', 'email-hint-2']);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => 'email-description',
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBe('email-description email-hint email-hint-2');
+  });
+
+  it('appends the error ID when the field has blocking errors and visibility is true', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBe('email-error');
+  });
+
+  it('does NOT append the error ID when visibility is false even with blocking errors', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBeNull();
+  });
+
+  it('appends the warning ID when the field has warning errors and visibility is true', () => {
+    const fieldState = fieldStateSignal([warningError('weak-password')]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'password',
+    });
+
+    expect(ariaDescribedBy()).toBe('password-warning');
+  });
+
+  it('appends both error and warning IDs when both kinds are present and visible', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+      warningError('weak-password'),
+    ]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'password',
+    });
+
+    expect(ariaDescribedBy()).toBe('password-error password-warning');
+  });
+
+  it('composes preserved + hint + error + warning IDs in that order', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+      warningError('weak-password'),
+    ]);
+    const hintIds = signal<readonly string[]>(['password-hint']);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => 'password-description',
+      fieldName: () => 'password',
+    });
+
+    expect(ariaDescribedBy()).toBe(
+      'password-description password-hint password-error password-warning',
+    );
+  });
+
+  it('deduplicates IDs that already appear in the preserved list', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+      warningError('weak-password'),
+    ]);
+    const hintIds = signal<readonly string[]>(['password-hint']);
+    const visibility = signal(true);
+
+    // Consumer's preserved list already contains every managed ID — the
+    // factory must not duplicate them.
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () =>
+        'password-hint password-error password-warning password-description',
+      fieldName: () => 'password',
+    });
+
+    expect(ariaDescribedBy()).toBe(
+      'password-hint password-error password-warning password-description',
+    );
+  });
+
+  it('deduplicates duplicate hint IDs supplied by the input signal', () => {
+    const fieldState = fieldStateSignal([]);
+    const hintIds = signal<readonly string[]>(['hint-a', 'hint-a', 'hint-b']);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBe('hint-a hint-b');
+  });
+
+  it('returns null when nothing accumulates', () => {
+    const fieldState = fieldStateSignal([]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBeNull();
+  });
+
+  it('returns null when field state is null and no preserved/hint IDs accumulate', () => {
+    const fieldState = signal<FieldState<unknown> | null>(null);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBeNull();
+  });
+
+  it('still appends preserved + hint IDs when field state is null', () => {
+    const fieldState = signal<FieldState<unknown> | null>(null);
+    const hintIds = signal<readonly string[]>(['email-hint']);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => 'email-description',
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBe('email-description email-hint');
+  });
+
+  it('re-reads preservedIds across reactive updates', () => {
+    // The directive's preserved-IDs reader is backed by `#domSnapshot()`,
+    // a signal — so when the snapshot changes, the factory must pick up the
+    // fresh preserved list. Drive that with a signal-backed reader here.
+    const preserved = signal<string | null>('first-description');
+    const fieldState = fieldStateSignal([]);
+    const hintIds = signal<readonly string[]>(['email-hint']);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => preserved(),
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBe('first-description email-hint');
+
+    preserved.set('second-description');
+    expect(ariaDescribedBy()).toBe('second-description email-hint');
+
+    preserved.set(null);
+    expect(ariaDescribedBy()).toBe('email-hint');
+  });
+
+  it('reacts to hint IDs being added and removed', () => {
+    const hintIds = signal<readonly string[]>([]);
+    const fieldState = fieldStateSignal([]);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBeNull();
+
+    hintIds.set(['email-hint']);
+    expect(ariaDescribedBy()).toBe('email-hint');
+
+    hintIds.set([]);
+    expect(ariaDescribedBy()).toBeNull();
+  });
+
+  it('reacts to visibility flipping while errors are present', () => {
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(false);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBeNull();
+
+    visibility.set(true);
+    expect(ariaDescribedBy()).toBe('email-error');
+
+    visibility.set(false);
+    expect(ariaDescribedBy()).toBeNull();
+  });
+
+  it('reacts to errors changing on the bound field state', () => {
+    const errors = signal<readonly ValidationError[]>([]);
+    const stub = signal<FieldState<unknown> | null>({
+      errors,
+    } as FieldState<unknown>);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState: stub,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => 'email',
+    });
+
+    expect(ariaDescribedBy()).toBeNull();
+
+    errors.set([{ kind: 'required', message: 'Required' }]);
+    expect(ariaDescribedBy()).toBe('email-error');
+
+    errors.set([warningError('weak')]);
+    expect(ariaDescribedBy()).toBe('email-warning');
+  });
+
+  it('reacts to the field name reader changing', () => {
+    const fieldName = signal<string | null>('email');
+    const fieldState = fieldStateSignal([
+      { kind: 'required', message: 'Required' },
+    ]);
+    const hintIds = signal<readonly string[]>([]);
+    const visibility = signal(true);
+
+    const ariaDescribedBy = createAriaDescribedBySignal({
+      fieldState,
+      hintIds,
+      visibility,
+      preservedIds: () => null,
+      fieldName: () => fieldName(),
+    });
+
+    expect(ariaDescribedBy()).toBe('email-error');
+
+    fieldName.set('username');
+    expect(ariaDescribedBy()).toBe('username-error');
+
+    fieldName.set(null);
+    expect(ariaDescribedBy()).toBeNull();
+  });
+});

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
@@ -1,0 +1,143 @@
+import { computed, type Signal } from '@angular/core';
+import type { FieldState } from '@angular/forms/signals';
+import { generateErrorId, generateWarningId } from '../field-resolution';
+import { isBlockingError, isWarningError } from '../warning-error';
+
+/**
+ * Reactive reader for the resolved field name. Invoked inside the resulting
+ * computed so signal-backed readers stay tracked. Returns `null` when no
+ * field name has been resolved yet.
+ */
+export type AriaDescribedByFieldNameReader = () => string | null;
+
+/**
+ * Reader for non-managed `aria-describedby` IDs that should be preserved
+ * verbatim (hints stamped by template, descriptions, etc.). Called per
+ * computed evaluation so consumers re-evaluating their preserved list see
+ * fresh values without re-creating the factory.
+ */
+export type AriaDescribedByPreservedIdsReader = () => string | null;
+
+/**
+ * Inputs for {@link createAriaDescribedBySignal}.
+ *
+ * `fieldState`, `hintIds`, and `visibility` are signals so the resulting
+ * `aria-describedby` value tracks each of them reactively. `preservedIds`
+ * and `fieldName` are plain readers so consumers can thread DOM reads or
+ * service queries through without forcing them into a `Signal` shape.
+ */
+export interface CreateAriaDescribedBySignalOptions {
+  /**
+   * The bound `FieldState` (or `null` when no field is bound yet).
+   * Drives error/warning detection on the same source of truth as the
+   * sibling factories (`createAriaInvalidSignal`, `createAriaRequiredSignal`).
+   */
+  readonly fieldState: Signal<FieldState<unknown> | null>;
+
+  /**
+   * Hint IDs to append after the preserved list. Typically comes from
+   * {@link createHintIdsSignal} but can be any signal of strings.
+   */
+  readonly hintIds: Signal<readonly string[]>;
+
+  /**
+   * Visibility computed (typically from `createErrorVisibility`). When
+   * `true`, error/warning IDs are appended whenever the field has matching
+   * errors. When `false`, no error or warning IDs are appended even if the
+   * field is invalid.
+   */
+  readonly visibility: Signal<boolean>;
+
+  /**
+   * Reader for non-managed IDs (e.g. existing hint IDs stamped into the
+   * DOM by the template, or description IDs the wrapper has registered).
+   * Called per computed evaluation; consumers re-evaluating their preserved
+   * list see fresh values automatically.
+   */
+  readonly preservedIds: AriaDescribedByPreservedIdsReader;
+
+  /**
+   * Reader for the resolved field name. Without a field name no managed
+   * error / warning IDs can be generated, so the factory falls back to
+   * returning the preserved list verbatim.
+   */
+  readonly fieldName: AriaDescribedByFieldNameReader;
+}
+
+/**
+ * Pure-signal factory that composes the `aria-describedby` attribute value
+ * for a Signal Forms control.
+ *
+ * Mirrors the resolution previously inlined in
+ * `NgxSignalFormAutoAria.ariaDescribedBy`:
+ *
+ * 1. Read the preserved (non-managed) ID list — these are IDs the toolkit
+ *    does not own (template-stamped hints, descriptions, etc.).
+ * 2. Append every hint ID from the supplied `hintIds` signal that is not
+ *    already preserved. Hints are managed by the toolkit, but consumers
+ *    may still preserve them when re-binding.
+ * 3. When `visibility()` is `true` AND the field has at least one blocking
+ *    error, append `generateErrorId(fieldName)`.
+ * 4. When `visibility()` is `true` AND the field has at least one warning
+ *    error, append `generateWarningId(fieldName)`.
+ * 5. Deduplicate while preserving insertion order.
+ * 6. Return the joined list, or `null` when nothing accumulated, so
+ *    consumers can drop the attribute entirely.
+ *
+ * The factory is unconditional and contains no DI: the manual-mode opt-out
+ * lives in the directive shell that wires this factory, not here. That
+ * keeps the contract clean and the factory reusable from any composition
+ * surface (custom wrappers built on Material, PrimeNG, Spartan, etc.).
+ *
+ * @public
+ */
+export function createAriaDescribedBySignal(
+  options: CreateAriaDescribedBySignalOptions,
+): Signal<string | null> {
+  const { fieldState, hintIds, visibility, preservedIds, fieldName } = options;
+
+  return computed((): string | null => {
+    const resolvedFieldName = fieldName();
+    const preserved = preservedIds();
+
+    // Without a field name no managed IDs can be generated. Mirror the
+    // directive's historical behaviour and return the preserved list
+    // verbatim so existing aria-describedby values remain intact.
+    if (!resolvedFieldName) {
+      return preserved;
+    }
+
+    const parts: string[] = preserved
+      ? preserved.split(' ').filter(Boolean)
+      : [];
+
+    for (const hintId of hintIds()) {
+      if (!parts.includes(hintId)) {
+        parts.push(hintId);
+      }
+    }
+
+    const state = fieldState();
+    const isVisible = visibility();
+
+    if (state && isVisible) {
+      const errors = state.errors();
+
+      if (errors.some(isBlockingError)) {
+        const errorId = generateErrorId(resolvedFieldName);
+        if (!parts.includes(errorId)) {
+          parts.push(errorId);
+        }
+      }
+
+      if (errors.some(isWarningError)) {
+        const warningId = generateWarningId(resolvedFieldName);
+        if (!parts.includes(warningId)) {
+          parts.push(warningId);
+        }
+      }
+    }
+
+    return parts.length > 0 ? parts.join(' ') : null;
+  });
+}

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -56,10 +56,14 @@ export {
 // (`NgxSignalFormAutoAria`) and the headless re-export in lockstep without
 // duplicating implementation or forming a cycle through this barrel.
 export {
+  createAriaDescribedBySignal,
   createAriaInvalidSignal,
   createAriaRequiredSignal,
   createHintIdsSignal,
+  type AriaDescribedByFieldNameReader,
+  type AriaDescribedByPreservedIdsReader,
   type AriaRequiredFieldState,
+  type CreateAriaDescribedBySignalOptions,
   type CreateHintIdsSignalOptions,
   type HintIdsFieldNameReader,
   type HintIdsIdentityLike,


### PR DESCRIPTION
## Summary

Final tracer-bullet slice of #38 (Auto-ARIA composition refactor). Extracts `aria-describedby` composition out of `NgxSignalFormAutoAria` into a pure signal factory so wrapper authors composing on top of Material, PrimeNG, Spartan, etc. can reuse the toolkit's `aria-describedby` resolution without inheriting the directive shell.

`createAriaDescribedBySignal({ fieldState, hintIds, visibility, preservedIds, fieldName })` returns `Signal<string | null>` that:

- Preserves non-managed IDs from the `preservedIds` reader (called per evaluation so consumers re-evaluating their preserved list see fresh values without re-creating the factory).
- Appends every ID from the `hintIds` signal that is not already preserved (deduplicates).
- Appends `generateErrorId(fieldName)` when `visibility()` is `true` and the field has at least one blocking error.
- Appends `generateWarningId(fieldName)` when `visibility()` is `true` and the field has at least one warning.
- Deduplicates while preserving insertion order.
- Returns `null` when nothing accumulates so consumers can drop the attribute entirely.

`NgxSignalFormAutoAria.ariaDescribedBy` now delegates to the factory; the manual-mode opt-out stays in the directive shell so the factory contract stays "fieldState in -> ARIA out" with no DI of its own. The directive's phased `afterEveryRender` flow (`earlyRead` -> `write`) is unchanged — the factory is a drop-in replacement for the inlined computed body.

The factory source lives in `packages/toolkit/core/utilities/aria/` (alongside `createHintIdsSignal`, `createAriaInvalidSignal`, `createAriaRequiredSignal`) to avoid the runtime module-graph cycle that placing the source under `/headless/` caused for the sibling slices, and is re-exported from `@ngx-signal-forms/toolkit/headless` (and the root barrel) per PRD #38's public-surface contract.

## Stacked PR note

This PR is **stacked on #51** (`feat/issue-41-create-hint-ids-signal`). The branch was based off `origin/feat/issue-41-create-hint-ids-signal` because this slice consumes `createHintIdsSignal` from PR #51, which is not yet on `main`. The diff will look clean once #51 merges. If conflicts surface after #51 merges, a quick rebase against `main` will resolve them.

## Acceptance criteria

- [x] `createAriaDescribedBySignal(...)` exists in `packages/toolkit` and is exported from the headless barrel
- [x] Unit spec covers: preserves non-managed IDs, appends hint IDs, appends error ID when visible, appends warning ID when visible, deduplicates, returns null when no IDs accumulate, `preservedIdsReader` re-read across reactive updates
- [x] `preservedIdsReader` is called per render so consumers re-evaluating non-managed IDs see fresh values
- [x] `NgxSignalFormAutoAria.ariaDescribedBy` computed delegates to the factory; manual-mode opt-out stays in the directive shell
- [x] Existing auto-aria specs pass unchanged (jsdom + browser, including the phased `afterEveryRender` flow and the first-render preservation note)
- [x] `pnpm nx test toolkit` green (1015 tests)
- [x] `pnpm nx build toolkit` green (all secondary entry points)

## Test plan

- [x] `pnpm nx test toolkit` — 1015/1015 passing including 18 new specs for `createAriaDescribedBySignal`
- [x] `pnpm nx test-browser toolkit` — 16/16 passing (the pre-existing `fieldState.errors is not a function` stderr in the visibility test is unrelated and exists on `main`)
- [x] `pnpm nx build toolkit` — all 7 entry points built (root, core, headless, assistive, debugger, form-field, vest)
- [x] `pnpm nx lint toolkit` — 0 errors (334 warnings, all pre-existing style + the same kind of style warnings already present on the sibling factory files)
- [x] `pnpm format` — clean (oxfmt via `workspace:format`)

Closes #46
Refs #38

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a reusable ARIA describedby signal factory for form field accessibility, enabling developers to dynamically compose aria-describedby attributes with support for preserved IDs, hint IDs, error states, and visibility conditions.
  * Exported new public API surface with associated types for ARIA describedby signal creation.

* **Tests**
  * Added comprehensive test coverage for ARIA describedby signal generation, including edge cases for ID deduplication, reactive updates, and conditional error/warning visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->