### PR TITLE
chore(toolkit): enable noUncheckedIndexedAccess and exactOptionalPropertyTypes for lib build

### DIFF
--- a/packages/toolkit/core/utilities/control-semantics.ts
+++ b/packages/toolkit/core/utilities/control-semantics.ts
@@ -143,9 +143,9 @@ export function readNgxSignalFormControlSemantics(
   );
 
   return {
-    kind: isNgxSignalFormControlKind(kind) ? kind : undefined,
-    layout: isNgxSignalFormControlLayout(layout) ? layout : undefined,
-    ariaMode: isNgxSignalFormControlAriaMode(ariaMode) ? ariaMode : undefined,
+    ...(isNgxSignalFormControlKind(kind) && { kind }),
+    ...(isNgxSignalFormControlLayout(layout) && { layout }),
+    ...(isNgxSignalFormControlAriaMode(ariaMode) && { ariaMode }),
   };
 }
 

--- a/packages/toolkit/core/utilities/warning-error.ts
+++ b/packages/toolkit/core/utilities/warning-error.ts
@@ -141,6 +141,6 @@ export function warningError(kind: string, message?: string): ValidationError {
 
   return {
     kind: `warn:${normalizedKind}`,
-    message,
+    ...(message !== undefined && { message }),
   };
 }

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.ts
@@ -230,8 +230,10 @@ export function createErrorMessageSignal(
         : null;
 
     const visibilityOptions: CreateErrorVisibilityOptions = {
-      strategy: options?.strategy,
-      submittedStatus: options?.submittedStatus,
+      ...(options?.strategy !== undefined && { strategy: options.strategy }),
+      ...(options?.submittedStatus !== undefined && {
+        submittedStatus: options.submittedStatus,
+      }),
     };
     // `createErrorVisibility` is typed against Angular's `Partial<ErrorVisibilityState>`
     // (signal-branded `invalid` / `touched`). Our `FieldStateLike` keeps the

--- a/packages/toolkit/tsconfig.lib.json
+++ b/packages/toolkit/tsconfig.lib.json
@@ -5,7 +5,9 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": []
+    "types": [],
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "exclude": [
     "./**/*.spec.ts",

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -109,8 +109,10 @@ export function validateVestWarnings<TValue>(
     includeErrors: false,
     includeWarnings: true,
     resetOnDestroy: options.resetOnDestroy ?? true,
-    only: options.only,
-    focusCurrentField: options.focusCurrentField,
+    ...(options.only !== undefined && { only: options.only }),
+    ...(options.focusCurrentField !== undefined && {
+      focusCurrentField: options.focusCurrentField,
+    }),
   });
 }
 
@@ -177,7 +179,9 @@ export function validateVest<TValue>(
     includeErrors: true,
     includeWarnings: options.includeWarnings ?? false,
     resetOnDestroy: options.resetOnDestroy ?? true,
-    only: options.only,
-    focusCurrentField: options.focusCurrentField,
+    ...(options.only !== undefined && { only: options.only }),
+    ...(options.focusCurrentField !== undefined && {
+      focusCurrentField: options.focusCurrentField,
+    }),
   });
 }

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -770,8 +770,10 @@ export function createVestAdapter(
     registerVestValidation(path, suite, {
       includeErrors,
       includeWarnings,
-      only: registerOptions.only,
-      focusCurrentField: registerOptions.focusCurrentField,
+      ...(registerOptions.only !== undefined && { only: registerOptions.only }),
+      ...(registerOptions.focusCurrentField !== undefined && {
+        focusCurrentField: registerOptions.focusCurrentField,
+      }),
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` to `packages/toolkit/tsconfig.lib.json` (lib build only — not spec files, see note below).
- Five conditional-spread fixes at the flag-violation sites: `control-semantics.ts`, `warning-error.ts`, `create-error-message-signal.ts`, `validate-vest.ts`, `vest-adapter.ts` — all use `...(x !== undefined && { prop: x })` pattern to satisfy `exactOptionalPropertyTypes`.
- `warningError()` without a `message` argument now omits the `message` key entirely instead of carrying `message: undefined`.

## Scope note: spec files excluded

`tsc -p packages/toolkit/tsconfig.spec.json --noEmit` currently fails with ~140 pre-existing typecheck errors (TS2322 ×68, TS2345 ×29, etc.) unrelated to this change. Vitest does not typecheck, so no CI gate runs `tsc` over spec files today. Promoting these flags to cover specs is a follow-up: fix the pre-existing errors → add a `tsc --noEmit` CI target → promote flags up to `tsconfig.json`. Tracked in `plans/README.md`.

**Note**: this branch and `fix/toolkit-warning-classification` both touch `warning-error.ts` in different functions (no conflict). Re-run `pnpm nx test toolkit && pnpm nx build toolkit` after merging both.

## Test plan

- [ ] `pnpm nx build toolkit` — exit 0 (the meaningful gate for lib-only strictness)
- [ ] `pnpm nx test toolkit` — all tests pass
- [ ] `pnpm nx lint toolkit` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)