### PR TITLE
fix(toolkit): resolve 5 correctness bugs (#73)

### DIFF
--- a/packages/toolkit/core/utilities/normalize-config.spec.ts
+++ b/packages/toolkit/core/utilities/normalize-config.spec.ts
@@ -42,4 +42,24 @@ describe('normalizeSignalFormsConfig', () => {
 
     expect(result).toEqual(DEFAULT_NGX_SIGNAL_FORMS_CONFIG);
   });
+
+  it('is a two-tier merge only — does not inherit from a parent config (documented divergence from provideNgxSignalFormsConfig)', () => {
+    // Regression for Bug 4 (issue #73): normalizeSignalFormsConfig is intentionally
+    // a simple two-tier utility (userConfig → defaults). It does NOT walk the DI
+    // injector tree. This test documents that divergence so future contributors
+    // do not accidentally "fix" the function by adding DI-based parent inheritance
+    // (which would break out-of-DI call sites like SSR server setups and unit tests).
+    //
+    // Production code should use provideNgxSignalFormsConfig() instead.
+    const result = normalizeSignalFormsConfig({ autoAria: false });
+
+    // Only user overrides and defaults apply — no parent-scope config is consulted.
+    expect(result.autoAria).toBe(false);
+    expect(result.defaultErrorStrategy).toBe(
+      DEFAULT_NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy,
+    );
+    expect(result.defaultFormFieldAppearance).toBe(
+      DEFAULT_NGX_SIGNAL_FORMS_CONFIG.defaultFormFieldAppearance,
+    );
+  });
 });

--- a/packages/toolkit/core/utilities/normalize-config.ts
+++ b/packages/toolkit/core/utilities/normalize-config.ts
@@ -5,6 +5,13 @@ import { DEFAULT_NGX_SIGNAL_FORMS_CONFIG } from '../tokens';
  * Normalizes user-provided configuration by merging with defaults.
  * Ensures all required configuration values are present.
  *
+ * **Two-tier merge only** — this function merges `config` with
+ * `DEFAULT_NGX_SIGNAL_FORMS_CONFIG` and does NOT walk the DI injector tree.
+ * Use `provideNgxSignalFormsConfig()` / `provideNgxSignalFormsConfigForComponent()`
+ * in production code so parent-scope overrides are inherited correctly.
+ * This utility is intended for unit tests, SSR server setups, or other
+ * out-of-DI call sites where the three-tier DI cascade is not available.
+ *
  * @param config - User-provided configuration (partial)
  * @returns Complete configuration with defaults applied
  */

--- a/packages/toolkit/core/utilities/submission-helpers.delegate.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.delegate.spec.ts
@@ -109,6 +109,47 @@ describe('submitWithWarnings native submit() delegation', () => {
     expect(submitSpy).toHaveBeenCalledOnce();
     expect(action).not.toHaveBeenCalled();
   });
+
+  it('skips the action when pending() is true after the microtask settlement delay', async () => {
+    // Regression for Bug 1 (issue #73): submitWithWarnings was missing the
+    // pending() guard that canSubmitWithWarnings already had. An async validator
+    // still in flight after the microtask delay could leave pending()=true while
+    // errorSummary() appears empty, causing the action to fire prematurely.
+    const pendingState = signal(true);
+    const errorsState = signal<ValidationError[]>([]);
+    const formTree = createMockFieldTree({
+      value: () => ({}),
+      valid: () => true,
+      invalid: () => false,
+      touched: () => true,
+      dirty: () => false,
+      errors: () => errorsState(),
+      pending: () => pendingState(),
+      disabled: () => false,
+      readonly: () => false,
+      hidden: () => false,
+      submitting: () => false,
+      reset: (): void => undefined,
+      markAsTouched: (): void => undefined,
+      markAsDirty: (): void => undefined,
+      errorSummary: () => errorsState(),
+    });
+    const action = vi.fn(async () => {});
+
+    submitSpy.mockImplementation(async (_form, options) => {
+      if (typeof options === 'object') await options.action?.();
+      return true;
+    });
+
+    // pending()=true → action must NOT fire.
+    await submitWithWarnings(formTree, action);
+    expect(action).not.toHaveBeenCalled();
+
+    // Once async validators settle, pending()=false → action fires.
+    pendingState.set(false);
+    await submitWithWarnings(formTree, action);
+    expect(action).toHaveBeenCalledOnce();
+  });
 });
 
 function createMockFieldTree<TValue>(

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -204,6 +204,12 @@ export async function submitWithWarnings<TModel>(
 
   await waitForValidationSettlement();
 
+  // Mirrors the canSubmitWithWarnings() guard: async validators may still be
+  // settling after the microtask delay — skip action until they resolve.
+  if (formTree().pending()) {
+    return;
+  }
+
   if (getBlockingErrors(formTree().errorSummary()).length > 0) {
     return;
   }

--- a/packages/toolkit/form-field/form-field-wrapper.identity.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.identity.spec.ts
@@ -33,6 +33,30 @@ describe('NgxFormFieldWrapper — shared field-identity convergence', () => {
     expect(errorContainer).toBeTruthy();
   });
 
+  it('resolves field name without synchronous DOM query — no crash when host is not an HTMLElement (Bug 5 / #73)', async () => {
+    // Regression: resolvedFieldName previously called requireHostElement() inside
+    // a computed(), which throws a TypeError in SSR environments where nativeElement
+    // is not HTMLElement. The fix removes the sync DOM fallback; the reactive
+    // afterEveryRender signal (#inputElementId) is the only fallback path.
+    // Here we verify that the component works correctly via the reactive path.
+    const { container, fixture } = await render(
+      `<ngx-form-field-wrapper [formField]="field">
+        <label for="name">Name</label>
+        <input id="name" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: invalidField() },
+      },
+    );
+    await fixture.whenStable();
+
+    // The reactive afterEveryRender path must resolve the field name to 'name'
+    // from the projected input's id attribute.
+    const errorContainer = container.querySelector('[id="name-error"]');
+    expect(errorContainer).toBeTruthy();
+  });
+
   it('does not drift when the projected control element is swapped', async () => {
     const useA = signal(true);
 

--- a/packages/toolkit/form-field/form-field-wrapper.identity.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.identity.spec.ts
@@ -33,12 +33,7 @@ describe('NgxFormFieldWrapper — shared field-identity convergence', () => {
     expect(errorContainer).toBeTruthy();
   });
 
-  it('resolves field name without synchronous DOM query — no crash when host is not an HTMLElement (Bug 5 / #73)', async () => {
-    // Regression: resolvedFieldName previously called requireHostElement() inside
-    // a computed(), which throws a TypeError in SSR environments where nativeElement
-    // is not HTMLElement. The fix removes the sync DOM fallback; the reactive
-    // afterEveryRender signal (#inputElementId) is the only fallback path.
-    // Here we verify that the component works correctly via the reactive path.
+  it('resolves field name from the projected input id via the reactive afterEveryRender path', async () => {
     const { container, fixture } = await render(
       `<ngx-form-field-wrapper [formField]="field">
         <label for="name">Name</label>
@@ -51,8 +46,6 @@ describe('NgxFormFieldWrapper — shared field-identity convergence', () => {
     );
     await fixture.whenStable();
 
-    // The reactive afterEveryRender path must resolve the field name to 'name'
-    // from the projected input's id attribute.
     const errorContainer = container.querySelector('[id="name-error"]');
     expect(errorContainer).toBeTruthy();
   });

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -735,17 +735,14 @@ export class NgxFormFieldWrapper<TValue = unknown> {
       }
     }
 
-    // Priority 2: Derive from input element's id attribute (signal updated by afterEveryRender)
+    // Priority 2: Derive from input element's id attribute (signal updated by
+    // afterEveryRender). This is the correct reactive path — the DOM is never
+    // queried synchronously inside a computed() to avoid SSR crashes
+    // (requireHostElement throws TypeError when nativeElement is not HTMLElement)
+    // and to keep the dependency graph fully reactive.
     const idFromInput = this.#inputElementId();
     if (idFromInput) {
       return idFromInput;
-    }
-
-    const controlId = findBoundControl(
-      requireHostElement(this.#elementRef),
-    )?.id;
-    if (controlId !== undefined && controlId.length > 0) {
-      return controlId;
     }
 
     if (isDevMode() && !this.#warnedUnresolvedFieldName) {

--- a/packages/toolkit/headless/src/lib/character-count.spec.ts
+++ b/packages/toolkit/headless/src/lib/character-count.spec.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { form, FormField } from '@angular/forms/signals';
 import { render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NgxHeadlessCharacterCount } from './character-count';
 
 describe('NgxHeadlessCharacterCount', () => {
@@ -522,6 +522,91 @@ describe('NgxHeadlessCharacterCount', () => {
 
       expect(screen.getByTestId('count').textContent?.trim()).toBe('5 / 100');
       expect(screen.queryByTestId('over-limit')).toBeFalsy();
+    });
+  });
+
+  describe('unsupported value type dev warning (regression for Bug 3 / #73)', () => {
+    // NgxHeadlessCharacterCount was silently returning 0 for unsupported types
+    // with no warning. The createCharacterCount factory already had a one-shot
+    // console.warn; this suite pins the same behaviour for the directive.
+
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('emits a console.warn once when the field value is an unsupported type', async () => {
+      @Component({
+        selector: 'ngx-test-unsupported-value',
+        imports: [FormField, NgxHeadlessCharacterCount],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <div
+            ngxHeadlessCharacterCount
+            #charCount="characterCount"
+            [field]="objectField"
+            [maxLength]="100"
+          >
+            <span data-testid="length">{{ charCount.currentLength() }}</span>
+          </div>
+        `,
+      })
+      class TestComponent {
+        // An object value is unsupported by the character count directive.
+        readonly #model = signal({ data: { nested: 'value' } });
+        readonly objectForm = form(this.#model);
+        readonly objectField = this.objectForm.data;
+      }
+
+      const { fixture } = await render(TestComponent);
+      await fixture.whenStable();
+
+      // currentLength should still return 0 (no crash).
+      expect(screen.getByTestId('length').textContent).toBe('0');
+
+      // A single console.warn should have been emitted.
+      expect(console.warn).toHaveBeenCalledOnce();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('NgxHeadlessCharacterCount'),
+        expect.anything(),
+        expect.stringContaining('0'),
+      );
+
+      // Trigger another change-detection cycle; warn must NOT fire again.
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(console.warn).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT warn for null or undefined values (treated as empty)', async () => {
+      @Component({
+        selector: 'ngx-test-null-value',
+        imports: [FormField, NgxHeadlessCharacterCount],
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: `
+          <div
+            ngxHeadlessCharacterCount
+            #charCount="characterCount"
+            [field]="nullableField"
+            [maxLength]="100"
+          >
+            <span data-testid="length">{{ charCount.currentLength() }}</span>
+          </div>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ tag: null as string | null });
+        readonly tagForm = form(this.#model);
+        readonly nullableField = this.tagForm.tag;
+      }
+
+      await render(TestComponent);
+
+      expect(screen.getByTestId('length').textContent).toBe('0');
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/toolkit/headless/src/lib/character-count.ts
+++ b/packages/toolkit/headless/src/lib/character-count.ts
@@ -1,4 +1,10 @@
-import { computed, Directive, input, type Signal } from '@angular/core';
+import {
+  computed,
+  Directive,
+  input,
+  isDevMode,
+  type Signal,
+} from '@angular/core';
 import type { FieldTree } from '@angular/forms/signals';
 import type { CharacterCountValue } from './utilities';
 
@@ -123,6 +129,11 @@ export class NgxHeadlessCharacterCount implements CharacterCountStateSignals {
    */
   readonly #fieldState = computed(() => this.field()());
 
+  // One-shot guard so the dev warning for an unsupported `value()` type fires
+  // at most once per directive instance instead of on every CD cycle.
+  // Matches the same pattern used by the `createCharacterCount` factory.
+  #warnedUnsupportedValue = false;
+
   /**
    * Current value length.
    */
@@ -131,6 +142,20 @@ export class NgxHeadlessCharacterCount implements CharacterCountStateSignals {
     const value = state.value();
     if (typeof value === 'string') return value.length;
     if (Array.isArray(value)) return value.length;
+    if (
+      isDevMode() &&
+      !this.#warnedUnsupportedValue &&
+      value !== null &&
+      value !== undefined
+    ) {
+      this.#warnedUnsupportedValue = true;
+      // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
+      console.warn(
+        '[ngx-signal-forms] NgxHeadlessCharacterCount: unsupported value type — expected `string` or `readonly string[]`, got',
+        value,
+        '— rendering length as 0.',
+      );
+    }
     return 0;
   });
 

--- a/packages/toolkit/headless/src/lib/character-count.ts
+++ b/packages/toolkit/headless/src/lib/character-count.ts
@@ -149,10 +149,16 @@ export class NgxHeadlessCharacterCount implements CharacterCountStateSignals {
       value !== undefined
     ) {
       this.#warnedUnsupportedValue = true;
+      // Log a type descriptor only — never the raw value, which may contain
+      // user-entered data and end up in dev consoles, CI logs, or screenshots.
+      const valueType =
+        typeof value === 'object'
+          ? (value.constructor?.name ?? 'object')
+          : typeof value;
       // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
       console.warn(
         '[ngx-signal-forms] NgxHeadlessCharacterCount: unsupported value type — expected `string` or `readonly string[]`, got',
-        value,
+        valueType,
         '— rendering length as 0.',
       );
     }

--- a/packages/toolkit/headless/src/lib/utilities.spec.ts
+++ b/packages/toolkit/headless/src/lib/utilities.spec.ts
@@ -6,6 +6,7 @@ import {
   validate,
   type ValidationError,
 } from '@angular/forms/signals';
+import { NGX_SIGNAL_FORM_CONTEXT } from '@ngx-signal-forms/toolkit/core';
 import { describe, expect, it } from 'vitest';
 import {
   createErrorState,
@@ -721,6 +722,95 @@ describe('Headless Utilities', () => {
       expect(errorState.hasWarnings()).toBe(true);
       expect(errorState.hasErrors()).toBe(false);
       expect(errorState.showWarnings()).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // createErrorState — form context inheritance (regression for Bug 2 / #73)
+  // ============================================================================
+
+  describe('createErrorState — on-submit strategy inherited from form context', () => {
+    // Regression for Bug 2 (issue #73): createErrorState was not calling
+    // injectFormContext(), so it always fell back to 'on-touch' even inside an
+    // on-submit form. The fix captures formContext at factory call time and
+    // passes it to resolveStrategyFromContext / resolveSubmittedStatusFromContext.
+
+    it('hides errors before submission when the form context uses on-submit strategy', () => {
+      const submittedStatus = signal<
+        'unsubmitted' | 'submitting' | 'submitted'
+      >('unsubmitted');
+
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: NGX_SIGNAL_FORM_CONTEXT,
+            useValue: {
+              errorStrategy: signal('on-submit'),
+              submittedStatus,
+              form: {},
+            },
+          },
+        ],
+      });
+
+      const model = signal({ email: '' });
+      const emailForm = TestBed.runInInjectionContext(() =>
+        form(
+          model,
+          schema((path) => {
+            validate(path.email, (ctx) =>
+              ctx.value() ? null : { kind: 'required', message: 'Required' },
+            );
+          }),
+        ),
+      );
+
+      const errorState = TestBed.runInInjectionContext(() =>
+        createErrorState({
+          field: emailForm.email,
+          fieldName: 'email',
+        }),
+      );
+
+      // on-submit strategy: field is invalid and touched, but errors are hidden
+      // until the form has been submitted.
+      emailForm.email().markAsTouched();
+      expect(errorState.hasErrors()).toBe(true);
+      expect(errorState.showErrors()).toBe(false);
+
+      // After submission the errors become visible.
+      submittedStatus.set('submitted');
+      expect(errorState.showErrors()).toBe(true);
+    });
+
+    it('falls back to on-touch when no form context is present', () => {
+      // Callers outside a form boundary (tests, standalone) must still work.
+      const model = signal({ email: '' });
+      const emailForm = TestBed.runInInjectionContext(() =>
+        form(
+          model,
+          schema((path) => {
+            validate(path.email, (ctx) =>
+              ctx.value() ? null : { kind: 'required', message: 'Required' },
+            );
+          }),
+        ),
+      );
+
+      const errorState = TestBed.runInInjectionContext(() =>
+        createErrorState({
+          field: emailForm.email,
+          fieldName: 'email',
+        }),
+      );
+
+      // Before touch: hidden.
+      expect(errorState.showErrors()).toBe(false);
+
+      // After touch: visible (on-touch fallback).
+      emailForm.email().markAsTouched();
+      expect(errorState.hasErrors()).toBe(true);
+      expect(errorState.showErrors()).toBe(true);
     });
   });
 });

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -525,10 +525,16 @@ export function createCharacterCount(
       value !== undefined
     ) {
       warnedUnsupportedValue = true;
+      // Log a type descriptor only — never the raw value, which may contain
+      // user-entered data and end up in dev consoles, CI logs, or screenshots.
+      const valueType =
+        typeof value === 'object'
+          ? (value.constructor?.name ?? 'object')
+          : typeof value;
       // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
       console.warn(
         '[ngx-signal-forms] createCharacterCount: unsupported value type — expected `string` or `readonly string[]`, got',
-        value,
+        valueType,
         '— rendering length as 0.',
       );
     }

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -303,9 +303,19 @@ export interface CreateErrorStateOptions<TValue = unknown> {
   readonly field: FieldTree<TValue>;
   /** Field name for ID generation. `null` disables ID generation. */
   readonly fieldName: ReactiveOrStatic<string | null>;
-  /** Error display strategy (defaults to 'on-touch') */
+  /**
+   * Error display strategy override.
+   *
+   * Resolution order: this option (when not `'inherit'`) → ambient
+   * `NGX_SIGNAL_FORM_CONTEXT.errorStrategy` → `'on-touch'`.
+   */
   readonly strategy?: ReactiveOrStatic<ErrorDisplayStrategy>;
-  /** Submitted status signal (optional) */
+  /**
+   * Submitted status override.
+   *
+   * Resolution order: this option (when not `undefined`) → ambient
+   * `NGX_SIGNAL_FORM_CONTEXT.submittedStatus` → `undefined`.
+   */
   readonly submittedStatus?: ReactiveOrStatic<SubmittedStatus | undefined>;
 }
 
@@ -337,8 +347,10 @@ export interface ErrorStateResult {
  * Creates error state signals for a form field.
  *
  * This utility provides the same state management as NgxHeadlessErrorState
- * but as standalone signals for programmatic use. Defaults to the 'on-touch'
- * strategy when no strategy is provided.
+ * but as standalone signals for programmatic use. When no `strategy` is
+ * provided, it resolves from the ambient `NGX_SIGNAL_FORM_CONTEXT` (set by
+ * `provideNgxSignalFormsConfig` or a parent form host) and falls back to
+ * `'on-touch'`. The same precedence applies to `submittedStatus`.
  *
  * ## Usage
  *

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -348,9 +348,10 @@ export interface ErrorStateResult {
  *
  * This utility provides the same state management as NgxHeadlessErrorState
  * but as standalone signals for programmatic use. When no `strategy` is
- * provided, it resolves from the ambient `NGX_SIGNAL_FORM_CONTEXT` (set by
- * `provideNgxSignalFormsConfig` or a parent form host) and falls back to
- * `'on-touch'`. The same precedence applies to `submittedStatus`.
+ * provided, it resolves from the ambient `NGX_SIGNAL_FORM_CONTEXT` (installed
+ * by the parent form host directive, `NgxSignalForm` on
+ * `form[formRoot][ngxSignalForm]`) and falls back to `'on-touch'`. The same
+ * precedence applies to `submittedStatus`.
  *
  * ## Usage
  *

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -2,8 +2,11 @@ import { computed, isDevMode, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   createUniqueId,
+  injectFormContext,
   isFieldStateInteractive,
   readDirectErrors,
+  resolveStrategyFromContext,
+  resolveSubmittedStatusFromContext,
   resolveValidationErrorMessage,
   showErrors,
   splitByKind,
@@ -382,26 +385,25 @@ export function createErrorState<TValue = unknown>(
 ): ErrorStateResult {
   const { field, fieldName, strategy, submittedStatus } = options;
 
+  // Capture form context at factory call time (inside injection context).
+  // Optional: callers outside a form boundary (tests, standalone components)
+  // get undefined and fall through to 'on-touch', matching the directive.
+  const formContext = injectFormContext();
+
   const fieldState = computed(() => field());
 
   const resolvedFieldName = computed(() => unwrapValue(fieldName));
 
   const resolvedStrategy = computed<ResolvedErrorDisplayStrategy>(() => {
-    if (strategy !== undefined) {
-      const resolved = unwrapValue(strategy);
-      if (resolved !== 'inherit') {
-        return resolved;
-      }
-    }
-
-    return 'on-touch';
+    const strategyValue =
+      strategy !== undefined ? unwrapValue(strategy) : undefined;
+    return resolveStrategyFromContext(strategyValue, formContext);
   });
 
   const resolvedSubmittedStatus = computed<SubmittedStatus | undefined>(() => {
-    if (submittedStatus !== undefined) {
-      return unwrapValue(submittedStatus);
-    }
-    return undefined;
+    const statusValue =
+      submittedStatus !== undefined ? unwrapValue(submittedStatus) : undefined;
+    return resolveSubmittedStatusFromContext(statusValue, formContext);
   });
 
   const showErrorsSignal = showErrors(


### PR DESCRIPTION
## Summary

Fixes all 5 correctness bugs identified in issue #73.

- **Bug 1 (Medium)** — `submitWithWarnings` was missing the `pending()` guard that `canSubmitWithWarnings` already had. An async validator still in flight after the `queueMicrotask` delay could leave `pending()=true` while `errorSummary()` appears empty, causing the action to fire prematurely on an invalid form snapshot.
- **Bug 2 (Medium)** — `createErrorState` (factory form) was not calling `injectFormContext()`, so it always fell back to `'on-touch'` even inside an `on-submit`-configured form. It now mirrors `NgxHeadlessErrorState` by capturing form context at factory call time and routing through `resolveStrategyFromContext` / `resolveSubmittedStatusFromContext`.
- **Bug 3 (Low)** — `NgxHeadlessCharacterCount` silently returned `0` for unsupported value types. Added a one-shot `#warnedUnsupportedValue` flag and `console.warn`, matching the existing warning in `createCharacterCount`.
- **Bug 4 (Low)** — `normalizeSignalFormsConfig` has always been a two-tier utility (no DI parent-scope inheritance). Added JSDoc documenting this intentional divergence from `provideNgxSignalFormsConfig` so future contributors don't accidentally "fix" it.
- **Bug 5 (Low)** — `NgxFormFieldWrapper.resolvedFieldName` contained a synchronous `findBoundControl(requireHostElement(...))` DOM query inside a `computed()`. `requireHostElement` throws `TypeError` in SSR when `nativeElement` is not `HTMLElement`. Removed the synchronous fallback; the reactive `afterEveryRender` signal (`#inputElementId`) is the correct path.

## Test plan

- [x] Regression test for Bug 1: pending guard in `submission-helpers.delegate.spec.ts`
- [x] Regression test for Bug 2: `on-submit` form context inheritance in `utilities.spec.ts`
- [x] Regression test for Bug 3: unsupported-type warning in `character-count.spec.ts`
- [x] Regression test for Bug 4: two-tier semantics documented in `normalize-config.spec.ts`
- [x] Regression test for Bug 5: reactive field-name resolution in `form-field-wrapper.identity.spec.ts`
- [x] `pnpm nx run toolkit:build` — ✅
- [x] `pnpm nx run toolkit:test` — 1107 tests, 67 files ✅
- [x] `pnpm nx run toolkit:test-browser` — 16 tests, 4 files ✅
- [x] `pnpm nx run toolkit:lint` — 0 errors ✅
- [x] `pnpm nx run-many --target=build,test --projects=demo,demo-material` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure submissions skip while validators are pending and run after settlement.
  * Emit a single dev-mode warning for unsupported character-count value types; treat non-strings as length 0.
  * Make form field name resolution more consistent by relying on explicit/name attributes.
  * Improve error-state behavior to respect form context strategies.

* **Tests**
  * Added regression tests covering submission timing, character-count warnings, field naming, and form-context error handling.

* **Documentation**
  * Expanded docs explaining two-tier merge behavior for form config normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->