### PR TITLE
fix(core): resolve v1.0.0 audit blockers

### DIFF
--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -44,6 +44,8 @@ releases will not include any of the renames below.
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
+- **BREAKING: `canSubmitWithWarnings()` now reads `errorSummary()`** — child-path blocking errors now correctly disable submission (see [§5c](#5c-cansubmitwithwarnings-now-aggregates-descendant-errors))
+- **BREAKING: `injectFieldControl()` validates the resolved value against the runtime `FieldTree` contract** — an id resolving to a non-`FieldTree` property now throws instead of silently returning an unsound cast (see [§5d](#5d-injectfieldcontrol-validates-the-resolved-fieldtree))
 
 ---
 
@@ -470,6 +472,54 @@ What changed for migrators:
   string.
 - **No runtime behavior change** for existing string entries or correctly typed
   factories — this is a compile-time tightening only.
+
+## 5c. `canSubmitWithWarnings()` now aggregates descendant errors
+
+`canSubmitWithWarnings()` previously gated on `formTree().errors()`, which
+only reports the root field's **own** errors. Validators are almost always
+placed on child paths (`path.email`, not `path`), so a blocking `required`
+error on a child field left the root's `errors()` empty and
+`canSubmitWithWarnings()` returned `true` — while its sibling helper
+`submitWithWarnings()` already correctly gated on `errorSummary()` (which
+aggregates descendant errors) and silently refused to submit. That mismatch
+produced a dead click: the submit button computed "submittable" while the
+actual submit call was a no-op.
+
+`canSubmitWithWarnings()` now reads `formTree().errorSummary()`, matching
+`submitWithWarnings()`.
+
+**Action:** If you built a form whose only blocking validators live at the
+form root (uncommon) and were relying on child-path errors being ignored by
+`canSubmitWithWarnings()`, that form's submit button will now correctly stay
+disabled until the child error clears. This is the intended fix — no code
+changes are needed unless you were compensating for the bug elsewhere (e.g.
+manually re-checking `errorSummary()` before calling `submitWithWarnings()`).
+
+## 5d. `injectFieldControl()` validates the resolved `FieldTree`
+
+`injectFieldControl()` previously validated only `isRecord(control) && part
+in control` while walking the dotted id path, then cast the final value to
+`FieldTree<TValue>` unconditionally. Any property reachable by the path —
+including one that happens to collide with non-control data on the form
+object — passed silently and was returned as though it were a real
+`FieldTree`, deferring the failure to a confusing error at the first
+downstream call site.
+
+`injectFieldControl()` now validates the resolved value with the existing
+`isFieldTree()` runtime guard and throws the same descriptive
+`"Field "…" not found in form"` error immediately when it fails the check.
+
+**Action:** No change needed for real Angular `form()` trees — they always
+satisfy the `FieldTree` contract. If you were passing a hand-rolled mock form
+into toolkit-consuming code under test, make sure the mocked leaf values are
+callable and resolve to an object exposing `value`, `touched`, `errors`,
+`errorSummary`, `submitting`, and `markAsTouched` as functions, plus a
+`fieldTree` back-reference to the callable itself (mirrors what
+`walkFieldTreeEntries()` already requires).
+
+Resolution also remains a **one-shot, non-reactive** lookup — the form
+instance and the element's `id` are both read once, at call time. This was
+previously undocumented; see the updated `injectFieldControl()` JSDoc.
 
 ### Control semantics contract — `ngxSignalFormControl`
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -488,12 +488,14 @@ actual submit call was a no-op.
 `canSubmitWithWarnings()` now reads `formTree().errorSummary()`, matching
 `submitWithWarnings()`.
 
-**Action:** If you built a form whose only blocking validators live at the
-form root (uncommon) and were relying on child-path errors being ignored by
-`canSubmitWithWarnings()`, that form's submit button will now correctly stay
-disabled until the child error clears. This is the intended fix — no code
-changes are needed unless you were compensating for the bug elsewhere (e.g.
-manually re-checking `errorSummary()` before calling `submitWithWarnings()`).
+**Action:** This affects forms with blocking validators on descendant paths
+(the common case, e.g. `path.email`) — previously, `canSubmitWithWarnings()`
+ignored those child-path errors, so such a form's submit button could appear
+submittable even while a child field was invalid. After this fix, that
+button will now correctly stay disabled until the child error clears. This
+is the intended fix — no code changes are needed unless you were
+compensating for the bug elsewhere (e.g. manually re-checking
+`errorSummary()` before calling `submitWithWarnings()`).
 
 ## 5d. `injectFieldControl()` validates the resolved `FieldTree`
 

--- a/packages/toolkit/core/utilities/inject-field-control.spec.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.spec.ts
@@ -28,6 +28,42 @@ function createMockFieldTree<TValue>(value: TValue): FieldTree<TValue> {
   return fieldTree;
 }
 
+/**
+ * Callable `FieldTree`-shaped mock for a group node (e.g. `address`),
+ * matching real Angular Signal Forms more faithfully than
+ * `createMockFieldTree`'s plain-object test-fixture parents: in a real form
+ * *every* node — the form root and every intermediate group, not just
+ * leaves — is itself callable (`typeof node === 'function'`) and satisfies
+ * `isFieldTree()`. Child fields are exposed as properties directly on the
+ * callable function object (mirroring `formInstance.address.city`).
+ *
+ * This is the shape that exposed the pre-fix bug: `injectFieldControl`'s
+ * path-navigation guard only accepted `typeof value === 'object'`, so it
+ * rejected the (callable) `address` group on the second path segment of
+ * `"address.city"` — and would have rejected `formInstance` itself on the
+ * very first segment of any single-level path in a real, non-mocked form.
+ */
+function createGroupFieldTree<TValue extends Record<string, unknown>>(
+  value: TValue,
+  children: { [K in keyof TValue]: FieldTree<TValue[K]> },
+): FieldTree<TValue> {
+  let fieldTree!: FieldTree<TValue>;
+  const call = () => ({
+    value: () => value,
+    touched: () => false,
+    errors: () => [],
+    errorSummary: () => [],
+    submitting: () => false,
+    markAsTouched: () => {},
+    invalid: () => false,
+    get fieldTree() {
+      return fieldTree;
+    },
+  });
+  fieldTree = Object.assign(call, children) as unknown as FieldTree<TValue>;
+  return fieldTree;
+}
+
 describe('injectFieldControl', () => {
   it('should resolve field control from form using id attribute', () => {
     const emailControl = createMockFieldTree('');
@@ -51,6 +87,43 @@ describe('injectFieldControl', () => {
   it('should resolve nested field control using dot notation', () => {
     const cityControl = createMockFieldTree('');
     const mockForm = { address: { city: cityControl } };
+    const mockContext: NgxSignalFormContext = {
+      form: mockForm,
+      submittedStatus: () => 'unsubmitted' as SubmittedStatus,
+      errorStrategy: () => 'on-touch',
+    };
+
+    const injector = Injector.create({
+      providers: [{ provide: NGX_SIGNAL_FORM_CONTEXT, useValue: mockContext }],
+    });
+
+    const element = document.createElement('input');
+    element.setAttribute('id', 'address.city');
+
+    const result = injectFieldControl(element, injector);
+    expect(result).toBe(cityControl);
+  });
+
+  it('should resolve nested field control when every ancestor node is a callable FieldTree (real form shape)', () => {
+    // Regression for a bug where path navigation's guard only accepted
+    // `typeof value === 'object'`, rejecting real (callable) FieldTree nodes
+    // at every level above the leaf — including `formInstance` itself. Only
+    // the plain-object mocks used elsewhere in this file (e.g. `{ address:
+    // { city } }`, where `address` is a non-callable plain object) ever
+    // passed. This test uses `createGroupFieldTree` so that both the form
+    // root and the `address` group are callable, matching how Angular's
+    // real Signal Forms `FieldTree` is shaped.
+    const cityControl = createMockFieldTree('');
+    const addressGroup = createGroupFieldTree(
+      { city: '' },
+      {
+        city: cityControl,
+      },
+    );
+    const mockForm = createGroupFieldTree(
+      { address: { city: '' } },
+      { address: addressGroup },
+    );
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
       submittedStatus: () => 'unsubmitted' as SubmittedStatus,

--- a/packages/toolkit/core/utilities/inject-field-control.spec.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.spec.ts
@@ -1,13 +1,36 @@
 import { ElementRef, Injector, signal } from '@angular/core';
+import type { FieldTree } from '@angular/forms/signals';
 import { describe, expect, it } from 'vitest';
 import type { SubmittedStatus } from '../types';
 import type { NgxSignalFormContext } from '../directives/ngx-signal-form';
 import { NGX_SIGNAL_FORM_CONTEXT } from '../tokens';
 import { injectFieldControl } from './inject-field-control';
 
+/**
+ * Minimal `FieldTree`-shaped mock satisfying the runtime contract enforced by
+ * `isFieldTree()` (callable, backing `FieldState` with the required methods
+ * and a `.fieldTree` back-reference to itself).
+ */
+function createMockFieldTree<TValue>(value: TValue): FieldTree<TValue> {
+  let fieldTree!: FieldTree<TValue>;
+  fieldTree = (() => ({
+    value: () => value,
+    touched: () => false,
+    errors: () => [],
+    errorSummary: () => [],
+    submitting: () => false,
+    markAsTouched: () => {},
+    invalid: () => false,
+    get fieldTree() {
+      return fieldTree;
+    },
+  })) as FieldTree<TValue>;
+  return fieldTree;
+}
+
 describe('injectFieldControl', () => {
   it('should resolve field control from form using id attribute', () => {
-    const emailControl = signal({ value: '', invalid: () => false });
+    const emailControl = createMockFieldTree('');
     const mockForm = { email: emailControl };
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
@@ -26,7 +49,7 @@ describe('injectFieldControl', () => {
   });
 
   it('should resolve nested field control using dot notation', () => {
-    const cityControl = signal({ value: '', invalid: () => false });
+    const cityControl = createMockFieldTree('');
     const mockForm = { address: { city: cityControl } };
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
@@ -46,7 +69,7 @@ describe('injectFieldControl', () => {
   });
 
   it('should work with ElementRef', () => {
-    const emailControl = signal({ value: '', invalid: () => false });
+    const emailControl = createMockFieldTree('');
     const mockForm = { email: emailControl };
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
@@ -170,5 +193,51 @@ describe('injectFieldControl', () => {
     expect(() => {
       injectFieldControl(element, injector);
     }).toThrow(/requires form context/i);
+  });
+
+  it('should throw instead of returning an unsound cast when the resolved value is not a FieldTree', () => {
+    // Regression: an id can collide with a non-field property on the form
+    // object (e.g. plain metadata, not a control). Path navigation used to
+    // validate only `isRecord(control) && part in control`, then blindly
+    // cast the result to `FieldTree`, deferring the failure to a confusing
+    // downstream call site instead of throwing here with a clear message.
+    const mockForm = { metadata: { note: 'plain data, not a FieldTree' } };
+    const mockContext: NgxSignalFormContext = {
+      form: mockForm,
+      submittedStatus: () => 'unsubmitted' as SubmittedStatus,
+      errorStrategy: () => 'on-touch',
+    };
+    const injector = Injector.create({
+      providers: [{ provide: NGX_SIGNAL_FORM_CONTEXT, useValue: mockContext }],
+    });
+
+    const element = document.createElement('input');
+    element.setAttribute('id', 'metadata');
+
+    expect(() => {
+      injectFieldControl(element, injector);
+    }).toThrow(/Field "metadata".*not.*(FieldTree|found)/is);
+  });
+
+  it('should throw when the resolved value is callable but does not satisfy the FieldState contract', () => {
+    // A callable property (e.g. a plain function living on the form object)
+    // passes a naive "is it a function" check but is not a real FieldTree —
+    // calling it does not produce a conforming FieldState.
+    const mockForm = { email: () => 'not a FieldState' };
+    const mockContext: NgxSignalFormContext = {
+      form: mockForm,
+      submittedStatus: () => 'unsubmitted' as SubmittedStatus,
+      errorStrategy: () => 'on-touch',
+    };
+    const injector = Injector.create({
+      providers: [{ provide: NGX_SIGNAL_FORM_CONTEXT, useValue: mockContext }],
+    });
+
+    const element = document.createElement('input');
+    element.setAttribute('id', 'email');
+
+    expect(() => {
+      injectFieldControl(element, injector);
+    }).toThrow(/Field "email".*not.*(FieldTree|found)/is);
   });
 });

--- a/packages/toolkit/core/utilities/inject-field-control.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.ts
@@ -3,6 +3,7 @@ import type { FieldTree } from '@angular/forms/signals';
 import { assertInjector } from './assert-injector';
 import { resolveFieldName } from './field-resolution';
 import { injectFormContext } from './inject-form-context';
+import { isFieldTree } from './walk-field-tree';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -17,7 +18,17 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  * @param element - The HTML element or ElementRef to resolve the field name from
  * @param injector - Optional injector for use outside injection context
  * @returns The resolved `FieldTree<TValue>` from the form
- * @throws Error if field cannot be resolved or form context is not found
+ * @throws Error if field cannot be resolved, the resolved value does not
+ *   satisfy the runtime `FieldTree` contract (see `isFieldTree`), or form
+ *   context is not found
+ *
+ * @remarks
+ * Resolution is a **one-shot, non-reactive** lookup: the form instance and
+ * the element's `id` are both read once, at injection/call time. Swapping
+ * the underlying form instance or assigning the element's `id` after this
+ * call resolves will NOT be reflected — the returned `FieldTree` reference
+ * is fixed for the lifetime of the caller. Re-invoke this function (e.g. in
+ * a fresh `computed()`) if you need to track a form or id that can change.
  *
  * @example
  * ```typescript
@@ -82,6 +93,13 @@ export function injectFieldControl<TValue = unknown>(
         );
       }
       control = control[part];
+    }
+
+    if (!isFieldTree(control)) {
+      throw new Error(
+        `[ngx-signal-forms] Field "${fieldName}" not found in form. ` +
+          `Resolved value does not satisfy the FieldTree contract.`,
+      );
     }
 
     return control as FieldTree<TValue>;

--- a/packages/toolkit/core/utilities/inject-field-control.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.ts
@@ -5,8 +5,15 @@ import { resolveFieldName } from './field-resolution';
 import { injectFormContext } from './inject-form-context';
 import { isFieldTree } from './walk-field-tree';
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
+// Real `FieldTree` nodes are callable (`typeof` is `'function'`, not
+// `'object'`) — see `isFieldTree` in `walk-field-tree.ts`, which requires
+// every node to be invokable in order to read its `FieldState`. A guard that
+// only accepted `'object'` would reject `formInstance` itself on the very
+// first path segment for any real form, since the form root is a
+// `FieldTree`. Only plain-object mocks (not real `FieldTree`s) would ever
+// satisfy such a guard, which is why this bug shipped without failing tests.
+const isNavigable = (value: unknown): value is Record<string, unknown> =>
+  (typeof value === 'object' || typeof value === 'function') && value !== null;
 
 /**
  * Custom Inject Function (CIF) for retrieving a specific field control from the form.
@@ -86,7 +93,7 @@ export function injectFieldControl<TValue = unknown>(
     let control: unknown = formInstance;
 
     for (const part of pathParts) {
-      if (!isRecord(control) || !(part in control)) {
+      if (!isNavigable(control) || !(part in control)) {
         throw new Error(
           `[ngx-signal-forms] Field "${fieldName}" not found in form. ` +
             `Could not access property "${part}".`,

--- a/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
@@ -320,6 +320,42 @@ describe('canSubmitWithWarnings', () => {
     expect(canSubmit()).toBe(false);
   });
 
+  it('returns false when a blocking error lives on a CHILD path, not the root', async () => {
+    // Regression for the root-vs-descendant mismatch: a validator on
+    // `path.email` (not `path` itself) puts the blocking error on the
+    // child FieldState's `errors()`. The root FieldState's own `errors()`
+    // stays empty — only `errorSummary()` aggregates descendant errors.
+    // `canSubmitWithWarnings` must agree with `submitWithWarnings` (which
+    // already reads `errorSummary()`) or the submit button computes
+    // "submittable" while the actual submit helper silently refuses.
+    const model = signal({ email: '' });
+    const f = TestBed.runInInjectionContext(() =>
+      form(
+        model,
+        schema<{ email: string }>((path) => {
+          validate(path.email, (ctx) => {
+            const value = ctx.value();
+            if (!value) {
+              return { kind: 'required', message: 'Email is required' };
+            }
+            return null;
+          });
+        }),
+      ),
+    );
+
+    // Root's own errors() stay empty; the blocking error only surfaces via
+    // errorSummary() on the root (or errors() on the child).
+    expect(f().errors()).toEqual([]);
+
+    const canSubmit = TestBed.runInInjectionContext(() =>
+      canSubmitWithWarnings(f),
+    );
+    await flush();
+
+    expect(canSubmit()).toBe(false);
+  });
+
   it('returns false while submitting()/pending() are true (mock form)', () => {
     // canSubmitWithWarnings reads `submitting()` and `pending()` on the
     // FieldState. Use a mock to drive both signals deterministically without

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -180,7 +180,11 @@ export function canSubmitWithWarnings(
       return false;
     }
 
-    return getBlockingErrors(formState.errors()).length === 0;
+    // `errors()` only reports the field's OWN errors; validators placed on
+    // child paths (the common case) never surface here. `errorSummary()`
+    // aggregates descendant errors too, matching what `submitWithWarnings()`
+    // gates on — keeping the two helpers in agreement.
+    return getBlockingErrors(formState.errorSummary()).length === 0;
   });
 }
 


### PR DESCRIPTION
Closes #159

## Summary

Fixes both verified blocker findings from audit #137 (core, wayfinder map #134).

### 1. `canSubmitWithWarnings()` ignored blocking errors on child fields (bug)

`canSubmitWithWarnings()` gated on `formTree().errors()`, which only reports
the root field's **own** errors. Validators are almost always placed on
child paths (e.g. `path.email`), so a blocking `required` error there left
the root's `errors()` empty — `canSubmitWithWarnings()` returned `true`
while its sibling `submitWithWarnings()` (which already read
`errorSummary()`) silently refused to submit. Result: a submit button that
computed "submittable" but produced a dead click.

Fix: `canSubmitWithWarnings()` now reads `formTree().errorSummary()`,
matching `submitWithWarnings()`. Added a regression test placing the
validator on a child path and asserting the button now correctly disables.

### 2. `injectFieldControl()`: unsound cast + undocumented one-shot resolution (type-safety)

Path navigation validated only `isRecord(control) && part in control`, then
unconditionally cast the result to `FieldTree<TValue>`. Any property
reachable via the id path — including one colliding with non-control data —
passed silently, deferring the failure to a confusing downstream call.

Fix: validate the resolved value with the existing `isFieldTree()` runtime
guard and throw the existing descriptive error immediately when it fails.
Also documented (JSDoc) the previously-undocumented one-shot, non-reactive
resolution semantics (form instance and element `id` are both read once,
at call time). Added regression tests for a non-`FieldTree` property
collision and a callable-but-non-conforming property.

## Breaking changes (rc phase, documented in `docs/MIGRATING_BETA_TO_V1.md` §5c/§5d)

- `canSubmitWithWarnings()` now aggregates descendant errors via
  `errorSummary()` instead of only the root's own `errors()`. Forms with
  child-path blocking errors that were previously (incorrectly) submittable
  will now correctly stay disabled.
- `injectFieldControl()` now throws when the id-resolved value does not
  satisfy the runtime `FieldTree` contract, instead of returning an unsound
  cast. Only affects callers whose id path resolves to non-control data.

## Test plan

- [x] Added failing-first regression tests for both fixes, then applied the
      minimal fix (TDD)
- [x] `pnpm nx run-many -t test,lint,build --projects=toolkit --skip-nx-cache` — all green (71 test files / 1171 tests, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Submission now correctly blocks when validation errors exist in nested child fields.
  * Field injection now validates the resolved field at runtime and reports a clear error if it can’t be used.

* **Documentation**
  * Updated migration guidance with the latest breaking-change details and usage notes.

* **Tests**
  * Added regression coverage for nested validation errors and invalid field injection cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->