### PR TITLE
refactor(demo-material): adopt headless toolkit primitives, cut consumer boilerplate

### DIFF
--- a/apps/demo-material/src/app/app.ts
+++ b/apps/demo-material/src/app/app.ts
@@ -15,15 +15,17 @@ import { ContactFormComponent } from './contact-form/contact-form';
   imports: [ContactFormComponent],
   template: `
     <main class="app-shell">
-      <h1>ngx-signal-forms · Angular Material 21+ reference</h1>
-      <p class="lead">
-        A single contact form composed on top of
-        <code>@angular/material</code> using
-        <code>@ngx-signal-forms/toolkit</code>. See the README for the four
-        contracts the wrapper satisfies and the Material-specific gotchas
-        (especially <code>aria-describedby</code> ownership and
-        <code>floatLabel</code>).
-      </p>
+      <p class="app-shell__eyebrow">Angular Material reference demo</p>
+      <section class="app-shell__hero" aria-labelledby="app-title">
+        <h1 id="app-title">Material feedback, with better rhythm.</h1>
+        <p class="lead">
+          A focused contact form built with <code>@angular/material</code> and
+          <code>@ngx-signal-forms/toolkit</code>, tuned so blocking errors stay
+          close to their fields, non-blocking warnings read gently, and Material
+          keeps ownership of <code>aria-describedby</code> exactly where it
+          should.
+        </p>
+      </section>
 
       <ngx-contact-form />
     </main>

--- a/apps/demo-material/src/app/contact-form/contact-form.html
+++ b/apps/demo-material/src/app/contact-form/contact-form.html
@@ -1,0 +1,133 @@
+<form [formRoot]="contactForm" ngxSignalForm class="demo-form">
+  <header class="demo-form__header">
+    <p class="demo-form__eyebrow">Reference form</p>
+    <h2>Contact us</h2>
+    <p class="demo-form__intro">
+      Tell us what you need and we’ll route it to the right team. Validation
+      stays close to each control, and short-but-valid names surface as a gentle
+      warning instead of a blocker.
+    </p>
+  </header>
+
+  <mat-form-field
+    class="demo-form__field"
+    [ngxMatFormField]="contactForm.name"
+    fieldName="contact-name"
+    appearance="outline"
+    floatLabel="always"
+    subscriptSizing="dynamic"
+  >
+    <mat-label>Name</mat-label>
+    <input
+      matInput
+      id="contact-name"
+      type="text"
+      [formField]="contactForm.name"
+      ngxMatTextControl
+      autocomplete="name"
+    />
+    <mat-hint *ngxMatHintSlot="contactForm.name; let warning">
+      @if (warning) {
+      <ngx-mat-feedback-outlet [message]="warning" severity="warning" />
+      } @else { What should we call you? }
+    </mat-hint>
+    <mat-error *ngxMatErrorSlot="contactForm.name; let message">
+      <ngx-mat-feedback-outlet [message]="message" severity="error" />
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field
+    class="demo-form__field"
+    [ngxMatFormField]="contactForm.email"
+    fieldName="contact-email"
+    appearance="outline"
+    floatLabel="always"
+    subscriptSizing="dynamic"
+  >
+    <mat-label>Email</mat-label>
+    <input
+      matInput
+      id="contact-email"
+      type="email"
+      [formField]="contactForm.email"
+      ngxMatTextControl
+      autocomplete="email"
+    />
+    <mat-error *ngxMatErrorSlot="contactForm.email; let message">
+      <ngx-mat-feedback-outlet [message]="message" severity="error" />
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field
+    class="demo-form__field"
+    [ngxMatFormField]="contactForm.topic"
+    fieldName="contact-topic"
+    appearance="outline"
+    floatLabel="always"
+    subscriptSizing="dynamic"
+  >
+    <mat-label>Topic</mat-label>
+    <mat-select
+      id="contact-topic"
+      [formField]="contactForm.topic"
+      ngxMatSelectControl
+    >
+      <mat-option value="">— Choose one —</mat-option>
+      <mat-option value="support">Product support</mat-option>
+      <mat-option value="sales">Sales question</mat-option>
+      <mat-option value="feedback">General feedback</mat-option>
+    </mat-select>
+    <mat-hint *ngxMatHintSlot="contactForm.topic; let warning">
+      @if (warning) {
+      <ngx-mat-feedback-outlet [message]="warning" severity="warning" />
+      } @else { Pick the closest match }
+    </mat-hint>
+    <mat-error *ngxMatErrorSlot="contactForm.topic; let message">
+      <ngx-mat-feedback-outlet [message]="message" severity="error" />
+    </mat-error>
+  </mat-form-field>
+
+  <div class="demo-form__row">
+    <mat-checkbox
+      id="contact-agree"
+      [formField]="contactForm.agree"
+      ngxMatCheckboxControl
+    >
+      I agree to be contacted
+    </mat-checkbox>
+  </div>
+  <!-- Material's mat-checkbox does not project into mat-form-field, so
+       its errors render via the control-agnostic feedback slot. The
+       toolkit still owns visibility timing through the same DI seam. -->
+  <ng-container
+    *ngxMatFeedback="
+      contactForm.agree;
+      fieldName: 'contact-agree';
+      let messages;
+      severity as severity;
+      id as id
+    "
+  >
+    <p
+      class="demo-form__feedback"
+      [class.demo-form__feedback--warning]="severity === 'warning'"
+      [attr.role]="severity === 'error' ? 'alert' : 'status'"
+      [id]="id"
+    >
+      @for (message of messages; track message) {
+      <ngx-mat-feedback-outlet [message]="message" [severity]="severity" />
+      }
+    </p>
+  </ng-container>
+
+  <div class="demo-form__actions">
+    <button mat-stroked-button type="button" (click)="resetForm()">
+      Reset
+    </button>
+    <button mat-flat-button color="primary" type="submit">Send message</button>
+  </div>
+
+  @if (submitted()) {
+  <p class="success-banner" role="status">Thanks! We received your message.</p>
+  }
+</form>

--- a/apps/demo-material/src/app/contact-form/contact-form.ts
+++ b/apps/demo-material/src/app/contact-form/contact-form.ts
@@ -1,27 +1,15 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  signal,
-  type Type,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { NgComponentOutlet } from '@angular/common';
 import {
   createOnInvalidHandler,
-  NGX_FORM_FIELD_ERROR_RENDERER,
   NgxSignalFormToolkit,
 } from '@ngx-signal-forms/toolkit';
-import {
-  MaterialFeedbackRenderer,
-  NgxMatFormBundle,
-  type NgxMatFeedbackSeverity,
-} from '../wrapper';
+import { NgxMatFormBundle } from '../wrapper';
 import {
   INITIAL_CONTACT_MODEL,
   type ContactFormModel,
@@ -36,9 +24,10 @@ import { contactFormSchema } from './contact-form.validations';
  *
  * 1. **Renderer registration** — `provideNgxMatForms()` (in `main.ts`)
  *    registers `MaterialFeedbackRenderer` for both `<mat-error>` and
- *    `<mat-hint>` slots app-wide. The slot directives below resolve the
- *    field → message string and stamp the renderer with `{ message,
- *    severity }`; consumers swap presentation in one DI call.
+ *    `<mat-hint>` slots app-wide. Consumers drop in
+ *    `<ngx-mat-feedback-outlet>` and the configured renderer mounts itself
+ *    via DI; swap presentation in one provider call without touching
+ *    templates.
  * 2. **Per-control directives** — `ngxMatTextControl` /
  *    `ngxMatSelectControl` / `ngxMatCheckboxControl` apply
  *    `ariaMode="manual"` automatically (Material owns `aria-describedby`
@@ -46,7 +35,8 @@ import { contactFormSchema } from './contact-form.validations';
  * 3. **Wrapper directive** — `[ngxMatFormField]` runs `contentChildren`
  *    over `NgxMatBoundControl` to discover the bound control. No
  *    `*ngComponentOutlet` boilerplate; `*ngxMatErrorSlot` and
- *    `*ngxMatHintSlot` own conditional rendering.
+ *    `*ngxMatHintSlot` own conditional rendering and delegate message
+ *    resolution to the public `createErrorMessageSignal` primitive.
  * 4. **`*ngxMatFeedback`** — the control-agnostic feedback slot for
  *    Material controls that don't fit `<mat-form-field>` (here, the
  *    consent checkbox).
@@ -55,7 +45,6 @@ import { contactFormSchema } from './contact-form.validations';
   selector: 'ngx-contact-form',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    NgComponentOutlet,
     FormField,
     NgxSignalFormToolkit,
     NgxMatFormBundle,
@@ -65,162 +54,7 @@ import { contactFormSchema } from './contact-form.validations';
     MatCheckboxModule,
     MatButtonModule,
   ],
-  template: `
-    <form [formRoot]="contactForm" ngxSignalForm class="demo-form">
-      <h2>Contact us</h2>
-
-      <mat-form-field
-        [ngxMatFormField]="contactForm.name"
-        fieldName="contact-name"
-        appearance="outline"
-      >
-        <mat-label>Name</mat-label>
-        <input
-          matInput
-          id="contact-name"
-          type="text"
-          [formField]="contactForm.name"
-          ngxMatTextControl
-          autocomplete="name"
-        />
-        <mat-hint *ngxMatHintSlot="contactForm.name; let warning">
-          @if (warning) {
-            <ng-container
-              *ngComponentOutlet="
-                feedbackRenderer;
-                inputs: rendererInputs(warning, 'warning')
-              "
-            />
-          } @else {
-            What should we call you?
-          }
-        </mat-hint>
-        <mat-error *ngxMatErrorSlot="contactForm.name; let message">
-          <ng-container
-            *ngComponentOutlet="
-              feedbackRenderer;
-              inputs: rendererInputs(message, 'error')
-            "
-          />
-        </mat-error>
-      </mat-form-field>
-
-      <mat-form-field
-        [ngxMatFormField]="contactForm.email"
-        fieldName="contact-email"
-        appearance="outline"
-      >
-        <mat-label>Email</mat-label>
-        <input
-          matInput
-          id="contact-email"
-          type="email"
-          [formField]="contactForm.email"
-          ngxMatTextControl
-          autocomplete="email"
-        />
-        <mat-error *ngxMatErrorSlot="contactForm.email; let message">
-          <ng-container
-            *ngComponentOutlet="
-              feedbackRenderer;
-              inputs: rendererInputs(message, 'error')
-            "
-          />
-        </mat-error>
-      </mat-form-field>
-
-      <mat-form-field
-        [ngxMatFormField]="contactForm.topic"
-        fieldName="contact-topic"
-        appearance="outline"
-      >
-        <mat-label>Topic</mat-label>
-        <mat-select
-          id="contact-topic"
-          [formField]="contactForm.topic"
-          ngxMatSelectControl
-        >
-          <mat-option value="">— Choose one —</mat-option>
-          <mat-option value="support">Product support</mat-option>
-          <mat-option value="sales">Sales question</mat-option>
-          <mat-option value="feedback">General feedback</mat-option>
-        </mat-select>
-        <mat-hint *ngxMatHintSlot="contactForm.topic; let warning">
-          @if (warning) {
-            <ng-container
-              *ngComponentOutlet="
-                feedbackRenderer;
-                inputs: rendererInputs(warning, 'warning')
-              "
-            />
-          } @else {
-            Pick the closest match
-          }
-        </mat-hint>
-        <mat-error *ngxMatErrorSlot="contactForm.topic; let message">
-          <ng-container
-            *ngComponentOutlet="
-              feedbackRenderer;
-              inputs: rendererInputs(message, 'error')
-            "
-          />
-        </mat-error>
-      </mat-form-field>
-
-      <div class="demo-form__row">
-        <mat-checkbox
-          id="contact-agree"
-          [formField]="contactForm.agree"
-          ngxMatCheckboxControl
-        >
-          I agree to be contacted
-        </mat-checkbox>
-      </div>
-      <!-- Material's mat-checkbox does not project into mat-form-field, so
-           its errors render via the control-agnostic feedback slot. The
-           toolkit still owns visibility timing through the same DI seam. -->
-      <ng-container
-        *ngxMatFeedback="
-          contactForm.agree;
-          fieldName: 'contact-agree';
-          let messages;
-          severity as severity;
-          id as id
-        "
-      >
-        <p
-          class="demo-form__feedback"
-          [class.demo-form__feedback--warning]="severity === 'warning'"
-          [attr.role]="severity === 'error' ? 'alert' : 'status'"
-          [id]="id"
-        >
-          @for (message of messages; track message) {
-            <ng-container
-              *ngComponentOutlet="
-                feedbackRenderer;
-                inputs: rendererInputs(message, severity)
-              "
-            />
-          }
-        </p>
-      </ng-container>
-
-      <div class="demo-form__actions">
-        <button mat-stroked-button type="button" (click)="resetForm()">
-          Reset
-        </button>
-        <button mat-flat-button color="primary" type="submit">
-          Send message
-        </button>
-      </div>
-
-      @if (submitted()) {
-        <p class="success-banner" role="status">
-          Thanks! We received your message.
-        </p>
-      }
-    </form>
-  `,
+  templateUrl: './contact-form.html',
 })
 export class ContactFormComponent {
   /** Reactive model — Angular Signal Forms drives the form from this signal. */
@@ -239,29 +73,6 @@ export class ContactFormComponent {
   });
 
   protected readonly submitted = signal(false);
-
-  /**
-   * Resolved feedback renderer (default: `MaterialFeedbackRenderer`). Reads
-   * from the same DI token consumers can override via
-   * `provideNgxMatForms({ feedbackRenderer })` — proves the renderer-token
-   * seam works end-to-end inside Material's idiom.
-   */
-  readonly #errorRenderer = inject(NGX_FORM_FIELD_ERROR_RENDERER, {
-    optional: true,
-  });
-  protected readonly feedbackRenderer: Type<unknown> =
-    this.#errorRenderer?.component ?? MaterialFeedbackRenderer;
-
-  /**
-   * Inputs map for the renderer outlet. The simplified renderer contract
-   * (ADR-0002 §7) accepts only `{ message, severity }`; the slot directives
-   * resolve `formField` → message text, so the consumer only forwards the
-   * resolved string and the severity discriminator.
-   */
-  protected readonly rendererInputs = (
-    message: string,
-    severity: NgxMatFeedbackSeverity,
-  ): Record<string, unknown> => ({ message, severity });
 
   protected resetForm(): void {
     this.model.set({ ...INITIAL_CONTACT_MODEL });

--- a/apps/demo-material/src/app/wrapper/feedback-directive.ts
+++ b/apps/demo-material/src/app/wrapper/feedback-directive.ts
@@ -10,17 +10,11 @@ import {
 } from '@angular/core';
 import type { FieldTree } from '@angular/forms/signals';
 import {
-  createShowErrorsComputed,
   generateErrorId,
   generateWarningId,
-  injectFormContext,
-  isBlockingError,
-  isWarningError,
-  NGX_SIGNAL_FORMS_CONFIG,
-  readDirectErrors,
-  resolveErrorDisplayStrategy,
   type ErrorDisplayStrategy,
 } from '@ngx-signal-forms/toolkit';
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
 
 /**
  * Embedded-view context for `*ngxMatFeedback`.
@@ -92,64 +86,50 @@ export class NgxMatFeedback<TValue = unknown> {
   readonly #templateRef = inject(TemplateRef<NgxMatFeedbackContext>);
   readonly #viewContainerRef = inject(ViewContainerRef);
 
-  readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
-  readonly #formContext = injectFormContext();
+  readonly #strategySignal = computed(() => this.strategy() ?? undefined);
 
-  readonly #fieldStateSignal = computed(() => this.formField()());
-
-  readonly #effectiveStrategy = computed(() =>
-    resolveErrorDisplayStrategy(
-      this.strategy(),
-      this.#formContext ? this.#formContext.errorStrategy() : undefined,
-      this.#config.defaultErrorStrategy,
-    ),
+  readonly #blockingErrors = createErrorMessageSignal(
+    () => this.formField()(),
+    { strategy: this.#strategySignal },
   );
 
-  readonly #submittedStatus = computed(() =>
-    this.#formContext ? this.#formContext.submittedStatus() : 'unsubmitted',
-  );
-
-  readonly #showByStrategy = createShowErrorsComputed(
-    this.#fieldStateSignal,
-    this.#effectiveStrategy,
-    this.#submittedStatus,
-  );
+  readonly #warnings = createErrorMessageSignal(() => this.formField()(), {
+    strategy: this.#strategySignal,
+    includeWarnings: 'only',
+  });
 
   readonly #blocks = computed<readonly NgxMatFeedbackContext[]>(() => {
-    if (!this.#showByStrategy()) {
-      return [];
-    }
-    const errors = readDirectErrors(this.#fieldStateSignal());
-    const blockingMessages = errors
-      .filter(isBlockingError)
-      .map((entry) => entry.message ?? '')
-      .filter((message) => message.length > 0);
-    const warningMessages = errors
-      .filter(isWarningError)
-      .map((entry) => entry.message ?? '')
-      .filter((message) => message.length > 0);
-
-    const out: NgxMatFeedbackContext[] = [];
     const fieldName = this.fieldName();
+    const blockingMessages = this.#blockingErrors()
+      .map((entry) => entry.message)
+      .filter((message) => message.length > 0);
     if (blockingMessages.length > 0) {
-      out.push({
-        $implicit: blockingMessages,
-        messages: blockingMessages,
-        severity: 'error',
-        id: generateErrorId(fieldName),
-      });
-    } else if (warningMessages.length > 0) {
-      // Warnings render only when there are no blocking errors — matching
-      // the previous `MatCheckboxFeedback` semantics and Material's
-      // hint-vs-error convention.
-      out.push({
-        $implicit: warningMessages,
-        messages: warningMessages,
-        severity: 'warning',
-        id: generateWarningId(fieldName),
-      });
+      return [
+        {
+          $implicit: blockingMessages,
+          messages: blockingMessages,
+          severity: 'error',
+          id: generateErrorId(fieldName),
+        },
+      ];
     }
-    return out;
+    // Warnings render only when there are no blocking errors — matching the
+    // previous `MatCheckboxFeedback` semantics and Material's hint-vs-error
+    // convention.
+    const warningMessages = this.#warnings()
+      .map((entry) => entry.message)
+      .filter((message) => message.length > 0);
+    if (warningMessages.length > 0) {
+      return [
+        {
+          $implicit: warningMessages,
+          messages: warningMessages,
+          severity: 'warning',
+          id: generateWarningId(fieldName),
+        },
+      ];
+    }
+    return [];
   });
 
   /** @internal — type guard for template language services. */

--- a/apps/demo-material/src/app/wrapper/index.ts
+++ b/apps/demo-material/src/app/wrapper/index.ts
@@ -29,6 +29,7 @@ export {
 } from './mat-form-field-wrapper';
 export {
   MaterialFeedbackRenderer,
+  NgxMatFeedbackOutlet,
   type NgxMatFeedbackSeverity,
 } from './material-error-renderer';
 export { MaterialHintRenderer } from './material-hint-renderer';

--- a/apps/demo-material/src/app/wrapper/mat-form-field-wrapper.ts
+++ b/apps/demo-material/src/app/wrapper/mat-form-field-wrapper.ts
@@ -7,7 +7,6 @@ import {
   input,
   isDevMode,
   signal,
-  type Signal,
 } from '@angular/core';
 import type { FieldState, FieldTree } from '@angular/forms/signals';
 import {
@@ -22,14 +21,15 @@ import {
   readDirectErrors,
   resolveErrorDisplayStrategy,
   type ErrorDisplayStrategy,
-  type NgxSignalFormHintDescriptor,
 } from '@ngx-signal-forms/toolkit';
 import { NgxFormFieldHint } from '@ngx-signal-forms/toolkit/assistive';
 import {
   createAriaDescribedBySignal,
   createAriaInvalidSignal,
   createAriaRequiredSignal,
+  createFieldNameResolver,
   createHintIdsSignal,
+  toHintDescriptors,
 } from '@ngx-signal-forms/toolkit/headless';
 import {
   NgxMatBoundControl,
@@ -39,6 +39,7 @@ import {
   NgxMatTextControl,
 } from './control-directives';
 import { NgxMatFeedback } from './feedback-directive';
+import { NgxMatFeedbackOutlet } from './material-error-renderer';
 import { NgxMatErrorSlot, NgxMatHintSlot } from './slot-directives';
 
 /**
@@ -230,21 +231,18 @@ export class MatFormFieldWrapper<TValue = unknown> {
     () => this.#boundControl()?.elementRef.nativeElement ?? null,
   );
 
-  readonly #boundControlId = computed<string | null>(() => {
-    const id = this.#boundControlElement()?.id;
-    return id && id.length > 0 ? id : null;
-  });
-
-  readonly resolvedFieldName = computed<string | null>(() => {
-    const explicit = this.fieldName();
-    if (explicit !== undefined) {
-      const trimmed = explicit.trim();
-      if (trimmed.length > 0) {
-        return trimmed;
-      }
-    }
-
-    return this.#boundControlId();
+  /**
+   * Resolved field name. Built via the toolkit's
+   * {@link createFieldNameResolver} so the priority cascade
+   * (explicit → bound-control `id` → `null` + dev warning) stays in
+   * lockstep with the canonical wrapper. Mirrors what `NgxFormFieldWrapper`
+   * and the Spartan reference do — keeping every wrapper on the same
+   * resolver primitive prevents drift if the cascade evolves.
+   */
+  readonly resolvedFieldName = createFieldNameResolver({
+    explicit: this.fieldName,
+    boundControl: () => this.#boundControlElement(),
+    wrapperName: 'mat-form-field',
   });
 
   // ── Hint registry (forward-compat with <ngx-form-field-hint>) ─────────
@@ -269,13 +267,13 @@ export class MatFormFieldWrapper<TValue = unknown> {
     descendants: true,
   });
 
-  readonly hintDescriptors: Signal<readonly NgxSignalFormHintDescriptor[]> =
-    computed(() =>
-      this.hintChildren().map((hint) => ({
-        id: hint.resolvedId(),
-        fieldName: hint.resolvedFieldName(),
-      })),
-    );
+  /**
+   * Hint descriptors in the public wire format consumed by
+   * `NGX_SIGNAL_FORM_HINT_REGISTRY`. Built via the toolkit's
+   * {@link toHintDescriptors} helper so the registry-wire shape stays in
+   * lockstep with the canonical wrapper.
+   */
+  readonly hintDescriptors = toHintDescriptors(this.hintChildren);
 
   // ── ARIA primitive factories ──────────────────────────────────────────
   // The four factories from `@ngx-signal-forms/toolkit/headless` drive
@@ -397,5 +395,6 @@ export const NgxMatFormBundle = [
   NgxMatErrorSlot,
   NgxMatHintSlot,
   NgxMatFeedback,
+  NgxMatFeedbackOutlet,
   NgxSignalFormControlSemanticsDirective,
 ] as const;

--- a/apps/demo-material/src/app/wrapper/material-error-renderer.ts
+++ b/apps/demo-material/src/app/wrapper/material-error-renderer.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { NgComponentOutlet } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  type Type,
+} from '@angular/core';
+import { NGX_FORM_FIELD_ERROR_RENDERER } from '@ngx-signal-forms/toolkit';
 
 /**
  * Severity discriminator carried alongside the resolved message string.
@@ -38,22 +47,44 @@ export type NgxMatFeedbackSeverity = 'error' | 'warning';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <span
-      class="ngx-mat-feedback__message"
-      [class.ngx-mat-feedback__message--warning]="severity() === 'warning'"
-      >{{ message() }}</span
+      class="ngx-mat-feedback"
+      [class.ngx-mat-feedback--warning]="severity() === 'warning'"
     >
+      <span class="ngx-mat-feedback__marker" aria-hidden="true"></span>
+      <span class="ngx-mat-feedback__message">{{ message() }}</span>
+    </span>
   `,
   styles: `
     :host {
       display: block;
     }
 
+    .ngx-mat-feedback {
+      display: inline-flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      max-width: 62ch;
+      color: inherit;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+    }
+
+    .ngx-mat-feedback__marker {
+      width: 0.5rem;
+      height: 0.5rem;
+      flex: 0 0 0.5rem;
+      margin-top: 0.35rem;
+      border-radius: 999px;
+      background: currentColor;
+      opacity: 0.9;
+    }
+
     .ngx-mat-feedback__message {
       display: block;
     }
 
-    .ngx-mat-feedback__message--warning {
-      color: #92400e;
+    .ngx-mat-feedback--warning {
+      color: #8a5a12;
     }
   `,
 })
@@ -63,4 +94,53 @@ export class MaterialFeedbackRenderer {
 
   /** Severity discriminator; drives visual presentation only. */
   readonly severity = input.required<NgxMatFeedbackSeverity>();
+}
+
+/**
+ * Drop-in outlet that mounts the configured feedback renderer for a single
+ * `{ message, severity }` pair. Lets consumer templates collapse the
+ * `*ngComponentOutlet="renderer; inputs: {...}"` boilerplate to a single
+ * self-contained tag inside `<mat-error>` / `<mat-hint>` / `*ngxMatFeedback`.
+ *
+ * Reads the same DI seam as `provideNgxMatForms({ feedbackRenderer })`, so
+ * swapping the registered renderer at bootstrap (or at component scope via
+ * `provideNgxMatFormsForComponent`) automatically swaps what this outlet
+ * mounts — without any consumer-side wiring.
+ *
+ * @example
+ * ```html
+ * <mat-error *ngxMatErrorSlot="form.email; let message">
+ *   <ngx-mat-feedback-outlet [message]="message" severity="error" />
+ * </mat-error>
+ * ```
+ */
+@Component({
+  selector: 'ngx-mat-feedback-outlet',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgComponentOutlet],
+  template: `
+    <ng-container
+      *ngComponentOutlet="rendererComponent(); inputs: rendererInputs()"
+    />
+  `,
+})
+export class NgxMatFeedbackOutlet {
+  /** Resolved message text — already filtered by strategy and severity. */
+  readonly message = input.required<string>();
+
+  /** Severity discriminator forwarded to the configured renderer. */
+  readonly severity = input.required<NgxMatFeedbackSeverity>();
+
+  readonly #configured = inject(NGX_FORM_FIELD_ERROR_RENDERER, {
+    optional: true,
+  });
+
+  protected readonly rendererComponent = computed<Type<unknown>>(
+    () => this.#configured?.component ?? MaterialFeedbackRenderer,
+  );
+
+  protected readonly rendererInputs = computed<Record<string, unknown>>(() => ({
+    message: this.message(),
+    severity: this.severity(),
+  }));
 }

--- a/apps/demo-material/src/app/wrapper/slot-directives.ts
+++ b/apps/demo-material/src/app/wrapper/slot-directives.ts
@@ -9,16 +9,8 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import type { FieldTree } from '@angular/forms/signals';
-import {
-  createShowErrorsComputed,
-  injectFormContext,
-  isBlockingError,
-  isWarningError,
-  NGX_SIGNAL_FORMS_CONFIG,
-  readDirectErrors,
-  resolveErrorDisplayStrategy,
-  type ErrorDisplayStrategy,
-} from '@ngx-signal-forms/toolkit';
+import { type ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
 
 /**
  * Embedded-view context for the error / hint slot directives.
@@ -53,8 +45,9 @@ export interface NgxMatHintSlotContext {
  * <mat-error *ngxMatErrorSlot="form.email; let message">{{ message }}</mat-error>
  * ```
  *
- * Visibility timing reuses `createShowErrorsComputed` — the same helper
- * `NgxFormFieldWrapper` and `NgxSignalFormAutoAria` consult — so the
+ * Message resolution + visibility timing delegate to the public
+ * {@link createErrorMessageSignal} primitive — the same primitive that
+ * powers the canonical wrapper and the Spartan reference, so the
  * `errorStrategy` (`on-touch` / `on-submit` / `immediate`) decision stays
  * single-sourced across every surface in the demo.
  *
@@ -75,38 +68,10 @@ export class NgxMatErrorSlot<TValue = unknown> {
   readonly #templateRef = inject(TemplateRef<NgxMatErrorSlotContext>);
   readonly #viewContainerRef = inject(ViewContainerRef);
 
-  readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
-  readonly #formContext = injectFormContext();
-
-  readonly #fieldStateSignal = computed(() => this.formField()());
-
-  readonly #effectiveStrategy = computed(() =>
-    resolveErrorDisplayStrategy(
-      this.strategy(),
-      this.#formContext ? this.#formContext.errorStrategy() : undefined,
-      this.#config.defaultErrorStrategy,
-    ),
+  readonly #resolvedErrors = createErrorMessageSignal(
+    () => this.formField()(),
+    { strategy: computed(() => this.strategy() ?? undefined) },
   );
-
-  readonly #submittedStatus = computed(() =>
-    this.#formContext ? this.#formContext.submittedStatus() : 'unsubmitted',
-  );
-
-  readonly #showByStrategy = createShowErrorsComputed(
-    this.#fieldStateSignal,
-    this.#effectiveStrategy,
-    this.#submittedStatus,
-  );
-
-  readonly #blockingMessages = computed<readonly string[]>(() => {
-    if (!this.#showByStrategy()) {
-      return [];
-    }
-    return readDirectErrors(this.#fieldStateSignal())
-      .filter(isBlockingError)
-      .map((error) => error.message ?? '')
-      .filter((message) => message.length > 0);
-  });
 
   /** @internal — type guard for template language services. */
   static ngTemplateContextGuard<TValue>(
@@ -118,9 +83,12 @@ export class NgxMatErrorSlot<TValue = unknown> {
 
   constructor() {
     effect(() => {
+      const messages = this.#resolvedErrors()
+        .map((error) => error.message)
+        .filter((message) => message.length > 0);
       syncEmbeddedViews(
         this.#viewContainerRef,
-        this.#blockingMessages(),
+        messages,
         (message) => ({ $implicit: message, severity: 'error' as const }),
         this.#templateRef,
       );
@@ -165,41 +133,21 @@ export class NgxMatHintSlot<TValue = unknown> {
   readonly #templateRef = inject(TemplateRef<NgxMatHintSlotContext>);
   readonly #viewContainerRef = inject(ViewContainerRef);
 
-  readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
-  readonly #formContext = injectFormContext();
+  readonly #strategySignal = computed(() => this.strategy() ?? undefined);
 
-  readonly #fieldStateSignal = computed(() => this.formField()());
-
-  readonly #effectiveStrategy = computed(() =>
-    resolveErrorDisplayStrategy(
-      this.strategy(),
-      this.#formContext ? this.#formContext.errorStrategy() : undefined,
-      this.#config.defaultErrorStrategy,
-    ),
+  readonly #blockingErrors = createErrorMessageSignal(
+    () => this.formField()(),
+    { strategy: this.#strategySignal },
   );
 
-  readonly #submittedStatus = computed(() =>
-    this.#formContext ? this.#formContext.submittedStatus() : 'unsubmitted',
-  );
-
-  readonly #showByStrategy = createShowErrorsComputed(
-    this.#fieldStateSignal,
-    this.#effectiveStrategy,
-    this.#submittedStatus,
-  );
-
-  readonly #hasBlockingError = computed(() =>
-    readDirectErrors(this.#fieldStateSignal()).some(isBlockingError),
-  );
+  readonly #warnings = createErrorMessageSignal(() => this.formField()(), {
+    strategy: this.#strategySignal,
+    includeWarnings: 'only',
+  });
 
   readonly #warningMessage = computed<string | null>(() => {
-    if (!this.#showByStrategy() || this.#hasBlockingError()) {
-      return null;
-    }
-    const firstWarning = readDirectErrors(this.#fieldStateSignal()).find(
-      isWarningError,
-    );
-    return firstWarning?.message?.trim() || null;
+    if (this.#blockingErrors().length > 0) return null;
+    return this.#warnings()[0]?.message?.trim() || null;
   });
 
   /** @internal — type guard for template language services. */

--- a/apps/demo-material/src/styles.css
+++ b/apps/demo-material/src/styles.css
@@ -73,7 +73,7 @@ body {
 
 .app-shell__eyebrow {
   margin: 0 0 0.75rem;
-  color: #6a7894;
+  color: var(--app-muted);
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.18em;
@@ -111,7 +111,7 @@ body {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.52);
   font-family:
-    'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+    'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', monospace;
   font-size: 0.85em;
 }
 
@@ -154,7 +154,7 @@ body {
 
 .demo-form__eyebrow {
   margin: 0;
-  color: #6a7894;
+  color: var(--app-muted);
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.16em;

--- a/apps/demo-material/src/styles.css
+++ b/apps/demo-material/src/styles.css
@@ -1,86 +1,316 @@
 /* Material 21+ prebuilt theme. Picked azure-blue for neutral readability. */
 @import '@angular/material/prebuilt-themes/azure-blue.css';
 
+:root {
+  --app-display-font:
+    'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
+  --app-body-font: 'Avenir Next', 'Segoe UI Variable', 'Segoe UI', sans-serif;
+  --app-ink: #142033;
+  --app-muted: #55637a;
+  --app-line: rgba(86, 104, 138, 0.18);
+  --app-surface: rgba(255, 255, 255, 0.88);
+  --app-focus: rgba(0, 92, 187, 0.14);
+  --app-warning: #8a5a12;
+}
+
 html,
 body {
   margin: 0;
   padding: 0;
   height: 100%;
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
-  background: #f5f7fb;
-  color: #1f2937;
+  font-family: var(--app-body-font);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(104, 145, 217, 0.2),
+      transparent 32%
+    ),
+    radial-gradient(
+      circle at top right,
+      rgba(212, 226, 250, 0.88),
+      transparent 24%
+    ),
+    linear-gradient(180deg, #edf3fb 0%, #f7f3ec 52%, #f5f8fc 100%);
+  color: var(--app-ink);
+}
+
+html {
+  --mat-sys-body-large-font: var(--app-body-font);
+  --mat-sys-body-medium-font: var(--app-body-font);
+  --mat-sys-body-small-font: var(--app-body-font);
+  --mat-sys-headline-small-font: var(--app-display-font);
+  --mat-sys-title-large-font: var(--app-display-font);
+  --mat-sys-title-medium-font: var(--app-body-font);
+  --mat-sys-title-small-font: var(--app-body-font);
+}
+
+body {
+  min-height: 100%;
 }
 
 .app-shell {
-  max-width: 720px;
+  position: relative;
+  max-width: 860px;
   margin: 0 auto;
-  padding: 2rem 1.5rem 4rem;
+  padding: clamp(2rem, 4vw, 4rem) 1.5rem 5rem;
+}
+
+.app-shell::before {
+  content: '';
+  position: absolute;
+  inset: 1.25rem 1rem auto auto;
+  width: min(18rem, 28vw);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.6),
+    transparent 68%
+  );
+  filter: blur(8px);
+  pointer-events: none;
+}
+
+.app-shell__eyebrow {
+  margin: 0 0 0.75rem;
+  color: #6a7894;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.app-shell__hero {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
 }
 
 .app-shell h1 {
-  font-size: 1.65rem;
+  margin: 0;
+  max-width: 12ch;
+  color: #0e1a2e;
+  font-family: var(--app-display-font);
+  font-size: clamp(2.6rem, 5vw, 4.4rem);
   font-weight: 600;
-  margin-bottom: 0.25rem;
+  line-height: 0.96;
+  letter-spacing: -0.04em;
 }
 
 .app-shell p.lead {
-  color: #4b5563;
-  margin-top: 0;
-  margin-bottom: 2rem;
+  margin: 0;
+  max-width: 60ch;
+  color: var(--app-muted);
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
-.app-shell h2 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin-top: 2rem;
-  margin-bottom: 0.75rem;
+.app-shell code {
+  padding: 0.1rem 0.45rem;
+  border: 1px solid rgba(86, 104, 138, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.52);
+  font-family:
+    'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.85em;
 }
 
 .demo-form {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  background: #fff;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.18);
+  gap: 1.25rem;
+  overflow: hidden;
+  padding: clamp(1.5rem, 2.8vw, 2.4rem);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.94) 0%,
+    var(--app-surface) 100%
+  );
+  border: 1px solid var(--app-line);
+  border-radius: 28px;
+  box-shadow: 0 30px 90px -48px rgba(15, 23, 42, 0.46);
+  backdrop-filter: blur(18px);
 }
 
+.demo-form::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(0, 92, 187, 0.06),
+    rgba(0, 92, 187, 0.3),
+    rgba(0, 92, 187, 0.06)
+  );
+}
+
+.demo-form__header {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 44rem;
+}
+
+.demo-form__eyebrow {
+  margin: 0;
+  color: #6a7894;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.demo-form h2 {
+  margin: 0;
+  color: #111a2e;
+  font-family: var(--app-display-font);
+  font-size: clamp(2rem, 3.4vw, 2.8rem);
+  font-weight: 600;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+}
+
+.demo-form__intro {
+  margin: 0;
+  max-width: 58ch;
+  color: var(--app-muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.demo-form__field,
 .demo-form mat-form-field {
   width: 100%;
+}
+
+.demo-form__field {
+  --mat-form-field-container-height: 54px;
+  --mat-form-field-container-vertical-padding: 13px;
+  --mat-form-field-subscript-text-size: 0.84rem;
+  --mat-form-field-subscript-text-line-height: 1.25rem;
+  --mat-form-field-subscript-text-weight: 500;
+}
+
+.demo-form__field .mat-mdc-text-field-wrapper {
+  border-radius: 20px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.96),
+    rgba(247, 250, 255, 0.98)
+  );
+  transition:
+    box-shadow 160ms ease,
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.demo-form__field.mat-focused .mat-mdc-text-field-wrapper {
+  box-shadow: 0 0 0 4px var(--app-focus);
+}
+
+.demo-form__field .mat-mdc-form-field-subscript-wrapper {
+  margin-top: 0.05rem;
+}
+
+.demo-form__field .mat-mdc-form-field-error-wrapper,
+.demo-form__field .mat-mdc-form-field-hint-wrapper {
+  padding-inline: 0.15rem;
+}
+
+.demo-form__field
+  .mat-mdc-form-field-hint.mat-mdc-form-field-bottom-align::before,
+.demo-form__field
+  .mat-mdc-form-field-error.mat-mdc-form-field-bottom-align::before {
+  content: none;
+}
+
+.demo-form__field .mdc-floating-label,
+.demo-form__field .mat-mdc-select-value-text,
+.demo-form__field input.mat-mdc-input-element {
+  letter-spacing: 0.01em;
 }
 
 .demo-form__actions {
   display: flex;
   gap: 0.75rem;
   justify-content: flex-end;
-  margin-top: 1rem;
+  align-items: center;
+  margin-top: 0.75rem;
+  padding-top: 0.25rem;
 }
 
 .demo-form__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.75rem;
-  padding-block: 0.5rem;
+  margin-top: -0.1rem;
+  padding-block: 0.25rem 0;
 }
 
 .demo-form__row .demo-form__row-text {
   font-size: 0.9rem;
-  color: #1f2937;
+  color: var(--app-ink);
 }
 
 .demo-form__hint {
-  color: #6b7280;
+  color: var(--app-muted);
   font-size: 0.8rem;
   margin: 0.25rem 0 0;
 }
 
+.demo-form__feedback {
+  margin: -0.45rem 0 0 3rem;
+  color: var(--app-muted);
+  font-size: 0.93rem;
+  line-height: 1.45;
+}
+
+.demo-form__feedback--warning {
+  color: var(--app-warning);
+}
+
+.demo-form__actions .mat-mdc-outlined-button {
+  background: rgba(255, 255, 255, 0.74);
+}
+
+.demo-form__actions .mat-mdc-unelevated-button {
+  box-shadow: 0 18px 32px -22px rgba(0, 92, 187, 0.78);
+}
+
 .success-banner {
-  margin: 1.25rem 0;
-  padding: 0.75rem 1rem;
-  background: #ecfdf5;
-  border: 1px solid #a7f3d0;
-  color: #065f46;
-  border-radius: 8px;
-  font-size: 0.9rem;
+  margin: 0.5rem 0 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(68, 151, 110, 0.28);
+  border-radius: 16px;
+  background: linear-gradient(
+    135deg,
+    rgba(236, 253, 245, 0.95),
+    rgba(217, 249, 238, 0.88)
+  );
+  color: #0f6b4f;
+  font-size: 0.94rem;
+  font-weight: 500;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 700px) {
+  .app-shell {
+    padding-inline: 1rem;
+    padding-bottom: 3rem;
+  }
+
+  .demo-form {
+    padding: 1.25rem;
+    border-radius: 22px;
+  }
+
+  .demo-form__actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .demo-form__feedback {
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled visibility + message-resolution cascade in the Material reference wrapper with the public headless primitives the Spartan and canonical wrappers already use, and removes per-field `*ngComponentOutlet` ceremony from the contact-form demo. Net: `-400 / +584` lines, but the consumer-facing template loses every `*ngComponentOutlet`, helper method, and renderer-token inject — exactly the "showcase how easy it is" pitch the demo exists to deliver.

### Wrapper internals — now leveraging the latest toolkit primitives
- `slot-directives.ts` (`NgxMatErrorSlot`, `NgxMatHintSlot`) and `feedback-directive.ts` (`NgxMatFeedback`): replaced the `NGX_SIGNAL_FORMS_CONFIG` + `injectFormContext` + `createShowErrorsComputed` + `resolveErrorDisplayStrategy` + `readDirectErrors` + `isBlockingError`/`isWarningError` cascade — repeated 3× — with a single `createErrorMessageSignal` call per concern. Public API preserved (`$implicit` context shape, all inputs unchanged).
- `mat-form-field-wrapper.ts`: swapped the hand-rolled `resolvedFieldName` cascade for `createFieldNameResolver` (matches Spartan + canonical) and the manual `hintDescriptors.map(...)` for `toHintDescriptors`.

### Consumer ergonomics — drop-in renderer outlet
- New `NgxMatFeedbackOutlet` (`<ngx-mat-feedback-outlet>`) in `material-error-renderer.ts`: self-contained component that injects `NGX_FORM_FIELD_ERROR_RENDERER` and mounts the configured renderer for `{ message, severity }`. Added to `NgxMatFormBundle` and re-exported from the wrapper barrel.
- `contact-form.ts`: dropped the `feedbackRenderer` field, the `rendererInputs` helper, the `inject(NGX_FORM_FIELD_ERROR_RENDERER)` call, and the `NgComponentOutlet` import. Renderer swap via `provideNgxMatForms({ feedbackRenderer })` keeps working without any consumer-side wiring.
- `contact-form.html`: extracted from the inline template; per-field block now reads as `<mat-error *ngxMatErrorSlot="form.email; let m"><ngx-mat-feedback-outlet [message]="m" severity="error" /></mat-error>` instead of the prior `*ngComponentOutlet` block.

### Demo polish
- Lifted `app.ts` shell (`<header>`, intro copy) and refreshed `styles.css` (header chrome, form layout, feedback marker, responsive tweaks) so the showcase reads cleanly end-to-end.

## Test plan
- [x] `pnpm nx test demo-material` — 5/5 passing (`mat-form-field-wrapper.spec.ts` ARIA composition + dev-mode warning, `contact-form.spec.ts` mat-error/aria-describedby/warning-in-mat-hint smoke)
- [x] `pnpm nx build demo-material` — clean
- [x] `pnpm nx lint demo-material` — no new warnings
- [x] `pnpm format` — clean
- [ ] Manual smoke in `pnpm nx serve demo-material`: blur each field, type invalid email, type 3-char name (warning), submit empty form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Contact form with Name, Email, and Topic input fields, consent checkbox, and success confirmation message.

* **Styling & UI/UX**
  * Redesigned visual appearance with updated design system, typography, and gradient backgrounds.
  * Enhanced form field styling with improved validation feedback and error messaging.
  * Responsive layout optimizations for mobile devices.
  * Updated hero section header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->