### PR TITLE
feat(headless): createErrorMessageSignal reactive error-message resolution

### DIFF
--- a/.github/instructions/ngx-signal-forms-toolkit.instructions.md
+++ b/.github/instructions/ngx-signal-forms-toolkit.instructions.md
@@ -206,7 +206,8 @@ Current public exports, grouped by category:
 **ARIA & ID generation:**
 
 - `buildAriaDescribedBy()`
-- `generateErrorId()` / `generateWarningId()` / `createUniqueId()`
+- `generateErrorId(fieldName, kind?)` — `{fieldName}-error` (container form, no `kind`) or `{fieldName}-error-{kind}` (per-error form). Per-error IDs are produced by `createErrorMessageSignal()` so external renderers and the in-tree wrapper interoperate on `aria-describedby` chains.
+- `generateWarningId()` / `createUniqueId()`
 
 **Message resolution:**
 
@@ -538,6 +539,7 @@ Public directives and helpers include:
 
 **Factory functions:**
 
+- `createErrorMessageSignal(field, options?)` — `Signal<readonly ResolvedFieldError[]>` combining the visibility cascade, 3-tier message resolution (validator `message` → `NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs (`{fieldName}-error-{kind}`). Auto-injects `NGX_ERROR_MESSAGES` unless `errorMessages` is supplied. Options: `includeWarnings` (`false` | `true` | `'only'`), `stripWarningPrefix` (default `true`), `strategy`, `submittedStatus`, `fieldName`, `errorMessages`, `injector`.
 - `createErrorState()` / `createCharacterCount()` / `createFieldStateFlags()`
 - `createUniqueId()`
 

--- a/.github/instructions/ngx-signal-forms-toolkit.instructions.md
+++ b/.github/instructions/ngx-signal-forms-toolkit.instructions.md
@@ -539,7 +539,7 @@ Public directives and helpers include:
 
 **Factory functions:**
 
-- `createErrorMessageSignal(field, options?)` — `Signal<readonly ResolvedFieldError[]>` combining the visibility cascade, 3-tier message resolution (validator `message` → `NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs (`{fieldName}-error-{kind}`). Auto-injects `NGX_ERROR_MESSAGES` unless `errorMessages` is supplied. Options: `includeWarnings` (`false` | `true` | `'only'`), `stripWarningPrefix` (default `true`), `strategy`, `submittedStatus`, `fieldName`, `errorMessages`, `injector`.
+- `createErrorMessageSignal(field, options?)` — `Signal<readonly ResolvedFieldError[]>` combining the visibility cascade, 3-tier message resolution (validator `message` → `NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs (`{fieldName}-error-{kind}`). Each entry is `{ kind, message, id, error }` — `kind`/`message`/`id` are flattened for template ergonomics, `error` is the raw `ValidationError` for consumers that need validator params. Auto-injects `NGX_ERROR_MESSAGES` unless `errorMessages` is supplied. Options: `includeWarnings` (`false` | `true` | `'only'`), `stripWarningPrefix` (default `true`), `strategy`, `submittedStatus`, `fieldName`, `errorMessages`, `injector`.
 - `createErrorState()` / `createCharacterCount()` / `createFieldStateFlags()`
 - `createUniqueId()`
 

--- a/.github/skills/ngx-signal-forms/headless/SKILL.md
+++ b/.github/skills/ngx-signal-forms/headless/SKILL.md
@@ -207,7 +207,11 @@ const resolved = createErrorMessageSignal(() => form.email(), {
   // includeWarnings: true | 'only' (default: false)
   // strategy / submittedStatus inherit from form context when omitted
 });
-// resolved() => readonly { error, message, id }[]
+// resolved() => readonly { kind, message, id, error }[]
+//   kind:    validator kind (lifted from error.kind for template ergonomics)
+//   message: resolved display string
+//   id:      `{fieldName}-error-{kind}` — stable for aria-describedby chains
+//   error:   raw ValidationError, for params/custom inspection
 ```
 
 ## Utility Functions

--- a/.github/skills/ngx-signal-forms/headless/SKILL.md
+++ b/.github/skills/ngx-signal-forms/headless/SKILL.md
@@ -183,6 +183,7 @@ with `NgxFormFieldError`, the wrapper, and other toolkit consumers). Prefer
 
 ```typescript
 import {
+  createErrorMessageSignal,
   createErrorState,
   createCharacterCount,
   createFieldStateFlags,
@@ -196,6 +197,17 @@ const state = createErrorState({
 });
 const count = createCharacterCount({ field: form.bio }); // maxLength auto-detected from validator
 const flags = createFieldStateFlags(() => form.email()); // boolean signal flags
+
+// Reactive resolved errors: visibility cascade + 3-tier message resolution
+// + stable per-error DOM IDs ({fieldName}-error-{kind}). Use this in custom
+// renderers that mount via `*ngComponentOutlet` or any component that wants
+// the directive's resolution logic without the directive itself.
+const resolved = createErrorMessageSignal(() => form.email(), {
+  fieldName: 'email',
+  // includeWarnings: true | 'only' (default: false)
+  // strategy / submittedStatus inherit from form context when omitted
+});
+// resolved() => readonly { error, message, id }[]
 ```
 
 ## Utility Functions

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ every bit of markup and styling.
 Key exports: `NgxHeadlessToolkit`, `NgxHeadlessErrorState`, `NgxHeadlessErrorSummary`,
 `NgxHeadlessNotification`, `NgxHeadlessCharacterCount`, `NgxHeadlessFieldset`,
 `NgxHeadlessFieldName`,
-`createErrorState()`, `createCharacterCount()`, `createFieldStateFlags()`,
-`readErrors()`, `dedupeValidationErrors()`.
+`createErrorMessageSignal()`, `createErrorState()`, `createCharacterCount()`,
+`createFieldStateFlags()`, `readErrors()`, `dedupeValidationErrors()`.
 
 **[→ Headless docs](./packages/toolkit/headless/README.md)** ·
 **Demo:** [`fieldset-utilities` (code)](./apps/demo/src/app/03-headless/fieldset-utilities) · [live](https://ngx-signal-forms.github.io/ngx-signal-forms/headless/fieldset-utilities/)

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -37,6 +37,7 @@ releases will not include any of the renames below.
 - **New: `NgxFormField` bundle** — convenience import array of wrapper + assistive parts + auto-ARIA directive
 - **New: fieldset toggle** — `includeNestedErrors` on fieldset; `submittedStatus` override input
 - **New: error component APIs** — `errors`, `listStyle`, `submittedStatus` inputs on `NgxFormFieldError`
+- **New: headless message resolution** — `createErrorMessageSignal()` combines visibility, the 3-tier message cascade, and stable per-error IDs for custom error renderers
 - **New: Vest options** — `only` selector, `resetOnDestroy`, `VEST_*_KIND_PREFIX` exports
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
@@ -486,6 +487,33 @@ usage patterns.
   the split between blocking errors and warnings, so
   `canSubmitWithWarnings()` lets a form submit while soft warnings
   remain visible. See [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md).
+
+### Headless error-message resolution — `createErrorMessageSignal()`
+
+`@ngx-signal-forms/toolkit/headless` now exports a `createErrorMessageSignal(field, options?)`
+primitive that returns a `Signal<readonly ResolvedFieldError[]>` combining the visibility
+cascade (`createErrorVisibility`), the 3-tier message cascade (validator `message` →
+`NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs
+(`{fieldName}-error-{kind}` via `generateErrorId`). Each entry is `{ kind, message, id, error }`
+— `kind`/`message`/`id` lifted to the top level for template ergonomics, with the raw
+`ValidationError` retained on `.error` for consumers that need validator params.
+
+Use it when you want the directive's resolution logic without the directive itself — for
+example inside a custom error renderer driven via `*ngComponentOutlet` or any component
+reading errors directly off a `FieldTree`. The in-tree `NgxFormFieldError` now consumes
+this primitive, so external renderers and the wrapper share one resolution path.
+
+```ts
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
+
+readonly resolvedErrors = createErrorMessageSignal(() => this.field()(), {
+  fieldName: 'email',
+  // includeWarnings: false (default) | true | 'only'
+});
+```
+
+See [`packages/toolkit/headless/README.md`](../packages/toolkit/headless/README.md#createerrormessagesignal)
+for full options and worked examples.
 
 ### `/debugger` entry point
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -270,15 +270,15 @@ provideFieldLabels(() => {
 
 ### ARIA and identity
 
-| Function                                        | Description                                                                                |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `buildAriaDescribedBy(fieldName, options)`      | Assemble `aria-describedby` for manual ARIA controls                                       |
-| `normalizeFieldName(value)`                     | Trim and null-collapse a candidate name into the v1 identity form                          |
-| `resolveFieldName(element)`                     | Read a usable field name from an element's `id` (trimmed, with `element.id` fallback)      |
-| `resolveFieldNameFromCandidates(...candidates)` | Pick the first non-blank field name from a precedence chain (explicit → host id → context) |
-| `generateErrorId(fieldName)`                    | Derive the `{fieldName}-error` element id used for `aria-describedby`                      |
-| `generateWarningId(fieldName)`                  | Derive the `{fieldName}-warning` element id used for `aria-describedby`                    |
-| `injectFormContext()`                           | Get `ngxSignalForm` context or `undefined`                                                 |
+| Function                                        | Description                                                                                 |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `buildAriaDescribedBy(fieldName, options)`      | Assemble `aria-describedby` for manual ARIA controls                                        |
+| `normalizeFieldName(value)`                     | Trim and null-collapse a candidate name into the v1 identity form                           |
+| `resolveFieldName(element)`                     | Read a usable field name from an element's `id` (trimmed, with `element.id` fallback)       |
+| `resolveFieldNameFromCandidates(...candidates)` | Pick the first non-blank field name from a precedence chain (explicit → host id → context)  |
+| `generateErrorId(fieldName, kind?)`             | Derive `{fieldName}-error` (container) or `{fieldName}-error-{kind}` (per-error) element id |
+| `generateWarningId(fieldName)`                  | Derive the `{fieldName}-warning` element id used for `aria-describedby`                     |
+| `injectFormContext()`                           | Get `ngxSignalForm` context or `undefined`                                                  |
 
 ### Other
 

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -830,6 +830,50 @@ describe('NgxFormFieldError', () => {
       expect(alert).toBeFalsy();
     });
 
+    // Regression: when both `[formField]` and `[errors]` are bound, the
+    // headless directive's `showErrors` short-circuits to override mode, but
+    // the resolved-errors accessor used to read `formField` first — so the
+    // alert container could go visible while `resolvedErrors()` resolved
+    // messages from the field's own errors instead of the override list.
+    // Fixed by inverting the order: override wins, formField is the fallback.
+    it('should prefer errorsOverride over formField when both are bound', async () => {
+      @Component({
+        selector: 'ngx-test-override-precedence',
+        imports: [FormField, NgxFormFieldError],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <input id="email" [formField]="contactForm.email" />
+          <ngx-form-field-error
+            [formField]="contactForm.email"
+            fieldName="email"
+            strategy="immediate"
+            [errors]="overrideErrors"
+          />
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email, { message: 'From field validator' });
+          }),
+        );
+        readonly overrideErrors = signal([
+          { kind: 'override', message: 'From override input' },
+        ]);
+      }
+
+      const { container } = await render(TestComponent);
+
+      const messages = container.querySelectorAll(
+        '.ngx-form-field-error__message',
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0].textContent).toContain('From override input');
+      expect(messages[0].textContent).not.toContain('From field validator');
+    });
+
     // Regression: createErrorMessageSignal pinned the directive's `strategy`
     // input even in `errorsOverride` mode. With `strategy="on-submit"` and no
     // submitted status, the headless directive's own `showErrors()` would

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -829,6 +829,42 @@ describe('NgxFormFieldError', () => {
       const alert = screen.queryByRole('alert');
       expect(alert).toBeFalsy();
     });
+
+    // Regression: createErrorMessageSignal pinned the directive's `strategy`
+    // input even in `errorsOverride` mode. With `strategy="on-submit"` and no
+    // submitted status, the headless directive's own `showErrors()` would
+    // bypass the strategy gate (override-mode short-circuit) and the
+    // error container would become visible — but the primitive's visibility
+    // cascade would still suppress message resolution, leaving an empty live
+    // region. Fixed by switching the primitive's strategy to `'immediate'`
+    // when `errorsOverride` is bound.
+    it('should resolve override errors under on-submit strategy without a submitted status', async () => {
+      @Component({
+        selector: 'ngx-test-override-on-submit-regression',
+        imports: [NgxFormFieldError],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <ngx-form-field-error
+            fieldName="address"
+            strategy="on-submit"
+            [errors]="errors"
+          />
+        `,
+      })
+      class TestComponent {
+        readonly errors = signal([
+          { kind: 'required', message: 'Street is required' },
+        ]);
+      }
+
+      const { container } = await render(TestComponent);
+
+      const messages = container.querySelectorAll(
+        '.ngx-form-field-error__message',
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0].textContent).toContain('Street is required');
+    });
   });
 
   describe('fieldName resolution from DI context', () => {

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -138,7 +138,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
           <ul class="ngx-form-field-error__list" role="list">
             @for (
               error of resolvedErrors();
-              track error.error.kind + ':' + error.message + ':' + $index
+              track \`\${error.kind}:\${error.message}:\${$index}\`
             ) {
               <li
                 class="ngx-form-field-error__message ngx-form-field-error__message--error"
@@ -150,7 +150,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
         } @else {
           @for (
             error of resolvedErrors();
-            track error.error.kind + ':' + error.message + ':' + $index
+            track \`\${error.kind}:\${error.message}:\${$index}\`
           ) {
             <p
               class="ngx-form-field-error__message ngx-form-field-error__message--error"
@@ -181,7 +181,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
           <ul class="ngx-form-field-error__list" role="list">
             @for (
               warning of resolvedWarnings();
-              track warning.error.kind + ':' + warning.message + ':' + $index
+              track \`\${warning.kind}:\${warning.message}:\${$index}\`
             ) {
               <li
                 class="ngx-form-field-error__message ngx-form-field-error__message--warning"
@@ -193,7 +193,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
         } @else {
           @for (
             warning of resolvedWarnings();
-            track warning.error.kind + ':' + warning.message + ':' + $index
+            track \`\${warning.kind}:\${warning.message}:\${$index}\`
           ) {
             <p
               class="ngx-form-field-error__message ngx-form-field-error__message--warning"

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -149,8 +149,8 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
           </ul>
         } @else {
           @for (
-            error of headless.resolvedErrors();
-            track error.kind + ':' + error.message + ':' + $index
+            error of resolvedErrors();
+            track error.error.kind + ':' + error.message + ':' + $index
           ) {
             <p
               class="ngx-form-field-error__message ngx-form-field-error__message--error"
@@ -192,8 +192,8 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
           </ul>
         } @else {
           @for (
-            warning of headless.resolvedWarnings();
-            track warning.kind + ':' + warning.message + ':' + $index
+            warning of resolvedWarnings();
+            track warning.error.kind + ':' + warning.message + ':' + $index
           ) {
             <p
               class="ngx-form-field-error__message ngx-form-field-error__message--warning"
@@ -394,6 +394,22 @@ export class NgxFormFieldError {
   // private field at evaluation time without tripping a forward-reference.
 
   /**
+   * Strategy passed to the resolved-errors primitive. Mirrors the headless
+   * directive's own override-mode short-circuit: when `errorsOverride` is
+   * bound the caller has already aggregated and gated the error list
+   * upstream, so the primitive's visibility cascade must bypass strategy
+   * (otherwise an `'on-submit'` strategy with no submitted status would
+   * leave `resolvedErrors()` empty while `errorContainerVisible` is true,
+   * rendering an empty live region).
+   */
+  readonly #resolvedErrorsStrategy = computed<ErrorDisplayStrategy | undefined>(
+    () =>
+      this.headless.errorsOverride() !== undefined
+        ? 'immediate'
+        : this.headless.strategy(),
+  );
+
+  /**
    * Blocking errors, resolved through the public {@link createErrorMessageSignal}
    * primitive. The strategy and submitted-status inputs are forwarded so the
    * primitive's visibility cascade matches the directive's `showErrors` —
@@ -403,7 +419,7 @@ export class NgxFormFieldError {
   protected readonly resolvedErrors = createErrorMessageSignal(
     this.#fieldStateAccessor,
     {
-      strategy: this.headless.strategy,
+      strategy: this.#resolvedErrorsStrategy,
       submittedStatus: this.headless.submittedStatus,
       fieldName: computed(() => this.#resolvedFieldName()),
     },

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -138,7 +138,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
           <ul class="ngx-form-field-error__list" role="list">
             @for (
               error of resolvedErrors();
-              track \`\${error.kind}:\${error.message}:\${$index}\`
+              track \`\${error.kind}:\${$index}\`
             ) {
               <li
                 class="ngx-form-field-error__message ngx-form-field-error__message--error"
@@ -150,7 +150,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
         } @else {
           @for (
             error of resolvedErrors();
-            track \`\${error.kind}:\${error.message}:\${$index}\`
+            track \`\${error.kind}:\${$index}\`
           ) {
             <p
               class="ngx-form-field-error__message ngx-form-field-error__message--error"
@@ -181,7 +181,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
           <ul class="ngx-form-field-error__list" role="list">
             @for (
               warning of resolvedWarnings();
-              track \`\${warning.kind}:\${warning.message}:\${$index}\`
+              track \`\${warning.kind}:\${$index}\`
             ) {
               <li
                 class="ngx-form-field-error__message ngx-form-field-error__message--warning"
@@ -193,7 +193,7 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
         } @else {
           @for (
             warning of resolvedWarnings();
-            track \`\${warning.kind}:\${warning.message}:\${$index}\`
+            track \`\${warning.kind}:\${$index}\`
           ) {
             <p
               class="ngx-form-field-error__message ngx-form-field-error__message--warning"

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -6,7 +6,7 @@ import {
   input,
   isDevMode,
 } from '@angular/core';
-import type { FieldTree } from '@angular/forms/signals';
+import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   injectFormContext,
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
@@ -19,7 +19,10 @@ import {
   createFieldMessageIdSignals,
   resolveFieldNameFromCandidates,
 } from '@ngx-signal-forms/toolkit/core';
-import { NgxHeadlessErrorState } from '@ngx-signal-forms/toolkit/headless';
+import {
+  createErrorMessageSignal,
+  NgxHeadlessErrorState,
+} from '@ngx-signal-forms/toolkit/headless';
 
 export type NgxFormFieldListStyle = 'plain' | 'bullets';
 
@@ -134,8 +137,8 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
         @if (usesBulletList()) {
           <ul class="ngx-form-field-error__list" role="list">
             @for (
-              error of headless.resolvedErrors();
-              track error.kind + ':' + error.message + ':' + $index
+              error of resolvedErrors();
+              track error.error.kind + ':' + error.message + ':' + $index
             ) {
               <li
                 class="ngx-form-field-error__message ngx-form-field-error__message--error"
@@ -177,8 +180,8 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
         @if (usesBulletList()) {
           <ul class="ngx-form-field-error__list" role="list">
             @for (
-              warning of headless.resolvedWarnings();
-              track warning.kind + ':' + warning.message + ':' + $index
+              warning of resolvedWarnings();
+              track warning.error.kind + ':' + warning.message + ':' + $index
             ) {
               <li
                 class="ngx-form-field-error__message ngx-form-field-error__message--warning"
@@ -278,6 +281,32 @@ export class NgxFormFieldError {
     this.headless.connectFieldState(computed(() => this.formField()?.()));
   }
 
+  /**
+   * Reactive accessor to the underlying field state, derived from the same
+   * `[formField]` input the headless directive consumes. Used to drive the
+   * `createErrorMessageSignal()` calls below so the in-tree wrapper and any
+   * external headless consumer share one resolution code path.
+   *
+   * In direct-errors mode (the host binds `[errors]`/`errorsOverride`),
+   * synthesise a minimal field-state shape from the override signal so the
+   * primitive's `createErrorVisibility` cascade still short-circuits to
+   * "visible" (matching the headless directive's own override-mode
+   * short-circuit) and `readDirectErrors` finds the override entries.
+   */
+  readonly #fieldStateAccessor = computed(() => {
+    const fieldState = this.formField()?.();
+    if (fieldState !== undefined) return fieldState;
+    const override = this.headless.errorsOverride()?.();
+    if (override === undefined) return undefined;
+    // Synthesised field-state surface: only the three accessors the primitive
+    // reads (`errors`, `invalid`, `touched`).
+    return {
+      errors: (): readonly ValidationError[] => override,
+      invalid: (): boolean => override.length > 0,
+      touched: (): boolean => true,
+    };
+  });
+
   // ── Field name / ID resolution ────────────────────────────────────────
   readonly #resolvedFieldName = computed<string | null>(() => {
     const resolvedFieldName = resolveFieldNameFromCandidates(
@@ -357,5 +386,43 @@ export class NgxFormFieldError {
    */
   protected readonly warningContainerVisible = computed(
     () => this.showWarnings() && this.headless.hasWarnings(),
+  );
+
+  // ── Resolved messages (delegate to the public createErrorMessageSignal) ──
+  // Keep these field initializers AFTER `#resolvedFieldName` so that the
+  // arrow-bodied `fieldName` accessor passed to the primitive can read the
+  // private field at evaluation time without tripping a forward-reference.
+
+  /**
+   * Blocking errors, resolved through the public {@link createErrorMessageSignal}
+   * primitive. The strategy and submitted-status inputs are forwarded so the
+   * primitive's visibility cascade matches the directive's `showErrors` —
+   * `errorContainerVisible` still gates rendering, so an empty list during
+   * hidden states is a no-op.
+   */
+  protected readonly resolvedErrors = createErrorMessageSignal(
+    this.#fieldStateAccessor,
+    {
+      strategy: this.headless.strategy,
+      submittedStatus: this.headless.submittedStatus,
+      fieldName: computed(() => this.#resolvedFieldName()),
+    },
+  );
+
+  /**
+   * Warnings, resolved through {@link createErrorMessageSignal} with
+   * `includeWarnings: 'only'`. Warnings use their own immediate-by-default
+   * visibility — the wrapper's `warningContainerVisible` gates rendering,
+   * and the primitive call uses `'immediate'` so warnings are always
+   * resolved when the field is invalid (the warning kinds themselves cause
+   * `field.invalid()` to be true upstream).
+   */
+  protected readonly resolvedWarnings = createErrorMessageSignal(
+    this.#fieldStateAccessor,
+    {
+      strategy: 'immediate',
+      includeWarnings: 'only',
+      fieldName: computed(() => this.#resolvedFieldName()),
+    },
   );
 }

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -287,24 +287,28 @@ export class NgxFormFieldError {
    * `createErrorMessageSignal()` calls below so the in-tree wrapper and any
    * external headless consumer share one resolution code path.
    *
-   * In direct-errors mode (the host binds `[errors]`/`errorsOverride`),
-   * synthesise a minimal field-state shape from the override signal so the
-   * primitive's `createErrorVisibility` cascade still short-circuits to
-   * "visible" (matching the headless directive's own override-mode
-   * short-circuit) and `readDirectErrors` finds the override entries.
+   * Override precedence matches `NgxHeadlessErrorState.showErrors`: when the
+   * host binds `[errors]`/`errorsOverride`, synthesise a minimal field-state
+   * shape from the override signal so the primitive's `createErrorVisibility`
+   * cascade short-circuits to "visible" and `readDirectErrors` finds the
+   * override entries. Only when no override is supplied do we fall through
+   * to the `[formField]` input. Reversing this order would let the alert
+   * container go visible (driven by `headless.showErrors`, which checks
+   * `errorsOverride` first) while `resolvedErrors()` read messages from
+   * `formField` instead.
    */
   readonly #fieldStateAccessor = computed(() => {
-    const fieldState = this.formField()?.();
-    if (fieldState !== undefined) return fieldState;
     const override = this.headless.errorsOverride()?.();
-    if (override === undefined) return undefined;
-    // Synthesised field-state surface: only the three accessors the primitive
-    // reads (`errors`, `invalid`, `touched`).
-    return {
-      errors: (): readonly ValidationError[] => override,
-      invalid: (): boolean => override.length > 0,
-      touched: (): boolean => true,
-    };
+    if (override !== undefined) {
+      // Synthesised field-state surface: only the three accessors the primitive
+      // reads (`errors`, `invalid`, `touched`).
+      return {
+        errors: (): readonly ValidationError[] => override,
+        invalid: (): boolean => override.length > 0,
+        touched: (): boolean => true,
+      };
+    }
+    return this.formField()?.();
   });
 
   // ── Field name / ID resolution ────────────────────────────────────────

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -427,11 +427,14 @@ export class NgxFormFieldError {
 
   /**
    * Warnings, resolved through {@link createErrorMessageSignal} with
-   * `includeWarnings: 'only'`. Warnings use their own immediate-by-default
-   * visibility — the wrapper's `warningContainerVisible` gates rendering,
-   * and the primitive call uses `'immediate'` so warnings are always
-   * resolved when the field is invalid (the warning kinds themselves cause
-   * `field.invalid()` to be true upstream).
+   * `includeWarnings: 'only'`. The primitive call pins `strategy: 'immediate'`
+   * unconditionally — warnings are informational and never gated by the
+   * blocking-error strategy, so the override-mode bypass that
+   * `#resolvedErrorsStrategy` performs for blocking errors is unnecessary
+   * here. `warningContainerVisible` (driven by `showWarnings`, which uses
+   * the warning-specific strategy cascade) controls rendering, and the
+   * primitive's immediate cascade ensures `resolvedWarnings()` is non-empty
+   * whenever warning kinds are present.
    */
   protected readonly resolvedWarnings = createErrorMessageSignal(
     this.#fieldStateAccessor,

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -51,6 +51,7 @@ export {
   type HintIdsRegistryLike,
   type HintIdsSignal,
 } from './utilities/aria/create-hint-ids-signal';
+export { assertInjector } from './utilities/assert-injector';
 export * from './utilities/cascading-resolver';
 export * from './utilities/create-error-visibility';
 export {

--- a/packages/toolkit/core/utilities/field-resolution.spec.ts
+++ b/packages/toolkit/core/utilities/field-resolution.spec.ts
@@ -77,6 +77,30 @@ describe('field-resolution', () => {
     it('should generate error ID for array field', () => {
       expect(generateErrorId('items[0].name')).toBe('items[0].name-error');
     });
+
+    it('should append kind suffix when supplied', () => {
+      expect(generateErrorId('email', 'required')).toBe('email-error-required');
+    });
+
+    it('should append kind suffix for nested field paths', () => {
+      expect(generateErrorId('address.city', 'minLength')).toBe(
+        'address.city-error-minLength',
+      );
+    });
+
+    it('should append kind suffix for array fields', () => {
+      expect(generateErrorId('items[0].name', 'required')).toBe(
+        'items[0].name-error-required',
+      );
+    });
+
+    it('should preserve container form when kind is undefined', () => {
+      expect(generateErrorId('email', undefined)).toBe('email-error');
+    });
+
+    it('should treat empty-string kind as a literal suffix', () => {
+      expect(generateErrorId('email', '')).toBe('email-error-');
+    });
   });
 
   describe('generateWarningId', () => {

--- a/packages/toolkit/core/utilities/field-resolution.ts
+++ b/packages/toolkit/core/utilities/field-resolution.ts
@@ -88,17 +88,31 @@ export function resolveFieldName(element: HTMLElement): string | null {
 /**
  * Generates an error ID for a field, following WCAG best practices.
  *
+ * When `kind` is omitted the result identifies the *container* that holds
+ * one or more error messages — the form returned by the toolkit's wrappers
+ * and used as a single `aria-describedby` target. When `kind` is supplied
+ * the result identifies a *specific error*, suitable for headless consumers
+ * that render one DOM node per error and want each node addressable on its
+ * own. Both forms remain stable so wrapper-rendered and headless-rendered
+ * IDs interoperate without the call site re-deriving the format.
+ *
  * @param fieldName - The field name
- * @returns The error ID in format: `{fieldName}-error`
+ * @param kind - Optional error kind (e.g. `'required'`); appended after the
+ *   `-error` suffix when present
+ * @returns `{fieldName}-error` (container form) or
+ *   `{fieldName}-error-{kind}` (per-error form)
  *
  * @example
  * ```typescript
- * generateErrorId('email') // Returns: 'email-error'
- * generateErrorId('address.city') // Returns: 'address.city-error'
+ * generateErrorId('email');                  // 'email-error'
+ * generateErrorId('email', 'required');      // 'email-error-required'
+ * generateErrorId('address.city', 'minLen'); // 'address.city-error-minLen'
  * ```
  */
-export function generateErrorId(fieldName: string): string {
-  return `${fieldName}-error`;
+export function generateErrorId(fieldName: string, kind?: string): string {
+  return kind === undefined
+    ? `${fieldName}-error`
+    : `${fieldName}-error-${kind}`;
 }
 
 /**

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -206,7 +206,14 @@ export class EmailErrors {
 }
 ```
 
-Each entry is `{ error, message, id }` where `id` is `{fieldName}-error-{kind}` so external renderers and the in-tree wrapper interoperate on `aria-describedby` chains without re-deriving the format. Options of note:
+Each entry is `{ kind, message, id, error }`:
+
+- `kind` — convenience copy of the validator kind, lifted to the top level so templates can write `entry.kind` instead of `entry.error.kind`.
+- `message` — the resolved display string after the 3-tier cascade.
+- `id` — `{fieldName}-error-{kind}`, stable so external renderers and the in-tree wrapper interoperate on `aria-describedby` chains without re-deriving the format.
+- `error` — the raw `ValidationError` from the field, kept for consumers that need validator-specific params or a non-stripped `message` override.
+
+Options of note:
 
 - `includeWarnings`: `false` (default), `true`, or `'only'` — selects blocking errors, both, or warnings only.
 - `stripWarningPrefix`: defaults to `true` (display-oriented); set to `false` to keep the `warn:` prefix visible for debugging.

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -22,6 +22,7 @@ import {
   NgxHeadlessCharacterCount,
   NgxHeadlessFieldset,
   NgxHeadlessFieldName,
+  createErrorMessageSignal,
   createErrorState,
   createCharacterCount,
   createFieldStateFlags,
@@ -177,6 +178,41 @@ Selector: `[ngxHeadlessFieldName]` · Export: `fieldName`
 Resolves field names and generates stable IDs for ARIA linking. Falls back to the host element `id` when `fieldName` is omitted. When neither a non-empty `fieldName` input nor a non-empty host `id` is provided, `resolvedFieldName()`, `errorId()`, and `warningId()` return `null` and the directive emits a one-shot `console.error` in dev mode. Downstream ARIA wiring should gate on a non-null value rather than produce unstable `"-error"` IDs.
 
 Signals: `resolvedFieldName()` (nullable), `errorId()` (nullable), `warningId()` (nullable).
+
+## Reactive primitives
+
+### createErrorMessageSignal
+
+A `Signal<readonly ResolvedFieldError[]>` that combines visibility gating, the 3-tier message cascade (validator `message` → `NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs in a single primitive. Use it when you want the directive's resolution logic without the directive itself — for example inside a custom error renderer that the form-field wrapper drives via `*ngComponentOutlet`, or in an Angular `Component` that opts to read errors directly off a `FieldTree`.
+
+```typescript
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
+
+@Component({
+  /* ... */
+})
+export class EmailErrors {
+  readonly field = input.required<FieldTree<string>>();
+
+  readonly resolvedErrors = createErrorMessageSignal(() => this.field()(), {
+    fieldName: 'email',
+  });
+
+  readonly resolvedWarnings = createErrorMessageSignal(() => this.field()(), {
+    includeWarnings: 'only',
+    fieldName: 'email',
+    strategy: 'immediate',
+  });
+}
+```
+
+Each entry is `{ error, message, id }` where `id` is `{fieldName}-error-{kind}` so external renderers and the in-tree wrapper interoperate on `aria-describedby` chains without re-deriving the format. Options of note:
+
+- `includeWarnings`: `false` (default), `true`, or `'only'` — selects blocking errors, both, or warnings only.
+- `stripWarningPrefix`: defaults to `true` (display-oriented); set to `false` to keep the `warn:` prefix visible for debugging.
+- `errorMessages`: explicit `Signal<ErrorMessageRegistry>` override; when omitted, the primitive auto-injects `NGX_ERROR_MESSAGES`.
+- `strategy` / `submittedStatus`: forwarded to `createErrorVisibility`. Omit to inherit from the form context.
+- `injector`: optional, for use outside an Angular injection context.
 
 ## Utility functions
 

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -17,6 +17,14 @@ import { NgxHeadlessFieldName } from './lib/field-name';
 import { NgxHeadlessFieldset } from './lib/fieldset';
 import { NgxHeadlessNotification } from './lib/notification';
 
+// Reactive primitives
+export {
+  createErrorMessageSignal,
+  type CreateErrorMessageSignalOptions,
+  type IncludeWarningsOption,
+  type ResolvedFieldError,
+} from './lib/create-error-message-signal';
+
 // Directives
 export {
   NgxHeadlessErrorState,

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
@@ -1,0 +1,466 @@
+import {
+  Injector,
+  runInInjectionContext,
+  signal,
+  type Signal,
+} from '@angular/core';
+import type { ValidationError } from '@angular/forms/signals';
+import {
+  NGX_ERROR_MESSAGES,
+  type ErrorMessageRegistry,
+} from '@ngx-signal-forms/toolkit/core';
+import { describe, expect, it } from 'vitest';
+import {
+  createErrorMessageSignal,
+  type ResolvedFieldError,
+} from './create-error-message-signal';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockFieldStateOptions {
+  readonly invalid?: boolean;
+  readonly touched?: boolean;
+  readonly errors?: readonly ValidationError[];
+  readonly name?: string;
+}
+
+function mockFieldState(opts: MockFieldStateOptions = {}) {
+  return {
+    invalid: signal(opts.invalid ?? (opts.errors?.length ?? 0) > 0),
+    touched: signal(opts.touched ?? true),
+    errors: signal<readonly ValidationError[]>(opts.errors ?? []),
+    name: () => opts.name ?? '',
+  };
+}
+
+function injectorWithRegistry(registry: ErrorMessageRegistry | null): Injector {
+  return Injector.create({
+    providers:
+      registry === null
+        ? []
+        : [{ provide: NGX_ERROR_MESSAGES, useValue: registry }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Registry-resolved messages
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — registry resolution', () => {
+  it('uses the validator message when present (tier 1)', () => {
+    const injector = injectorWithRegistry({
+      required: 'Registry says required',
+    });
+    const field = mockFieldState({
+      invalid: true,
+      touched: true,
+      errors: [{ kind: 'required', message: 'Validator says required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'email' }),
+    );
+
+    expect(result()).toEqual<readonly ResolvedFieldError[]>([
+      {
+        error: { kind: 'required', message: 'Validator says required' },
+        message: 'Validator says required',
+        id: 'email-error-required',
+      },
+    ]);
+  });
+
+  it('falls back to the registry when the validator omits a message (tier 2)', () => {
+    const injector = injectorWithRegistry({
+      required: 'Registry says required',
+    });
+    const field = mockFieldState({
+      errors: [{ kind: 'required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'email' }),
+    );
+
+    expect(result()[0]?.message).toBe('Registry says required');
+    expect(result()[0]?.id).toBe('email-error-required');
+  });
+
+  it('preserves an explicit empty-string validator message (suppression)', () => {
+    const injector = injectorWithRegistry({
+      required: 'Registry says required',
+    });
+    const field = mockFieldState({
+      errors: [{ kind: 'required', message: '' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'email' }),
+    );
+
+    expect(result()[0]?.message).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default-fallback messages
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — default fallback', () => {
+  it('falls back to default messages when no registry entry exists (tier 3)', () => {
+    const injector = injectorWithRegistry({});
+    const field = mockFieldState({
+      errors: [{ kind: 'required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'email' }),
+    );
+
+    expect(result()[0]?.message).toBe('This field is required');
+  });
+
+  it('produces default messages when no registry is provided at all', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({
+      errors: [{ kind: 'email' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'contact' }),
+    );
+
+    expect(result()[0]?.message).toBe('Please enter a valid email address');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Visibility filtering — integration with createErrorVisibility
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — visibility filtering', () => {
+  it('returns an empty list when the visibility cascade hides errors', () => {
+    const injector = injectorWithRegistry(null);
+    // Untouched + on-touch (default) → visibility hides errors
+    const field = mockFieldState({
+      invalid: true,
+      touched: false,
+      errors: [{ kind: 'required', message: 'Required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'email' }),
+    );
+
+    expect(result()).toEqual([]);
+  });
+
+  it('emits messages when the field becomes touched (default on-touch strategy)', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({
+      invalid: true,
+      touched: false,
+      errors: [{ kind: 'required', message: 'Required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'email' }),
+    );
+
+    expect(result()).toEqual([]);
+
+    field.touched.set(true);
+    expect(result().length).toBe(1);
+    expect(result()[0]?.message).toBe('Required');
+  });
+
+  it('honors an explicit immediate strategy (errors visible while untouched)', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({
+      invalid: true,
+      touched: false,
+      errors: [{ kind: 'required', message: 'Required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'email',
+        strategy: 'immediate',
+      }),
+    );
+
+    expect(result().length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// includeWarnings option
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — includeWarnings', () => {
+  const errors: readonly ValidationError[] = [
+    { kind: 'required', message: 'Required' },
+    { kind: 'warn:weak', message: 'Could be stronger' },
+    { kind: 'minLength', message: 'Too short' },
+    { kind: 'warn:trim', message: 'Trim whitespace' },
+  ];
+
+  it('returns blocking errors only when includeWarnings is false (default)', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({ errors });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'f' }),
+    );
+
+    expect(result().map((r) => r.error.kind)).toEqual([
+      'required',
+      'minLength',
+    ]);
+  });
+
+  it('returns blocking errors first then warnings when includeWarnings is true', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({ errors });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'f',
+        includeWarnings: true,
+      }),
+    );
+
+    expect(result().map((r) => r.error.kind)).toEqual([
+      'required',
+      'minLength',
+      'warn:weak',
+      'warn:trim',
+    ]);
+  });
+
+  it('returns warnings only when includeWarnings is "only"', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({ errors });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'f',
+        includeWarnings: 'only',
+      }),
+    );
+
+    expect(result().map((r) => r.error.kind)).toEqual([
+      'warn:weak',
+      'warn:trim',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripWarningPrefix option
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — stripWarningPrefix', () => {
+  it('strips the warn: prefix from default messages by default', () => {
+    const injector = injectorWithRegistry(null);
+    // No registry, no validator message → falls through to default fallback,
+    // which is where stripWarningPrefix takes effect.
+    const field = mockFieldState({
+      errors: [{ kind: 'warn:weak_password' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'password',
+        includeWarnings: 'only',
+      }),
+    );
+
+    expect(result()[0]?.message).toBe('weak password');
+  });
+
+  it('keeps the warn: prefix when stripWarningPrefix is false', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({
+      errors: [{ kind: 'warn:weak_password' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'password',
+        includeWarnings: 'only',
+        stripWarningPrefix: false,
+      }),
+    );
+
+    expect(result()[0]?.message).toBe('warn:weak password');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Explicit errorMessages option (no DI)
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — explicit errorMessages option', () => {
+  it('uses the explicit registry instead of injecting NGX_ERROR_MESSAGES', () => {
+    // Even though DI provides one registry, the explicit option wins.
+    const injector = injectorWithRegistry({ required: 'Injected: required' });
+    const explicit = signal<ErrorMessageRegistry>({
+      required: 'Explicit: required',
+    });
+    const field = mockFieldState({
+      errors: [{ kind: 'required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'email',
+        errorMessages: explicit,
+      }),
+    );
+
+    expect(result()[0]?.message).toBe('Explicit: required');
+  });
+
+  it('works without an injection context when errorMessages and injector are provided', () => {
+    // No `runInInjectionContext` wrapping — only the explicit injector option.
+    const injector = injectorWithRegistry(null);
+    const explicit = signal<ErrorMessageRegistry>({
+      required: 'Explicit: required',
+    });
+    const field = mockFieldState({
+      errors: [{ kind: 'required' }],
+    });
+
+    const result = createErrorMessageSignal(() => field, {
+      fieldName: 'email',
+      errorMessages: explicit,
+      injector,
+    });
+
+    expect(result()[0]?.message).toBe('Explicit: required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ID composition — generateErrorId(fieldName, kind)
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — DOM IDs', () => {
+  it('builds per-error IDs in the form `{fieldName}-error-{kind}`', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({
+      errors: [
+        { kind: 'required', message: 'Required' },
+        { kind: 'minLength', message: 'Too short' },
+      ],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'address.city' }),
+    );
+
+    expect(result().map((r) => r.id)).toEqual([
+      'address.city-error-required',
+      'address.city-error-minLength',
+    ]);
+  });
+
+  it('reads the field name from a reactive signal when fieldName is one', () => {
+    const injector = injectorWithRegistry(null);
+    const fieldName = signal<string | null>('first');
+    const field = mockFieldState({
+      errors: [{ kind: 'required', message: 'R' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName }),
+    );
+
+    expect(result()[0]?.id).toBe('first-error-required');
+
+    fieldName.set('second');
+    expect(result()[0]?.id).toBe('second-error-required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reactivity — registry swap mid-render
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — reactive registry', () => {
+  it('re-resolves messages when the explicit registry signal changes', () => {
+    const injector = injectorWithRegistry(null);
+    const registry = signal<ErrorMessageRegistry>({ required: 'EN: required' });
+    const field = mockFieldState({
+      errors: [{ kind: 'required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, {
+        fieldName: 'name',
+        errorMessages: registry,
+      }),
+    );
+
+    expect(result()[0]?.message).toBe('EN: required');
+
+    registry.set({ required: 'JA: 必須' });
+    expect(result()[0]?.message).toBe('JA: 必須');
+
+    // Swapping a factory function in mid-flight also works (i18n pattern).
+    registry.set({
+      required: ({ minLength }: Record<string, unknown>) =>
+        `Need at least ${typeof minLength === 'number' ? minLength : 0}`,
+    });
+    expect(result()[0]?.message).toBe('Need at least 0');
+  });
+
+  it('re-resolves messages when the field errors change', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({
+      errors: [{ kind: 'required' }],
+    });
+
+    const result: Signal<readonly ResolvedFieldError[]> = runInInjectionContext(
+      injector,
+      () => createErrorMessageSignal(() => field, { fieldName: 'name' }),
+    );
+
+    expect(result()[0]?.error.kind).toBe('required');
+
+    field.errors.set([{ kind: 'minLength', minLength: 8 } as ValidationError]);
+    expect(result()[0]?.error.kind).toBe('minLength');
+    expect(result()[0]?.message).toBe('Minimum 8 characters required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — edge cases', () => {
+  it('returns an empty list for a null/undefined field state', () => {
+    const injector = injectorWithRegistry(null);
+    const accessor = () => null;
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(accessor, { fieldName: 'x' }),
+    );
+
+    expect(result()).toEqual([]);
+  });
+
+  it('returns an empty list for a field with no errors', () => {
+    const injector = injectorWithRegistry(null);
+    const field = mockFieldState({ invalid: false, errors: [] });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'x' }),
+    );
+
+    expect(result()).toEqual([]);
+  });
+});

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
@@ -65,9 +65,10 @@ describe('createErrorMessageSignal — registry resolution', () => {
 
     expect(result()).toEqual<readonly ResolvedFieldError[]>([
       {
-        error: { kind: 'required', message: 'Validator says required' },
+        kind: 'required',
         message: 'Validator says required',
         id: 'email-error-required',
+        error: { kind: 'required', message: 'Validator says required' },
       },
     ]);
   });
@@ -215,10 +216,7 @@ describe('createErrorMessageSignal — includeWarnings', () => {
       createErrorMessageSignal(() => field, { fieldName: 'f' }),
     );
 
-    expect(result().map((r) => r.error.kind)).toEqual([
-      'required',
-      'minLength',
-    ]);
+    expect(result().map((r) => r.kind)).toEqual(['required', 'minLength']);
   });
 
   it('returns blocking errors first then warnings when includeWarnings is true', () => {
@@ -232,7 +230,7 @@ describe('createErrorMessageSignal — includeWarnings', () => {
       }),
     );
 
-    expect(result().map((r) => r.error.kind)).toEqual([
+    expect(result().map((r) => r.kind)).toEqual([
       'required',
       'minLength',
       'warn:weak',
@@ -251,10 +249,7 @@ describe('createErrorMessageSignal — includeWarnings', () => {
       }),
     );
 
-    expect(result().map((r) => r.error.kind)).toEqual([
-      'warn:weak',
-      'warn:trim',
-    ]);
+    expect(result().map((r) => r.kind)).toEqual(['warn:weak', 'warn:trim']);
   });
 });
 
@@ -429,10 +424,10 @@ describe('createErrorMessageSignal — reactive registry', () => {
       () => createErrorMessageSignal(() => field, { fieldName: 'name' }),
     );
 
-    expect(result()[0]?.error.kind).toBe('required');
+    expect(result()[0]?.kind).toBe('required');
 
     field.errors.set([{ kind: 'minLength', minLength: 8 } as ValidationError]);
-    expect(result()[0]?.error.kind).toBe('minLength');
+    expect(result()[0]?.kind).toBe('minLength');
     expect(result()[0]?.message).toBe('Minimum 8 characters required');
   });
 });
@@ -451,6 +446,21 @@ describe('createErrorMessageSignal — edge cases', () => {
     );
 
     expect(result()).toEqual([]);
+  });
+
+  it('exposes the raw ValidationError for consumers that need params', () => {
+    const injector = injectorWithRegistry(null);
+    const raw: ValidationError = {
+      kind: 'minLength',
+      minLength: 8,
+    } as ValidationError;
+    const field = mockFieldState({ errors: [raw] });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'password' }),
+    );
+
+    expect(result()[0]?.error).toBe(raw);
   });
 
   it('returns an empty list for a field with no errors', () => {

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.ts
@@ -17,20 +17,24 @@ import {
 /**
  * One resolved validation error, ready for rendering.
  *
- * - `error` — the raw `ValidationError` from the field, so consumers can
- *   inspect `kind`, `message` overrides, custom params, etc.
+ * - `kind` — convenience copy of `error.kind`, lifted to the top level so
+ *   templates can write `entry.kind` instead of `entry.error.kind`.
  * - `message` — the resolved display string after the 3-tier cascade
  *   (validator message → registry → default).
  * - `id` — DOM ID built via `generateErrorId(fieldName, error.kind)`.
  *   Stable so external renderers and the in-tree wrapper can interoperate
  *   on `aria-describedby` without re-deriving IDs.
+ * - `error` — the raw `ValidationError` from the field, kept for consumers
+ *   that need access to validator-specific params, custom fields, or a
+ *   non-stripped `message` override.
  *
  * @public
  */
 export interface ResolvedFieldError {
-  readonly error: ValidationError;
+  readonly kind: string;
   readonly message: string;
   readonly id: string;
+  readonly error: ValidationError;
 }
 
 /**
@@ -264,11 +268,12 @@ export function createErrorMessageSignal(
       const fieldName = resolvedFieldName();
 
       return ordered.map((error) => ({
-        error,
+        kind: error.kind,
         message: resolveValidationErrorMessage(error, registry, {
           stripWarningPrefix,
         }),
         id: generateErrorId(fieldName, error.kind),
+        error,
       }));
     });
   });

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.ts
@@ -1,0 +1,294 @@
+import { computed, inject, type Injector, type Signal } from '@angular/core';
+import type { ValidationError } from '@angular/forms/signals';
+import {
+  assertInjector,
+  createErrorVisibility,
+  generateErrorId,
+  NGX_ERROR_MESSAGES,
+  readDirectErrors,
+  resolveValidationErrorMessage,
+  splitByKind,
+  type CreateErrorVisibilityOptions,
+  type ErrorDisplayStrategy,
+  type ErrorMessageRegistry,
+  type SubmittedStatus,
+} from '@ngx-signal-forms/toolkit/core';
+
+/**
+ * One resolved validation error, ready for rendering.
+ *
+ * - `error` — the raw `ValidationError` from the field, so consumers can
+ *   inspect `kind`, `message` overrides, custom params, etc.
+ * - `message` — the resolved display string after the 3-tier cascade
+ *   (validator message → registry → default).
+ * - `id` — DOM ID built via `generateErrorId(fieldName, error.kind)`.
+ *   Stable so external renderers and the in-tree wrapper can interoperate
+ *   on `aria-describedby` without re-deriving IDs.
+ *
+ * @public
+ */
+export interface ResolvedFieldError {
+  readonly error: ValidationError;
+  readonly message: string;
+  readonly id: string;
+}
+
+/**
+ * Controls which subset of a field's errors `createErrorMessageSignal`
+ * returns.
+ *
+ * - `false` (default) — blocking errors only
+ * - `true` — blocking errors first, then warnings (preserves order)
+ * - `'only'` — warnings only
+ *
+ * @public
+ */
+export type IncludeWarningsOption = boolean | 'only';
+
+/**
+ * Options for {@link createErrorMessageSignal}.
+ *
+ * @public
+ */
+export interface CreateErrorMessageSignalOptions {
+  /**
+   * Strip the `warn:` prefix from default messages for unknown kinds.
+   *
+   * Defaults to `true` because this primitive is display-oriented — users
+   * shouldn't see internal `warn:` prefixes leaking into rendered text.
+   * This is a small but deliberate divergence from
+   * {@link resolveValidationErrorMessage}, whose default is `false`
+   * (debugging-oriented).
+   *
+   * @default true
+   */
+  readonly stripWarningPrefix?: boolean;
+
+  /**
+   * Whether to include warnings in the resolved list.
+   *
+   * @default false
+   * @see {@link IncludeWarningsOption}
+   */
+  readonly includeWarnings?: IncludeWarningsOption;
+
+  /**
+   * Explicit error-message registry override.
+   *
+   * When provided, the primitive uses this signal **instead of** injecting
+   * `NGX_ERROR_MESSAGES`. Useful for tests, headless utilities, or call
+   * sites that need a different registry per usage. Reactive: changes are
+   * tracked.
+   */
+  readonly errorMessages?: Signal<ErrorMessageRegistry>;
+
+  /**
+   * Field name used to build per-error DOM IDs via
+   * {@link generateErrorId}. When omitted the primitive falls back to the
+   * field's own `name()` if the field state exposes one; otherwise IDs are
+   * built from the empty string (yielding `-error-{kind}`), which is rarely
+   * useful — supply `fieldName` explicitly when consumers care about
+   * `aria-describedby` wiring.
+   */
+  readonly fieldName?: string | Signal<string | null | undefined>;
+
+  /**
+   * Error display strategy override forwarded to {@link createErrorVisibility}.
+   *
+   * Static value or `Signal<ErrorDisplayStrategy | undefined>`. Omit to
+   * inherit from the form context (or fall back to `'on-touch'`).
+   */
+  readonly strategy?:
+    | ErrorDisplayStrategy
+    | Signal<ErrorDisplayStrategy | undefined>;
+
+  /**
+   * Submission status override forwarded to {@link createErrorVisibility}.
+   *
+   * Only relevant for the `'on-submit'` strategy. Omit to inherit from the
+   * form context.
+   */
+  readonly submittedStatus?:
+    | SubmittedStatus
+    | Signal<SubmittedStatus | undefined>;
+
+  /**
+   * Optional injector for use outside an Angular injection context (e.g.
+   * unit tests, `runInInjectionContext` wrappers). When omitted the
+   * function must be called inside a DI context.
+   */
+  // Angular's Injector is inherently mutable; Readonly<Injector> is not practical here.
+  // oxlint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- Angular's Injector is mutable by design
+  readonly injector?: Injector;
+}
+
+/**
+ * Minimal field-state surface the primitive reads. Intentionally looser than
+ * Angular's `FieldState`: we only need `invalid()`, `touched()`, and
+ * `errors()`, plus an optional `name()` for fallback ID composition. Using
+ * a loose shape lets host adapters (e.g. wrapper components projecting an
+ * external errors signal) feed in synthesised states without a cast.
+ *
+ * Angular's `Signal<T>` is structurally `(() => T) & { ... brand }`; the
+ * callable shape is enough at runtime, so the primitive types these as
+ * plain getters and only the visibility-cascade adapter needs the brand.
+ */
+interface FieldStateLike {
+  readonly invalid?: () => boolean;
+  readonly touched?: () => boolean;
+  readonly errors?: () => readonly ValidationError[];
+  readonly name?: () => string;
+}
+type FieldStateInput = FieldStateLike | null | undefined;
+type FieldStateAccessor = () => FieldStateInput;
+
+/**
+ * Reactive error-message resolution primitive for Angular Signal Forms.
+ *
+ * Produces a visibility-filtered, message-resolved view of a field's
+ * validation errors. Combines three concerns the toolkit otherwise asks
+ * consumers to compose by hand:
+ *
+ * 1. {@link createErrorVisibility} — gate by the error display strategy
+ *    cascade (DI context → `'on-touch'` default).
+ * 2. {@link resolveValidationErrorMessage} — apply the 3-tier message
+ *    cascade (validator message → registry → default).
+ * 3. {@link generateErrorId} — produce per-error DOM IDs that match the
+ *    in-tree wrapper, so `aria-describedby` wiring stays in lockstep.
+ *
+ * The registry is auto-injected from `NGX_ERROR_MESSAGES`. Pass
+ * `options.errorMessages` to override (useful in tests or when running
+ * outside a DI context).
+ *
+ * @param field A reactive accessor for the field state (e.g.
+ *   `() => myFormField()`). Returning `null`/`undefined` yields an empty
+ *   list. Mirrors the shape accepted by {@link createErrorVisibility}.
+ * @param options Optional behavior overrides.
+ * @returns A `Signal<readonly ResolvedFieldError[]>` that re-emits when
+ *   the field, registry, or visibility changes. Empty when errors should
+ *   not be displayed.
+ *
+ * @example Inside a component (DI auto-wired)
+ * ```typescript
+ * @Component({ ... })
+ * export class EmailField {
+ *   readonly field = input.required<FieldTree<string>>();
+ *
+ *   readonly errorMessages = createErrorMessageSignal(
+ *     () => this.field()(),
+ *     { fieldName: 'email' },
+ *   );
+ * }
+ * ```
+ *
+ * @example With warnings rendered after errors
+ * ```typescript
+ * readonly all = createErrorMessageSignal(() => field(), {
+ *   includeWarnings: true,
+ *   fieldName: 'password',
+ * });
+ * ```
+ *
+ * @example Warnings only (e.g. an `<aside>` slot)
+ * ```typescript
+ * readonly warnings = createErrorMessageSignal(() => field(), {
+ *   includeWarnings: 'only',
+ *   fieldName: 'password',
+ * });
+ * ```
+ *
+ * @example Explicit registry (no DI)
+ * ```typescript
+ * const registry = signal<ErrorMessageRegistry>({ required: 'Required.' });
+ * const messages = createErrorMessageSignal(() => field(), {
+ *   errorMessages: registry,
+ *   fieldName: 'name',
+ *   injector: TestBed.inject(Injector),
+ * });
+ * ```
+ *
+ * @public
+ */
+export function createErrorMessageSignal(
+  field: FieldStateAccessor,
+  options?: CreateErrorMessageSignalOptions,
+): Signal<readonly ResolvedFieldError[]> {
+  return assertInjector(createErrorMessageSignal, options?.injector, () => {
+    const registrySignal = options?.errorMessages;
+    // Only auto-inject when no explicit registry is supplied. Calling
+    // `inject()` when a registry is already provided would force callers to
+    // wrap every test in `runInInjectionContext`, defeating the explicit
+    // override.
+    const injectedRegistry =
+      registrySignal === undefined
+        ? inject(NGX_ERROR_MESSAGES, { optional: true })
+        : null;
+
+    const visibilityOptions: CreateErrorVisibilityOptions = {
+      strategy: options?.strategy,
+      submittedStatus: options?.submittedStatus,
+    };
+    // `createErrorVisibility` is typed against Angular's `Partial<ErrorVisibilityState>`
+    // (signal-branded `invalid` / `touched`). Our `FieldStateLike` keeps the
+    // surface as plain getters because the runtime cascade only calls them.
+    // Casting at the boundary is safe — tested via the visibility specs in
+    // `create-error-message-signal.spec.ts`.
+    const showErrors = createErrorVisibility(
+      field as Parameters<typeof createErrorVisibility>[0],
+      visibilityOptions,
+    );
+
+    const include = options?.includeWarnings ?? false;
+    const stripWarningPrefix = options?.stripWarningPrefix ?? true;
+    const fieldNameOption = options?.fieldName;
+
+    const resolvedFieldName = computed<string>(() => {
+      if (typeof fieldNameOption === 'string') return fieldNameOption;
+      if (typeof fieldNameOption === 'function') {
+        return fieldNameOption() ?? readNameFromField(field) ?? '';
+      }
+      return readNameFromField(field) ?? '';
+    });
+
+    return computed<readonly ResolvedFieldError[]>(() => {
+      if (!showErrors()) return EMPTY;
+
+      const errors = readDirectErrors(field());
+      if (errors.length === 0) return EMPTY;
+
+      const split = splitByKind(errors);
+      const ordered = orderByInclude(split.blocking, split.warnings, include);
+      if (ordered.length === 0) return EMPTY;
+
+      const registry = registrySignal ? registrySignal() : injectedRegistry;
+      const fieldName = resolvedFieldName();
+
+      return ordered.map((error) => ({
+        error,
+        message: resolveValidationErrorMessage(error, registry, {
+          stripWarningPrefix,
+        }),
+        id: generateErrorId(fieldName, error.kind),
+      }));
+    });
+  });
+}
+
+const EMPTY: readonly ResolvedFieldError[] = Object.freeze([]);
+
+function orderByInclude(
+  blocking: readonly ValidationError[],
+  warnings: readonly ValidationError[],
+  include: IncludeWarningsOption,
+): readonly ValidationError[] {
+  if (include === 'only') return warnings;
+  if (include) return [...blocking, ...warnings];
+  return blocking;
+}
+
+function readNameFromField(accessor: FieldStateAccessor): string | null {
+  const state = accessor();
+  if (!state || typeof state !== 'object') return null;
+  const name = state.name;
+  return typeof name === 'function' ? name() : null;
+}


### PR DESCRIPTION
## Summary

Implements the tracer-bullet slice of #39 — adds the public `createErrorMessageSignal(field, options?)` primitive to `@ngx-signal-forms/toolkit/headless` and routes the in-tree `NgxFormFieldError` through it.

- New primitive returns `Signal<readonly ResolvedFieldError[]>` where each entry carries `{ error, message, id }`. The `id` is built via `generateErrorId(fieldName, error.kind)` so external renderers and the in-tree wrapper share the same DOM-ID scheme.
- Internally composes (no parallel logic) `createErrorVisibility` (visibility cascade), `resolveValidationErrorMessage` (3-tier message cascade), `splitByKind` (warnings vs blocking), and `generateErrorId` (extended with optional `kind`).
- Auto-injects `NGX_ERROR_MESSAGES`; `options.errorMessages` (a `Signal<ErrorMessageRegistry>`) overrides DI for tests / explicit-injector call sites and is fully reactive (registry swaps re-resolve mid-render — covered by spec).
- `includeWarnings: false | true | 'only'` selects which slice surfaces; with `true` blocking errors come first then warnings, preserving order.
- `NgxFormFieldError` now resolves both blocking and warning messages through `createErrorMessageSignal`. Warning visibility stays under the wrapper's existing `warningStrategy` input — the wrapper passes `strategy: 'immediate'` to the warnings call so resolution always runs when the field is invalid, and the wrapper-level `warningContainerVisible` continues to gate rendering.
- `errorsOverride` mode in the wrapper is preserved by feeding the override through a synthesised field-state shape so `createErrorVisibility` short-circuits to "visible" exactly the way the headless directive does today.

## Public-divergence note

The primitive defaults `stripWarningPrefix` to `true` (display-oriented) — a deliberate, small divergence from `resolveValidationErrorMessage`'s own `false` default (debugging-oriented). Documented inline; flagged for human review during PR.

## Test plan

- [x] `pnpm nx test toolkit` — 1086 / 1086 green (21 new specs in `create-error-message-signal.spec.ts`)
- [x] `pnpm nx build toolkit` — clean build of all 6 secondary entry points
- [x] `pnpm nx affected -t test,build,lint --base=origin/main` — green
- [x] `pnpm format` (oxfmt) — clean
- [x] `form-field-error.spec.ts` passes UNCHANGED post-migration (the wrapper continues to render the same DOM)
- [ ] Manual review of the `stripWarningPrefix: true` default vs the resolver's `false` default
- [ ] Spot-check the `errorsOverride` synthesised-state shim (covered by `should render bullet lists when requested`, but worth a second look)

Closes #44
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resolved error/warning messages are now surfaced as stable, per-item entries with predictable DOM IDs and improved visibility handling; field-level overrides are respected.
  * Configurable warning modes: include, suppress, or warnings-only.
* **Bug Fixes**
  * More reliable error display when overrides or submit strategies are used; fixes empty live-region cases.
* **Documentation**
  * Docs and examples updated to show the new resolved-error primitive and ID behavior.
* **Tests**
  * Added tests for message resolution, visibility, IDs, and override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->