### PR TITLE
fix(ci): repair GitHub Pages deploy after Vite migration

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -67,10 +67,10 @@ jobs:
 
       - name: Build Demo
         # nx-safe.sh retries locally if Nx Cloud rejects workspace authorization.
-        run: bash .github/scripts/nx-safe.sh pnpm exec nx run demo:build --configuration=production --baseHref=/ngx-signal-forms/
+        run: bash .github/scripts/nx-safe.sh pnpm exec nx run demo:build --configuration=production --base=/ngx-signal-forms/
 
       - name: Create 404.html for SPA routing
-        run: cp dist/apps/demo/browser/index.html dist/apps/demo/browser/404.html
+        run: cp dist/apps/demo/index.html dist/apps/demo/404.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -78,8 +78,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # The application builder output is usually in a 'browser' subdirectory
-          path: dist/apps/demo/browser
+          path: dist/apps/demo
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -1,9 +1,28 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import analog from '@analogjs/vite-plugin-angular';
 import { join } from 'node:path';
 
 const appDir = import.meta.dirname;
+
+// Vite rewrites asset URLs for the configured `base` but leaves the
+// `<base href>` element alone, which breaks Angular's router on subpath
+// deployments (e.g. GitHub Pages at /ngx-signal-forms/). Align the tag.
+function alignBaseHref(): Plugin {
+  let base = '/';
+  return {
+    name: 'ngx-align-base-href',
+    configResolved(resolved) {
+      base = resolved.base;
+    },
+    transformIndexHtml(html) {
+      return html.replace(
+        /<base href="[^"]*"\s*\/?>/,
+        `<base href="${base}" />`,
+      );
+    },
+  };
+}
 
 export default defineConfig({
   root: join(appDir, 'src'),
@@ -26,5 +45,6 @@ export default defineConfig({
       tsconfig: '../tsconfig.app.json',
     }),
     nxViteTsPaths(),
+    alignBaseHref(),
   ],
 });


### PR DESCRIPTION
## Summary

The Deploy Demo workflow has been failing on every push to `main` since 2026-05-05 (5 consecutive failures, latest [run 25453685677](https://github.com/ngx-signal-forms/ngx-signal-forms/actions/runs/25453685677/job/74677353703)). The demo app was migrated to `@analogjs/vite-plugin-angular` in 0405d5d but the deploy workflow still used Angular CLI builder conventions.

Three fixes:

- **`--baseHref` → `--base`** — Angular flag forwarded by `nx:run-commands` to `vite build`, which errored with `CACError: Unknown option \`--baseHref\``.
- **`dist/apps/demo/browser` → `dist/apps/demo`** — Vite outputs to the configured `outDir` directly (no `browser/` subdirectory), so the 404.html copy and pages artifact upload pointed at a missing path.
- **`<base href>` rewrite** — Vite rewrites asset URLs for the configured base but leaves `<base href>` alone, which would break Angular's router on the `/ngx-signal-forms/` subpath. Added a small vite plugin `alignBaseHref` that rewrites the tag using the resolved base, keeping `/` for local dev.

Verified locally with `pnpm exec nx run demo:build --configuration=production --base=/ngx-signal-forms/ --skip-nx-cache`:
- `<base href="/ngx-signal-forms/" />` ✓
- assets prefixed with `/ngx-signal-forms/...` ✓
- output at `dist/apps/demo/` ✓

## Test plan

- [ ] Deploy Demo workflow succeeds on this PR's merge to `main`
- [ ] Site loads at https://ngx-signal-forms.github.io/ngx-signal-forms/ and router navigation works (no 404 on deep links thanks to existing `404.html` SPA fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo deployment workflow with enhanced build stability and corrected base URL handling for subpath deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->