### PR TITLE
docs(vest): scope native validateStandardSchema vs the toolkit adapter

### DIFF
--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -25,8 +25,8 @@ const signupForm = form(model, (path) => {
 
 **Use the toolkit's `validateVest` / `validateVestWarnings`** when you need something the Standard Schema interface cannot express:
 
-- **`warn:*` warning severity** — Standard Schema only models blocking issues; it has no `warn()` / severity concept. Surfacing Vest `warn()` output as toolkit warnings is the irreducible reason this bridge exists.
-- **`only()` focused runs** — thread the changed field into `suite.run(value, field)` so large suites validate one field at a time instead of re-running every test.
+- **`warn:*` warning severity** — Standard Schema only models blocking issues; it has no `warn()` / severity concept. Surfacing Vest `warn()` output as toolkit warnings is the primary reason this bridge exists.
+- **`only()` focused runs** — thread the changed field into the suite (the adapter prefers the canonical `suite.only(field).run(value)` form, falling back to `suite.run(value, field)`) so large suites validate one field at a time instead of re-running every test.
 - **`resetOnDestroy` lifecycle** — call `suite.reset()` when the hosting injection context tears down, so module-scope suite state does not leak across mounts.
 
 The adapter reads Vest's full `run()` result, mapping blocking errors **and** `warn()` output in a single pass — so enabling warnings never costs a second suite run.
@@ -285,7 +285,7 @@ suites where per-field isolation matters.
 Angular treats every `ValidationError` as blocking. For forms that should allow warnings:
 
 1. Set `ignoreValidators: 'all'` in the `submission` config
-2. Inside `action`, check `hasOnlyWarnings(form().errorSummary())`
+2. Inside `action`, check `hasOnlyWarnings(form().errorSummary())` — `errorSummary()` yields only the fields that errored, so it is not a full-tree enumeration (use the tree walker for that)
 3. Return early and focus the first invalid field when blocking errors remain
 
 ## Related documentation

--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -4,9 +4,32 @@
 
 ## Why this entry point exists
 
-Angular Signal Forms already supports Standard Schema validators through `validateStandardSchema()`, and Vest 6 implements Standard Schema. This entry point adds a toolkit-branded adapter that maps Vest's richer suite results — including `warn()` guidance — into toolkit-native warning messages.
+Angular Signal Forms already supports Standard Schema validators through `validateStandardSchema()`, and Vest 6 suites implement Standard Schema. This entry point adds a toolkit-branded adapter that maps Vest's richer suite results — including `warn()` guidance — into toolkit-native warning messages.
 
 Use it **together with** Angular validators and Standard Schema tools like Zod, not instead of them.
+
+### Native `validateStandardSchema()` vs. the toolkit adapter
+
+Because Vest 6 suites are Standard Schema, you may not need this entry point at all. Reach for the smallest tool that covers your case:
+
+**Use native `validateStandardSchema(path, suite)`** (zero toolkit code) when you only need **blocking** validation. This works for any Standard-Schema library (Zod, Valibot, ArkType) and for a plain Vest 6 suite alike:
+
+```typescript
+import { form, validateStandardSchema } from '@angular/forms/signals';
+
+const signupForm = form(model, (path) => {
+  // A Vest 6 suite is a Standard Schema — pass it directly.
+  validateStandardSchema(path, signupSuite);
+});
+```
+
+**Use the toolkit's `validateVest` / `validateVestWarnings`** when you need something the Standard Schema interface cannot express:
+
+- **`warn:*` warning severity** — Standard Schema only models blocking issues; it has no `warn()` / severity concept. Surfacing Vest `warn()` output as toolkit warnings is the irreducible reason this bridge exists.
+- **`only()` focused runs** — thread the changed field into `suite.run(value, field)` so large suites validate one field at a time instead of re-running every test.
+- **`resetOnDestroy` lifecycle** — call `suite.reset()` when the hosting injection context tears down, so module-scope suite state does not leak across mounts.
+
+The adapter reads Vest's full `run()` result, mapping blocking errors **and** `warn()` output in a single pass — so enabling warnings never costs a second suite run.
 
 ## Installation
 


### PR DESCRIPTION
## What

Adds a scoping section to `packages/toolkit/vest/README.md` clarifying when to use Angular's native `validateStandardSchema(path, suite)` vs. the toolkit's `validateVest` adapter.

Implements #89 · part of PRD #85.

## Content (verified against Vest 6 docs)

- **Native `validateStandardSchema(path, suite)`** (zero toolkit code) for **blocking-only** validation — Vest 6 suites *are* Standard Schema, same as Zod/Valibot/ArkType. Includes a code example.
- **`validateVest` / `validateVestWarnings`** for the three things Standard Schema cannot express: `warn:*` warning severity (the irreducible reason the bridge exists), `only()` focused runs, and `resetOnDestroy` lifecycle.

Docs-only. No historical release notes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Vest adapter README: clarified when to use the toolkit-branded adapter vs direct validation, how external validator warnings are surfaced as toolkit warnings, support for focused/changed-field runs, and reset-on-destroy behavior via lifecycle integration. Explained that blocking errors and warnings come from a single validation pass, and clarified submit guidance—error summary reports only errored fields; use a tree-walker for full-tree coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->