### PR TITLE
fix(toolkit): treat empty-kind errors as blocking and guard submitWithWarnings against re-entrancy

### DIFF
--- a/packages/toolkit/core/utilities/submission-helpers.delegate.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.delegate.spec.ts
@@ -1,35 +1,18 @@
 import { signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const { submitSpy } = vi.hoisted(() => ({
-  submitSpy: vi.fn(),
-}));
-
-vi.mock('@angular/forms/signals', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@angular/forms/signals')>();
-  return {
-    ...actual,
-    submit: submitSpy,
-  };
-});
+import { describe, expect, it, vi } from 'vitest';
 
 import { submitWithWarnings } from './submission-helpers';
 
-describe('submitWithWarnings native submit() delegation', () => {
-  beforeEach(() => {
-    submitSpy.mockReset();
-  });
+describe('submitWithWarnings markAsTouched() delegation', () => {
+  it('delegates touch-all to markAsTouched() on the root form tree', async () => {
+    const errorsState = signal<ValidationError[]>([]);
+    const markAsTouched = vi.fn((): void => undefined);
 
-  it('delegates touched-state updates to Angular submit() with ignoreValidators="all"', async () => {
-    const errorsState = signal<ValidationError[]>([
-      { kind: 'required', message: 'Password is required' },
-    ]);
     const formTree = createMockFieldTree({
       value: () => ({}),
-      valid: () => false,
-      invalid: () => true,
+      valid: () => true,
+      invalid: () => false,
       touched: () => false,
       dirty: () => false,
       errors: () => errorsState(),
@@ -39,38 +22,26 @@ describe('submitWithWarnings native submit() delegation', () => {
       hidden: () => false,
       submitting: () => false,
       reset: (): void => undefined,
-      markAsTouched: (): void => undefined,
+      markAsTouched,
       markAsDirty: (): void => undefined,
       errorSummary: () => errorsState(),
     });
     const action = vi.fn(async () => {});
 
-    submitSpy.mockImplementation(async (_form, options) => {
-      expect(options).toMatchObject({
-        ignoreValidators: 'all',
-        action: expect.any(Function),
-      });
-      queueMicrotask(() => {
-        errorsState.set([
-          { kind: 'warn:weak-password', message: 'Weak password' },
-        ]);
-      });
-      if (typeof options === 'object') {
-        await options.action?.();
-      }
-      return true;
-    });
-
     await submitWithWarnings(formTree, action);
 
-    expect(submitSpy).toHaveBeenCalledOnce();
+    // markAsTouched() must be called before any validation gate check.
+    expect(markAsTouched).toHaveBeenCalledOnce();
+    // No blocking errors → action runs.
     expect(action).toHaveBeenCalledOnce();
   });
 
-  it('keeps the warning-aware gate at the caller layer after native submit() runs', async () => {
+  it('calls markAsTouched() even when blocking errors remain (touch-all is unconditional)', async () => {
     const errorsState = signal<ValidationError[]>([
       { kind: 'required', message: 'Email is required' },
     ]);
+    const markAsTouched = vi.fn((): void => undefined);
+
     const formTree = createMockFieldTree({
       value: () => ({}),
       valid: () => false,
@@ -84,29 +55,17 @@ describe('submitWithWarnings native submit() delegation', () => {
       hidden: () => false,
       submitting: () => false,
       reset: (): void => undefined,
-      markAsTouched: (): void => undefined,
+      markAsTouched,
       markAsDirty: (): void => undefined,
       errorSummary: () => errorsState(),
     });
     const action = vi.fn(async () => {});
 
-    submitSpy.mockImplementation(async (_form, options) => {
-      expect(options).toMatchObject({
-        ignoreValidators: 'all',
-        action: expect.any(Function),
-      });
-      queueMicrotask(() => {
-        errorsState.set([{ kind: 'required', message: 'Email is required' }]);
-      });
-      if (typeof options === 'object') {
-        await options.action?.();
-      }
-      return false;
-    });
-
     await submitWithWarnings(formTree, action);
 
-    expect(submitSpy).toHaveBeenCalledOnce();
+    // markAsTouched() must still be called even when submission is blocked.
+    expect(markAsTouched).toHaveBeenCalledOnce();
+    // Blocking errors → action does NOT run.
     expect(action).not.toHaveBeenCalled();
   });
 
@@ -117,6 +76,8 @@ describe('submitWithWarnings native submit() delegation', () => {
     // errorSummary() appears empty, causing the action to fire prematurely.
     const pendingState = signal(true);
     const errorsState = signal<ValidationError[]>([]);
+    const markAsTouched = vi.fn((): void => undefined);
+
     const formTree = createMockFieldTree({
       value: () => ({}),
       valid: () => true,
@@ -130,16 +91,11 @@ describe('submitWithWarnings native submit() delegation', () => {
       hidden: () => false,
       submitting: () => false,
       reset: (): void => undefined,
-      markAsTouched: (): void => undefined,
+      markAsTouched,
       markAsDirty: (): void => undefined,
       errorSummary: () => errorsState(),
     });
     const action = vi.fn(async () => {});
-
-    submitSpy.mockImplementation(async (_form, options) => {
-      if (typeof options === 'object') await options.action?.();
-      return true;
-    });
 
     // pending()=true → action must NOT fire.
     await submitWithWarnings(formTree, action);

--- a/packages/toolkit/core/utilities/submission-helpers.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.spec.ts
@@ -1,8 +1,8 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import type { FieldTree } from '@angular/forms/signals';
+import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import { describe, expect, it, vi } from 'vitest';
-import { hasSubmitted } from './submission-helpers';
+import { hasSubmitted, submitWithWarnings } from './submission-helpers';
 /**
  * Test suite for submission helper utilities.
  *
@@ -177,7 +177,104 @@ describe('Submission Helpers', () => {
       expect(hasSubmittedResult()).toBe(true);
     });
   });
+
+  describe('submitWithWarnings re-entrancy', () => {
+    it('deferred-action overlap: concurrent calls run action exactly once', async () => {
+      // Arrange: an action whose completion we can control manually.
+      let resolveAction!: () => void;
+      const actionPromise = new Promise<void>((res) => {
+        resolveAction = res;
+      });
+      const action = vi.fn(() => actionPromise);
+
+      const formTree = createMockFieldTreeForSubmit({
+        submitting: () => false,
+        pending: () => false,
+        errorSummary: () => [],
+      });
+
+      // Act: fire two concurrent submitWithWarnings calls before the action resolves.
+      const p1 = submitWithWarnings(formTree, action);
+      const p2 = submitWithWarnings(formTree, action);
+
+      // Resolve the deferred action.
+      resolveAction();
+      await Promise.all([p1, p2]);
+
+      // Assert: action was only invoked once — the second call was dropped.
+      expect(action).toHaveBeenCalledOnce();
+    });
+
+    it('native overlap: bails out without invoking action when submitting() is true', async () => {
+      const action = vi.fn(async () => {});
+
+      const formTree = createMockFieldTreeForSubmit({
+        submitting: () => true,
+        pending: () => false,
+        errorSummary: () => [],
+      });
+
+      await submitWithWarnings(formTree, action);
+
+      expect(action).not.toHaveBeenCalled();
+    });
+
+    it('recovery after rejection: form is re-submittable after action rejects', async () => {
+      const workingAction = vi.fn(async () => {});
+      let callCount = 0;
+      const rejectingAction = vi.fn(() => {
+        callCount++;
+        return Promise.reject(new Error('network error'));
+      });
+
+      const formTree = createMockFieldTreeForSubmit({
+        submitting: () => false,
+        pending: () => false,
+        errorSummary: () => [],
+      });
+
+      // First call: action rejects → helper rejects too.
+      await expect(
+        submitWithWarnings(formTree, rejectingAction),
+      ).rejects.toThrow('network error');
+      expect(callCount).toBe(1);
+
+      // Second call: form should be re-submittable after the rejection cleared
+      // the in-flight guard in the finally block.
+      await submitWithWarnings(formTree, workingAction);
+      expect(workingAction).toHaveBeenCalledOnce();
+    });
+  });
 });
+
+/**
+ * Helper: Create a minimal mock FieldTree suitable for submitWithWarnings tests.
+ *
+ * @param overrides - Overrideable state accessors
+ */
+function createMockFieldTreeForSubmit(overrides: {
+  submitting: () => boolean;
+  pending: () => boolean;
+  errorSummary: () => ValidationError[];
+}): FieldTree<unknown> {
+  return createMockFieldTree({
+    value: () => ({}),
+    valid: () => true,
+    invalid: () => false,
+    touched: () => false,
+    dirty: () => false,
+    errors: () => [],
+    disabled: () => false,
+    readonly: () => false,
+    hidden: () => false,
+    submittedStatus: () => 'unsubmitted' as const,
+    reset: createVoidSpy(),
+    markAsTouched: createVoidSpy(),
+    markAsDirty: createVoidSpy(),
+    resetSubmittedStatus: createVoidSpy(),
+    ...overrides,
+  });
+}
 
 /**
  * Helper: Create mock FieldTree with controllable submitting signal.

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -164,7 +164,7 @@ export function getBlockingErrors(
 // submitting() cannot serve as this guard: the helper runs the user action
 // OUTSIDE any native submit, so submitting() is false during `await action()`
 // — exactly the window a double-click hits.
-const inFlightSubmits = new WeakSet();
+const inFlightSubmits = new WeakSet<FieldTree<unknown>>();
 
 /**
  * Computed signal indicating whether a form can be submitted with warnings.
@@ -187,10 +187,11 @@ export function canSubmitWithWarnings(
 /**
  * Submits a form, allowing warnings to pass through.
  *
- * Marks all form fields as touched (including all descendants), waits one
- * microtask for any async validators to settle, then invokes `action` only
- * when there are no blocking errors. Warnings (errors whose `kind` starts
- * with `'warn:'`) do not block submission.
+ * Marks all form fields as touched (including all descendants), yields one
+ * microtask so that synchronously-resolving validation state propagates, then
+ * invokes `action` only when there are no blocking errors. Still-pending async
+ * validators are handled by the `pending()` guard that follows the yield.
+ * Warnings (errors whose `kind` starts with `'warn:'`) do not block submission.
  *
  * **Re-entrancy**: concurrent calls for the same `formTree` — from a
  * double-click, Enter spam, or an overlapping native submit — are silently

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -7,11 +7,7 @@ import {
   type Signal,
   type WritableSignal,
 } from '@angular/core';
-import {
-  submit,
-  type FieldTree,
-  type ValidationError,
-} from '@angular/forms/signals';
+import { type FieldTree, type ValidationError } from '@angular/forms/signals';
 import type { SubmittedStatus } from '../types';
 import { isBlockingError } from './warning-error';
 import { isFieldTree } from './walk-field-tree';
@@ -164,6 +160,12 @@ export function getBlockingErrors(
   return errors.filter((error) => isBlockingError(error));
 }
 
+// Tracks form trees with a submitWithWarnings() call in flight. Native
+// submitting() cannot serve as this guard: the helper runs the user action
+// OUTSIDE any native submit, so submitting() is false during `await action()`
+// — exactly the window a double-click hits.
+const inFlightSubmits = new WeakSet();
+
 /**
  * Computed signal indicating whether a form can be submitted with warnings.
  *
@@ -185,9 +187,18 @@ export function canSubmitWithWarnings(
 /**
  * Submits a form, allowing warnings to pass through.
  *
- * Angular's native `submit()` now owns the "mark every field as touched"
- * side effect, so this helper delegates that step and keeps only the
- * warning-aware gate in toolkit land.
+ * Marks all form fields as touched (including all descendants), waits one
+ * microtask for any async validators to settle, then invokes `action` only
+ * when there are no blocking errors. Warnings (errors whose `kind` starts
+ * with `'warn:'`) do not block submission.
+ *
+ * **Re-entrancy**: concurrent calls for the same `formTree` — from a
+ * double-click, Enter spam, or an overlapping native submit — are silently
+ * dropped. The in-flight guard is cleared in the `finally` block so the form
+ * is always re-submittable after the current call settles (even on rejection).
+ *
+ * @param formTree - The root `FieldTree` of the form to submit
+ * @param action - Async callback invoked only when no blocking errors remain
  *
  * @public
  */
@@ -195,26 +206,35 @@ export async function submitWithWarnings<TModel>(
   formTree: FieldTree<TModel>,
   action: () => Promise<void>,
 ): Promise<void> {
-  // This native submit call exists only for Angular's touch-all side effect.
-  // The warning-aware gate and the real user action still live below.
-  await submit(formTree, {
-    ignoreValidators: 'all',
-    action: () => Promise.resolve(undefined),
-  });
-
-  await waitForValidationSettlement();
-
-  // Mirrors the canSubmitWithWarnings() guard: async validators may still be
-  // settling after the microtask delay — skip action until they resolve.
-  if (formTree().pending()) {
+  // Re-entrant call (double-click, Enter spam) or overlapping native
+  // submission: bail out instead of running the action a second time.
+  if (formTree().submitting() || inFlightSubmits.has(formTree)) {
     return;
   }
 
-  if (getBlockingErrors(formTree().errorSummary()).length > 0) {
-    return;
-  }
+  inFlightSubmits.add(formTree);
+  try {
+    // Signal Forms (stable since Angular 22) exposes markAsTouched(), which
+    // marks the field AND all descendants touched — the only side effect the
+    // previous native-submit-with-noop-action delegation existed to trigger.
+    formTree().markAsTouched();
 
-  await action();
+    await waitForValidationSettlement();
+
+    // Mirrors the canSubmitWithWarnings() guard: async validators may still be
+    // settling after the microtask delay — skip action until they resolve.
+    if (formTree().pending()) {
+      return;
+    }
+
+    if (getBlockingErrors(formTree().errorSummary()).length > 0) {
+      return;
+    }
+
+    await action();
+  } finally {
+    inFlightSubmits.delete(formTree);
+  }
 }
 
 function assertFieldTree(value: unknown): asserts value is FieldTree<unknown> {
@@ -226,9 +246,8 @@ function assertFieldTree(value: unknown): asserts value is FieldTree<unknown> {
 }
 
 function waitForValidationSettlement(): Promise<void> {
-  // Preserve the existing blur-vs-submit safety gap: touched state is now
-  // delegated to Angular's native submit flow, but the error summary can still
-  // lag by one microtask when the active control is mid-blur as submit fires.
+  // Preserve the blur-vs-submit safety gap: the error summary can lag by one
+  // microtask when the active control is mid-blur as markAsTouched() fires.
   return new Promise((resolve) => {
     queueMicrotask(resolve);
   });

--- a/packages/toolkit/core/utilities/warning-error.spec.ts
+++ b/packages/toolkit/core/utilities/warning-error.spec.ts
@@ -53,9 +53,27 @@ describe('warning-error utilities', () => {
       expect(isBlockingError(warning)).toBe(false);
     });
 
-    it('returns false for invalid inputs', () => {
-      expect(isBlockingError({ kind: '', message: 'Empty kind' })).toBe(false);
-      expect(isBlockingError({} as ValidationError)).toBe(false);
+    it('treats malformed errors as blocking (fail-safe)', () => {
+      // Under unified semantics, any error that is not a valid warning is
+      // blocking — including errors with empty or non-string kind values.
+      // A malformed validator result must never silently allow submission.
+      expect(isBlockingError({ kind: '', message: 'Empty kind' })).toBe(true);
+      expect(isBlockingError({} as ValidationError)).toBe(true);
+    });
+
+    it('returns true for well-formed blocking kinds', () => {
+      expect(isBlockingError({ kind: 'required' })).toBe(true);
+    });
+
+    it('consistency with splitByKind: isBlockingError matches the blocking bucket', () => {
+      const emptyKind: ValidationError = { kind: '', message: 'x' };
+      const blocking: ValidationError = { kind: 'required' };
+      const warning = warningError('weak');
+
+      for (const error of [emptyKind, blocking, warning]) {
+        const { blocking: blockingBucket } = splitByKind([error]);
+        expect(blockingBucket.includes(error)).toBe(isBlockingError(error));
+      }
     });
   });
 

--- a/packages/toolkit/core/utilities/warning-error.ts
+++ b/packages/toolkit/core/utilities/warning-error.ts
@@ -22,26 +22,29 @@ export function isWarningError(error: ValidationError): boolean {
 
 /**
  * Type guard to check if a validation error is a blocking error.
- * Blocking errors are errors with `kind` NOT starting with `'warn:'`.
+ * Any error whose `kind` does NOT start with `'warn:'` is blocking — including
+ * malformed errors with an empty or non-string `kind`. This is intentional:
+ * a malformed validator result must never silently allow form submission
+ * (fail-safe semantics). Matches the semantics of `splitByKind`, which routes
+ * every non-warning error into the `blocking` bucket.
  *
  * @param error - The validation error to check
- * @returns `true` if the error is blocking, `false` if it's a warning or invalid
+ * @returns `true` if the error is not a warning (including malformed errors),
+ *   `false` only if the error is a valid warning (kind starts with `'warn:'`)
  *
  * @example
  * ```typescript
  * const error = { kind: 'required', message: 'Field required' };
  * const warning = warningError('weak-password', 'Consider stronger password');
+ * const malformed = { kind: '', message: 'Missing kind' };
  *
- * isBlockingError(error);   // true
- * isBlockingError(warning); // false
+ * isBlockingError(error);     // true
+ * isBlockingError(warning);   // false
+ * isBlockingError(malformed); // true  — fail-safe: treated as blocking
  * ```
  */
 export function isBlockingError(error: ValidationError): boolean {
-  return (
-    typeof error.kind === 'string' &&
-    error.kind.length > 0 &&
-    !error.kind.startsWith('warn:')
-  );
+  return !isWarningError(error);
 }
 
 /**

--- a/packages/toolkit/core/utilities/warning-error.ts
+++ b/packages/toolkit/core/utilities/warning-error.ts
@@ -21,7 +21,7 @@ export function isWarningError(error: ValidationError): boolean {
 }
 
 /**
- * Type guard to check if a validation error is a blocking error.
+ * Predicate that checks if a validation error is a blocking error.
  * Any error whose `kind` does NOT start with `'warn:'` is blocking — including
  * malformed errors with an empty or non-string `kind`. This is intentional:
  * a malformed validator result must never silently allow form submission


### PR DESCRIPTION
## Summary

- **`isBlockingError`**: empty/malformed-kind errors (`kind: ''` or missing prefix) were returning `false` (non-blocking) while `splitByKind` was routing them to the `blocking` bucket — an inconsistency that could silently allow form submissions with untriaged errors. Fixed to `return !isWarningError(error)` (fail-safe: anything that isn't a `warn:` prefix blocks).
- **`submitWithWarnings`**: replaced the fake `submit(formTree, { ignoreValidators: 'all', action: noop })` delegation (which existed solely for its touch-all side effect) with the stable Angular 22 `FieldState.markAsTouched()` API (`@publicApi 22.0`). Added a `WeakSet` in-flight guard with a `finally` block so the form is never left stuck after a rejected action.
- Tests updated: `warning-error.spec.ts` (flipped the empty-kind assertion, added consistency test), `submission-helpers.spec.ts` (3 re-entrancy scenarios), `submission-helpers.delegate.spec.ts` (rewrote to test `markAsTouched()` delegation, the old mechanism was removed).

## Decisions to double-check in review

- **Empty-kind errors are now blocking**: one existing test pinned the old (inconsistent) behavior and was superseded. This changes the public `isBlockingError` semantics — worth confirming before 1.0.
- **`markAsTouched()` vs native `submit()`**: wrapping the user action *inside* native `submit()` would keep `submitting()` true during `await action()` (nicer for disable-while-submitting). That's a follow-up design question; this PR matches the existing observable behavior while fixing the re-entrancy gap.

## Test plan

- [ ] `pnpm nx test toolkit` — all 1168 tests pass
- [ ] `pnpm nx build toolkit` — exit 0
- [ ] `pnpm nx lint toolkit` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents re-entrant/double submissions so concurrent calls invoke the action at most once.
  * Treats malformed or unspecified validation errors as blocking for fail-safe behavior.
  * Ensures all fields are marked as touched before validation and gates action when validation is pending or blocking errors exist.
* **Tests**
  * Expanded tests for submission re-entrancy, pending-state behavior, and error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->