### PR TITLE
fix(demo-spartan-e2e): deconflict port 4220 collision with demo-primeng (→4221)

### DIFF
--- a/apps/demo-spartan-e2e/playwright.config.ts
+++ b/apps/demo-spartan-e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import { workspaceRoot } from '@nx/devkit';
 import { nxE2EPreset } from '@nx/playwright/preset';
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env['BASE_URL'] ?? 'http://localhost:4220';
+const baseURL = process.env['BASE_URL'] ?? 'http://localhost:4221';
 const isCI = Boolean(process.env['CI']);
 
 const preset = nxE2EPreset(__filename, { testDir: './src' });
@@ -24,7 +24,7 @@ export default defineConfig({
   },
   webServer: {
     command: 'pnpm nx serve demo-spartan',
-    url: 'http://localhost:4220',
+    url: 'http://localhost:4221',
     reuseExistingServer: !isCI,
     cwd: workspaceRoot,
     timeout: 120000,

--- a/apps/demo-spartan/README.md
+++ b/apps/demo-spartan/README.md
@@ -262,7 +262,7 @@ Verify in DevTools:
 
 ```bash
 pnpm nx serve demo-spartan
-# Open http://localhost:4220, focus + blur the empty Display name field.
+# Open http://localhost:4221, focus + blur the empty Display name field.
 # In DevTools, the <input id="display-name"> shows:
 #   aria-invalid="true"
 #   aria-describedby="display-name-hint display-name-error"
@@ -315,7 +315,7 @@ alias (no `@spartan-ng/*` reaches `packages/toolkit/package.json`).
 ## Run it
 
 ```bash
-pnpm nx serve demo-spartan          # dev server on http://localhost:4220
+pnpm nx serve demo-spartan          # dev server on http://localhost:4221
 pnpm nx run demo-spartan:build      # production build
 pnpm nx run demo-spartan:test       # smoke spec (vitest)
 pnpm nx run demo-spartan-e2e:e2e    # Playwright spec

--- a/apps/demo-spartan/project.json
+++ b/apps/demo-spartan/project.json
@@ -30,10 +30,10 @@
       },
       "configurations": {
         "production": {
-          "command": "vite preview --port 4220"
+          "command": "vite preview --port 4221"
         },
         "development": {
-          "command": "vite --port 4220"
+          "command": "vite --port 4221"
         }
       }
     },
@@ -56,7 +56,7 @@
       "defaultConfiguration": "production",
       "options": {
         "buildTarget": "demo-spartan:build:production",
-        "port": 4220,
+        "port": 4221,
         "staticFilePath": "dist/apps/demo-spartan",
         "spa": true
       }

--- a/apps/demo-spartan/vite.config.mts
+++ b/apps/demo-spartan/vite.config.mts
@@ -10,11 +10,11 @@ export default defineConfig({
   publicDir: join(appDir, 'public'),
   cacheDir: '../../node_modules/.vite/apps/demo-spartan',
   server: {
-    port: 4220,
+    port: 4221,
     host: 'localhost',
   },
   preview: {
-    port: 4220,
+    port: 4221,
     host: 'localhost',
   },
   build: {


### PR DESCRIPTION
## What

Moves the `demo-spartan` app/e2e off port **4220 → 4221** to end a hard port collision with `demo-primeng` (also 4220).

## Why (root cause of the flaky `demo-spartan-e2e:e2e-ci`)

`demo-spartan` and `demo-primeng` both hard-code port **4220** — in `vite` dev, `vite preview`, `serve-static`, and the e2e Playwright `url`. When `nx affected` runs both e2e projects in parallel — which **any toolkit change triggers** — one binds 4220 and the other's server gets `net::ERR_CONNECTION_REFUSED`. That is exactly the failure seen on PRs #90, #92, and #94 (three unrelated changesets, same Spartan e2e failure, same connection-refused), while the main `demo-e2e` (port 4200) passed 238/238.

Ports in use: `4200` demo · `4201` demo-material · `4220` demo-primeng → **4221** is free for demo-spartan.

## Changes (4 files, all demo-spartan)
- `apps/demo-spartan/project.json` — `vite --port`, `vite preview --port`, `serve-static` port → 4221
- `apps/demo-spartan/vite.config.mts` — `server.port` / `preview.port` → 4221
- `apps/demo-spartan-e2e/playwright.config.ts` — `baseURL` default + `webServer.url` → 4221
- `apps/demo-spartan/README.md` — doc references → 4221

Serve method unchanged (still `nx serve demo-spartan`), consistent with the other passing demos. `demo-primeng` is intentionally untouched (keeps 4220).

## Verification
CI is the real test (the collision only manifests under parallel `nx affected`). This unblocks the Spartan e2e on #90/#92/#94 — none of which the failure was actually caused by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development server port from 4220 to 4221 in build and server configurations.
  * Updated documentation to reflect the new development server port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->