### PR TITLE
feat(toolkit): native formFieldBindings discovery (native-first, DOM-probe fallback)

### DIFF
--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -70,6 +70,10 @@ export {
 } from './utilities/field-interactivity';
 export * from './utilities/field-resolution';
 export * from './utilities/find-bound-control';
+export {
+  resolveBoundControlFromBindings,
+  type FormFieldBindingsState,
+} from './utilities/resolve-bound-control-from-bindings';
 export type * from './utilities/field-state-types';
 export * from './utilities/focus-first-invalid';
 export {

--- a/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.spec.ts
+++ b/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.spec.ts
@@ -52,6 +52,7 @@ describe('resolveBoundControlFromBindings', () => {
   it('returns the first registered binding element inside the host', () => {
     const host = document.createElement('div');
     const input = document.createElement('input');
+    input.id = 'control';
     host.append(input);
 
     expect(
@@ -59,11 +60,42 @@ describe('resolveBoundControlFromBindings', () => {
     ).toBe(input);
   });
 
+  it('skips an id-less binding host so the caller falls through to its DOM probe', () => {
+    // The CSS-selector fallback only matches elements with an `[id]`. An id-less
+    // `[formField]` host (e.g. `<my-control formField><input id>`) must not win
+    // here — returning it would shadow the inner `<input id>` and break PR #92's
+    // "identical output" invariant. The resolver returns null so the probe runs.
+    const host = document.createElement('div');
+    const idless = document.createElement('div');
+    host.append(idless);
+
+    expect(
+      resolveBoundControlFromBindings(fieldStateWithBindings([idless]), host),
+    ).toBeNull();
+  });
+
+  it('skips id-less binding hosts but still returns a later id-bearing one', () => {
+    const host = document.createElement('div');
+    const idless = document.createElement('div');
+    const withId = document.createElement('input');
+    withId.id = 'control';
+    host.append(idless, withId);
+
+    expect(
+      resolveBoundControlFromBindings(
+        fieldStateWithBindings([idless, withId]),
+        host,
+      ),
+    ).toBe(withId);
+  });
+
   it('ignores bindings whose element is outside this host (field bound across wrappers)', () => {
     const host = document.createElement('div');
     const otherHost = document.createElement('div');
     const outside = document.createElement('input');
+    outside.id = 'outside';
     const inside = document.createElement('input');
+    inside.id = 'inside';
     otherHost.append(outside);
     host.append(inside);
 

--- a/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.spec.ts
+++ b/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type FormFieldBindingsState,
+  resolveBoundControlFromBindings,
+} from './resolve-bound-control-from-bindings';
+
+/**
+ * Builds a structural stand-in for a `FieldState` that exposes only the
+ * `formFieldBindings` signal this resolver reads. Each entry is reduced to its
+ * `element` — the single property the resolver consumes from a `FormField`.
+ */
+function fieldStateWithBindings(
+  elements: readonly unknown[],
+): FormFieldBindingsState {
+  const bindings = elements.map((element) => ({ element }));
+  return {
+    formFieldBindings: () =>
+      bindings as unknown as ReturnType<
+        FormFieldBindingsState['formFieldBindings']
+      >,
+  };
+}
+
+describe('resolveBoundControlFromBindings', () => {
+  it('returns null when the field state lacks a formFieldBindings signal (mock state)', () => {
+    const host = document.createElement('div');
+    // A partial/mock field state — the shape the wrapper unit tests bind:
+    // no `formFieldBindings` signal, so the resolver must bail to its caller's
+    // DOM-probe fallback rather than throw.
+    const mockState = {
+      invalid: () => false,
+    } as unknown as FormFieldBindingsState;
+
+    expect(resolveBoundControlFromBindings(mockState, host)).toBeNull();
+  });
+
+  it('returns null for null/undefined field state', () => {
+    const host = document.createElement('div');
+
+    expect(resolveBoundControlFromBindings(null, host)).toBeNull();
+    expect(resolveBoundControlFromBindings(undefined, host)).toBeNull();
+  });
+
+  it('returns null when the binding registry is empty', () => {
+    const host = document.createElement('div');
+
+    expect(
+      resolveBoundControlFromBindings(fieldStateWithBindings([]), host),
+    ).toBeNull();
+  });
+
+  it('returns the first registered binding element inside the host', () => {
+    const host = document.createElement('div');
+    const input = document.createElement('input');
+    host.append(input);
+
+    expect(
+      resolveBoundControlFromBindings(fieldStateWithBindings([input]), host),
+    ).toBe(input);
+  });
+
+  it('ignores bindings whose element is outside this host (field bound across wrappers)', () => {
+    const host = document.createElement('div');
+    const otherHost = document.createElement('div');
+    const outside = document.createElement('input');
+    const inside = document.createElement('input');
+    otherHost.append(outside);
+    host.append(inside);
+
+    expect(
+      resolveBoundControlFromBindings(
+        fieldStateWithBindings([outside, inside]),
+        host,
+      ),
+    ).toBe(inside);
+  });
+
+  it('skips non-HTMLElement binding hosts', () => {
+    const host = document.createElement('div');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    host.append(svg);
+
+    expect(
+      resolveBoundControlFromBindings(fieldStateWithBindings([svg]), host),
+    ).toBeNull();
+  });
+});

--- a/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.ts
+++ b/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.ts
@@ -22,12 +22,25 @@ export type FormFieldBindingsState = Pick<
  * Prefers `fieldState.formFieldBindings()` — the canonical, framework-owned
  * source of truth for which DOM element a field is bound to — over probing the
  * host DOM with a CSS selector. Returns the first binding whose host `element`
- * is an `HTMLElement` mounted inside `hostEl`.
+ * is an `HTMLElement` mounted inside `hostEl` **and carrying a non-empty `id`**.
  *
  * Scoping to `hostEl.contains(...)` matters because a single `FieldTree` can be
  * bound to multiple controls (e.g. the same field rendered in two wrappers, or
  * a radio group spread across siblings); only the binding projected into *this*
  * wrapper host is relevant to the wrapper's chrome and ARIA derivations.
+ *
+ * ## Why the `id` guard is load-bearing (native-vs-fallback invariant)
+ *
+ * The legacy discovery path (`findBoundControl`'s `BOUND_CONTROL_SELECTOR`)
+ * only ever matches elements that carry an `[id]`. To preserve PR #92's
+ * "identical output" invariant, the native path must agree: it may only win
+ * for an element the fallback could also have produced. Without this guard, an
+ * id-less `[formField]` host — e.g. `<my-control formField><input id="x">…` —
+ * would let the wrapper element (`my-control`, no id) win over the inner
+ * `<input id="x">`, nulling out `inputId`/`resolvedFieldName` and diverging
+ * from the established CSS-selector behaviour. By skipping id-less binding
+ * elements here, an id-less native host falls through to the existing probe,
+ * which still finds the inner `<input id="x">`.
  *
  * Returns `null` (so callers fall back to their existing discovery path) when:
  * - `fieldState` is a partial/mock state without a `formFieldBindings` signal
@@ -36,7 +49,9 @@ export type FormFieldBindingsState = Pick<
  *   render or two before the projected `[formField]` directive initializes), or
  * - the wrapper hosts a plain control with no `[formField]` directive of its own
  *   (the wrapper carries the `FieldTree`; the inner control is a bare
- *   `<input id="...">`), which never appears in the registry.
+ *   `<input id="...">`), which never appears in the registry, or
+ * - every registered binding element inside this host lacks an `id` (the native
+ *   match would diverge from the CSS-selector fallback — see above).
  *
  * @internal
  */
@@ -52,7 +67,16 @@ export function resolveBoundControlFromBindings(
 
   for (const binding of formFieldBindings()) {
     const element = binding.element;
-    if (element instanceof HTMLElement && hostEl.contains(element)) {
+    // Require a non-empty `id`: the CSS-selector fallback only ever matches
+    // elements with an `[id]`, so accepting an id-less native host here would
+    // break the "identical output" invariant (an id-less `[formField]` wrapper
+    // would shadow its inner `<input id>`). Falling through lets the probe find
+    // that inner control instead.
+    if (
+      element instanceof HTMLElement &&
+      element.id.length > 0 &&
+      hostEl.contains(element)
+    ) {
       return element;
     }
   }

--- a/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.ts
+++ b/packages/toolkit/core/utilities/resolve-bound-control-from-bindings.ts
@@ -1,0 +1,61 @@
+import type { FieldState } from '@angular/forms/signals';
+
+/**
+ * Minimal FieldState contract required to read Angular's native form-field
+ * binding registry.
+ *
+ * Picked from the real `FieldState` so the type stays in lock-step with the
+ * framework, while keeping the surface this module touches small enough to be
+ * satisfied by partial/mock field states in tests. `formFieldBindings` is a
+ * signal of the `[formField]` (and custom-control) directive instances Angular
+ * has registered against this field — each exposes the DOM `element` hosting
+ * the binding.
+ */
+export type FormFieldBindingsState = Pick<
+  FieldState<unknown>,
+  'formFieldBindings'
+>;
+
+/**
+ * Resolve the bound control element from Angular's native binding registry.
+ *
+ * Prefers `fieldState.formFieldBindings()` — the canonical, framework-owned
+ * source of truth for which DOM element a field is bound to — over probing the
+ * host DOM with a CSS selector. Returns the first binding whose host `element`
+ * is an `HTMLElement` mounted inside `hostEl`.
+ *
+ * Scoping to `hostEl.contains(...)` matters because a single `FieldTree` can be
+ * bound to multiple controls (e.g. the same field rendered in two wrappers, or
+ * a radio group spread across siblings); only the binding projected into *this*
+ * wrapper host is relevant to the wrapper's chrome and ARIA derivations.
+ *
+ * Returns `null` (so callers fall back to their existing discovery path) when:
+ * - `fieldState` is a partial/mock state without a `formFieldBindings` signal
+ *   (the wrapper's unit tests bind a plain mock signal), or
+ * - no control has registered a binding yet (the registry can be empty for a
+ *   render or two before the projected `[formField]` directive initializes), or
+ * - the wrapper hosts a plain control with no `[formField]` directive of its own
+ *   (the wrapper carries the `FieldTree`; the inner control is a bare
+ *   `<input id="...">`), which never appears in the registry.
+ *
+ * @internal
+ */
+export function resolveBoundControlFromBindings(
+  fieldState: FormFieldBindingsState | null | undefined,
+  // oxlint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- DOM APIs operate on mutable HTMLElement instances.
+  hostEl: HTMLElement,
+): HTMLElement | null {
+  const formFieldBindings = fieldState?.formFieldBindings;
+  if (typeof formFieldBindings !== 'function') {
+    return null;
+  }
+
+  for (const binding of formFieldBindings()) {
+    const element = binding.element;
+    if (element instanceof HTMLElement && hostEl.contains(element)) {
+      return element;
+    }
+  }
+
+  return null;
+}

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -43,6 +43,7 @@ import {
   NGX_SIGNAL_FORM_HINT_REGISTRY,
   NgxFieldIdentity,
   isElementCssVisible,
+  resolveBoundControlFromBindings,
   toHintDescriptors,
 } from '@ngx-signal-forms/toolkit/core';
 import {
@@ -996,10 +997,20 @@ export class NgxFormFieldWrapper<TValue = unknown> {
       earlyRead: () => {
         const hostEl = requireHostElement(this.#elementRef);
 
+        // Resolve the bound control from Angular's native binding registry
+        // first; `readFormFieldWrapperDomSnapshot` falls back to DOM probing
+        // when the registry is empty (plain `<input id>` controls, the
+        // pre-init render window, or mock field states in unit tests).
+        const nativeControl = resolveBoundControlFromBindings(
+          this.#fieldState(),
+          hostEl,
+        );
+
         return readFormFieldWrapperDomSnapshot(
           hostEl,
           this.#boundControlElement(),
           this.#controlPresets,
+          nativeControl,
         );
       },
       // oxlint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- afterEveryRender passes DOM-backed render state with mutable HTMLElement references.

--- a/packages/toolkit/form-field/form-field.utils.spec.ts
+++ b/packages/toolkit/form-field/form-field.utils.spec.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { NGX_SIGNAL_FORM_CONTROL_KIND_VALUES } from '@ngx-signal-forms/toolkit/core';
+import {
+  DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS,
+  NGX_SIGNAL_FORM_CONTROL_KIND_VALUES,
+} from '@ngx-signal-forms/toolkit/core';
 import type { NgxSignalFormControlKind } from '@ngx-signal-forms/toolkit';
 import {
   hasPaddedControlContent,
   isSelectionGroupKind,
   isTextualControlKind,
+  readFormFieldWrapperDomSnapshot,
   supportsOutlinedAppearance,
 } from './form-field.utils';
 
@@ -120,6 +124,67 @@ describe('CONTROL_KIND_CAPABILITIES exhaustiveness', () => {
         EXPECTED_CAPABILITIES[kind].paddedContent,
       );
     });
+  });
+});
+
+describe('readFormFieldWrapperDomSnapshot — native-vs-fallback precedence', () => {
+  /**
+   * Builds the projected-control region the snapshot's selection-control and
+   * label scans expect, then appends `controls` into the `__main` slot. Returns
+   * the host so callers can position a competing `findBoundControl` match.
+   */
+  function hostWithProjectedControls(
+    ...controls: readonly HTMLElement[]
+  ): HTMLElement {
+    const host = document.createElement('div');
+    const content = document.createElement('div');
+    content.className = 'ngx-signal-form-field-wrapper__content';
+    const main = document.createElement('div');
+    main.className = 'ngx-signal-form-field-wrapper__main';
+    main.append(...controls);
+    content.append(main);
+    host.append(content);
+    return host;
+  }
+
+  it('prefers the native binding element (with an id) over a competing findBoundControl match', () => {
+    // Two id-bearing controls in the host: `findBoundControl` would match the
+    // first `<input id>` via the CSS selector, but a non-null `nativeControl`
+    // must win — the native binding registry is the source of truth.
+    const probeMatch = document.createElement('input');
+    probeMatch.id = 'probe-match';
+    const native = document.createElement('input');
+    native.id = 'native-control';
+    const host = hostWithProjectedControls(probeMatch, native);
+
+    const snapshot = readFormFieldWrapperDomSnapshot(
+      host,
+      null,
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS,
+      native,
+    );
+
+    expect(snapshot.inputEl).toBe(native);
+    expect(snapshot.inputId).toBe('native-control');
+  });
+
+  it('falls back to findBoundControl when nativeControl is null', () => {
+    // No native binding (id-less host filtered upstream, mock state, or
+    // pre-init window): the snapshot must run the DOM probe and find the
+    // inner `<input id>`.
+    const probeMatch = document.createElement('input');
+    probeMatch.id = 'probe-match';
+    const host = hostWithProjectedControls(probeMatch);
+
+    const snapshot = readFormFieldWrapperDomSnapshot(
+      host,
+      null,
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS,
+      null,
+    );
+
+    expect(snapshot.inputEl).toBe(probeMatch);
+    expect(snapshot.inputId).toBe('probe-match');
   });
 });
 

--- a/packages/toolkit/form-field/form-field.utils.ts
+++ b/packages/toolkit/form-field/form-field.utils.ts
@@ -89,6 +89,13 @@ export function readFormFieldWrapperDomSnapshot(
     cachedControl?.isConnected &&
     hostEl.contains(cachedControl) &&
     cachedControl.hasAttribute('id');
+  // `nativeControl` wins when present. The native-vs-fallback invariant
+  // (PR #92: native and CSS-selector paths must produce identical output) is
+  // upheld upstream in `resolveBoundControlFromBindings`, which only returns a
+  // binding element that carries a non-empty `id` — exactly the constraint the
+  // `findBoundControl` selector enforces. An id-less `[formField]` host
+  // therefore arrives here as `nativeControl === null` and falls through to the
+  // probe, which still finds the inner `<input id>`.
   const inputEl =
     nativeControl ?? (cacheHit ? cachedControl : findBoundControl(hostEl));
 

--- a/packages/toolkit/form-field/form-field.utils.ts
+++ b/packages/toolkit/form-field/form-field.utils.ts
@@ -66,7 +66,16 @@ export function readFormFieldWrapperDomSnapshot(
   hostEl: HTMLElement,
   cachedControl: HTMLElement | null,
   controlPresets: NgxSignalFormControlPresetRegistry,
+  nativeControl: HTMLElement | null,
 ): FormFieldWrapperDomSnapshot {
+  // Prefer Angular's native binding registry: when the field reports a
+  // `[formField]` binding inside this host, that element is the canonical
+  // bound control and we skip DOM probing entirely. The registry is empty
+  // for plain `<input id>` controls (the wrapper carries the `FieldTree`)
+  // and for a render or two before the projected directive initializes, so
+  // the `findBoundControl` selector below stays as the fallback that keeps
+  // those cases — and the unit tests that bind a mock field state — working.
+  //
   // DOM-query cache: reuse the previously bound control when it is
   // still mounted inside this host AND still carries an `id` (without
   // the id it no longer satisfies the `findBoundControl` selector).
@@ -80,7 +89,8 @@ export function readFormFieldWrapperDomSnapshot(
     cachedControl?.isConnected &&
     hostEl.contains(cachedControl) &&
     cachedControl.hasAttribute('id');
-  const inputEl = cacheHit ? cachedControl : findBoundControl(hostEl);
+  const inputEl =
+    nativeControl ?? (cacheHit ? cachedControl : findBoundControl(hostEl));
 
   return {
     inputEl,


### PR DESCRIPTION
## What

Adopts Angular's native binding registry (`FieldState.formFieldBindings()`) as the **primary** bound-control discovery path in `NgxFormFieldWrapper`, with the existing DOM probe retained as a fallback.

New `@internal` `resolveBoundControlFromBindings(fieldState, hostEl)` returns the first binding's `.element` mounted inside the wrapper host (scoped via `hostEl.contains(...)`, so a field bound across multiple controls resolves the right one). The wrapper prefers it: `nativeControl ?? findBoundControl(hostEl)`. The kept DOM-attr semantics inference + label/selection scans receive the same element, so id / `aria-describedby` / `aria-invalid` / `aria-required` output is identical across both paths.

Implements #87 · part of PRD #85.

## Why partial (find-bound-control retained — intentional)

The native registry cannot fully replace the probe; three cases still need the fallback:
1. a plain `<input id="…">` projected control with **no `[formField]` of its own** (the wrapper carries the `FieldTree`) never appears in `formFieldBindings()`;
2. the registry is empty for a render or two before a projected `[formField]` initializes;
3. unit tests bind a partial mock `FieldState` without a `formFieldBindings` signal.

Fully deleting `find-bound-control` would mean dropping support for plain-id projected controls — a breaking public-contract change, out of scope here (flagged for a possible follow-up).

## Verification
- ✅ typecheck clean, oxlint 0 errors
- ✅ **full toolkit jsdom suite: 1113 pass** (+6 new `resolve-bound-control-from-bindings.spec`)
- Browser specs deferred to CI.

> Note: touches `core/index.ts` (adds the internal export); minor rebase may be needed against #86's PR #90 which removes the walker export from the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
