### PR TITLE
feat(toolkit): dispatch ngx-form-field-hint via NGX_FORM_FIELD_HINT_RENDERER

### DIFF
--- a/apps/demo-material/src/app/wrapper/index.ts
+++ b/apps/demo-material/src/app/wrapper/index.ts
@@ -65,12 +65,16 @@ export interface NgxMatFormsProviderOptions {
 }
 
 /**
- * Application-level provider that registers the Material feedback renderer
- * for both `NGX_FORM_FIELD_ERROR_RENDERER` and `NGX_FORM_FIELD_HINT_RENDERER`.
+ * Application-level provider that registers the Material renderers for the
+ * toolkit's feedback and hint slots: `MaterialFeedbackRenderer` for
+ * `NGX_FORM_FIELD_ERROR_RENDERER` and `MaterialHintRenderer` for
+ * `NGX_FORM_FIELD_HINT_RENDERER`. The two slots get distinct renderers
+ * because the feedback renderer requires `message` + `severity` inputs that
+ * the hint dispatch can't supply.
  *
  * Recommended path for apps that consume the Material reference wrapper —
- * one call at bootstrap registers the default `MaterialFeedbackRenderer`
- * (or a consumer-supplied override) once for the entire app.
+ * one call at bootstrap registers both defaults (or consumer-supplied
+ * overrides via `feedbackRenderer` / `hintRenderer`) once for the entire app.
  *
  * @example
  * ```ts

--- a/apps/demo-material/src/app/wrapper/index.ts
+++ b/apps/demo-material/src/app/wrapper/index.ts
@@ -10,6 +10,7 @@ import {
   provideFormFieldHintRenderer,
 } from '@ngx-signal-forms/toolkit';
 import { MaterialFeedbackRenderer } from './material-error-renderer';
+import { MaterialHintRenderer } from './material-hint-renderer';
 
 export {
   NgxMatBoundControl,
@@ -30,6 +31,7 @@ export {
   MaterialFeedbackRenderer,
   type NgxMatFeedbackSeverity,
 } from './material-error-renderer';
+export { MaterialHintRenderer } from './material-hint-renderer';
 export {
   NgxMatErrorSlot,
   NgxMatHintSlot,
@@ -39,8 +41,14 @@ export {
 
 /**
  * Optional override shape for `provideNgxMatForms*`. When omitted, the
- * Material reference's default `MaterialFeedbackRenderer` is registered
- * for both error and hint slots.
+ * Material reference registers `MaterialFeedbackRenderer` for the error slot
+ * and `MaterialHintRenderer` for the hint slot.
+ *
+ * The two slots use distinct default renderers because the error renderer's
+ * input contract (`{ message, severity }`) is wired by the slot directives
+ * (`*ngxMatErrorSlot` / `*ngxMatFeedback`), whereas the hint renderer's input
+ * contract (`{ resolvedFieldName, resolvedId, position }`) is supplied by
+ * `<ngx-form-field-hint>` when consumers project it into the form-field.
  */
 export interface NgxMatFormsProviderOptions {
   /**
@@ -48,6 +56,12 @@ export interface NgxMatFormsProviderOptions {
    * error/warning blocks of `*ngxMatFeedback`.
    */
   readonly feedbackRenderer?: { readonly component: Type<unknown> };
+  /**
+   * Override the renderer dispatched by `<ngx-form-field-hint>` via
+   * `NGX_FORM_FIELD_HINT_RENDERER` when consumers project the toolkit's hint
+   * component into a `<mat-form-field>`.
+   */
+  readonly hintRenderer?: { readonly component: Type<unknown> };
 }
 
 /**
@@ -71,11 +85,13 @@ export interface NgxMatFormsProviderOptions {
 export function provideNgxMatForms(
   options?: NgxMatFormsProviderOptions,
 ): EnvironmentProviders[] {
-  const component =
+  const errorComponent =
     options?.feedbackRenderer?.component ?? MaterialFeedbackRenderer;
+  const hintComponent =
+    options?.hintRenderer?.component ?? MaterialHintRenderer;
   return [
-    provideFormFieldErrorRenderer({ component }),
-    provideFormFieldHintRenderer({ component }),
+    provideFormFieldErrorRenderer({ component: errorComponent }),
+    provideFormFieldHintRenderer({ component: hintComponent }),
   ];
 }
 
@@ -103,10 +119,12 @@ export function provideNgxMatForms(
 export function provideNgxMatFormsForComponent(
   options?: NgxMatFormsProviderOptions,
 ): Provider[] {
-  const component =
+  const errorComponent =
     options?.feedbackRenderer?.component ?? MaterialFeedbackRenderer;
+  const hintComponent =
+    options?.hintRenderer?.component ?? MaterialHintRenderer;
   return [
-    ...provideFormFieldErrorRendererForComponent({ component }),
-    ...provideFormFieldHintRendererForComponent({ component }),
+    ...provideFormFieldErrorRendererForComponent({ component: errorComponent }),
+    ...provideFormFieldHintRendererForComponent({ component: hintComponent }),
   ];
 }

--- a/apps/demo-material/src/app/wrapper/material-hint-renderer.ts
+++ b/apps/demo-material/src/app/wrapper/material-hint-renderer.ts
@@ -1,0 +1,60 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/**
+ * Default hint renderer for the Material reference wrapper.
+ *
+ * Dispatched by `<ngx-form-field-hint>` via `NGX_FORM_FIELD_HINT_RENDERER`
+ * when consumers project that component into a `<mat-form-field>`. Renders a
+ * Material-flavoured hint shell (matching `<mat-hint>` typography and colour)
+ * around the consumer-supplied `<ng-content>` so the hint visually integrates
+ * with surrounding Material chrome without requiring the consumer to swap
+ * `<ngx-form-field-hint>` out for `<mat-hint>`.
+ *
+ * The renderer accepts (but does not require) the metadata
+ * `<ngx-form-field-hint>` exposes (`resolvedFieldName`, `resolvedId`,
+ * `position`); it consumes only what it needs for presentation. `position`
+ * drives text alignment for parity with the toolkit's own hint chrome.
+ *
+ * Note: when consumers prefer the slot-directive flow
+ * (`<mat-hint *ngxMatHintSlot>`), this renderer is not involved — that path
+ * is owned by `NgxMatHintSlot` and does not consult
+ * `NGX_FORM_FIELD_HINT_RENDERER`.
+ */
+@Component({
+  selector: 'ngx-material-hint-renderer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<span class="ngx-mat-hint__message"><ng-content /></span>`,
+  host: {
+    '[attr.data-position]': 'position() ?? null',
+  },
+  styles: `
+    :host {
+      display: block;
+      font-size: 0.75rem;
+      line-height: 1rem;
+      color: rgba(0, 0, 0, 0.6);
+    }
+
+    :host([data-position='left']) {
+      text-align: left;
+    }
+
+    :host([data-position='right']) {
+      text-align: right;
+    }
+
+    .ngx-mat-hint__message {
+      display: block;
+    }
+  `,
+})
+export class MaterialHintRenderer {
+  /** Field name surfaced by `<ngx-form-field-hint>`; presentation-agnostic. */
+  readonly resolvedFieldName = input<string | null>(null);
+
+  /** Stable hint id surfaced by `<ngx-form-field-hint>`; informational. */
+  readonly resolvedId = input<string | null>(null);
+
+  /** Alignment hint forwarded to the host element for parity with Material chrome. */
+  readonly position = input<'left' | 'right' | null>(null);
+}

--- a/apps/demo-primeng/src/app/form-field/prime-field-hint.ts
+++ b/apps/demo-primeng/src/app/form-field/prime-field-hint.ts
@@ -1,20 +1,24 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * PrimeNG-flavoured hint renderer.
  *
  * Registered via `provideFormFieldHintRenderer({ component: ... })` and
- * referenced through `NGX_FORM_FIELD_HINT_RENDERER`. The first-party toolkit
- * wrapper currently projects `<ngx-form-field-hint>` content directly rather
- * than going through this token (the token is reserved for future parity);
- * the PrimeNG wrapper keeps that same projection model, but we still register
- * a hint renderer here so the seam is exercised end-to-end and so consumers
- * who switch to the dynamic-outlet model in the future inherit Prime's
- * `<small class="p-text-secondary">` idiom by default.
+ * dispatched by `<ngx-form-field-hint>` through `NGX_FORM_FIELD_HINT_RENDERER`.
+ * Wraps the projected hint content in a Prime-styled `<small>` so consumer
+ * copy inherits the design system's secondary-text idiom without changing
+ * the consumer template.
+ *
+ * Accepts (but does not require) the metadata `<ngx-form-field-hint>`
+ * exposes (`resolvedFieldName`, `resolvedId`, `position`); only `position`
+ * is consumed for visual alignment, the rest stay informational.
  */
 @Component({
   selector: 'prime-field-hint',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.data-position]': 'position() ?? null',
+  },
   styles: `
     :host {
       display: block;
@@ -22,7 +26,24 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       line-height: 1.2;
       color: var(--p-text-muted-color, #6b7280);
     }
+
+    :host([data-position='left']) {
+      text-align: left;
+    }
+
+    :host([data-position='right']) {
+      text-align: right;
+    }
   `,
-  template: `<ng-content />`,
+  template: `<small class="p-text-secondary"><ng-content /></small>`,
 })
-export class PrimeFieldHintComponent {}
+export class PrimeFieldHintComponent {
+  /** Field name surfaced by `<ngx-form-field-hint>`; presentation-agnostic. */
+  readonly resolvedFieldName = input<string | null>(null);
+
+  /** Stable hint id surfaced by `<ngx-form-field-hint>`; informational. */
+  readonly resolvedId = input<string | null>(null);
+
+  /** Alignment hint forwarded to the host element for parity. */
+  readonly position = input<'left' | 'right' | null>(null);
+}

--- a/apps/demo-spartan/src/app/wrapper/index.ts
+++ b/apps/demo-spartan/src/app/wrapper/index.ts
@@ -1,0 +1,81 @@
+import {
+  type EnvironmentProviders,
+  type Provider,
+  type Type,
+} from '@angular/core';
+import {
+  provideFormFieldErrorRenderer,
+  provideFormFieldErrorRendererForComponent,
+  provideFormFieldHintRenderer,
+  provideFormFieldHintRendererForComponent,
+} from '@ngx-signal-forms/toolkit';
+import { NgxSpartanFormFieldError } from './spartan-form-field-error';
+import { NgxSpartanFormFieldHint } from './spartan-form-field-hint';
+
+export {
+  NgxSpartanFormBundle,
+  NgxSpartanFormField,
+} from './spartan-form-field';
+export { NgxSpartanFormFieldError } from './spartan-form-field-error';
+export { NgxSpartanFormFieldHint } from './spartan-form-field-hint';
+
+/**
+ * Optional override shape for `provideNgxSpartanForms*`. When omitted, the
+ * Spartan reference's default `NgxSpartanFormFieldError` and
+ * `NgxSpartanFormFieldHint` are registered. Mirrors the override surface of
+ * `provideNgxMatForms` and `provideNgxPrimeForms` so the three references
+ * stay shape-compatible (see ADR-0002 §8).
+ */
+export interface NgxSpartanFormsProviderOptions {
+  /**
+   * Override the renderer instantiated for `NGX_FORM_FIELD_ERROR_RENDERER`.
+   */
+  readonly errorRenderer?: { readonly component: Type<unknown> };
+  /**
+   * Override the renderer instantiated for `NGX_FORM_FIELD_HINT_RENDERER`.
+   */
+  readonly hintRenderer?: { readonly component: Type<unknown> };
+}
+
+/**
+ * Application-level provider that registers the Spartan-flavoured renderer
+ * pair for both error and hint slots in one call. Mirrors `provideNgxMatForms`
+ * and `provideNgxPrimeForms` so consumers get a single bootstrap entry point
+ * per design-system reference.
+ *
+ * @example
+ * ```ts
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideNgxSpartanForms()],
+ * });
+ * ```
+ */
+export function provideNgxSpartanForms(
+  options?: NgxSpartanFormsProviderOptions,
+): EnvironmentProviders[] {
+  const errorComponent =
+    options?.errorRenderer?.component ?? NgxSpartanFormFieldError;
+  const hintComponent =
+    options?.hintRenderer?.component ?? NgxSpartanFormFieldHint;
+  return [
+    provideFormFieldErrorRenderer({ component: errorComponent }),
+    provideFormFieldHintRenderer({ component: hintComponent }),
+  ];
+}
+
+/**
+ * Component-scoped override for the "swap renderer in one screen" use case.
+ * Mirrors `provideNgxMatFormsForComponent` / `provideNgxPrimeFormsForComponent`.
+ */
+export function provideNgxSpartanFormsForComponent(
+  options?: NgxSpartanFormsProviderOptions,
+): Provider[] {
+  const errorComponent =
+    options?.errorRenderer?.component ?? NgxSpartanFormFieldError;
+  const hintComponent =
+    options?.hintRenderer?.component ?? NgxSpartanFormFieldHint;
+  return [
+    ...provideFormFieldErrorRendererForComponent({ component: errorComponent }),
+    ...provideFormFieldHintRendererForComponent({ component: hintComponent }),
+  ];
+}

--- a/apps/demo-spartan/src/app/wrapper/spartan-form-field-hint.ts
+++ b/apps/demo-spartan/src/app/wrapper/spartan-form-field-hint.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/**
+ * Spartan-flavoured hint renderer.
+ *
+ * Registered via `provideFormFieldHintRenderer({ component: ... })` and
+ * dispatched by `<ngx-form-field-hint>` through `NGX_FORM_FIELD_HINT_RENDERER`.
+ * Wraps the projected hint content in a helm-styled `<small>` so consumer
+ * copy inherits Spartan's secondary-text idiom (`text-muted-foreground`
+ * + `text-xs`) without the consumer template having to learn helm classes.
+ *
+ * Accepts (but does not require) the metadata `<ngx-form-field-hint>`
+ * exposes (`resolvedFieldName`, `resolvedId`, `position`); only `position`
+ * is consumed for visual alignment, the rest stay informational.
+ */
+@Component({
+  selector: 'spartan-form-field-hint',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.data-position]': 'position() ?? null',
+    class: 'block',
+  },
+  styles: `
+    :host([data-position='left']) {
+      text-align: left;
+    }
+
+    :host([data-position='right']) {
+      text-align: right;
+    }
+  `,
+  template: `<small class="text-muted-foreground text-xs leading-snug"
+    ><ng-content
+  /></small>`,
+})
+export class NgxSpartanFormFieldHint {
+  /** Field name surfaced by `<ngx-form-field-hint>`; presentation-agnostic. */
+  readonly resolvedFieldName = input<string | null>(null);
+
+  /** Stable hint id surfaced by `<ngx-form-field-hint>`; informational. */
+  readonly resolvedId = input<string | null>(null);
+
+  /** Alignment hint forwarded to the host element for parity. */
+  readonly position = input<'left' | 'right' | null>(null);
+}

--- a/apps/demo-spartan/src/main.ts
+++ b/apps/demo-spartan/src/main.ts
@@ -2,6 +2,7 @@ import { isDevMode, provideZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
 import { App } from './app/app';
+import { provideNgxSpartanForms } from './app/wrapper';
 
 // Wrap in async IIFE so the JIT compiler import only loads in dev (Angular
 // Vite builder needs it for templateUrl/styleUrls during local dev).
@@ -22,6 +23,11 @@ void (async () => {
         defaultErrorStrategy: 'on-touch',
         autoAria: true,
       }),
+      // Single bootstrap entry point for the Spartan reference renderers.
+      // Registers both NGX_FORM_FIELD_ERROR_RENDERER and
+      // NGX_FORM_FIELD_HINT_RENDERER with the helm-flavoured components,
+      // mirroring `provideNgxMatForms()` and `provideNgxPrimeForms()`.
+      provideNgxSpartanForms(),
     ],
   });
 })();

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -74,15 +74,24 @@ so hint IDs flow into `aria-describedby` purely through DI. The descriptor
 shape is the public wire format — see `NgxSignalFormHintDescriptor` in
 `@ngx-signal-forms/toolkit`.
 
-### 3. `NGX_FORM_FIELD_ERROR_RENDERER` (and optionally `NGX_FORM_FIELD_HINT_RENDERER`)
+### 3. `NGX_FORM_FIELD_ERROR_RENDERER` and `NGX_FORM_FIELD_HINT_RENDERER`
 
-Inject the renderer token with `{ optional: true }`, fall back to
-`NgxFormFieldError` (or `NgxFormFieldHint`) when it returns `null`, and
-instantiate the resolved component via `*ngComponentOutlet`. This is the
-seam that lets consumers swap a Material-styled error component into your
-wrapper without forking it. The token JSDoc spells out the contract:
-the wrapper owns the default fallback; consumers override via the
-provider helpers documented below.
+Inject the error renderer token with `{ optional: true }`, fall back to
+`NgxFormFieldError` when it returns `null`, and instantiate the resolved
+component via `*ngComponentOutlet`. This is the seam that lets consumers
+swap a Material-styled error component into your wrapper without forking
+it. The token JSDoc spells out the contract: the wrapper owns the default
+fallback; consumers override via the provider helpers documented below.
+
+The hint renderer (`NGX_FORM_FIELD_HINT_RENDERER`) is dispatched **inside**
+`NgxFormFieldHint` itself — wrappers do not need to call
+`*ngComponentOutlet` for the hint slot. Register a hint renderer via
+`provideFormFieldHintRenderer(...)` and any projected
+`<ngx-form-field-hint>` automatically renders the configured component with
+the projected content forwarded into its default `<ng-content>` slot. The
+renderer receives `{ resolvedFieldName, resolvedId, position }` as inputs;
+declare all three with `input()` (any default is fine) because Angular's
+`componentRef.setInput` rejects writes to undeclared inputs.
 
 ### 4. `NgxSignalFormAutoAria`
 
@@ -553,10 +562,12 @@ generic `inputs` signature).
 - [ ] Wrapper does **not** write `aria-invalid`, `aria-required`, or
       `aria-describedby` on its host element — those belong on the bound
       control and are owned by `NgxSignalFormAutoAria`.
-- [ ] Optional: provide `NGX_FORM_FIELD_HINT_RENDERER` symmetry if your
-      wrapper's hint slot uses an outlet rather than projected
-      `<ng-content>`. (The first-party wrapper currently projects content
-      directly; the token is reserved for future parity.)
+- [ ] Optional: register `NGX_FORM_FIELD_HINT_RENDERER` via
+      `provideFormFieldHintRenderer(...)` if you want projected
+      `<ngx-form-field-hint>` instances to render with design-system chrome.
+      `NgxFormFieldHint` dispatches through the token internally, so the
+      wrapper itself does not need a hint outlet — the registration is
+      enough.
 
 ## Common pitfalls
 

--- a/packages/toolkit/assistive/hint.spec.ts
+++ b/packages/toolkit/assistive/hint.spec.ts
@@ -1,5 +1,13 @@
-import { signal } from '@angular/core';
-import { NGX_SIGNAL_FORM_FIELD_CONTEXT } from '@ngx-signal-forms/toolkit';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
+import {
+  NGX_FORM_FIELD_HINT_RENDERER,
+  NGX_SIGNAL_FORM_FIELD_CONTEXT,
+} from '@ngx-signal-forms/toolkit';
 import { render, screen } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
 import { NgxFormFieldHint } from './hint';
@@ -519,6 +527,141 @@ describe('NgxFormFieldHint', () => {
       const span = container.querySelector('span[style*="color"]');
       expect(span).toBeInTheDocument();
       expect(span).toHaveTextContent('Important note');
+    });
+  });
+
+  describe('Renderer dispatch (NGX_FORM_FIELD_HINT_RENDERER)', () => {
+    @Component({
+      selector: 'stub-hint-renderer',
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `
+        <div data-testid="stub-hint-renderer">
+          <span data-testid="resolved-field-name">{{
+            resolvedFieldName() ?? 'null'
+          }}</span>
+          <span data-testid="resolved-id">{{ resolvedId() }}</span>
+          <span data-testid="position">{{ position() ?? 'null' }}</span>
+          <div data-testid="projected">
+            <ng-content />
+          </div>
+        </div>
+      `,
+    })
+    class StubHintRenderer {
+      readonly resolvedFieldName = input<string | null>(null);
+      readonly resolvedId = input.required<string>();
+      readonly position = input<'left' | 'right' | null>(null);
+    }
+
+    it('dispatches to the registered renderer instead of projecting directly', async () => {
+      await render(
+        `<ngx-form-field-hint>Format: 123-456-7890</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          providers: [
+            {
+              provide: NGX_FORM_FIELD_HINT_RENDERER,
+              useValue: { component: StubHintRenderer },
+            },
+          ],
+        },
+      );
+
+      expect(screen.getByTestId('stub-hint-renderer')).toBeInTheDocument();
+    });
+
+    it('forwards projected content into the renderer’s default ng-content slot', async () => {
+      const view = await render(
+        `<ngx-form-field-hint>Format: 123-456-7890</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          providers: [
+            {
+              provide: NGX_FORM_FIELD_HINT_RENDERER,
+              useValue: { component: StubHintRenderer },
+            },
+          ],
+        },
+      );
+
+      view.detectChanges();
+      const projected = screen.getByTestId('projected');
+      expect(projected.textContent).toContain('Format: 123-456-7890');
+    });
+
+    it('passes resolvedFieldName, resolvedId, and position as inputs', async () => {
+      await render(
+        `<ngx-form-field-hint position="left">Hint copy</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          providers: [
+            {
+              provide: NGX_SIGNAL_FORM_FIELD_CONTEXT,
+              useValue: { fieldName: signal('email') },
+            },
+            {
+              provide: NGX_FORM_FIELD_HINT_RENDERER,
+              useValue: { component: StubHintRenderer },
+            },
+          ],
+        },
+      );
+
+      expect(screen.getByTestId('resolved-field-name').textContent).toBe(
+        'email',
+      );
+      expect(screen.getByTestId('resolved-id').textContent).toBe('email-hint');
+      expect(screen.getByTestId('position').textContent).toBe('left');
+    });
+
+    it('preserves the host element’s id and field-name attributes when dispatched', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint id="custom-hint">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          providers: [
+            {
+              provide: NGX_FORM_FIELD_HINT_RENDERER,
+              useValue: { component: StubHintRenderer },
+            },
+          ],
+        },
+      );
+
+      const host = container.querySelector('ngx-form-field-hint');
+      expect(host).toHaveAttribute('id', 'custom-hint');
+      expect(host).toHaveAttribute('data-ngx-signal-form-hint', 'true');
+      expect(screen.getByTestId('resolved-id').textContent).toBe('custom-hint');
+    });
+  });
+
+  describe('Renderer dispatch fallback', () => {
+    it('projects content directly when no renderer is registered', async () => {
+      await render(
+        `<ngx-form-field-hint>Direct projection</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+        },
+      );
+
+      expect(screen.getByText('Direct projection')).toBeInTheDocument();
+    });
+
+    it('treats an explicitly null renderer the same as none registered', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint>Direct projection</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          providers: [
+            { provide: NGX_FORM_FIELD_HINT_RENDERER, useValue: null },
+          ],
+        },
+      );
+
+      expect(screen.getByText('Direct projection')).toBeInTheDocument();
+      expect(
+        container.querySelector('[data-testid="stub-hint-renderer"]'),
+      ).toBeNull();
     });
   });
 });

--- a/packages/toolkit/assistive/hint.ts
+++ b/packages/toolkit/assistive/hint.ts
@@ -1,14 +1,19 @@
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   ElementRef,
   inject,
   input,
   signal,
+  ViewContainerRef,
+  type ComponentRef,
 } from '@angular/core';
 import {
   createUniqueId,
+  NGX_FORM_FIELD_HINT_RENDERER,
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
 } from '@ngx-signal-forms/toolkit';
 
@@ -18,8 +23,28 @@ import {
  * Provides visual guidance and instructions without blocking form submission.
  * Commonly used for format examples, field instructions, or contextual help.
  *
+ * ## Renderer dispatch
+ *
+ * When `NGX_FORM_FIELD_HINT_RENDERER` is registered (typically by a custom
+ * wrapper via `provideFormFieldHintRenderer(...)`), `<ngx-form-field-hint>`
+ * lifts its projected children off the host after the first render and
+ * mounts the configured renderer component as a host child, forwarding the
+ * lifted nodes into the renderer's default `<ng-content />` slot. The
+ * dispatched renderer receives the metadata `<ngx-form-field-hint>` already
+ * exposes as inputs: `{ resolvedFieldName: string | null, resolvedId:
+ * string, position: 'left' | 'right' | null }` — renderers must declare all
+ * three with `input()` because Angular's `componentRef.setInput` rejects
+ * writes to undeclared inputs.
+ *
+ * The dispatch only runs in browser contexts (`afterNextRender`); SSR keeps
+ * the projected fallback content. When no renderer is registered, content
+ * is projected directly via `<ng-content />` — preserving backwards
+ * compatibility for consumers using `<ngx-form-field-hint>` outside a
+ * wrapper.
+ *
  * Key features:
  * - Content projection for flexible hint text
+ * - Renderer-token dispatch for design-system-flavoured chrome
  * - Semantic HTML for accessibility
  * - Themeable via CSS custom properties
  * - Optional position control (left/right alignment)
@@ -68,7 +93,7 @@ import {
 @Component({
   selector: 'ngx-form-field-hint',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <ng-content /> `,
+  template: `<ng-content />`,
   styles: `
     :host {
       display: block;
@@ -109,11 +134,23 @@ import {
 })
 export class NgxFormFieldHint {
   readonly #elementRef = inject(ElementRef<HTMLElement>);
+  readonly #viewContainerRef = inject(ViewContainerRef);
   readonly #fieldContext = inject(NGX_SIGNAL_FORM_FIELD_CONTEXT, {
+    optional: true,
+  });
+  readonly #hintRenderer = inject(NGX_FORM_FIELD_HINT_RENDERER, {
     optional: true,
   });
 
   readonly #explicitId = signal<string | null>(null);
+
+  /**
+   * Component reference for the dispatched renderer (when one is registered).
+   * Created imperatively after the first render so the projected children
+   * are already attached to the host and can be moved into the dynamic
+   * component's `<ng-content />` slot via `projectableNodes`.
+   */
+  #dispatchedRef: ComponentRef<unknown> | null = null;
 
   /**
    * Text alignment position.
@@ -160,5 +197,55 @@ export class NgxFormFieldHint {
     if (existingId !== null && existingId.length > 0) {
       this.#explicitId.set(existingId);
     }
+
+    const renderer = this.#hintRenderer;
+    if (renderer === null) return;
+
+    // Dispatch path: after the first render, lift the projected children
+    // off the host and hand them to the configured renderer's default
+    // `<ng-content />` via `projectableNodes`. The dynamic component is
+    // appended as a sibling inside the host element, so the host keeps
+    // owning the live region the wrapper or auto-aria layer points at.
+    //
+    // `afterNextRender` is browser-only by design — the dispatch path
+    // walks live DOM and is meaningless server-side; SSR keeps the
+    // projected fallback content from the static template.
+    afterNextRender(() => {
+      const host = this.#elementRef.nativeElement;
+      const projected: Node[] = [];
+      while (host.firstChild !== null) {
+        projected.push(host.removeChild(host.firstChild));
+      }
+      this.#dispatchedRef = this.#viewContainerRef.createComponent<unknown>(
+        renderer.component,
+        { projectableNodes: [projected] },
+      );
+      this.#applyRendererInputs(this.#dispatchedRef);
+      // Move the dynamic component's host element into our own host so the
+      // rendered chrome sits visually inside `<ngx-form-field-hint>` rather
+      // than next to it. `ViewContainerRef` anchors the new view at a
+      // sibling position by default; relocating keeps the wrapper's host
+      // styles (font-size, color, padding) wrapping the renderer's chrome.
+      host.append(this.#dispatchedRef.location.nativeElement);
+    });
+
+    // Keep the dispatched renderer's inputs in lockstep with the metadata
+    // signals — `position` and the resolved id/field-name flow through
+    // here whenever they change after the dispatch is wired up.
+    effect(() => {
+      // Track signal reads so the effect re-fires on changes.
+      this.position();
+      this.resolvedFieldName();
+      this.resolvedId();
+      if (this.#dispatchedRef !== null) {
+        this.#applyRendererInputs(this.#dispatchedRef);
+      }
+    });
+  }
+
+  #applyRendererInputs(ref: ComponentRef<unknown>): void {
+    ref.setInput('resolvedFieldName', this.resolvedFieldName());
+    ref.setInput('resolvedId', this.resolvedId());
+    ref.setInput('position', this.position());
   }
 }

--- a/packages/toolkit/core/tokens.ts
+++ b/packages/toolkit/core/tokens.ts
@@ -215,22 +215,24 @@ export interface NgxFormFieldErrorRenderer {
 }
 
 /**
- * Renderer contract for a form-field wrapper's hint slot when that wrapper
- * chooses to instantiate a configured hint component, for example via
- * `*ngComponentOutlet`.
+ * Renderer contract for the hint slot dispatched by `NgxFormFieldHint`.
  *
- * The first-party `NgxFormFieldWrapper` projects `<ngx-form-field-hint>`
- * content directly and does not consult a hint renderer for its hint slot.
- * This contract therefore applies to wrappers that opt into dynamic hint
- * rendering.
+ * When registered, `<ngx-form-field-hint>` instantiates the configured
+ * component via `*ngComponentOutlet` and forwards projected content into
+ * the renderer's default `<ng-content />` slot. The renderer receives the
+ * metadata `NgxFormFieldHint` already exposes as inputs:
+ * `{ resolvedFieldName: string | null, resolvedId: string, position:
+ * 'left' | 'right' | null }`. Renderers must declare all three with
+ * `input()` — Angular's `componentRef.setInput` rejects writes to
+ * undeclared inputs, so omitting any of them errors at runtime.
  *
- * Hint renderers receive no wrapper-bound inputs; when instantiated, they
- * consume `NGX_SIGNAL_FORM_FIELD_CONTEXT` (and any other DI tokens)
- * directly.
+ * When no provider is registered, `NgxFormFieldHint` falls back to direct
+ * `<ng-content />` projection (preserving backwards compatibility for
+ * consumers using the component outside a wrapper).
  *
- * The provided `component` must be a standalone component — wrappers that
- * instantiate it via `*ngComponentOutlet` without `ngComponentOutletNgModule`
- * cannot resolve module-declared components.
+ * The provided `component` must be a standalone component —
+ * `*ngComponentOutlet` is invoked without `ngComponentOutletNgModule`, so
+ * module-declared components are not supported.
  *
  * @public
  */
@@ -258,14 +260,15 @@ export const NGX_FORM_FIELD_ERROR_RENDERER =
   );
 
 /**
- * Injection token for form-field wrapper implementations that render the
- * hint slot via a component outlet.
+ * Injection token consulted by `NgxFormFieldHint` to dispatch hint
+ * rendering through a custom design-system-flavoured component.
  *
- * The first-party `NgxFormFieldWrapper` currently renders projected hint
- * content directly and does not consult this token. Wrappers that do render
- * hints dynamically may use this token to resolve a custom hint renderer,
- * typically falling back to `NgxFormFieldHint` from
- * `@ngx-signal-forms/toolkit/assistive` when no provider is registered.
+ * When registered, `<ngx-form-field-hint>` instantiates the configured
+ * component via `*ngComponentOutlet` and forwards projected content into
+ * the renderer's default `<ng-content />` slot — see
+ * {@link NgxFormFieldHintRenderer} for the input contract. When no
+ * provider is registered, `NgxFormFieldHint` falls back to direct content
+ * projection (`<ng-content />`).
  *
  * The token itself has no factory — consumers injecting it directly should
  * use `{ optional: true }` and treat `null` as "no custom hint renderer

--- a/packages/toolkit/core/tokens.ts
+++ b/packages/toolkit/core/tokens.ts
@@ -217,10 +217,11 @@ export interface NgxFormFieldErrorRenderer {
 /**
  * Renderer contract for the hint slot dispatched by `NgxFormFieldHint`.
  *
- * When registered, `<ngx-form-field-hint>` instantiates the configured
- * component via `*ngComponentOutlet` and forwards projected content into
- * the renderer's default `<ng-content />` slot. The renderer receives the
- * metadata `NgxFormFieldHint` already exposes as inputs:
+ * When registered, `<ngx-form-field-hint>` dynamically instantiates the
+ * configured component (via `ViewContainerRef.createComponent` with
+ * `projectableNodes`) and forwards projected content into the renderer's
+ * default `<ng-content />` slot. The renderer receives the metadata
+ * `NgxFormFieldHint` already exposes as inputs:
  * `{ resolvedFieldName: string | null, resolvedId: string, position:
  * 'left' | 'right' | null }`. Renderers must declare all three with
  * `input()` — Angular's `componentRef.setInput` rejects writes to
@@ -230,9 +231,9 @@ export interface NgxFormFieldErrorRenderer {
  * `<ng-content />` projection (preserving backwards compatibility for
  * consumers using the component outside a wrapper).
  *
- * The provided `component` must be a standalone component —
- * `*ngComponentOutlet` is invoked without `ngComponentOutletNgModule`, so
- * module-declared components are not supported.
+ * The provided `component` must be a standalone component — it is
+ * instantiated without an `NgModuleRef`, so module-declared components are
+ * not supported.
  *
  * @public
  */
@@ -263,12 +264,12 @@ export const NGX_FORM_FIELD_ERROR_RENDERER =
  * Injection token consulted by `NgxFormFieldHint` to dispatch hint
  * rendering through a custom design-system-flavoured component.
  *
- * When registered, `<ngx-form-field-hint>` instantiates the configured
- * component via `*ngComponentOutlet` and forwards projected content into
- * the renderer's default `<ng-content />` slot — see
- * {@link NgxFormFieldHintRenderer} for the input contract. When no
- * provider is registered, `NgxFormFieldHint` falls back to direct content
- * projection (`<ng-content />`).
+ * When registered, `<ngx-form-field-hint>` dynamically instantiates the
+ * configured component (via `ViewContainerRef.createComponent` with
+ * `projectableNodes`) and forwards projected content into the renderer's
+ * default `<ng-content />` slot — see {@link NgxFormFieldHintRenderer} for
+ * the input contract. When no provider is registered, `NgxFormFieldHint`
+ * falls back to direct content projection (`<ng-content />`).
  *
  * The token itself has no factory — consumers injecting it directly should
  * use `{ optional: true }` and treat `null` as "no custom hint renderer


### PR DESCRIPTION
## Summary

`NGX_FORM_FIELD_HINT_RENDERER` was advertised as part of the wrapper contract but `NgxFormFieldHint` ignored it — the demo wrappers' `provideFormFieldHintRenderer` registrations were silent no-ops. This PR wires the dispatch end-to-end (mirroring the existing error-renderer flow) and updates the docs + reference wrappers.

- `NgxFormFieldHint` now lifts its projected children off the host after the first render and mounts the configured renderer as a host child, forwarding `{ resolvedFieldName, resolvedId, position }` as inputs and the lifted nodes into the renderer's default `<ng-content />`. Falls back to direct `<ng-content />` when no renderer is registered.
- `provideNgxMatForms()` now registers a dedicated `MaterialHintRenderer` for the hint slot — the existing `MaterialFeedbackRenderer` requires `message`+`severity` inputs the hint dispatch can't supply, so the previous combined registration would have crashed at runtime.
- `PrimeFieldHintComponent` declares the metadata inputs to comply with the dispatched contract.
- `docs/CUSTOM_WRAPPERS.md` and the token JSDocs no longer describe hint dispatch as "future / optional".

Closes #61

## Test plan

- [x] `pnpm nx test toolkit` (1071 tests, all pass — including 7 new tests covering both dispatch and fallback paths in `assistive/hint.spec.ts`)
- [x] `pnpm nx build toolkit`
- [x] `pnpm nx affected -t test,build,lint --base=origin/main`
- [x] `pnpm nx run-many -t test --projects=demo-material,demo-primeng,demo-spartan` (5 tests, all pass)
- [x] `pnpm format`

## Notes

- The dispatch implementation imperatively calls `ViewContainerRef.createComponent` after `afterNextRender`. An earlier attempt with `*ngComponentOutlet` + `ngComponentOutletContent` hit Angular's known limitation that `<ng-content />` inside `@if` doesn't project (issues angular/angular#56962, #58120, #62046), so we capture nodes via plain DOM removal once they're attached to the host.
- The dispatch path is browser-only by design; SSR keeps the projected fallback content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable hint renderer support alongside error renderers, allowing independent control over how form hints are displayed.
  * Introduced hint positioning capability (left/right alignment) for Material and PrimeNG wrappers.

* **Documentation**
  * Updated custom wrapper guide to clarify hint and error renderer contracts and configuration steps.

* **Tests**
  * Added comprehensive test coverage for hint renderer dispatch and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->