### PR TITLE
feat(vest)!: only() auto-focus + resetOnDestroy defaults to true

### DIFF
--- a/.github/skills/ngx-signal-forms/references/api.md
+++ b/.github/skills/ngx-signal-forms/references/api.md
@@ -623,8 +623,9 @@ import {
 
 interface ValidateVestOptions<TValue = unknown> {
   includeWarnings?: boolean; // default: false — surface warn() as toolkit warnings
-  resetOnDestroy?: boolean; // default: false — call suite.reset() on DestroyRef teardown
+  resetOnDestroy?: boolean; // default: true — call suite.reset() on DestroyRef teardown; pass false to persist state across mounts
   only?: VestOnlyFieldSelector<TValue>; // default: undefined — focus the run on a field
+  focusCurrentField?: boolean; // default: false — derive the focused field name from the bound field's ctx.pathKeys() (dotted, e.g. items.0.sku); ignored when `only` is set; root-bound falls back to a whole-suite run
 }
 
 type VestOnlyFieldSelector<TValue> = (

--- a/.github/skills/ngx-signal-forms/vest/SKILL.md
+++ b/.github/skills/ngx-signal-forms/vest/SKILL.md
@@ -79,11 +79,12 @@ const signupForm = form(signupModel, (path) => {
 
 #### Options
 
-| Option            | Default | Purpose                                                                                                                                                                                          |
-| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `includeWarnings` | `false` | Surface `warn()` results as toolkit warnings (`kind` prefixed with `warn:vest:`).                                                                                                                |
-| `resetOnDestroy`  | `false` | Call `suite.reset()` via `DestroyRef.onDestroy()` when the hosting injection context tears down. **Strongly recommended for module-scope suites** — see _Suite lifecycle_ below.                 |
-| `only`            | _none_  | `VestOnlyFieldSelector` — `(ctx) => string \| readonly string[] \| undefined`. Threads a field name into `suite.run(value, fieldName)` for per-field focused runs; default runs the whole suite. |
+| Option              | Default | Purpose                                                                                                                                                                                                                                               |
+| ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `includeWarnings`   | `false` | Surface `warn()` results as toolkit warnings (`kind` prefixed with `warn:vest:`).                                                                                                                                                                     |
+| `resetOnDestroy`    | `true`  | Call `suite.reset()` via `DestroyRef.onDestroy()` when the hosting injection context tears down. **Enabled by default** for module-scope suites — pass `{ resetOnDestroy: false }` to persist suite state across mounts. See _Suite lifecycle_ below. |
+| `only`              | _none_  | `VestOnlyFieldSelector` — `(ctx) => string \| readonly string[] \| undefined`. Threads a field name into `suite.run(value, fieldName)` for per-field focused runs; default runs the whole suite.                                                      |
+| `focusCurrentField` | `false` | Derive the focused Vest field name from the bound field's `ctx.pathKeys()` (dotted, e.g. `items.0.sku`). Ignored when `only` is set; falls back to a whole-suite run when bound to the form root.                                                     |
 
 ### Suite lifecycle
 
@@ -100,11 +101,18 @@ export const signupSuite = create((data: SignupModel) => {
 
 Without a teardown hook, state bleeds across component mounts — a second mount
 can see stale errors from a previous session, or async tests from an unmounted
-form can resolve into the new one. Enable `resetOnDestroy: true` to wire
-`suite.reset()` into `DestroyRef`:
+form can resolve into the new one. The adapter wires `suite.reset()` into
+`DestroyRef` **by default** (`resetOnDestroy: true`), so this is handled for you:
 
 ```typescript
-validateVest(path, signupSuite, { resetOnDestroy: true });
+validateVest(path, signupSuite); // resets suite state on teardown automatically
+```
+
+Pass `{ resetOnDestroy: false }` only when you deliberately want suite state to
+persist across mounts:
+
+```typescript
+validateVest(path, signupSuite, { resetOnDestroy: false });
 ```
 
 ### Focused runs with `only`
@@ -130,6 +138,19 @@ validateVest(path, suite, {
 
 Default behavior (no `only` option) re-runs every test body on each change —
 correct but wasteful for large suites.
+
+When you bind `validateVest` to a specific field path, pass
+`{ focusCurrentField: true }` to derive the focused field name automatically
+from `ctx.pathKeys()` — no `only` selector needed:
+
+```typescript
+validateVest(path.email, suite, { focusCurrentField: true });
+```
+
+The derived name is the dotted path (e.g. `items.0.sku` for nested/array
+fields). Bound to the form root, the path is empty and the adapter falls back
+to a whole-suite run. An explicit `only` selector always overrides
+`focusCurrentField`.
 
 ### `validateVestWarnings(path, suite)`
 
@@ -187,5 +208,5 @@ For Angular 21.2 `submit()` with Vest warnings, pass `{ ignoreValidators: 'all' 
 - If Vest warnings appear as blocking errors: ensure `{ includeWarnings: true }` is passed to `validateVest()` and that the suite uses `warn()` before `enforce()`.
 - If Vest results don't update reactively: confirm the suite receives the reactive signal value — pass `signalModel()` not `signalModel`.
 - If Vest v5 is installed: upgrade to `vest@^6.0.0` — v6+ implements the Standard Schema interface required by this adapter.
-- If stale errors appear on a second mount of a form using a module-scope suite: set `resetOnDestroy: true` so suite state clears on component teardown.
+- If stale errors appear on a second mount of a form using a module-scope suite: the adapter clears suite state on teardown by default — confirm `resetOnDestroy` has not been set to `false`. (Conversely, if you _want_ suite state to persist across mounts, pass `{ resetOnDestroy: false }`.)
 - If detecting Vest-origin errors in a custom strategy or test: import `VEST_ERROR_KIND_PREFIX` / `VEST_WARNING_KIND_PREFIX` and match against `error.kind` instead of hard-coding the string.

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -38,7 +38,8 @@ releases will not include any of the renames below.
 - **New: fieldset toggle** — `includeNestedErrors` on fieldset; `submittedStatus` override input
 - **New: error component APIs** — `errors`, `listStyle`, `submittedStatus` inputs on `NgxFormFieldError`
 - **New: headless message resolution** — `createErrorMessageSignal()` combines visibility, the 3-tier message cascade, and stable per-error IDs for custom error renderers
-- **New: Vest options** — `only` selector, `resetOnDestroy`, `VEST_*_KIND_PREFIX` exports
+- **New: Vest options** — `only` selector, `focusCurrentField` auto-focus, `VEST_*_KIND_PREFIX` exports
+- **BREAKING: Vest `resetOnDestroy` now defaults to `true`** — the adapter resets module-scope suite state on teardown by default; pass `{ resetOnDestroy: false }` to keep persisting state across mounts
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=21.2.0 <22.0.0`
@@ -607,11 +608,33 @@ import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 
 ### Vest adapter additions
 
-- `resetOnDestroy: true` — wires `suite.reset()` into `DestroyRef` so
-  module-scope suites don't leak state across component mounts.
+- **BREAKING — `resetOnDestroy` now defaults to `true`.** The adapter wires
+  `suite.reset()` into `DestroyRef` by default so module-scope suites don't leak
+  state across component mounts (previously this was opt-in via
+  `resetOnDestroy: true`, defaulting to `false`).
+
+  **Action:** Consumers who deliberately rely on persisted suite state across
+  mounts (e.g. memoized async results or accumulated suite state intended to
+  survive a remount) **must now pass `{ resetOnDestroy: false }`** to opt out.
+  Everyone else can drop the now-redundant `{ resetOnDestroy: true }` — it is the
+  default.
+
+  ```typescript
+  // Before (v1 beta): opt in to reset
+  validateVest(path, suite, { resetOnDestroy: true });
+
+  // After (v1): reset is the default — opt out to persist state
+  validateVest(path, suite); // resets on teardown
+  validateVest(path, suite, { resetOnDestroy: false }); // persists across mounts
+  ```
+
 - `only: (ctx) => string | string[] | undefined` — threads a focused field name
   into `suite.run(value, fieldName)` (or `suite.only(field).run(...)`), enabling
   per-field Vest runs for large suites.
+- `focusCurrentField: true` — derives the focused Vest field name automatically
+  from the bound field's `ctx.pathKeys()` (dotted, e.g. `items.0.sku`); ignored
+  when `only` is set and falls back to a whole-suite run when bound to the form
+  root.
 - Exported kind prefixes `VEST_ERROR_KIND_PREFIX` (`'vest:'`) and
   `VEST_WARNING_KIND_PREFIX` (`'warn:vest:'`) for stable consumer checks.
 

--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -134,19 +134,21 @@ First-class adapter for Vest suites. Reads `suite.run()` results and maps blocki
 ```typescript
 validateVest(path, suite); // blocking errors only
 validateVest(path, suite, { includeWarnings: true }); // + warn() as toolkit warnings
-validateVest(path, suite, { resetOnDestroy: true }); // clear suite state on teardown
+validateVest(path, suite, { resetOnDestroy: false }); // opt out of teardown reset (now the default)
 validateVest(path, suite, { only: (ctx) => ctx.value().focusedField });
+validateVest(path.email, suite, { focusCurrentField: true }); // auto-focus the bound field
 ```
 
 Blocking errors and warnings are read from the same Vest run — enabling warnings does not require a second suite pass.
 
 #### Options
 
-| Option            | Default | Description                                                                                                                                                                                    |
-| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `includeWarnings` | `false` | Surface `warn()` results as toolkit warnings (`kind` prefixed with `warn:vest:`).                                                                                                              |
-| `resetOnDestroy`  | `false` | Call `suite.reset()` via `DestroyRef.onDestroy()` when the hosting injection context tears down. Strongly recommended for module-scope suites (see [Suite lifecycle](#suite-lifecycle) below). |
-| `only`            | _none_  | Selector `(ctx) => string \| string[] \| undefined` that threads a field name into `suite.run(value, fieldName)` (or `suite.only(field).run(value)` where the suite exposes that shorthand).   |
+| Option              | Default | Description                                                                                                                                                                                                                                                                           |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `includeWarnings`   | `false` | Surface `warn()` results as toolkit warnings (`kind` prefixed with `warn:vest:`).                                                                                                                                                                                                     |
+| `resetOnDestroy`    | `true`  | Call `suite.reset()` via `DestroyRef.onDestroy()` when the hosting injection context tears down. Enabled by default for module-scope suites; pass `{ resetOnDestroy: false }` only to deliberately persist suite state across mounts (see [Suite lifecycle](#suite-lifecycle) below). |
+| `only`              | _none_  | Selector `(ctx) => string \| string[] \| undefined` that threads a field name into `suite.run(value, fieldName)` (or `suite.only(field).run(value)` where the suite exposes that shorthand).                                                                                          |
+| `focusCurrentField` | `false` | Derive the focused Vest field name automatically from the field this validator is bound to (`ctx.pathKeys()`, dotted — e.g. `items.0.sku`). Ignored when `only` is provided; falls back to a whole-suite run when bound to the form root.                                             |
 
 ### Exported constants
 
@@ -231,14 +233,21 @@ hook, suite state bleeds across component mounts. A second mount can see
 stale errors from a previous session, or async tests from an unmounted form
 can continue resolving and leak errors into the new one.
 
-Enable `resetOnDestroy: true` to wire `suite.reset()` into `DestroyRef`:
+To prevent this foot-gun, the adapter wires `suite.reset()` into `DestroyRef`
+**by default** (`resetOnDestroy: true`). It calls `suite.reset()` (and drops
+its internal run cache) when the injection context that registered the
+validator is destroyed — no configuration needed:
 
 ```typescript
-validateVest(path, signupSuite, { resetOnDestroy: true });
+validateVest(path, signupSuite); // resets suite state on teardown automatically
 ```
 
-The adapter calls `suite.reset()` (and drops its internal run cache) when the
-injection context that registered the validator is destroyed.
+Pass `{ resetOnDestroy: false }` only when you deliberately want suite state to
+persist across mounts:
+
+```typescript
+validateVest(path, signupSuite, { resetOnDestroy: false }); // opt out of teardown reset
+```
 
 ### Async caveats
 
@@ -279,6 +288,22 @@ validateVest(path, suite, {
 The default behavior (no `only` option) runs the whole suite on every change,
 which stays correct but re-executes every test body. Use `only` for large
 suites where per-field isolation matters.
+
+#### Auto-focus the bound field
+
+When you bind `validateVest` to a specific field path, pass
+`{ focusCurrentField: true }` to derive the focused Vest field name
+automatically — no hand-written `only` selector required:
+
+```typescript
+validateVest(path.email, suite, { focusCurrentField: true });
+```
+
+The adapter reads the bound field's dotted path from `ctx.pathKeys()` (e.g.
+`items.0.sku` for a nested/array field) and threads it into the focused run.
+When the validator is bound to the **form root** the derived path is empty, so
+the adapter falls back to a whole-suite run. An explicit `only` selector always
+wins — `focusCurrentField` is ignored when `only` is provided.
 
 ## Using Angular `submit()` with warnings
 

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -4,7 +4,7 @@ import {
   Component,
   signal,
 } from '@angular/core';
-import { form, FormField } from '@angular/forms/signals';
+import { applyEach, form, FormField } from '@angular/forms/signals';
 import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
@@ -760,6 +760,116 @@ describe('validateVest', () => {
     const errors = fixture.componentInstance.f.email().errors();
     expect(errors).toHaveLength(1);
     expect(errors[0]?.message).toBe('Email is required');
+  });
+
+  it('falls back to a whole-suite run when focusCurrentField is bound to the form root', async () => {
+    // A root-bound validator has an empty `ctx.pathKeys()`, so the derived Vest
+    // field name is `undefined` and the adapter must run the whole suite
+    // (`suite.run(value)`) rather than focusing an empty field name.
+    const focusedFields: Array<string | readonly string[] | false> = [];
+    const fullRunValues: Array<{ email: string }> = [];
+    const baseSuite = create((data: { email: string }, field?: string) => {
+      only(field);
+      test('email', 'Email is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+    const suite = {
+      ...baseSuite,
+      only(field: string | readonly string[] | false) {
+        focusedFields.push(field);
+        return {
+          run: (value: { email: string }) => baseSuite.only(field).run(value),
+        };
+      },
+      run(value: { email: string }) {
+        fullRunValues.push(value);
+        return baseSuite.run(value);
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-autofocus-root',
+      imports: [FormField],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `<input [formField]="f.email" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      // Bound to the form root, not `path.email`.
+      readonly f = form(this.model, (path) => {
+        validateVest(path, suite, { focusCurrentField: true });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // No focused run was attempted; the whole-suite `run(value)` ran instead.
+    expect(focusedFields).toHaveLength(0);
+    expect(fullRunValues.length).toBeGreaterThan(0);
+    // The whole suite still surfaces the error on the bound field.
+    const errors = fixture.componentInstance.f.email().errors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe('Email is required');
+  });
+
+  it('derives the dotted Vest field name from a nested/array path for focusCurrentField', async () => {
+    // For a validator bound to an array element's `sku` field via `applyEach`,
+    // `ctx.pathKeys()` yields `['items', '0', 'sku']`, so the derived Vest
+    // field name must be the dotted path `items.0.sku`.
+    const focusedFields: Array<string | readonly string[] | false> = [];
+    const ranTests: string[] = [];
+    const baseSuite = create((sku: string, field?: string) => {
+      only(field);
+      test('items.0.sku', 'SKU is required', () => {
+        ranTests.push('items.0.sku');
+        enforce(sku).isNotBlank();
+      });
+      test('other', 'Other is required', () => {
+        ranTests.push('other');
+        enforce('').isNotBlank();
+      });
+    });
+    const suite = {
+      ...baseSuite,
+      only(field: string | readonly string[] | false) {
+        focusedFields.push(field);
+        return {
+          run: (value: string) => baseSuite.only(field).run(value),
+        };
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-autofocus-nested',
+      imports: [FormField],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `<input [formField]="f.items[0].sku" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ items: [{ sku: '' }] });
+      // `applyEach` binds the validator to each array element's `sku` field,
+      // so the bound path is `items.0.sku` for the first element.
+      readonly f = form(this.model, (path) => {
+        applyEach(path.items, (item) => {
+          validateVest(item.sku, suite, { focusCurrentField: true });
+        });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // The derived focus is the full dotted path for the nested array field.
+    expect(focusedFields).toContain('items.0.sku');
+    // Only the focused field's test body executed.
+    expect(ranTests).toContain('items.0.sku');
+    expect(ranTests).not.toContain('other');
+    // And the focused field still surfaces its error.
+    const errors = fixture.componentInstance.f.items[0].sku().errors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe('SKU is required');
   });
 
   it('lets an explicit only selector override focusCurrentField', async () => {

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -9,7 +9,7 @@ import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { create, enforce, group, only, test, warn } from 'vest';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   VEST_ERROR_KIND_PREFIX,
   VEST_WARNING_KIND_PREFIX,
@@ -807,28 +807,24 @@ describe('validateVest', () => {
     expect(focusedFields).not.toContain('email');
   });
 
-  it('warns once in dev when registered without resetOnDestroy', async () => {
-    const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
-
-    // A suite that exposes `reset` (the recommendation only applies to suites
-    // that can be reset). A fresh suite instance avoids the once-per-suite
-    // WeakSet de-dupe from other tests.
+  it('resets suite state on destroy by default (no resetOnDestroy passed)', async () => {
     const baseSuite = create((data: { email: string }) => {
       test('email', 'Email is required', () => {
         enforce(data.email).isNotBlank();
       });
     });
+
+    let resetCount = 0;
     const suite = {
       ...baseSuite,
       reset: () => {
+        resetCount += 1;
         baseSuite.reset();
       },
     };
 
     @Component({
-      selector: 'ngx-test-vest-warn-reset',
+      selector: 'ngx-test-vest-reset-default',
       imports: [FormField],
       changeDetection: ChangeDetectionStrategy.OnPush,
       template: `<input [formField]="f.email" />`,
@@ -836,43 +832,36 @@ describe('validateVest', () => {
     class TestComponent {
       readonly model = signal({ email: '' });
       readonly f = form(this.model, (path) => {
-        // Registered twice on purpose: the dev warning must still fire only
-        // once per suite.
+        // No resetOnDestroy option: the adapter resets on destroy by default.
         validateVest(path, suite);
-        validateVestWarnings(path, suite);
       });
     }
 
-    await render(TestComponent);
+    const { fixture } = await render(TestComponent);
     await TestBed.inject(ApplicationRef).whenStable();
+    fixture.destroy();
 
-    const resetCalls = consoleWarnSpy.mock.calls.filter(([first]) =>
-      String(first).includes('registered without `resetOnDestroy`'),
-    );
-    expect(resetCalls).toHaveLength(1);
-
-    consoleWarnSpy.mockRestore();
+    expect(resetCount).toBe(1);
   });
 
-  it('does not warn when resetOnDestroy is enabled', async () => {
-    const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
-
+  it('lets resetOnDestroy: false opt out of reset-on-destroy', async () => {
     const baseSuite = create((data: { email: string }) => {
       test('email', 'Email is required', () => {
         enforce(data.email).isNotBlank();
       });
     });
+
+    let resetCount = 0;
     const suite = {
       ...baseSuite,
       reset: () => {
+        resetCount += 1;
         baseSuite.reset();
       },
     };
 
     @Component({
-      selector: 'ngx-test-vest-warn-reset-ok',
+      selector: 'ngx-test-vest-reset-optout',
       imports: [FormField],
       changeDetection: ChangeDetectionStrategy.OnPush,
       template: `<input [formField]="f.email" />`,
@@ -880,19 +869,15 @@ describe('validateVest', () => {
     class TestComponent {
       readonly model = signal({ email: '' });
       readonly f = form(this.model, (path) => {
-        validateVest(path, suite, { resetOnDestroy: true });
+        validateVest(path, suite, { resetOnDestroy: false });
       });
     }
 
-    await render(TestComponent);
+    const { fixture } = await render(TestComponent);
     await TestBed.inject(ApplicationRef).whenStable();
+    fixture.destroy();
 
-    const resetCalls = consoleWarnSpy.mock.calls.filter(([first]) =>
-      String(first).includes('registered without `resetOnDestroy`'),
-    );
-    expect(resetCalls).toHaveLength(0);
-
-    consoleWarnSpy.mockRestore();
+    expect(resetCount).toBe(0);
   });
 
   it('invokes suite.only(fieldName) when the suite exposes the shorthand API', async () => {

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -702,6 +702,199 @@ describe('validateVest', () => {
     expect(runCount.focused).toBeGreaterThan(0);
   });
 
+  it('auto-focuses the bound field via focusCurrentField with zero only() wiring', async () => {
+    // `focusCurrentField` derives the Vest field name from the field this
+    // validator is bound to (here `email`, from `ctx.pathKeys()`), so the
+    // focused run executes only that field's test body — no hand-written
+    // `only` selector required.
+    const focusedFields: Array<string | readonly string[] | false> = [];
+    const ranTests: string[] = [];
+
+    const baseSuite = create((email: string, field?: string) => {
+      only(field);
+      test('email', 'Email is required', () => {
+        ranTests.push('email');
+        enforce(email).isNotBlank();
+      });
+      test('other', 'Other is required', () => {
+        ranTests.push('other');
+        enforce(email).isNotBlank();
+      });
+    });
+
+    const suite = {
+      ...baseSuite,
+      only(field: string | readonly string[] | false) {
+        focusedFields.push(field);
+        return {
+          run: (value: string) => {
+            return baseSuite.only(field).run(value);
+          },
+        };
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-autofocus',
+      imports: [FormField],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `<input [formField]="f.email" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly f = form(this.model, (path) => {
+        validateVest(path.email, suite, { focusCurrentField: true });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // The derived focus targets the bound field name only.
+    expect(focusedFields).toContain('email');
+    expect(focusedFields).not.toContain('other');
+    // Only the focused field's test body executed.
+    expect(ranTests).toContain('email');
+    expect(ranTests).not.toContain('other');
+    // And the focused field still surfaces its error.
+    const errors = fixture.componentInstance.f.email().errors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe('Email is required');
+  });
+
+  it('lets an explicit only selector override focusCurrentField', async () => {
+    // When both are supplied the explicit `only` selector wins, keeping
+    // existing hand-wired focus working unchanged.
+    const focusedFields: Array<string | readonly string[] | false> = [];
+    const baseSuite = create((email: string, field?: string) => {
+      only(field);
+      test('email', 'Email is required', () => {
+        enforce(email).isNotBlank();
+      });
+    });
+    const suite = {
+      ...baseSuite,
+      only(field: string | readonly string[] | false) {
+        focusedFields.push(field);
+        return {
+          run: (value: string) => {
+            return baseSuite.only(field).run(value);
+          },
+        };
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-autofocus-override',
+      imports: [FormField],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `<input [formField]="f.email" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly f = form(this.model, (path) => {
+        validateVest(path.email, suite, {
+          focusCurrentField: true,
+          only: () => 'explicit-name',
+        });
+      });
+    }
+
+    await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(focusedFields).toContain('explicit-name');
+    expect(focusedFields).not.toContain('email');
+  });
+
+  it('warns once in dev when registered without resetOnDestroy', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    // A suite that exposes `reset` (the recommendation only applies to suites
+    // that can be reset). A fresh suite instance avoids the once-per-suite
+    // WeakSet de-dupe from other tests.
+    const baseSuite = create((data: { email: string }) => {
+      test('email', 'Email is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+    const suite = {
+      ...baseSuite,
+      reset: () => {
+        baseSuite.reset();
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-warn-reset',
+      imports: [FormField],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `<input [formField]="f.email" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly f = form(this.model, (path) => {
+        // Registered twice on purpose: the dev warning must still fire only
+        // once per suite.
+        validateVest(path, suite);
+        validateVestWarnings(path, suite);
+      });
+    }
+
+    await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const resetCalls = consoleWarnSpy.mock.calls.filter(([first]) =>
+      String(first).includes('registered without `resetOnDestroy`'),
+    );
+    expect(resetCalls).toHaveLength(1);
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('does not warn when resetOnDestroy is enabled', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const baseSuite = create((data: { email: string }) => {
+      test('email', 'Email is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+    const suite = {
+      ...baseSuite,
+      reset: () => {
+        baseSuite.reset();
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-warn-reset-ok',
+      imports: [FormField],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      template: `<input [formField]="f.email" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly f = form(this.model, (path) => {
+        validateVest(path, suite, { resetOnDestroy: true });
+      });
+    }
+
+    await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const resetCalls = consoleWarnSpy.mock.calls.filter(([first]) =>
+      String(first).includes('registered without `resetOnDestroy`'),
+    );
+    expect(resetCalls).toHaveLength(0);
+
+    consoleWarnSpy.mockRestore();
+  });
+
   it('invokes suite.only(fieldName) when the suite exposes the shorthand API', async () => {
     const baseSuite = create((data: { email: string }) => {
       test('email', 'Email is required', () => {

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -77,6 +77,26 @@ export interface ValidateVestOptions<TValue = unknown> {
    * @default undefined (full-suite run)
    */
   only?: VestOnlyFieldSelector<TValue>;
+
+  /**
+   * Derive the Vest field name to focus automatically from the field this
+   * validator is bound to, giving you Vest's per-field focused run with zero
+   * wiring. When `true` and {@link only} is not provided, the adapter resolves
+   * the current field's dotted Vest name from `ctx.pathKeys()` and passes it to
+   * the focused run (`suite.only(name).run(value)` or
+   * `suite.run(value, name)`).
+   *
+   * Bind `validateVest` to the specific field path you want focused (e.g.
+   * `validateVest(path.email, suite, { focusCurrentField: true })`) so the
+   * derived name targets that field. When the validator is bound to the form
+   * root the derived path is empty and the run falls back to a whole-suite run.
+   *
+   * Ignored when {@link only} is provided — an explicit selector always wins so
+   * existing wiring keeps working unchanged.
+   *
+   * @default false (full-suite run)
+   */
+  focusCurrentField?: boolean;
 }
 
 type VestFieldPath<TValue> = SchemaPath<TValue> & SchemaPathTree<TValue>;
@@ -166,6 +186,7 @@ interface VestValidationRegistrationOptions<TValue> {
   readonly includeErrors: boolean;
   readonly includeWarnings: boolean;
   readonly only?: VestOnlyFieldSelector<TValue>;
+  readonly focusCurrentField?: boolean;
 }
 
 /**
@@ -286,6 +307,27 @@ function parseVestFieldPath(fieldPath: string): Array<string | number> {
 }
 
 /**
+ * Derives the Vest field name for the field a validator is bound to from the
+ * Angular field context's `pathKeys` (the keys leading from the form root to
+ * the current field). Produces the dotted notation Vest uses for field
+ * targeting (e.g. `['user', 'email'] -> 'user.email'`, `['items', '0', 'sku']
+ * -> 'items.0.sku'`), which is the inverse of {@link parseVestFieldPath}.
+ *
+ * Returns `undefined` for a root-bound validator (empty path) so the caller
+ * falls back to a whole-suite run instead of focusing an empty field name.
+ */
+function deriveVestFieldNameFromContext<TValue>(
+  ctx: FieldContext<TValue>,
+): string | undefined {
+  const pathKeys = ctx.pathKeys();
+  if (pathKeys.length === 0) {
+    return undefined;
+  }
+
+  return pathKeys.join('.');
+}
+
+/**
  * Resolves a Vest warning path to the matching Angular field tree. When the
  * target path is missing, the current field tree is used as a safe fallback.
  *
@@ -310,11 +352,23 @@ function resolveVestWarningFieldTree(
     // oxlint-disable-next-line unicorn/new-for-builtins -- Object() coercion is intentional runtime wrap for own-property probing on callable field trees.
     const container = Object(current) as object;
     const segmentKey = typeof segment === 'number' ? String(segment) : segment;
-    if (!Object.hasOwn(container, segmentKey)) {
+
+    // Angular Signal Forms field trees are proxies whose traps throw
+    // `Reflect.getOwnPropertyDescriptor called on non-object` when probed on a
+    // leaf node (no further children). This happens when a Vest field name is
+    // resolved against a validator bound to that leaf — e.g. the
+    // `focusCurrentField` auto-focus path, where the bound field *is* the
+    // target. Treat any probe failure as "no such child" and fall back to the
+    // bound field tree, which is the correct target in that case.
+    let next: unknown;
+    try {
+      if (!Object.hasOwn(container, segmentKey)) {
+        return fieldTree;
+      }
+      next = Reflect.get(container, segmentKey);
+    } catch {
       return fieldTree;
     }
-
-    const next = Reflect.get(container, segmentKey);
     if (next === undefined) {
       return fieldTree;
     }
@@ -589,7 +643,17 @@ function registerVestValidation<TValue>(
   const resolveFocus = (
     ctx: FieldContext<TValue>,
   ): string | readonly string[] | undefined => {
-    return options.only ? options.only(ctx) : undefined;
+    // An explicit `only` selector always wins so existing wiring is unchanged.
+    if (options.only) {
+      return options.only(ctx);
+    }
+
+    // Opt-in auto-focus: derive the Vest field name from the bound field.
+    if (options.focusCurrentField) {
+      return deriveVestFieldNameFromContext(ctx);
+    }
+
+    return undefined;
   };
 
   validateTree(path, (ctx) => {
@@ -728,13 +792,18 @@ function registerVestValidation<TValue>(
 export function validateVestWarnings<TValue>(
   path: VestFieldPath<TValue>,
   suite: VestRunnableSuite<TValue>,
-  options: Pick<ValidateVestOptions<TValue>, 'resetOnDestroy' | 'only'> = {},
+  options: Pick<
+    ValidateVestOptions<TValue>,
+    'resetOnDestroy' | 'only' | 'focusCurrentField'
+  > = {},
 ): void {
+  warnIfNoResetOnDestroy(suite, options.resetOnDestroy);
   maybeRegisterResetOnDestroy(suite, options.resetOnDestroy);
   registerVestValidation(path, suite, {
     includeErrors: false,
     includeWarnings: true,
     only: options.only,
+    focusCurrentField: options.focusCurrentField,
   });
 }
 
@@ -759,6 +828,11 @@ export function validateVestWarnings<TValue>(
  * adapter then invokes `suite.run(value, fieldName)` (or
  * `suite.only(fieldName).run(value)` where supported) rather than a full-suite
  * run. Works with suite callbacks that use `only(fieldName)` internally.
+ *
+ * Pass `{ focusCurrentField: true }` (without `only`) to get the same focused
+ * run with zero wiring: the adapter derives the Vest field name from the field
+ * this validator is bound to. Bind to the specific field path you want focused,
+ * e.g. `validateVest(path.email, suite, { focusCurrentField: true })`.
  *
  * @example
  * ```typescript
@@ -788,12 +862,59 @@ export function validateVest<TValue>(
   suite: VestRunnableSuite<TValue>,
   options: ValidateVestOptions<TValue> = {},
 ): void {
+  warnIfNoResetOnDestroy(suite, options.resetOnDestroy);
   maybeRegisterResetOnDestroy(suite, options.resetOnDestroy);
   registerVestValidation(path, suite, {
     includeErrors: true,
     includeWarnings: options.includeWarnings ?? false,
     only: options.only,
+    focusCurrentField: options.focusCurrentField,
   });
+}
+
+/**
+ * Tracks suites that have already emitted the missing-`resetOnDestroy` dev
+ * warning so the guidance fires at most once per suite, even when the same
+ * module-scope suite drives many fields or re-mounts repeatedly.
+ */
+const resetOnDestroyWarnedSuites = new WeakSet();
+
+/**
+ * Emits a one-time dev-mode warning when a Vest suite is registered without
+ * `resetOnDestroy`. Module-scope suites (the documented Vest pattern) retain
+ * state across component mounts, so omitting `resetOnDestroy` is the most
+ * common foot-gun. Non-breaking: the default stays `false` and this only logs.
+ *
+ * No-op outside dev mode, when `resetOnDestroy` is truthy, when the suite does
+ * not expose a `reset` callable (nothing to recommend), or when this suite has
+ * already warned.
+ */
+function warnIfNoResetOnDestroy(
+  suite: VestRunnableSuite<unknown>,
+  resetOnDestroy: boolean | undefined,
+): void {
+  if (resetOnDestroy || !isDevMode()) {
+    return;
+  }
+
+  if (typeof (suite as { reset?: unknown }).reset !== 'function') {
+    return;
+  }
+
+  const suiteKey = suite as object;
+  if (resetOnDestroyWarnedSuites.has(suiteKey)) {
+    return;
+  }
+  resetOnDestroyWarnedSuites.add(suiteKey);
+
+  // oxlint-disable-next-line no-console -- dev-mode configuration guidance
+  console.warn(
+    '[ngx-signal-forms] Vest suite registered without `resetOnDestroy`. ' +
+      'Module-scope suites retain state (last result, pending async tests, ' +
+      'memoization) across component mounts, which can leak stale validation ' +
+      'state. Pass `{ resetOnDestroy: true }` to clear the suite when the ' +
+      'hosting component is destroyed.',
+  );
 }
 
 /**

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -55,11 +55,14 @@ export interface ValidateVestOptions<TValue = unknown> {
    *
    * Vest suites created with `create()` retain state across runs (last result,
    * pending async tests, test memoization). When consumers declare suites at
-   * module scope (the recommended pattern), state can leak across component
-   * mounts. Enabling this option registers a `DestroyRef.onDestroy()` hook
+   * module scope (the recommended pattern), that state leaks across component
+   * mounts. The toolkit registers a `DestroyRef.onDestroy()` hook **by default**
    * that clears suite state when the hosting component tears down.
    *
-   * @default false
+   * Set to `false` only when you deliberately want suite state to persist
+   * across mounts.
+   *
+   * @default true
    */
   resetOnDestroy?: boolean;
 
@@ -797,8 +800,7 @@ export function validateVestWarnings<TValue>(
     'resetOnDestroy' | 'only' | 'focusCurrentField'
   > = {},
 ): void {
-  warnIfNoResetOnDestroy(suite, options.resetOnDestroy);
-  maybeRegisterResetOnDestroy(suite, options.resetOnDestroy);
+  maybeRegisterResetOnDestroy(suite, options.resetOnDestroy ?? true);
   registerVestValidation(path, suite, {
     includeErrors: false,
     includeWarnings: true,
@@ -819,10 +821,10 @@ export function validateVestWarnings<TValue>(
  * `ngx-form-field-wrapper`, and related components can render them as
  * polite, non-blocking guidance.
  *
- * Pass `{ resetOnDestroy: true }` to call `suite.reset()` when the hosting
- * injection context is destroyed. This is strongly recommended for suites
- * declared at module scope (the documented Vest pattern) because suite state
- * otherwise bleeds across component mounts.
+ * By default the adapter calls `suite.reset()` when the hosting injection
+ * context is destroyed, so module-scope suites (the documented Vest pattern)
+ * do not bleed state across component mounts. Pass `{ resetOnDestroy: false }`
+ * to opt out when you deliberately want suite state to persist.
  *
  * Pass `{ only: (ctx) => fieldName }` to enable per-field focused runs. The
  * adapter then invokes `suite.run(value, fieldName)` (or
@@ -853,7 +855,7 @@ export function validateVestWarnings<TValue>(
  *
  * const loginModel = signal<LoginModel>({ email: '' });
  * const loginForm = form(loginModel, (path) => {
- *   validateVest(path, loginSuite, { resetOnDestroy: true });
+ *   validateVest(path, loginSuite); // resets on destroy by default
  * });
  * ```
  */
@@ -862,59 +864,13 @@ export function validateVest<TValue>(
   suite: VestRunnableSuite<TValue>,
   options: ValidateVestOptions<TValue> = {},
 ): void {
-  warnIfNoResetOnDestroy(suite, options.resetOnDestroy);
-  maybeRegisterResetOnDestroy(suite, options.resetOnDestroy);
+  maybeRegisterResetOnDestroy(suite, options.resetOnDestroy ?? true);
   registerVestValidation(path, suite, {
     includeErrors: true,
     includeWarnings: options.includeWarnings ?? false,
     only: options.only,
     focusCurrentField: options.focusCurrentField,
   });
-}
-
-/**
- * Tracks suites that have already emitted the missing-`resetOnDestroy` dev
- * warning so the guidance fires at most once per suite, even when the same
- * module-scope suite drives many fields or re-mounts repeatedly.
- */
-const resetOnDestroyWarnedSuites = new WeakSet();
-
-/**
- * Emits a one-time dev-mode warning when a Vest suite is registered without
- * `resetOnDestroy`. Module-scope suites (the documented Vest pattern) retain
- * state across component mounts, so omitting `resetOnDestroy` is the most
- * common foot-gun. Non-breaking: the default stays `false` and this only logs.
- *
- * No-op outside dev mode, when `resetOnDestroy` is truthy, when the suite does
- * not expose a `reset` callable (nothing to recommend), or when this suite has
- * already warned.
- */
-function warnIfNoResetOnDestroy(
-  suite: VestRunnableSuite<unknown>,
-  resetOnDestroy: boolean | undefined,
-): void {
-  if (resetOnDestroy || !isDevMode()) {
-    return;
-  }
-
-  if (typeof (suite as { reset?: unknown }).reset !== 'function') {
-    return;
-  }
-
-  const suiteKey = suite as object;
-  if (resetOnDestroyWarnedSuites.has(suiteKey)) {
-    return;
-  }
-  resetOnDestroyWarnedSuites.add(suiteKey);
-
-  // oxlint-disable-next-line no-console -- dev-mode configuration guidance
-  console.warn(
-    '[ngx-signal-forms] Vest suite registered without `resetOnDestroy`. ' +
-      'Module-scope suites retain state (last result, pending async tests, ' +
-      'memoization) across component mounts, which can leak stale validation ' +
-      'state. Pass `{ resetOnDestroy: true }` to clear the suite when the ' +
-      'hosting component is destroyed.',
-  );
 }
 
 /**


### PR DESCRIPTION
## What

Two ergonomics improvements to `@ngx-signal-forms/toolkit/vest`, plus a verified peer-floor finding. Implements #91.

### 1. `only()` auto-focus (additive)
New opt-in `focusCurrentField?: boolean`. When `true` and no explicit `only` is provided, the adapter derives the Vest field name from the bound field's context (`ctx.pathKeys()` → dotted name) and threads it into the focused run. Explicit `only` still wins. Root-bound validators fall back to a whole-suite run.

### 2. `resetOnDestroy` now defaults to `true` (⚠ breaking — by maintainer decision)
Flips the default from `false` to `true`, so Vest suite state is cleared on destroy by default — removing the module-scope state-leak foot-gun outright. Opt out with `{ resetOnDestroy: false }`. (An earlier non-breaking dev-warn approach was replaced by this cleaner default flip on the maintainer's call, since we're on RC.)

Also hardens `resolveVestWarningFieldTree` with a try/catch around the proxy probe (Angular leaf field trees throw when probed) — only converts a throw into the pre-existing safe fallback; needed for the leaf-bound auto-focus path.

## Peer floor (investigated, no change)
Verified Vest's `~standard` interface landed in **vest@6.0.0** (extracted tarballs for 6.0.0/6.0.3/6.1.0/6.2.0/6.3.0 — all have it; 5.4.x do not). The current peer floor is already `>=6.0.0`, so it **already** aligns. Open question for maintainers: whether to keep the `<6.3.0` exclusion.

## Verification
- ✅ typecheck clean, oxlint 0 errors
- ✅ **validate-vest specs: 21 pass** (auto-focus targets bound field; explicit `only` overrides; reset-on-destroy by default; `{ resetOnDestroy: false }` opts out). Browser specs deferred to CI.

## BREAKING CHANGE
`validateVest` / `validateVestWarnings` call `suite.reset()` on destroy by default. Suites that intentionally persist state across mounts must pass `{ resetOnDestroy: false }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
