### PR TITLE
fix(form-field): add forced-colors mappings and convert physical to logical padding

### DIFF
--- a/packages/toolkit/assistive/form-field-error.css
+++ b/packages/toolkit/assistive/form-field-error.css
@@ -198,3 +198,28 @@
     --_error-border-width-default: 2px;
   }
 }
+
+/* Windows High Contrast (`forced-colors: active`): soft text colors and */
+/* transparent backgrounds are overridden by the system, erasing the */
+/* error/warning semantic. Map to explicit system colors instead. */
+@media (forced-colors: active) {
+  .ngx-form-field-error {
+    forced-color-adjust: none;
+    background: Canvas;
+    color: CanvasText;
+  }
+
+  .ngx-form-field-error--error {
+    background: Mark;
+    color: MarkText;
+  }
+
+  .ngx-form-field-error--warning {
+    color: CanvasText;
+    background: Canvas;
+  }
+
+  .ngx-form-field-error--empty {
+    background: transparent;
+  }
+}

--- a/packages/toolkit/assistive/form-field-error.css
+++ b/packages/toolkit/assistive/form-field-error.css
@@ -212,11 +212,17 @@
   .ngx-form-field-error--error {
     background: Mark;
     color: MarkText;
+    /* Remap theme-variable border to match the error foreground so the */
+    /* border remains visible and consistent when consumers opt-in to borders */
+    /* (e.g. via prefers-contrast: more or a custom --ngx-signal-form-error-border-width). */
+    border-color: Mark;
   }
 
   .ngx-form-field-error--warning {
     color: CanvasText;
     background: Canvas;
+    /* Remap theme-variable border to a visible system color in HCM. */
+    border-color: CanvasText;
   }
 
   .ngx-form-field-error--empty {

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -1108,6 +1108,11 @@
     )
     .ngx-signal-form-field-wrapper__content {
     border-color: Mark;
+
+    &:focus-within {
+      border-color: Mark;
+      box-shadow: none;
+    }
   }
 
   :host(
@@ -1115,11 +1120,21 @@
     )
     .ngx-signal-form-field-wrapper__content {
     border-color: CanvasText;
+
+    &:focus-within {
+      border-color: CanvasText;
+      box-shadow: none;
+    }
   }
 
+  /* Neutralize color-mix() box-shadow and border-color overrides from the */
+  /* normal focus rules — the outline: Highlight below is the sole focus */
+  /* signal in forced-colors mode. */
   :host(.ngx-signal-form-field-wrapper--textual)
     .ngx-signal-form-field-wrapper__content:focus-within {
     outline: 2px solid Highlight;
     outline-offset: 2px;
+    box-shadow: none;
+    border-color: Highlight;
   }
 }

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -572,13 +572,13 @@
 }
 
 .ngx-signal-form-field-wrapper__prefix {
-  padding-right: var(--_field-space-md);
+  padding-inline-end: var(--_field-space-md);
 }
 
 .ngx-signal-form-field-wrapper__suffix {
   color: var(--_suffix-color);
   gap: var(--_suffix-gap);
-  padding-left: var(--_field-space-md);
+  padding-inline-start: var(--_field-space-md);
 }
 
 /* Modern :has() based dynamic padding - adjust main content when prefix/suffix present */
@@ -805,7 +805,7 @@
     .ngx-signal-form-field-wrapper__prefix:not(:empty)
   ) {
   .ngx-signal-form-field-wrapper__prefix {
-    padding-right: var(--_field-space-sm);
+    padding-inline-end: var(--_field-space-sm);
   }
 }
 
@@ -815,7 +815,7 @@
     .ngx-signal-form-field-wrapper__suffix:not(:empty)
   ) {
   .ngx-signal-form-field-wrapper__suffix {
-    padding-left: var(--_field-space-sm);
+    padding-inline-start: var(--_field-space-sm);
   }
 }
 
@@ -1089,4 +1089,37 @@
   )
 ) {
   --ngx-form-field-hint-display: none;
+}
+
+/* Windows High Contrast (`forced-colors: active`): color-mix() borders and */
+/* soft state backgrounds flatten to system colors, erasing the invalid/ */
+/* warning distinction. Map states to explicit system colors instead. */
+@media (forced-colors: active) {
+  :host(.ngx-signal-form-field-wrapper--textual)
+    .ngx-signal-form-field-wrapper__content {
+    forced-color-adjust: none;
+    background: Field;
+    color: FieldText;
+    border: 2px solid FieldText;
+  }
+
+  :host(
+      .ngx-signal-form-field-wrapper--invalid.ngx-signal-form-field-wrapper--textual
+    )
+    .ngx-signal-form-field-wrapper__content {
+    border-color: Mark;
+  }
+
+  :host(
+      .ngx-signal-form-field-wrapper--warning.ngx-signal-form-field-wrapper--textual
+    )
+    .ngx-signal-form-field-wrapper__content {
+    border-color: CanvasText;
+  }
+
+  :host(.ngx-signal-form-field-wrapper--textual)
+    .ngx-signal-form-field-wrapper__content:focus-within {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
 }


### PR DESCRIPTION
## Summary

- **Forced-colors (Windows High Contrast)**: `form-field-wrapper.css` and `form-field-error.css` now have `@media (forced-colors: active)` blocks, matching what `form-field-notification.css` already had. Field borders map to `FieldText`/`Mark`/`CanvasText` system colors; error/warning text maps to `Mark`/`MarkText` and `Canvas`/`CanvasText`; focus ring uses `Highlight`.
- **Logical properties**: 4 physical `padding-right`/`padding-left` declarations converted to `padding-inline-end`/`padding-inline-start` for correct RTL layout.

## Test plan

- [ ] `pnpm nx build toolkit` — exit 0
- [ ] `pnpm nx lint toolkit` — exit 0
- [ ] Manual: open the demo app in Windows High Contrast mode (or Chrome DevTools forced-colors emulation) and verify field borders, error/warning text, and focus indicators remain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)