### PR TITLE
fix(packaging): resolve v1.0.0 audit blockers

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -55,8 +55,9 @@ The Vest adapter is optional and only required when importing
 ## Runtime and tooling baseline
 
 The toolkit's `engines.node` matches the Angular 22 toolchain used in this repo:
-`^20.19.0 || ^22.12.0 || >=24.0.0`. Consumers should use an active LTS Node
-version compatible with Angular 22 and their package manager/tooling stack.
+`^22.22.3 || ^24.15.0 || >=26.0.0` (mirrors `@angular/core@22`'s own `engines`
+field). Consumers should use an active LTS Node version compatible with
+Angular 22 and their package manager/tooling stack.
 
 The repository currently validates and publishes with the following Node
 versions:

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -44,6 +44,7 @@ releases will not include any of the renames below.
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
+- **BREAKING: `@angular/common` is now a declared peer dependency** — it was always required at runtime (form-field wrapper/fieldset use `NgComponentOutlet`/`NgTemplateOutlet`) but was previously undeclared
 
 ---
 
@@ -693,6 +694,21 @@ queried the attributes in tests — switch tests to assert `role` instead.
 Peer dependencies now constrain `@angular/core` and `@angular/forms` to
 `>=22.0.0 <23.0.0`. See [`COMPATIBILITY.md`](../COMPATIBILITY.md) for the
 reasoning. If you are already on Angular 22, no migration action is required.
+
+### `@angular/common` is now a declared peer dependency
+
+`NgxFormFieldWrapper` and `NgxFormFieldset` have always imported
+`NgComponentOutlet` / `NgTemplateOutlet` from `@angular/common` at runtime,
+but the package previously declared `@angular/common` as a devDependency
+only, not a peer dependency. This worked by accident whenever a consuming
+app already depended on `@angular/common` (virtually all Angular apps do),
+but strict installers and dependency audits correctly flagged it as an
+undeclared dependency. `package.json` now lists
+`"@angular/common": ">=22.0.0 <23.0.0"` under `peerDependencies`, matching
+the `@angular/core` / `@angular/forms` range. No action is required for
+apps that already have `@angular/common` installed (every Angular app
+does); package managers with strict peer resolution will now correctly
+surface it instead of silently allowing the gap.
 
 ---
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -25,6 +25,7 @@
     "provenance": true
   },
   "peerDependencies": {
+    "@angular/common": ">=22.0.0 <23.0.0",
     "@angular/core": ">=22.0.0 <23.0.0",
     "@angular/forms": ">=22.0.0 <23.0.0",
     "vest": ">=6.0.0 <6.3.0 || >=6.3.1"

--- a/packages/toolkit/project.json
+++ b/packages/toolkit/project.json
@@ -34,6 +34,7 @@
         "commands": [
           "mkdir -p dist/packages/toolkit",
           "cp README.md dist/packages/toolkit/README.md",
+          "cp LICENSE dist/packages/toolkit/LICENSE",
           "node packages/toolkit/scripts/strip-internal-exports.mjs"
         ],
         "parallel": false,

--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Regression tests for packaging concerns that only surface once the
+// package is actually installed/published — undeclared peer deps, missing
+// license text in the tarball, and stale compatibility docs. These read the
+// checked-in source of truth directly rather than the built dist output.
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+) as {
+  peerDependencies?: Record<string, string>;
+  engines?: { node?: string };
+};
+
+const projectJson = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../project.json'), 'utf8'),
+) as {
+  targets: { 'post-build': { options: { commands: string[] } } };
+};
+
+describe('packages/toolkit/package.json', () => {
+  it('declares @angular/common as a peer dependency', () => {
+    // form-field-wrapper.ts and form-fieldset.ts import NgComponentOutlet /
+    // NgTemplateOutlet from '@angular/common' at runtime — the built fesm
+    // bundle contains a genuine top-level import of it, so it must be a
+    // declared peer dependency, not just a devDependency.
+    expect(packageJson.peerDependencies).toHaveProperty('@angular/common');
+  });
+});
+
+describe('packages/toolkit/project.json post-build target', () => {
+  it('copies LICENSE into the publish root alongside README.md', () => {
+    const commands = projectJson.targets['post-build'].options.commands;
+    const copiesLicense = commands.some((command) =>
+      /\bcp\b.*\bLICENSE\b.*dist\/packages\/toolkit/.test(command),
+    );
+    expect(copiesLicense).toBe(true);
+  });
+});
+
+describe('COMPATIBILITY.md', () => {
+  it('documents the same engines.node range as package.json', () => {
+    const compatibilityMd = readFileSync(
+      resolve(import.meta.dirname, '../../../COMPATIBILITY.md'),
+      'utf8',
+    );
+    expect(packageJson.engines?.node).toBeTruthy();
+    expect(compatibilityMd).toContain(packageJson.engines?.node);
+  });
+});

--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -21,12 +21,18 @@ const projectJson = JSON.parse(
 };
 
 describe('packages/toolkit/package.json', () => {
-  it('declares @angular/common as a peer dependency', () => {
+  it('declares @angular/common as a peer dependency with the same range as @angular/core', () => {
     // form-field-wrapper.ts and form-fieldset.ts import NgComponentOutlet /
     // NgTemplateOutlet from '@angular/common' at runtime — the built fesm
     // bundle contains a genuine top-level import of it, so it must be a
-    // declared peer dependency, not just a devDependency.
+    // declared peer dependency, not just a devDependency. It must also track
+    // the same Angular major/minor range as @angular/core — a drifted range
+    // would let a consumer install a common/core version pair that the
+    // package was never validated against.
     expect(packageJson.peerDependencies).toHaveProperty('@angular/common');
+    expect(packageJson.peerDependencies?.['@angular/common']).toBe(
+      packageJson.peerDependencies?.['@angular/core'],
+    );
   });
 });
 

--- a/packages/toolkit/scripts/strip-internal-exports.mjs
+++ b/packages/toolkit/scripts/strip-internal-exports.mjs
@@ -37,7 +37,10 @@ const pkgJsonPath = join(distRoot, 'package.json');
 
 const PACKAGE_CORE_SPECIFIER = '@ngx-signal-forms/toolkit/core';
 const RELATIVE_MJS_SPECIFIER = './ngx-signal-forms-toolkit-core.mjs';
-const RELATIVE_DTS_SPECIFIER = './ngx-signal-forms-toolkit-core';
+// TypeScript's node16/nodenext module resolution requires an explicit
+// extension on relative ESM specifiers in declaration files; `.js` maps to
+// the sibling `.d.ts` file.
+const RELATIVE_DTS_SPECIFIER = './ngx-signal-forms-toolkit-core.js';
 const CORE_FESM_BASENAME = 'ngx-signal-forms-toolkit-core.mjs';
 const CORE_DTS_BASENAME = 'ngx-signal-forms-toolkit-core.d.ts';
 

--- a/packages/toolkit/scripts/strip-internal-exports.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-exports.spec.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Regression test for the post-build hardening script that hides the
+// build-time-only `/core` entry point from the published package. The
+// script rewrites sibling bundles' `'@ngx-signal-forms/toolkit/core'`
+// specifiers to relative paths pointing at the co-located `core` bundle.
+//
+// `.d.ts` files are ESM under `"type": "module"`, so under TypeScript's
+// node16/nodenext module resolution a relative specifier in a declaration
+// file must carry an explicit extension. A specifier like
+// `'./ngx-signal-forms-toolkit-core'` (no extension) breaks consumers using
+// nodenext resolution (SSR, tsc builds, Jest/Vitest with nodenext) with
+// TS2307, even though Angular CLI's bundler resolution masks the problem.
+
+const scriptPath = resolve(import.meta.dirname, './strip-internal-exports.mjs');
+
+describe('strip-internal-exports.mjs', () => {
+  let workDir: string;
+
+  afterEach(() => {
+    if (workDir) rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('rewrites .d.ts core specifiers to an extension-carrying relative path', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'strip-internal-exports-'));
+    const distRoot = join(workDir, 'dist/packages/toolkit');
+    const fesmDir = join(distRoot, 'fesm2022');
+    const typesDir = join(distRoot, 'types');
+    await mkdir(fesmDir, { recursive: true });
+    await mkdir(typesDir, { recursive: true });
+
+    // Sibling entry that re-exports the internal /core entry, plus the core
+    // bundle itself (which must be left untouched, not self-rewritten).
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      `export * from '@ngx-signal-forms/toolkit/core';\n`,
+    );
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit-core.mjs'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      `export * from '@ngx-signal-forms/toolkit/core';\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(distRoot, 'package.json'),
+      JSON.stringify({
+        exports: {
+          '.': './fesm2022/ngx-signal-forms-toolkit.mjs',
+          './core': './fesm2022/ngx-signal-forms-toolkit-core.mjs',
+        },
+      }),
+    );
+
+    execFileSync(process.execPath, [scriptPath], { cwd: workDir });
+
+    const dts = readFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      'utf8',
+    );
+    const mjs = readFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      'utf8',
+    );
+
+    // The .mjs rewrite already carries an extension and must be unaffected.
+    expect(mjs).toContain(`from './ngx-signal-forms-toolkit-core.mjs'`);
+
+    // The .d.ts rewrite must carry an explicit extension for node16/nodenext
+    // consumers to resolve it — the bare (extensionless) specifier must be
+    // gone entirely, not just supplemented.
+    expect(dts).not.toMatch(/'\.\/ngx-signal-forms-toolkit-core'/);
+    expect(dts).toContain(`from './ngx-signal-forms-toolkit-core.js'`);
+  });
+});

--- a/packages/toolkit/scripts/strip-internal-exports.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-exports.spec.ts
@@ -20,10 +20,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 const scriptPath = resolve(import.meta.dirname, './strip-internal-exports.mjs');
 
 describe('strip-internal-exports.mjs', () => {
-  let workDir: string;
+  let workDir: string | undefined;
 
   afterEach(() => {
-    if (workDir) rmSync(workDir, { recursive: true, force: true });
+    if (workDir !== undefined)
+      rmSync(workDir, { recursive: true, force: true });
   });
 
   it('rewrites .d.ts core specifiers to an extension-carrying relative path', async () => {

--- a/packages/toolkit/vitest.shared.mts
+++ b/packages/toolkit/vitest.shared.mts
@@ -9,7 +9,7 @@ import { type UserWorkspaceConfig } from 'vitest/config';
 process.env.NX_DAEMON ??= 'false';
 
 export const toolkitSpecRoots =
-  '{src,core,form-field,headless,assistive,testing,vest}';
+  '{src,core,form-field,headless,assistive,testing,vest,scripts}';
 export const toolkitSpecFiles = `${toolkitSpecRoots}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`;
 export const toolkitBrowserSpecFiles = `${toolkitSpecRoots}/**/*.browser.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`;
 


### PR DESCRIPTION
Closes #164

Fixes the 4 verified blocker findings from packaging audit #143 (wayfinder map #134).

## Fixes

1. **Missing `@angular/common` peerDependency** — `form-field-wrapper.ts` and `form-fieldset.ts` import `NgComponentOutlet`/`NgTemplateOutlet` from `@angular/common` at runtime (verified: the built fesm bundle has a genuine top-level import), but it was only a devDependency. Added `"@angular/common": ">=22.0.0 <23.0.0"` to `peerDependencies` in `packages/toolkit/package.json`, matching the `@angular/core`/`@angular/forms` range.
2. **Published tarball missing LICENSE** — `packages/toolkit/project.json`'s `post-build` target now copies `LICENSE` into `dist/packages/toolkit/LICENSE` alongside the existing `README.md` copy, so the MIT license text ships with the `"license": "MIT"` field.
3. **`strip-internal-exports.mjs` emitted extensionless `.d.ts` relative imports** — under `"type": "module"`, TypeScript's node16/nodenext resolution requires explicit extensions on relative ESM specifiers in declaration files. Changed `RELATIVE_DTS_SPECIFIER` from `'./ngx-signal-forms-toolkit-core'` to `'./ngx-signal-forms-toolkit-core.js'` (verified against the real dist output post-build — both `ngx-signal-forms-toolkit.d.ts` and `ngx-signal-forms-toolkit-headless.d.ts` now resolve correctly).
4. **`COMPATIBILITY.md` stale `engines.node`** — updated the documented range from `^20.19.0 || ^22.12.0 || >=24.0.0` to `^22.22.3 || ^24.15.0 || >=26.0.0`, matching `packages/toolkit/package.json` (which mirrors `@angular/core@22`'s own `engines` field).

## TDD

Regression tests were written first and confirmed failing before each fix:
- `packages/toolkit/scripts/packaging.spec.ts` — asserts the peerDependency, the post-build LICENSE copy command, and that `COMPATIBILITY.md` contains the same `engines.node` string as `package.json`.
- `packages/toolkit/scripts/strip-internal-exports.spec.ts` — runs the actual post-build script against a fixture dist tree and asserts the rewritten `.d.ts` specifier carries a `.js` extension while the `.mjs` rewrite is untouched.
- Added `scripts` to `toolkitSpecRoots` in `vitest.shared.mts` so these specs are picked up by the existing jsdom test config.

## Breaking changes

- **`@angular/common` is now a required peerDependency** (rc-phase break, allowed per release policy). Documented in `docs/MIGRATING_BETA_TO_V1.md` (new "At a glance" bullet + new subsection under "Angular peer-dependency ceiling"). No action needed for consumers that already depend on `@angular/common` (virtually all Angular apps do) — strict/isolated installers will now correctly surface it as a peer dependency instead of silently tolerating the gap.

## Verification

```
pnpm nx run-many -t test,lint,build --projects=toolkit
```
All green: 73 test files / 1172 tests passed, lint clean, build clean. Also manually inspected `dist/packages/toolkit` post-build to confirm `LICENSE` is present and the `.d.ts` specifiers carry `.js` extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package compatibility requirements to match the supported Node.js and Angular versions.
  * Added a required shared Angular dependency so installs surface missing setup earlier.
  * Improved published package output to include the license file.
  * Adjusted generated module references for better compatibility with modern Node.js resolution.

* **Tests**
  * Added regression coverage for packaging and module-reference handling.
  * Expanded test discovery to include script-level specs.

* **Documentation**
  * Clarified migration guidance and compatibility expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->