### PR TITLE
feat(toolkit): add injectable NgxControlPresetRegistry over preset token

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -227,7 +227,22 @@ For component-scoped overrides: `provideNgxSignalFormControlPresetsForComponent(
 `NGX_SIGNAL_FORM_CONTROL_PRESETS` token. The token stays the source of truth,
 so the registry observes whatever the **calling injector** resolves — including
 component- and feature-scoped `provideNgxSignalFormControlPresetsForComponent()`
-overrides:
+overrides.
+
+`NgxControlPresetRegistry` is `providedIn: null`, so list it in the relevant
+`providers` array (or environment injector) before injecting it — each provided
+node then captures the presets effective at that node:
+
+```typescript
+@Component({
+  // ...
+  providers: [NgxControlPresetRegistry],
+})
+export class MyComponent {
+  private readonly registry = inject(NgxControlPresetRegistry);
+  // ...
+}
+```
 
 ```typescript
 const registry = inject(NgxControlPresetRegistry);

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -221,6 +221,30 @@ provideNgxSignalFormControlPresets({
 
 For component-scoped overrides: `provideNgxSignalFormControlPresetsForComponent()`.
 
+#### Reading presets with `NgxControlPresetRegistry`
+
+`NgxControlPresetRegistry` is an injectable read/merge surface over the
+`NGX_SIGNAL_FORM_CONTROL_PRESETS` token. The token stays the source of truth,
+so the registry observes whatever the **calling injector** resolves — including
+component- and feature-scoped `provideNgxSignalFormControlPresetsForComponent()`
+overrides:
+
+```typescript
+const registry = inject(NgxControlPresetRegistry);
+
+registry.resolve('slider'); // → effective { layout, ariaMode } for 'slider'
+registry.kinds(); // → readonly list of registered control kinds
+```
+
+Use `extend()` for a merge-not-replace layering: only the fields you pass are
+overridden, every other kind (and untouched field) is preserved:
+
+```typescript
+const next = registry.extend({ slider: { layout: 'custom' } });
+// next.slider.layout === 'custom'
+// next.slider.ariaMode is unchanged; next.switch, next.composite, ... all stay default
+```
+
 ### Field labels
 
 Override how field paths appear in error summaries:

--- a/packages/toolkit/core/directives/control-semantics.spec.ts
+++ b/packages/toolkit/core/directives/control-semantics.spec.ts
@@ -1,6 +1,7 @@
 import { Component, signal, viewChild } from '@angular/core';
 import { render, screen } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
+import { provideNgxSignalFormControlPresetsForComponent } from '../providers/control-semantics.provider';
 import {
   DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS,
   NGX_SIGNAL_FORM_CONTROL_PRESETS,
@@ -197,6 +198,52 @@ describe('NgxSignalFormControlSemanticsDirective', () => {
         'custom',
       );
       expect(host.getAttribute('data-ngx-signal-form-control-aria-mode')).toBe(
+        'manual',
+      );
+    });
+  });
+
+  describe('Component-scoped preset overrides', () => {
+    it('renders different layout/aria-mode attributes for a child that provides a component-scoped override vs a parent at default', async () => {
+      @Component({
+        selector: 'app-child-host',
+        template:
+          '<div data-testid="child" ngxSignalFormControl="slider"></div>',
+        imports: [NgxSignalFormControlSemanticsDirective],
+        providers: [
+          provideNgxSignalFormControlPresetsForComponent({
+            slider: { layout: 'custom', ariaMode: 'manual' },
+          }),
+        ],
+      })
+      class ChildHostComponent {}
+
+      @Component({
+        template: `
+          <div data-testid="parent" ngxSignalFormControl="slider"></div>
+          <app-child-host />
+        `,
+        imports: [NgxSignalFormControlSemanticsDirective, ChildHostComponent],
+      })
+      class ParentComponent {}
+
+      await render(ParentComponent);
+      const parent = screen.getByTestId('parent');
+      const child = screen.getByTestId('child');
+
+      // Parent observes the application default for slider...
+      expect(parent.getAttribute('data-ngx-signal-form-control-layout')).toBe(
+        DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.slider.layout,
+      );
+      expect(
+        parent.getAttribute('data-ngx-signal-form-control-aria-mode'),
+      ).toBe(DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.slider.ariaMode);
+
+      // ...while the child observes its component-scoped override end-to-end.
+      expect(child.getAttribute('data-ngx-signal-form-control-layout')).toBe(
+        'custom',
+      );
+      expect(child.getAttribute('data-ngx-signal-form-control-aria-mode')).toBe(
         'manual',
       );
     });

--- a/packages/toolkit/core/directives/control-semantics.ts
+++ b/packages/toolkit/core/directives/control-semantics.ts
@@ -133,8 +133,12 @@ export class NgxSignalFormControlSemanticsDirective {
     return value ?? {};
   });
 
-  // Recognized-kind set sourced from the registry so the directive validates
-  // against the effective registry rather than a separately-derived list.
+  // Recognized-kind set sourced from the effective registry (the keys the
+  // calling injector resolves) rather than a separately-derived default list.
+  // For every official provider this is identical to the built-in kind set; it
+  // only diverges if a consumer supplies NGX_SIGNAL_FORM_CONTROL_PRESETS with a
+  // different key set, in which case validating against the registry the
+  // directive actually resolves presets from is the intended contract.
   readonly #recognizedKinds = new Set<string>(this.#presetRegistry.kinds());
 
   readonly kind = computed(() => {

--- a/packages/toolkit/core/directives/control-semantics.ts
+++ b/packages/toolkit/core/directives/control-semantics.ts
@@ -1,8 +1,6 @@
 import { computed, Directive, ElementRef, inject, input } from '@angular/core';
-import {
-  NGX_SIGNAL_FORM_ARIA_MODE,
-  NGX_SIGNAL_FORM_CONTROL_PRESETS,
-} from '../tokens';
+import { NgxControlPresetRegistry } from '../services/control-preset-registry';
+import { NGX_SIGNAL_FORM_ARIA_MODE } from '../tokens';
 import type {
   NgxSignalFormControlAriaMode,
   NgxSignalFormControlKind,
@@ -87,6 +85,7 @@ type NgxSignalFormControlDirectiveValue =
     '[attr.data-ngx-signal-form-control-aria-mode]': 'ariaMode()',
   },
   providers: [
+    NgxControlPresetRegistry,
     {
       provide: NGX_SIGNAL_FORM_ARIA_MODE,
       useFactory: () => inject(NgxSignalFormControlSemanticsDirective).ariaMode,
@@ -94,7 +93,9 @@ type NgxSignalFormControlDirectiveValue =
   ],
 })
 export class NgxSignalFormControlSemanticsDirective {
-  readonly #presets = inject(NGX_SIGNAL_FORM_CONTROL_PRESETS);
+  // Provided at this directive's node so it observes element-scoped preset
+  // overrides; the token remains the backing source of truth.
+  readonly #presetRegistry = inject(NgxControlPresetRegistry);
 
   /**
    * Host element this directive is applied to.
@@ -132,15 +133,19 @@ export class NgxSignalFormControlSemanticsDirective {
     return value ?? {};
   });
 
+  // Recognized-kind set sourced from the registry so the directive validates
+  // against the effective registry rather than a separately-derived list.
+  readonly #recognizedKinds = new Set<string>(this.#presetRegistry.kinds());
+
   readonly kind = computed(() => {
     const kind = this.#baseSemantics().kind;
 
-    return isNgxSignalFormControlKind(kind) ? kind : null;
+    return kind !== undefined && this.#recognizedKinds.has(kind) ? kind : null;
   });
 
   readonly layout = computed(() => {
     const kind = this.kind();
-    const preset = kind ? this.#presets[kind] : undefined;
+    const preset = kind ? this.#presetRegistry.resolve(kind) : undefined;
     const layout =
       this.layoutOverride() ?? this.#baseSemantics().layout ?? preset?.layout;
 
@@ -149,7 +154,7 @@ export class NgxSignalFormControlSemanticsDirective {
 
   readonly ariaMode = computed(() => {
     const kind = this.kind();
-    const preset = kind ? this.#presets[kind] : undefined;
+    const preset = kind ? this.#presetRegistry.resolve(kind) : undefined;
     const ariaMode =
       this.ariaModeOverride() ??
       this.#baseSemantics().ariaMode ??

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -16,6 +16,7 @@ export * from './providers/field-labels.provider';
 export * from './providers/form-field-renderer.provider';
 
 // Services
+export * from './services/control-preset-registry';
 export * from './services/field-identity';
 
 // Directives

--- a/packages/toolkit/core/providers/control-semantics.provider.ts
+++ b/packages/toolkit/core/providers/control-semantics.provider.ts
@@ -14,7 +14,25 @@ import {
 } from '../utilities/control-semantics';
 import { createCascadingResolver } from '../utilities/cascading-resolver';
 
-function mergeNgxSignalFormControlPresets(
+/**
+ * Merges partial preset overrides onto a base registry, returning a new fully
+ * resolved registry. Override fields cascade
+ * (`input → parent → built-in default`) per kind, and unknown kinds are
+ * ignored (with a dev-mode warning) so the result always satisfies the full
+ * {@link NgxSignalFormControlPresetRegistry} shape.
+ *
+ * This is the single source of truth for preset cascade logic — both the DI
+ * providers and {@link NgxControlPresetRegistry} reuse it instead of
+ * duplicating the merge rules.
+ *
+ * @param parentPresetsOrNull Base registry to merge onto, or `null` to start
+ *   from {@link DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS}.
+ * @param presets Partial overrides to apply on top of the base registry.
+ * @returns A new fully resolved preset registry (the input is not mutated).
+ *
+ * @internal
+ */
+export function mergeNgxSignalFormControlPresets(
   parentPresetsOrNull: NgxSignalFormControlPresetRegistry | null,
   presets: NgxSignalFormControlPresetOverrides,
 ): NgxSignalFormControlPresetRegistry {

--- a/packages/toolkit/core/services/control-preset-registry.spec.ts
+++ b/packages/toolkit/core/services/control-preset-registry.spec.ts
@@ -1,0 +1,109 @@
+import { createEnvironmentInjector, EnvironmentInjector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import {
+  provideNgxSignalFormControlPresets,
+  provideNgxSignalFormControlPresetsForComponent,
+} from '../providers/control-semantics.provider';
+import { DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS } from '../tokens';
+import { NGX_SIGNAL_FORM_CONTROL_KIND_VALUES } from '../utilities/control-semantics';
+import { NgxControlPresetRegistry } from './control-preset-registry';
+
+const createInjectorFromEnvProviders = (
+  providers: Parameters<typeof createEnvironmentInjector>[0],
+  parent: EnvironmentInjector = TestBed.inject(EnvironmentInjector),
+) => createEnvironmentInjector(providers, parent);
+
+const injectRegistry = (injector: EnvironmentInjector) =>
+  injector.get(NgxControlPresetRegistry);
+
+describe('NgxControlPresetRegistry', () => {
+  it('resolve(kind) returns the default preset when no override is registered', () => {
+    const injector = createInjectorFromEnvProviders([NgxControlPresetRegistry]);
+
+    const registry = injectRegistry(injector);
+
+    expect(registry.resolve('switch')).toEqual(
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.switch,
+    );
+  });
+
+  it('kinds() set-equals the default registered kinds', () => {
+    const injector = createInjectorFromEnvProviders([NgxControlPresetRegistry]);
+
+    const registry = injectRegistry(injector);
+
+    expect(new Set(registry.kinds())).toEqual(
+      new Set(NGX_SIGNAL_FORM_CONTROL_KIND_VALUES),
+    );
+  });
+
+  it('reflects an environment-scoped override in resolve() while keeping other kinds at default', () => {
+    const injector = createInjectorFromEnvProviders([
+      provideNgxSignalFormControlPresets({
+        slider: { ariaMode: 'manual' },
+      }),
+      NgxControlPresetRegistry,
+    ]);
+
+    const registry = injectRegistry(injector);
+
+    expect(registry.resolve('slider')).toEqual({
+      layout: DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.slider.layout,
+      ariaMode: 'manual',
+    });
+    // merge-not-replace: untouched kinds stay at their defaults.
+    expect(registry.resolve('switch')).toEqual(
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.switch,
+    );
+  });
+
+  it('respects the calling injector: a component-scoped override IS reflected by resolve()', () => {
+    const parentInjector = createInjectorFromEnvProviders([
+      NgxControlPresetRegistry,
+    ]);
+    const childInjector = createInjectorFromEnvProviders(
+      [
+        ...provideNgxSignalFormControlPresetsForComponent({
+          composite: { layout: 'group' },
+        }),
+        NgxControlPresetRegistry,
+      ],
+      parentInjector,
+    );
+
+    const childRegistry = injectRegistry(childInjector);
+    const parentRegistry = injectRegistry(parentInjector);
+
+    // The child injector's registry observes the component-scoped override...
+    expect(childRegistry.resolve('composite')).toEqual({
+      layout: 'group',
+      ariaMode: DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.composite.ariaMode,
+    });
+    // ...while the parent injector's registry still sees the default.
+    expect(parentRegistry.resolve('composite')).toEqual(
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.composite,
+    );
+  });
+
+  it('extend() merges with current presets rather than replacing the whole map', () => {
+    const injector = createInjectorFromEnvProviders([NgxControlPresetRegistry]);
+
+    const registry = injectRegistry(injector);
+    const extended = registry.extend({ slider: { layout: 'custom' } });
+
+    // The overridden field is applied...
+    expect(extended.slider).toEqual({
+      layout: 'custom',
+      ariaMode: DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.slider.ariaMode,
+    });
+    // ...every other kind is preserved (merge-not-replace).
+    expect(extended.switch).toEqual(
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.switch,
+    );
+    // The registry's own resolve() is not mutated by extend().
+    expect(registry.resolve('slider')).toEqual(
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS.slider,
+    );
+  });
+});

--- a/packages/toolkit/core/services/control-preset-registry.ts
+++ b/packages/toolkit/core/services/control-preset-registry.ts
@@ -1,0 +1,93 @@
+import { Injectable, inject } from '@angular/core';
+import { mergeNgxSignalFormControlPresets } from '../providers/control-semantics.provider';
+import { NGX_SIGNAL_FORM_CONTROL_PRESETS } from '../tokens';
+import type {
+  NgxSignalFormControlKind,
+  NgxSignalFormControlPreset,
+  NgxSignalFormControlPresetOverrides,
+  NgxSignalFormControlPresetRegistry,
+} from '../types';
+
+/**
+ * Injectable read/merge surface over the {@link NGX_SIGNAL_FORM_CONTROL_PRESETS}
+ * token.
+ *
+ * The token stays the source of truth: this service reads whatever effective
+ * registry the *calling injector* resolves, so component- and feature-scoped
+ * `provideNgxSignalFormControlPresetsForComponent(...)` overrides are observed
+ * exactly like a direct token injection would. Because it is
+ * `providedIn: null`, the service must be listed in a `providers` array (or
+ * environment injector); each provided node captures the presets effective at
+ * that node.
+ *
+ * It exposes an ergonomic, typed alternative to reaching into the token
+ * directly:
+ *
+ * - {@link resolve} — the effective preset for a single control kind.
+ * - {@link kinds} — the registered control kinds (drives the control-semantics
+ *   directive's recognized-kind set).
+ * - {@link extend} — a merge-not-replace helper that layers partial overrides
+ *   on top of the current registry without discarding untouched kinds.
+ *
+ * @example Read the effective preset for a kind
+ * ```ts
+ * const registry = inject(NgxControlPresetRegistry);
+ * const slider = registry.resolve('slider'); // { layout, ariaMode }
+ * ```
+ *
+ * @example Merge-not-replace extension
+ * ```ts
+ * const registry = inject(NgxControlPresetRegistry);
+ * // Only `slider.layout` changes; every other kind (and `slider.ariaMode`)
+ * // is preserved from the current registry.
+ * const next = registry.extend({ slider: { layout: 'custom' } });
+ * ```
+ *
+ * @public
+ */
+@Injectable({ providedIn: null })
+export class NgxControlPresetRegistry {
+  // Resolved within the providing injector's context, so component- and
+  // feature-scoped overrides of NGX_SIGNAL_FORM_CONTROL_PRESETS are honored.
+  readonly #presets = inject(NGX_SIGNAL_FORM_CONTROL_PRESETS);
+
+  /**
+   * Returns the effective preset for a control kind in the calling injector.
+   *
+   * @param kind Control kind to look up.
+   * @returns The resolved preset (`layout` + `ariaMode`) for the kind.
+   */
+  resolve(kind: NgxSignalFormControlKind): NgxSignalFormControlPreset {
+    return this.#presets[kind];
+  }
+
+  /**
+   * Returns the registered control kinds, derived from the effective registry.
+   *
+   * Consumed by `NgxSignalFormControlSemanticsDirective` as its
+   * recognized-kind set so the runtime list never drifts from the registry.
+   *
+   * @returns A readonly array of registered control kinds.
+   */
+  kinds(): readonly NgxSignalFormControlKind[] {
+    return Object.keys(this.#presets) as NgxSignalFormControlKind[];
+  }
+
+  /**
+   * Merges partial overrides on top of the current registry and returns a new
+   * fully resolved registry. Untouched kinds (and untouched fields within an
+   * overridden kind) keep their current values — this merges rather than
+   * replacing the whole map. The service's own state is not mutated.
+   *
+   * Reuses {@link mergeNgxSignalFormControlPresets} so cascade rules stay in
+   * one place.
+   *
+   * @param overrides Partial preset overrides to layer on the current registry.
+   * @returns A new fully resolved preset registry.
+   */
+  extend(
+    overrides: NgxSignalFormControlPresetOverrides,
+  ): NgxSignalFormControlPresetRegistry {
+    return mergeNgxSignalFormControlPresets(this.#presets, overrides);
+  }
+}

--- a/packages/toolkit/index.ts
+++ b/packages/toolkit/index.ts
@@ -23,6 +23,7 @@ export {
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
   NGX_SIGNAL_FORM_HINT_REGISTRY,
   NGX_SIGNAL_FORMS_CONFIG,
+  NgxControlPresetRegistry,
   NgxFieldIdentity,
   NgxSignalFormAutoAria,
   NgxSignalFormControlSemanticsDirective,


### PR DESCRIPTION
## What

Adds `NgxControlPresetRegistry`, an injectable read/merge surface over the existing `NGX_SIGNAL_FORM_CONTROL_PRESETS` token:

- `resolve(kind): NgxSignalFormControlPreset` — effective preset for a kind
- `kinds(): readonly NgxSignalFormControlKind[]` — registered control kinds
- `extend(overrides): NgxSignalFormControlPresetRegistry` — merge-not-replace layering helper

Refactors `NgxSignalFormControlSemanticsDirective` to consume the service for its recognized-kind set and preset lookups, with no behavior change. Extracts and exports `mergeNgxSignalFormControlPresets` from the provider so cascade logic is reused rather than duplicated. Exports the service from `core/index.ts` and the public root barrel `packages/toolkit/index.ts`, and documents `resolve`/`kinds`/`extend` (with the merge example) in the README.

## Why

§19 "Potential Deepenings #2": formalize the preset registry as an Angular service, giving consumers an ergonomic, typed read/merge API instead of reaching into the token directly.

## Design note (per maintainer decision)

The service is `providedIn: null` and reads `NGX_SIGNAL_FORM_CONTROL_PRESETS` within the **calling injector's** context — NOT a frozen `providedIn: 'root'` singleton. Component/feature-scoped `provideNgxSignalFormControlPresetsForComponent(...)` overrides are therefore reflected by `resolve()`. The directive provides the service at its own node so element-scoped overrides are observed. The token remains the source of truth, so existing `provide…` overrides keep working.

## Verification

| Command | Result |
| --- | --- |
| `pnpm nx test toolkit` | 69 files, 1135 tests passed (5 new in `control-preset-registry.spec.ts`) |
| `pnpm nx build toolkit` | Built all entry points successfully |
| `pnpm nx test debugger` | 2 files, 33 tests passed (downstream `/core` consumer) |
| `pnpm nx lint toolkit` | exit 0 (pre-existing warnings only) |

TDD red-first: the new spec failed (unresolved import) before the service existed, then went green. The pre-existing `control-semantics.spec.ts` (directive) and `control-semantics.provider.spec.ts` stay green as the no-behavior-change guard.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)