### PR TITLE
feat(demo): add createErrorMessageSignal demo route under headless

### DIFF
--- a/apps/demo/src/app/03-headless/README.md
+++ b/apps/demo/src/app/03-headless/README.md
@@ -15,6 +15,9 @@ This section is the escape hatch for teams that cannot adopt the `NgxFormField` 
 - **[fieldset-utilities](./fieldset-utilities/README.md)** — headless fieldset grouping plus the `createErrorState` / `createCharacterCount` / `createFieldStateFlags` utilities applied to a delivery form.
   - What you'll learn: `NgxHeadlessToolkit` bundle · `ngxHeadlessErrorSummary` click-to-focus · `ngxHeadlessFieldset` aggregation · composing custom UI from utility factories · `provideFieldLabels()` for custom summary labels.
 
+- **[error-message-signal](./error-message-signal/README.md)** — `createErrorMessageSignal` exercised across all three `includeWarnings` modes with reactive registry swapping and `aria-describedby` wiring.
+  - What you'll learn: flat `@for` iteration without an outer `@if` gate · blocking-only vs. all-errors vs. warnings-only views · stable per-error IDs for `aria-describedby` · reactive `errorMessages` signal override.
+
 ## 🧠 Core concepts
 
 - **Renderless directives** — headless directives expose state via template context; you own every DOM node. See [headless README](../../../../../packages/toolkit/headless/README.md).

--- a/apps/demo/src/app/03-headless/error-message-signal/README.md
+++ b/apps/demo/src/app/03-headless/error-message-signal/README.md
@@ -1,0 +1,66 @@
+# Error Message Signal
+
+> **Flat error iteration:** `createErrorMessageSignal` — visibility gating, message resolution, and stable ARIA IDs in one primitive.
+
+## 🎯 What this demo shows
+
+A password field wired to three simultaneous `createErrorMessageSignal` instances, each demonstrating a different `includeWarnings` mode, plus a live registry swap button to show reactive message re-resolution.
+
+## 📐 Key patterns
+
+### Flat `@for` — no outer `@if`
+
+```html
+<ul>
+  @for (entry of errors(); track entry.kind) {
+  <li [id]="entry.id">{{ entry.message }}</li>
+  }
+</ul>
+```
+
+The signal already handles visibility gating: when errors shouldn't be shown (field untouched, form not submitted) it returns `[]`, so the list renders nothing naturally. No wrapper `@if` required.
+
+### `aria-describedby` from signal IDs
+
+```typescript
+readonly ariaDescribedByBlocking = computed(() => {
+  const ids = this.blockingErrors().map(e => e.id);
+  return ids.length > 0 ? ids.join(' ') : null;
+});
+```
+
+```html
+<input [attr.aria-describedby]="ariaDescribedByBlocking()" />
+```
+
+IDs are `{fieldName}-error-{kind}` — the same format the in-tree wrapper uses, so swapping between headless and wrapper never breaks `aria-describedby` chains.
+
+### Reactive registry swap
+
+```typescript
+readonly activeRegistry = signal<ErrorMessageRegistry>(REGISTRY_VERBOSE);
+
+readonly errors = createErrorMessageSignal(
+  () => this.form.password(),
+  { fieldName: 'password', errorMessages: this.activeRegistry },
+);
+
+toggleRegistry(): void {
+  this.activeRegistry.set(this.verboseRegistry() ? REGISTRY_TERSE : REGISTRY_VERBOSE);
+}
+```
+
+Swapping `activeRegistry` causes all three signal instances to re-resolve their messages without re-creating them.
+
+## 🔍 Three `includeWarnings` modes
+
+| Mode          | Option                    | Output                                  |
+| ------------- | ------------------------- | --------------------------------------- |
+| Blocking only | _(default)_               | `required`, `minLength` errors          |
+| All           | `includeWarnings: true`   | Blocking first, then warnings           |
+| Warnings only | `includeWarnings: 'only'` | `warn:*` entries, rendered in `<aside>` |
+
+## ➡️ Related
+
+- [Headless section README](../README.md) — overview of all headless demos
+- [packages/toolkit/headless/README.md](../../../../../packages/toolkit/headless/README.md) — `createErrorMessageSignal` API reference

--- a/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.content.ts
+++ b/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.content.ts
@@ -1,0 +1,47 @@
+export const ERROR_MESSAGE_SIGNAL_CONTENT = {
+  demonstrated: {
+    icon: '🧪',
+    title: 'createErrorMessageSignal',
+    sections: [
+      {
+        title: 'Primitive options',
+        items: [
+          '<strong>default (false):</strong> Blocking errors only — flat @for, no outer @if',
+          '<strong>includeWarnings: true:</strong> Blocking errors first, then warnings in order',
+          "<strong>includeWarnings: 'only':</strong> Warnings only, rendered in an &lt;aside&gt; slot",
+        ],
+      },
+      {
+        title: 'ARIA & registry',
+        items: [
+          '<strong>aria-describedby:</strong> Wired from ResolvedFieldError.id — no manual ID math',
+          '<strong>errorMessages signal:</strong> Reactive registry swap re-resolves messages mid-render',
+        ],
+      },
+    ],
+  },
+  learning: {
+    title: 'When to use createErrorMessageSignal',
+    sections: [
+      {
+        title: 'Custom error renderers',
+        items: [
+          'Own the entire error DOM without a directive wrapper',
+          'Feed resolved messages into a design-system component',
+        ],
+      },
+      {
+        title: 'Flat iteration pattern',
+        items: [
+          '@for over the signal — empty array means no output, no outer @if needed',
+          'IDs are stable across re-renders — safe for aria-describedby chains',
+        ],
+      },
+    ],
+    nextStep: {
+      text: 'Next: prebuilt wrappers →',
+      link: '/form-field-wrapper/complex-forms',
+      linkText: 'Complex Forms',
+    },
+  },
+} as const;

--- a/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.form.ts
+++ b/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.form.ts
@@ -1,0 +1,388 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
+import {
+  form,
+  FormField,
+  FormRoot,
+  minLength,
+  required,
+  schema,
+  validate,
+} from '@angular/forms/signals';
+import { createOnInvalidHandler } from '@ngx-signal-forms/toolkit';
+import {
+  createErrorMessageSignal,
+  type ResolvedFieldError,
+} from '@ngx-signal-forms/toolkit/headless';
+
+interface PasswordModel {
+  password: string;
+}
+
+const passwordSchema = schema<PasswordModel>((path) => {
+  required(path.password);
+  minLength(path.password, 8);
+
+  validate(path.password, (ctx) => {
+    const value = ctx.value();
+    if (value && value.length > 0 && value.length < 12) {
+      return {
+        kind: 'warn:weak-password',
+        message: 'Consider using 12+ characters for a stronger password',
+      };
+    }
+    return null;
+  });
+
+  validate(path.password, (ctx) => {
+    const value = ctx.value();
+    if (value && value.length > 0 && !/[^a-zA-Z0-9]/u.test(value)) {
+      return {
+        kind: 'warn:no-special-chars',
+        message: 'Adding symbols (!, @, #…) improves password strength',
+      };
+    }
+    return null;
+  });
+});
+
+const REGISTRY_VERBOSE = {
+  required: 'Password is required — please enter a value',
+  minLength: (params: Record<string, unknown>) =>
+    `Password must be at least ${String(params['minLength'])} characters long`,
+  'warn:weak-password': 'Weak password — consider using 12 or more characters',
+  'warn:no-special-chars':
+    'No special characters detected — adding symbols (!, @, #) improves security',
+} as const;
+
+const REGISTRY_TERSE = {
+  required: 'Required',
+  minLength: (params: Record<string, unknown>) =>
+    `Min ${String(params['minLength'])} chars`,
+  'warn:weak-password': 'Weak password',
+  'warn:no-special-chars': 'Add symbols for strength',
+} as const;
+
+function ariaDescribedBy(errors: readonly ResolvedFieldError[]): string | null {
+  const ids = errors.map((e) => e.id);
+  return ids.length > 0 ? ids.join(' ') : null;
+}
+
+@Component({
+  selector: 'ngx-error-message-signal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormField, FormRoot],
+  styles: `
+    .demo-section {
+      border: 1px solid var(--ngx-border-color, #e5e7eb);
+      border-radius: 0.5rem;
+      padding: 1rem;
+      margin-block-start: 1rem;
+    }
+
+    .demo-section__title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--ngx-muted-color, #6b7280);
+      margin-block-end: 0.5rem;
+    }
+
+    .error-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .error-item {
+      font-size: 0.75rem;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+    }
+
+    .error-item--blocking {
+      color: #dc2626;
+      background: #fef2f2;
+    }
+
+    .error-item--warning {
+      color: #d97706;
+      background: #fffbeb;
+    }
+
+    :host-context(.dark) .error-item--blocking {
+      color: #fca5a5;
+      background: rgb(127 29 29 / 0.2);
+    }
+
+    :host-context(.dark) .error-item--warning {
+      color: #fcd34d;
+      background: rgb(120 53 15 / 0.2);
+    }
+
+    .registry-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.625rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .registry-badge--verbose {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+
+    .registry-badge--terse {
+      background: #d1fae5;
+      color: #065f46;
+    }
+  `,
+  template: `
+    <div class="px-6 pt-0 pb-6">
+      <h2 class="mb-4 text-2xl font-bold">createErrorMessageSignal</h2>
+      <p class="mb-6 text-gray-600 dark:text-gray-400">
+        A reactive primitive that combines visibility gating, 3-tier message
+        resolution, and stable per-error DOM IDs — without a directive.
+      </p>
+
+      <form [formRoot]="passwordForm" class="max-w-xl space-y-6">
+        <!-- ── Registry toggle ───────────────────────────────────────── -->
+        <div
+          class="flex items-center gap-3 rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-600"
+        >
+          <span class="text-sm text-gray-600 dark:text-gray-400">
+            Registry:
+            <span
+              class="registry-badge"
+              [class.registry-badge--verbose]="verboseRegistry()"
+              [class.registry-badge--terse]="!verboseRegistry()"
+            >
+              {{ verboseRegistry() ? 'verbose' : 'terse' }}
+            </span>
+          </span>
+          <button
+            type="button"
+            class="btn-secondary text-xs"
+            data-testid="toggle-registry"
+            (click)="toggleRegistry()"
+          >
+            Swap registry
+          </button>
+          <span class="text-xs text-gray-400 dark:text-gray-500">
+            Messages re-resolve reactively
+          </span>
+        </div>
+
+        <!-- ── Password input ────────────────────────────────────────── -->
+        <div class="space-y-2">
+          <label for="password" class="text-sm font-medium"> Password * </label>
+          <input
+            id="password"
+            type="text"
+            class="form-input"
+            [formField]="passwordForm.password"
+            placeholder="Enter a password…"
+            autocomplete="new-password"
+            data-testid="password-input"
+            [attr.aria-invalid]="blockingErrors().length > 0 ? 'true' : null"
+            [attr.aria-describedby]="ariaDescribedByBlocking()"
+          />
+        </div>
+
+        <!-- ── Mode 1: blocking errors only (default) ────────────────── -->
+        <div class="demo-section" data-testid="section-blocking">
+          <p class="demo-section__title">
+            Mode 1 — blocking errors only (default)
+          </p>
+          <p class="mb-2 text-xs text-gray-500 dark:text-gray-400">
+            <code
+              class="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-800"
+            >
+              createErrorMessageSignal(() =&gt; field())
+            </code>
+          </p>
+
+          <ul class="error-list" role="list" aria-label="Blocking errors">
+            @for (entry of blockingErrors(); track entry.kind) {
+              <li
+                [id]="entry.id"
+                class="error-item error-item--blocking"
+                role="alert"
+                [attr.data-testid]="'blocking-error-' + entry.kind"
+              >
+                {{ entry.message }}
+              </li>
+            }
+          </ul>
+
+          @if (blockingErrors().length === 0) {
+            <p class="text-xs text-gray-400 dark:text-gray-500">
+              No blocking errors to display
+            </p>
+          }
+        </div>
+
+        <!-- ── Mode 2: blocking + warnings ──────────────────────────── -->
+        <div class="demo-section" data-testid="section-all">
+          <p class="demo-section__title">
+            Mode 2 — blocking + warnings
+            <code
+              class="rounded bg-gray-100 px-1 py-0.5 text-xs normal-case dark:bg-gray-800"
+            >
+              includeWarnings: true
+            </code>
+          </p>
+
+          <ul
+            class="error-list"
+            role="list"
+            aria-label="All errors and warnings"
+          >
+            @for (entry of allErrors(); track entry.kind) {
+              <li
+                [id]="entry.id"
+                class="error-item"
+                [class.error-item--blocking]="!entry.kind.startsWith('warn:')"
+                [class.error-item--warning]="entry.kind.startsWith('warn:')"
+                [attr.data-testid]="'all-error-' + entry.kind"
+              >
+                {{ entry.message }}
+              </li>
+            }
+          </ul>
+
+          @if (allErrors().length === 0) {
+            <p class="text-xs text-gray-400 dark:text-gray-500">
+              No errors or warnings to display
+            </p>
+          }
+        </div>
+
+        <!-- ── Mode 3: warnings only in an aside ─────────────────────── -->
+        <div class="demo-section" data-testid="section-warnings">
+          <p class="demo-section__title">
+            Mode 3 — warnings only
+            <code
+              class="rounded bg-gray-100 px-1 py-0.5 text-xs normal-case dark:bg-gray-800"
+            >
+              includeWarnings: 'only'
+            </code>
+          </p>
+
+          <aside aria-label="Password warnings">
+            <ul class="error-list" role="list">
+              @for (entry of warningsOnly(); track entry.kind) {
+                <li
+                  [id]="entry.id"
+                  class="error-item error-item--warning"
+                  role="status"
+                  aria-live="polite"
+                  [attr.data-testid]="'warning-' + entry.kind"
+                >
+                  {{ entry.message }}
+                </li>
+              }
+            </ul>
+
+            @if (warningsOnly().length === 0) {
+              <p class="text-xs text-gray-400 dark:text-gray-500">
+                No warnings to display
+              </p>
+            }
+          </aside>
+        </div>
+
+        <div class="flex gap-4">
+          <button
+            type="submit"
+            class="btn-primary"
+            [disabled]="passwordForm().submitting()"
+          >
+            @if (passwordForm().submitting()) {
+              Submitting...
+            } @else {
+              Submit
+            }
+          </button>
+          <button type="button" (click)="reset()" class="btn-secondary">
+            Reset
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+})
+export class ErrorMessageSignalComponent {
+  readonly #initialData: PasswordModel = { password: '' };
+  readonly #model = signal(this.#initialData);
+
+  readonly passwordForm = form(this.#model, passwordSchema, {
+    submission: {
+      action: async (data) => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 400);
+        });
+        console.log('Submitted:', data());
+      },
+      onInvalid: createOnInvalidHandler(),
+    },
+  });
+
+  protected readonly verboseRegistry = signal(true);
+  protected readonly activeRegistry = signal<
+    typeof REGISTRY_VERBOSE | typeof REGISTRY_TERSE
+  >(REGISTRY_VERBOSE);
+
+  // 1. Blocking errors only (default)
+  protected readonly blockingErrors = createErrorMessageSignal(
+    () => this.passwordForm.password(),
+    { fieldName: 'password', errorMessages: this.activeRegistry },
+  );
+
+  // 2. Blocking + warnings
+  protected readonly allErrors = createErrorMessageSignal(
+    () => this.passwordForm.password(),
+    {
+      fieldName: 'password',
+      includeWarnings: true,
+      errorMessages: this.activeRegistry,
+    },
+  );
+
+  // 3. Warnings only
+  protected readonly warningsOnly = createErrorMessageSignal(
+    () => this.passwordForm.password(),
+    {
+      fieldName: 'password',
+      includeWarnings: 'only',
+      errorMessages: this.activeRegistry,
+    },
+  );
+
+  // aria-describedby for the password input — derived from blocking error IDs
+  protected readonly ariaDescribedByBlocking = computed(() =>
+    ariaDescribedBy(this.blockingErrors()),
+  );
+
+  protected toggleRegistry(): void {
+    const next = this.verboseRegistry() ? REGISTRY_TERSE : REGISTRY_VERBOSE;
+    this.activeRegistry.set(next);
+    this.verboseRegistry.update((v) => !v);
+  }
+
+  protected reset(): void {
+    this.passwordForm().reset();
+    this.#model.set(this.#initialData);
+  }
+}

--- a/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.page.ts
+++ b/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.page.ts
@@ -1,0 +1,44 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ExampleCardsComponent,
+  PageHeaderComponent,
+  SplitLayoutComponent,
+} from '../../ui';
+import { ERROR_MESSAGE_SIGNAL_CONTENT } from './error-message-signal.content';
+import { ErrorMessageSignalComponent } from './error-message-signal.form';
+
+@Component({
+  selector: 'ngx-error-message-signal-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+  `,
+  imports: [
+    ExampleCardsComponent,
+    ErrorMessageSignalComponent,
+    PageHeaderComponent,
+    SplitLayoutComponent,
+  ],
+  template: `
+    <ngx-page-header
+      title="createErrorMessageSignal"
+      subtitle="Flat error iteration with visibility gating, message resolution, and stable ARIA IDs"
+    />
+
+    <ngx-example-cards
+      [demonstrated]="content.demonstrated"
+      [learning]="content.learning"
+    >
+      <ngx-split-layout>
+        <ngx-error-message-signal left />
+      </ngx-split-layout>
+    </ngx-example-cards>
+  `,
+})
+export class ErrorMessageSignalPageComponent {
+  protected readonly content = ERROR_MESSAGE_SIGNAL_CONTENT;
+}

--- a/apps/demo/src/app/app.routes.ts
+++ b/apps/demo/src/app/app.routes.ts
@@ -79,6 +79,14 @@ export const appRoutes: Routes = [
           ),
         title: getRouteTitle('/headless/fieldset-utilities'),
       },
+      {
+        path: 'error-message-signal',
+        loadComponent: () =>
+          import('./03-headless/error-message-signal/error-message-signal.page').then(
+            (m) => m.ErrorMessageSignalPageComponent,
+          ),
+        title: getRouteTitle('/headless/error-message-signal'),
+      },
     ],
   },
 

--- a/packages/demo-shared/src/lib/routes.metadata.ts
+++ b/packages/demo-shared/src/lib/routes.metadata.ts
@@ -3,6 +3,7 @@ export const DEMO_PATHS = {
   errorDisplayModes: '/toolkit-core/error-display-modes',
   warningSupport: '/toolkit-core/warning-support',
   fieldsetUtilities: '/headless/fieldset-utilities',
+  errorMessageSignal: '/headless/error-message-signal',
   complexForms: '/form-field-wrapper/complex-forms',
   fieldsetAppearance: '/form-field-wrapper/fieldset-appearance',
   customControls: '/form-field-wrapper/custom-controls',
@@ -51,6 +52,10 @@ export const DEMO_CATEGORIES = [
       {
         path: '/headless/fieldset-utilities',
         label: 'Fieldset + Utilities',
+      },
+      {
+        path: '/headless/error-message-signal',
+        label: 'Error Message Signal',
       },
     ],
   },

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -185,6 +185,8 @@ Signals: `resolvedFieldName()` (nullable), `errorId()` (nullable), `warningId()`
 
 A `Signal<readonly ResolvedFieldError[]>` that combines visibility gating, the 3-tier message cascade (validator `message` → `NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs in a single primitive. Use it when you want the directive's resolution logic without the directive itself — for example inside a custom error renderer that the form-field wrapper drives via `*ngComponentOutlet`, or in an Angular `Component` that opts to read errors directly off a `FieldTree`.
 
+See a runnable example at `apps/demo/src/app/03-headless/error-message-signal/`.
+
 ```typescript
 import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
 


### PR DESCRIPTION
## Summary

- Adds `apps/demo/src/app/03-headless/error-message-signal/` — a new demo route at `/headless/error-message-signal`
- Demonstrates all three `includeWarnings` modes (`false` / `true` / `'only'`) simultaneously on a single password field
- Shows `aria-describedby` wiring via `ResolvedFieldError.id` and a reactive registry swap using `Signal<ErrorMessageRegistry>` — tracer-bullet for user story 2 from #39

## Test plan

- [ ] Navigate to `/headless/error-message-signal` in the demo app and confirm the route loads
- [ ] Interact with the password field (touch, type short value, type value without symbols) and verify all three mode panels update correctly
- [ ] Click "Swap registry" and confirm message text changes reactively without page reload
- [ ] Verify `aria-describedby` on the input points at the rendered `<li>` IDs (inspect with browser dev tools)
- [ ] Confirm sidebar nav shows "Error Message Signal" under the Headless group
- [ ] `pnpm nx build demo` passes
- [ ] `pnpm nx test demo-shared` passes (routes.metadata spec)

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interactive demo showcasing error message signal functionality with multiple display modes and accessibility support.

* **Documentation**
  * Added documentation for the Error Message Signal demo with usage examples and best practices.
  * Updated toolkit documentation with a reference link to the demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->