### PR TITLE
ci(workflows): avoid Nx Cloud in format checks

### DIFF
--- a/.github/scripts/nx-safe.sh
+++ b/.github/scripts/nx-safe.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Runs a command, retrying without Nx Cloud if the run hard-fails because
 # Nx Cloud rejects or cannot serve the workspace (auth failure, org disabled,
-# or plan/quota rejection). Nx Cloud stays enabled when it's healthy; CI never
-# blocks when it isn't.
+# or plan/quota rejection), or if Nx Cloud's downloaded hotfix bootstrap goes
+# missing from the local cache. Nx Cloud stays enabled when it's healthy; CI
+# never blocks when it isn't.
 #
 # Nx already tolerates transient remote-cache outages during task execution, so
 # this wrapper only handles the failures that abort the command before local
@@ -19,12 +20,31 @@ set -uo pipefail
 # Classifier pattern. Kept as a single ERE so a match can be logged with the
 # offending line for debuggability on fallback.
 readonly NX_CLOUD_FAILURE_PATTERN='(Exiting run|organization has been disabled|workspace has been disabled|unable to be authorized|status code (401|402|403)|quota|credit(s)? (exceeded|exhausted)|plan limit|free plan|payment required)'
+readonly NX_CLOUD_HOTFIX_MISSING_PATTERN="Cannot find module '.*[.]nx/cache/cloud/"
+readonly NX_CLOUD_UPDATE_MANAGER_PATTERN='nx-cloud/update-manager[.]js'
+
+is_nx_cloud_hotfix_failure() {
+  local file_path=$1
+
+  grep -qiE "$NX_CLOUD_HOTFIX_MISSING_PATTERN" "$file_path" &&
+    grep -qiE "$NX_CLOUD_UPDATE_MANAGER_PATTERN" "$file_path"
+}
 
 is_nx_cloud_hard_failure() {
   local file_path=$1
 
-  grep -qi 'Nx Cloud' "$file_path" &&
-    grep -qiE "$NX_CLOUD_FAILURE_PATTERN" "$file_path"
+  if grep -qi 'Nx Cloud' "$file_path" &&
+    grep -qiE "$NX_CLOUD_FAILURE_PATTERN" "$file_path"; then
+    return 0
+  fi
+
+  is_nx_cloud_hotfix_failure "$file_path"
+}
+
+first_nx_cloud_failure_line() {
+  local file_path=$1
+
+  grep -iE "$NX_CLOUD_FAILURE_PATTERN|$NX_CLOUD_HOTFIX_MISSING_PATTERN|$NX_CLOUD_UPDATE_MANAGER_PATTERN" "$file_path" | head -n 1 || true
 }
 
 if [ "$#" -eq 0 ]; then
@@ -44,7 +64,7 @@ fi
 
 if is_nx_cloud_hard_failure "$logfile"; then
   # Surface the matched line so fallbacks are never silent in CI logs.
-  matched_line=$(grep -iE "$NX_CLOUD_FAILURE_PATTERN" "$logfile" | head -n 1 || true)
+  matched_line=$(first_nx_cloud_failure_line "$logfile")
   echo "::warning title=Nx Cloud unavailable::Retrying '$*' locally without Nx Cloud. Trigger: ${matched_line:-<no match line captured>}"
 
   # Persist a cloud-less environment for downstream steps in the same job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
         run: bash .github/scripts/nx-safe.sh pnpm exec nx report
 
       - name: Check formatting
+        env:
+          NX_NO_CLOUD: 'true'
+          NX_DAEMON: 'false'
         run: bash .github/scripts/nx-safe.sh pnpm run format:check
 
       - name: Lint with GitHub annotations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,9 @@ jobs:
         run: bash .github/scripts/nx-safe.sh pnpm exec nx report --outputStyle=static
 
       - name: Check formatting
+        env:
+          NX_NO_CLOUD: 'true'
+          NX_DAEMON: 'false'
         run: bash .github/scripts/nx-safe.sh pnpm run format:check
 
       - name: Verify Quality (Lint, Test, Build, E2E)


### PR DESCRIPTION
Run the format-check steps in CI and release with NX_NO_CLOUD=true so Nx Cloud bootstrap issues cannot fail formatting after the target already succeeds.

Extend nx-safe.sh to treat missing .nx/cache/cloud hotfix modules from nx-cloud/update-manager.js as Nx Cloud hard failures and retry locally without cloud access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Nx Cloud failure detection and error reporting in CI/CD pipeline.
  * Enhanced formatting validation step reliability by isolating cloud dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->