### PR TITLE
docs(issue-99): refresh Angular public-API watch list against 22.0.0

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,16 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   (`warn:*` prefix), Vest results, etc. Shape is not known at compile time; the
   toolkit humanizes its `kind` string for display and types its registry
   factory params as `any`.
+- **Warning** — a _non-blocking_ validation error, identified by a `warn:`
+  prefix on its `kind`. It is **per-error**: one field can simultaneously carry
+  a blocking error _and_ a warning, and the toolkit splits the two on the
+  prefix. Deliberately **not** modelled on Angular's per-field `SEVERITY`
+  metadata (which appears in post-22.0.0 docs and is absent from the pinned
+  `22.0.0`): `SEVERITY` aggregates to a field's _highest_ severity and so
+  cannot express "error A on this field blocks, error B is a warning". The
+  toolkit will only retire `warn:` for a _per-`ValidationError`_ severity/blocking
+  signal from Angular, not for field-level `SEVERITY`. Synonym to avoid: "soft
+  error".
 - **WCAG 2.2 AA** — the accessibility conformance level this project targets.
   Toolkit components must satisfy it unconditionally (hard fail in Vitest browser
   specs). Demo apps track compliance against a versioned baseline; deviations

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -617,11 +617,16 @@ export interface ErrorSummaryEntryData {
 }
 
 /**
- * Duck-typed access to `ValidationError.WithFieldTree` properties.
+ * Minimal structural view of the `fieldTree` members this module reads off an
+ * `errorSummary()` entry (`name()`, `focusBoundControl()`).
  *
- * Angular Signal Forms' `errorSummary()` returns errors with an optional
- * `fieldTree` reference, but the public `ValidationError` type doesn't
- * include it. This type bridges the gap via duck-typing.
+ * As of Angular 22.0.0 the framework *does* export `ValidationError.WithFieldTree`
+ * publicly (the Vest adapter consumes it directly), so this is no longer bridging
+ * a missing type. It is kept as a deliberately narrow, **all-optional** structural
+ * type because these helpers accept a bare `ValidationError`: errors emitted by
+ * custom validators / Vest need not carry a `fieldTree`, so every access stays
+ * guarded at runtime rather than asserting the framework's non-optional
+ * `WithFieldTree` shape.
  */
 type ValidationErrorWithFieldTree = ValidationError & {
   fieldTree?: () =>


### PR DESCRIPTION
## What

Refreshes the **#99** Angular public-API watch list against the pinned `@angular/* 22.0.0` types + latest angular.dev docs, and applies the one safe, trigger-met cleanup. No behavior change — comment + glossary only.

## Why

The watch-list status notes (dated 2026-06-05) had gone stale after the move to stable `22.0.0`. Re-verifying each trigger against the installed types and current docs showed the list was no longer telling the truth about itself.

## Changes

- **`CONTEXT.md`** — new **"Warning"** glossary entry. The toolkit's per-error `warn:` convention is deliberately distinct from Angular's per-field `SEVERITY` metadata (post-`22.0.0`, aggregated to a field's *highest* severity): `SEVERITY` cannot express "error A on this field blocks, error B is a warning", so it does **not** retire `warn:`.
- **`packages/toolkit/headless/src/lib/utilities.ts`** — corrects a stale comment claiming `ValidationError.WithFieldTree` isn't in the public type. It is public as of `22.0.0` (the Vest adapter consumes it directly). The local narrow structural alias is **kept deliberately**: these helpers accept a bare `ValidationError`, and custom/Vest errors may lack `fieldTree`, so access stays runtime-guarded rather than asserting the framework's non-optional shape.

## Issue #99 re-scored (done on the issue itself)

| Item | Outcome |
|---|---|
| #5 Error aggregation typing | ✅ **Trigger MET** — `errorSummary()` documented public; box checked, comment corrected (this PR) |
| #2 Bound-control discovery | ✅ **Resolved by clarification** — `formFieldBindings()` already native-first; CSS fallback is **permanent** (false-premise trigger) |
| #4 Warning convention | 🔶 **Dormant, trigger sharpened** — per-field `SEVERITY` rejected as insufficient; wait for per-`ValidationError` severity |
| #1 Field-tree walking | ❌ **Dormant** — only consumer is `libs/debugger` (full-tree walk; `errorSummary()` is not a substitute) |
| #3 Submission history | ❌ **Dormant** — no native was-submitted signal in `22.0.0` |

## Verification

- `pnpm nx build toolkit` — green.
- Comment + Markdown only; no runtime/type surface change.

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added glossary entry explaining non-blocking validation warnings and their behavior
  * Updated validation error documentation to reflect current Angular compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->