### PR TITLE
test(demo-material): pin createErrorMessageSignal behavior in *ngxMatFeedback spec

### DIFF
--- a/apps/demo-material/README.md
+++ b/apps/demo-material/README.md
@@ -149,6 +149,12 @@ warning block) so each block owns a single stable ID
 `aria-describedby` manually if Material's auto-aggregation is not
 available.
 
+Internally, `*ngxMatFeedback` resolves messages through the public
+`createErrorMessageSignal` primitive, so any registry configured via
+`NGX_ERROR_MESSAGES` (e.g. through `provideErrorMessages`) flows through
+the same 3-tier cascade (validator message → registry → default) used by
+the in-tree `NgxFormFieldError`.
+
 ### Renderer registration
 
 ```ts

--- a/apps/demo-material/src/app/wrapper/feedback-directive.spec.ts
+++ b/apps/demo-material/src/app/wrapper/feedback-directive.spec.ts
@@ -1,0 +1,142 @@
+import {
+  Component,
+  provideZonelessChangeDetection,
+  signal,
+} from '@angular/core';
+import { FormField, form, schema, validate } from '@angular/forms/signals';
+import {
+  NgxSignalFormToolkit,
+  provideErrorMessages,
+  provideNgxSignalFormsConfig,
+  warningError,
+} from '@ngx-signal-forms/toolkit';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxMatFeedback } from './feedback-directive';
+
+interface AgreeModel {
+  agree: boolean;
+}
+
+/**
+ * Pins the registry-bypass fix from issue #66: before the migration to
+ * `createErrorMessageSignal`, `*ngxMatFeedback` resolved messages by reading
+ * `error.message` directly and never consulted `NGX_ERROR_MESSAGES`. The
+ * second test pins the "warnings hidden when blocking errors are present"
+ * Material convention preserved by the migration.
+ */
+describe('*ngxMatFeedback — registry resolution + severity precedence', () => {
+  it('renders a registry-provided message when the validator omits `message:`', async () => {
+    @Component({
+      selector: 'ngx-host',
+      imports: [FormField, NgxSignalFormToolkit, NgxMatFeedback],
+      template: `
+        <form [formRoot]="form" ngxSignalForm>
+          <input type="checkbox" [formField]="form.agree" />
+          <ng-container
+            *ngxMatFeedback="
+              form.agree;
+              fieldName: 'agree';
+              let messages;
+              severity as severity;
+              id as id
+            "
+          >
+            <div
+              [attr.role]="severity === 'error' ? 'alert' : 'status'"
+              [id]="id"
+            >
+              @for (message of messages; track message) {
+                <span data-testid="msg">{{ message }}</span>
+              }
+            </div>
+          </ng-container>
+        </form>
+      `,
+    })
+    class HostComponent {
+      readonly form = form<AgreeModel>(
+        signal({ agree: false }),
+        schema<AgreeModel>((path) => {
+          // No `message:` — the resolver must fall through to the registry.
+          validate(path.agree, (ctx) =>
+            ctx.value() ? null : { kind: 'required' },
+          );
+        }),
+      );
+    }
+
+    const view = await render(HostComponent, {
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNgxSignalFormsConfig({
+          defaultErrorStrategy: 'immediate',
+          autoAria: false,
+        }),
+        provideErrorMessages({ required: 'Please agree before continuing' }),
+      ],
+    });
+
+    expect(view.getByTestId('msg').textContent).toContain(
+      'Please agree before continuing',
+    );
+  });
+
+  it('suppresses the warning block when blocking errors are present', async () => {
+    @Component({
+      selector: 'ngx-host',
+      imports: [FormField, NgxSignalFormToolkit, NgxMatFeedback],
+      template: `
+        <form [formRoot]="form" ngxSignalForm>
+          <input type="checkbox" [formField]="form.agree" />
+          <ng-container
+            *ngxMatFeedback="
+              form.agree;
+              fieldName: 'agree';
+              let messages;
+              severity as severity
+            "
+          >
+            <div [attr.data-severity]="severity">
+              @for (message of messages; track message) {
+                <span data-testid="msg">{{ message }}</span>
+              }
+            </div>
+          </ng-container>
+        </form>
+      `,
+    })
+    class HostComponent {
+      readonly form = form<AgreeModel>(
+        signal({ agree: false }),
+        schema<AgreeModel>((path) => {
+          validate(path.agree, (ctx) => {
+            if (!ctx.value()) {
+              return [
+                { kind: 'required', message: 'Required' },
+                warningError('warn:weak', 'Soft warning'),
+              ];
+            }
+            return null;
+          });
+        }),
+      );
+    }
+
+    const view = await render(HostComponent, {
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNgxSignalFormsConfig({
+          defaultErrorStrategy: 'immediate',
+          autoAria: false,
+        }),
+      ],
+    });
+
+    const block = view.container.querySelector('[data-severity]');
+    expect(block?.getAttribute('data-severity')).toBe('error');
+    const messages = view.queryAllByTestId('msg').map((el) => el.textContent);
+    expect(messages).toEqual(['Required']);
+    expect(messages.join(' ')).not.toContain('Soft warning');
+  });
+});

--- a/apps/demo-material/src/app/wrapper/feedback-directive.ts
+++ b/apps/demo-material/src/app/wrapper/feedback-directive.ts
@@ -127,23 +127,30 @@ export class NgxMatFeedback<TValue = unknown> {
   );
 
   /**
-   * Warnings — surfaced immediately (informational, not gated by the
-   * blocking-error strategy), then suppressed below when blocking errors are
-   * present so the directive renders at most one block per kind.
+   * Warnings share the directive's strategy/submission gating with errors —
+   * Material's `*ngxMatFeedback` historically gated both via the same
+   * `#showByStrategy`, so forwarding `#effectiveStrategy` keeps existing
+   * consumers' "wait for touch / submit" behavior. `#blocks` then suppresses
+   * warnings whenever blocking errors are present so at most one block
+   * renders per field. (This deliberately differs from the Spartan slice in
+   * #65, which mirrors `NgxFormFieldError`'s `'immediate'` warning default.)
    */
   readonly #resolvedWarnings = createErrorMessageSignal(
     this.#fieldStateAccessor,
     {
-      strategy: 'immediate',
+      strategy: this.#effectiveStrategy,
+      submittedStatus: this.#submittedStatus,
       includeWarnings: 'only',
     },
   );
 
   readonly #blocks = computed<readonly NgxMatFeedbackContext[]>(() => {
     const fieldName = this.fieldName();
-    const blockingMessages = this.#resolvedErrors().map(
-      (entry) => entry.message,
-    );
+    // Filter empty strings so a deliberate `message: ''` validator/registry
+    // override doesn't render a live region with an ID + role but no text.
+    const blockingMessages = this.#resolvedErrors()
+      .map((entry) => entry.message)
+      .filter((message) => message !== '');
     if (blockingMessages.length > 0) {
       return [
         {
@@ -163,9 +170,9 @@ export class NgxMatFeedback<TValue = unknown> {
     // Warnings render only when there are no blocking errors — matching the
     // previous `MatCheckboxFeedback` semantics and Material's hint-vs-error
     // convention.
-    const warningMessages = this.#resolvedWarnings().map(
-      (entry) => entry.message,
-    );
+    const warningMessages = this.#resolvedWarnings()
+      .map((entry) => entry.message)
+      .filter((message) => message !== '');
     if (warningMessages.length > 0) {
       return [
         {

--- a/apps/demo-material/src/app/wrapper/feedback-directive.ts
+++ b/apps/demo-material/src/app/wrapper/feedback-directive.ts
@@ -10,17 +10,14 @@ import {
 } from '@angular/core';
 import type { FieldTree } from '@angular/forms/signals';
 import {
-  createShowErrorsComputed,
   generateErrorId,
   generateWarningId,
   injectFormContext,
-  isBlockingError,
-  isWarningError,
   NGX_SIGNAL_FORMS_CONFIG,
-  readDirectErrors,
   resolveErrorDisplayStrategy,
   type ErrorDisplayStrategy,
 } from '@ngx-signal-forms/toolkit';
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
 
 /**
  * Embedded-view context for `*ngxMatFeedback`.
@@ -46,6 +43,12 @@ export interface NgxMatFeedbackContext {
  * non-blocking warnings — so each block owns a single stable ID
  * (`{fieldName}-error` / `{fieldName}-warning`) that consumers can wire into
  * the bound control's `aria-describedby` chain by hand.
+ *
+ * Message resolution delegates to the public `createErrorMessageSignal`
+ * primitive, so consumers that configure `NGX_ERROR_MESSAGES` see registry
+ * values surface here through the same 3-tier cascade
+ * (validator message → registry → default) as the in-tree
+ * `NgxFormFieldError`.
  *
  * @example
  * ```html
@@ -95,7 +98,7 @@ export class NgxMatFeedback<TValue = unknown> {
   readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
   readonly #formContext = injectFormContext();
 
-  readonly #fieldStateSignal = computed(() => this.formField()());
+  readonly #fieldStateAccessor = computed(() => this.formField()());
 
   readonly #effectiveStrategy = computed(() =>
     resolveErrorDisplayStrategy(
@@ -109,47 +112,72 @@ export class NgxMatFeedback<TValue = unknown> {
     this.#formContext ? this.#formContext.submittedStatus() : 'unsubmitted',
   );
 
-  readonly #showByStrategy = createShowErrorsComputed(
-    this.#fieldStateSignal,
-    this.#effectiveStrategy,
-    this.#submittedStatus,
+  /**
+   * Blocking errors, resolved through the public primitive. The strategy and
+   * submission status are forwarded so the primitive's visibility cascade
+   * matches the directive's own; the registry is auto-injected from
+   * `NGX_ERROR_MESSAGES`.
+   */
+  readonly #resolvedErrors = createErrorMessageSignal(
+    this.#fieldStateAccessor,
+    {
+      strategy: this.#effectiveStrategy,
+      submittedStatus: this.#submittedStatus,
+    },
+  );
+
+  /**
+   * Warnings — surfaced immediately (informational, not gated by the
+   * blocking-error strategy), then suppressed below when blocking errors are
+   * present so the directive renders at most one block per kind.
+   */
+  readonly #resolvedWarnings = createErrorMessageSignal(
+    this.#fieldStateAccessor,
+    {
+      strategy: 'immediate',
+      includeWarnings: 'only',
+    },
   );
 
   readonly #blocks = computed<readonly NgxMatFeedbackContext[]>(() => {
-    if (!this.#showByStrategy()) {
-      return [];
-    }
-    const errors = readDirectErrors(this.#fieldStateSignal());
-    const blockingMessages = errors
-      .filter(isBlockingError)
-      .map((entry) => entry.message ?? '')
-      .filter((message) => message.length > 0);
-    const warningMessages = errors
-      .filter(isWarningError)
-      .map((entry) => entry.message ?? '')
-      .filter((message) => message.length > 0);
-
-    const out: NgxMatFeedbackContext[] = [];
     const fieldName = this.fieldName();
+    const blockingMessages = this.#resolvedErrors().map(
+      (entry) => entry.message,
+    );
     if (blockingMessages.length > 0) {
-      out.push({
-        $implicit: blockingMessages,
-        messages: blockingMessages,
-        severity: 'error',
-        id: generateErrorId(fieldName),
-      });
-    } else if (warningMessages.length > 0) {
-      // Warnings render only when there are no blocking errors — matching
-      // the previous `MatCheckboxFeedback` semantics and Material's
-      // hint-vs-error convention.
-      out.push({
-        $implicit: warningMessages,
-        messages: warningMessages,
-        severity: 'warning',
-        id: generateWarningId(fieldName),
-      });
+      return [
+        {
+          $implicit: blockingMessages,
+          messages: blockingMessages,
+          severity: 'error',
+          // Container IDs use the kind-less `generateErrorId(name)` /
+          // `generateWarningId(name)` shape so they stay in lockstep with
+          // the consumer's `aria-describedby` wiring. Do not substitute
+          // `ResolvedFieldError.id` — that ID embeds the validator `kind`
+          // and would break that wiring.
+          id: generateErrorId(fieldName),
+        },
+      ];
     }
-    return out;
+
+    // Warnings render only when there are no blocking errors — matching the
+    // previous `MatCheckboxFeedback` semantics and Material's hint-vs-error
+    // convention.
+    const warningMessages = this.#resolvedWarnings().map(
+      (entry) => entry.message,
+    );
+    if (warningMessages.length > 0) {
+      return [
+        {
+          $implicit: warningMessages,
+          messages: warningMessages,
+          severity: 'warning',
+          id: generateWarningId(fieldName),
+        },
+      ];
+    }
+
+    return [];
   });
 
   /** @internal — type guard for template language services. */


### PR DESCRIPTION
## Summary

Originally migrated `*ngxMatFeedback` from a hand-rolled message resolver to the public `createErrorMessageSignal` primitive (issue #66). After main absorbed that migration via #69 in cleaner form (the primitive injects the form context internally, dropping the explicit `injectFormContext` / `NGX_SIGNAL_FORMS_CONFIG` plumbing), this PR's surviving delta is:

- A focused unit spec (`feedback-directive.spec.ts`) pinning two behaviors the migration introduced:
  1. A registry-provided message (`provideErrorMessages`) flows through when the validator omits `message:` — pins the registry-bypass fix.
  2. The warning block is suppressed when blocking errors are present — Material's hint-vs-error convention.
- A README note in `apps/demo-material/README.md` documenting that `*ngxMatFeedback` now resolves through the same 3-tier cascade (validator message → `NGX_ERROR_MESSAGES` → default) as `NgxFormFieldError`.

Closes #66.

## Test plan

- [x] `pnpm nx test demo-material` — 7/7 pass (2 new + 5 existing)
- [x] `pnpm nx lint demo-material` — clean
- [x] `pnpm nx build demo-material` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wrapper documentation clarifying how error message resolution flows through the message registry and validator cascade.

* **Tests**
  * Added comprehensive test specifications for feedback directive message resolution and error severity handling, including registry fallback behavior and blocking vs. warning error precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->