### PR TITLE
fix(toolkit): apply missed post-merge review follow-ups

### DIFF
--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -22,8 +22,9 @@ in `@spartan-ng/ui`, then come back through `nx g @spartan-ng/cli:ui …`.
 
 ## Consumed in-tree only
 
-This library is not built or published. Apps consume it through the
-`@spartan-ng/helm/*` tsconfig path aliases declared in
+This library is not consumed from built or published artifacts in this
+repo. Apps consume it through the `@spartan-ng/helm/*` tsconfig path
+aliases declared in
 `tsconfig.base.json`, which point directly at each secondary
 entrypoint's `src/index.ts`. The build target, `package.json`
 peerDependencies, and `ng-package.json` files are leftover Spartan-CLI

--- a/packages/toolkit/core/utilities/wrapper-helpers.ts
+++ b/packages/toolkit/core/utilities/wrapper-helpers.ts
@@ -98,9 +98,13 @@ export function createErrorRendererInputs<TValue>(
   options: CreateErrorRendererInputsOptions<TValue>,
 ): Signal<Record<string, unknown>> {
   const { formField, strategy, submittedStatus } = options;
-  return computed<Record<string, unknown>>(() => ({
-    formField: formField(),
-    strategy: strategy(),
-    submittedStatus: submittedStatus(),
-  }));
+  return computed<Record<string, unknown>>(() => {
+    const inputs = {
+      formField: formField(),
+      strategy: strategy(),
+      submittedStatus: submittedStatus(),
+    } satisfies NgxFormFieldErrorRendererInputs<TValue>;
+
+    return inputs;
+  });
 }


### PR DESCRIPTION
## Summary

Apply two review-driven follow-ups that were made locally after PR #57 was already merged, but never landed on main.

### Included changes

- enforce NgxFormFieldErrorRendererInputs<TValue> at compile time in createErrorRendererInputs()
- clarify that ui-helm is consumed in-tree via tsconfig path aliases rather than built or published artifacts in this repo

## Why this PR exists

PR #57 merged successfully, but these two accepted review fixes were committed locally afterward and therefore missed the merged branch. This follow-up ports them cleanly onto main without changing runtime behavior.

## Verification

- editor/type checks for the touched files are clean

Refs #48
Refs #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation on how the UI library is consumed from built artifacts.

* **Refactor**
  * Improved internal type handling with no impact to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->