### PR TITLE
fix(assistive): resolve v1.0.0 audit blockers

### DIFF
--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -43,6 +43,9 @@ releases will not include any of the renames below.
 - **BREAKING: `ErrorMessageRegistry` is now strongly typed per built-in kind** — factory params for built-in kinds (`minLength`, `min`, `pattern`, …) are typed; custom kinds stay `any` (see [§5b](#5b-error-message-registry-is-now-strongly-typed))
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
+- **A11y fix** — assistive live-region containers no longer toggle `aria-hidden`/`[hidden]` while empty, and `NgxFormFieldError`'s `id` binding no longer emits the literal string `"null"` (see [§6](#6-v100-audit-blockers-live-region-focus-and-dark-mode-fixes))
+- **A11y fix** — `NgxFormFieldErrorSummary`'s `autoFocus` now only fires under the resolved `'on-submit'` strategy, never `'on-touch'`/`'immediate'` (see [§6](#6-v100-audit-blockers-live-region-focus-and-dark-mode-fixes))
+- **BREAKING (a11y fix)** — dark mode no longer detects a `.dark` ancestor class via `:host-context()` (non-standard, unsupported in Firefox/Safari); class-based dark-mode apps must override the public `--ngx-signal-form-*` custom properties directly (see [§6](#6-v100-audit-blockers-live-region-focus-and-dark-mode-fixes))
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
 
 ---
@@ -560,6 +563,99 @@ import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
   `,
 })
 ```
+
+---
+
+## 6. v1.0.0 audit blockers: live-region, focus, and dark-mode fixes
+
+The `assistive` entry point (`NgxFormFieldError`, `NgxFormFieldNotification`,
+`NgxFormFieldErrorSummary`) shipped a handful of accessibility defects that
+were fixed as part of the v1.0.0 release audit. None of these rename or
+remove an input/output, but they change runtime DOM/behavior in ways some
+consumers (especially tests) may depend on.
+
+### `id` binding no longer emits the literal string `"null"`
+
+`NgxFormFieldError`'s error/warning containers used a **property** binding
+(`[id]`) for their generated id. Binding `null` to the DOM `id` property
+coerces to the string `"null"` (WebIDL `DOMString`), so every empty
+container in the document ended up with `id="null"` — a real duplicate-id
+bug. This is now an **attribute** binding (`[attr.id]`), matching
+`NgxFormFieldNotification`, so a `null`/unresolvable id removes the
+attribute entirely instead of emitting `"null"`.
+
+- **Before:** `id="null"` could appear on empty error/warning containers.
+- **After:** the `id` attribute is simply absent.
+- If any test asserted `element.getAttribute('id') === 'null'`, update it to
+  assert `element.hasAttribute('id') === false`.
+
+### Empty live regions no longer toggle `aria-hidden` / `[hidden]`
+
+`NgxFormFieldError`, `NgxFormFieldNotification`, and
+`NgxFormFieldErrorSummary` previously toggled `aria-hidden="true"` and
+`[hidden]` on their live-region containers while empty, removing them from
+the DOM once the first error/warning/entry arrived. Flipping `aria-hidden`
+off in the same change-detection pass that inserts the first message is
+functionally equivalent to inserting a brand-new live region — which
+reintroduces the exact NVDA + Chrome "missed first announcement" bug the
+always-mounted container pattern exists to avoid.
+
+The containers now stay mounted **and exposed** at all times; the `@if` in
+each template already guarantees zero content (including whitespace) while
+empty, and visual collapse is handled entirely by the existing `--empty`
+CSS class.
+
+- **Before:** `screen.queryByRole('alert')` (and `'status'`) returned `null`
+  while there were no errors/warnings/entries, because the empty container
+  carried `aria-hidden`/`[hidden]` and Testing Library's accessible-role
+  queries exclude hidden elements by default.
+- **After:** the container is always found by role; assert on its content
+  instead — e.g. `expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('')`.
+- `NgxFormFieldErrorSummary`'s `role="alert"` container is now also
+  rendered unconditionally (previously it was only added to the DOM once
+  there were entries, which risked the same missed-first-announcement
+  timing bug on the very first submit).
+
+### `NgxFormFieldErrorSummary` `autoFocus` no longer fires under `'on-touch'` / `'immediate'`
+
+`autoFocus` (default `true`) is documented as implementing the GOV.UK/WAI
+pattern of moving focus to the summary "after a failed submit." Previously
+it fired on _any_ 0 → N entries transition, including under the default
+`'on-touch'` strategy — so blurring the first invalid field mid-fill (or,
+under `'immediate'`, simply loading an already-invalid form) silently
+stole focus. This violated WCAG 3.2.1/3.2.2 and contradicted the documented
+contract.
+
+`autoFocus` now only moves focus when the resolved strategy (explicit
+`strategy` input → form context → `'on-touch'` default) is `'on-submit'`.
+Under `'on-touch'`/`'immediate'`, focus is never moved automatically,
+regardless of the `autoFocus` value.
+
+- If you depended on the old on-touch/immediate auto-focus behavior, move
+  focus yourself (e.g. in a submit handler) or switch the summary's
+  `strategy` to `'on-submit'`.
+- The new `resolvedStrategy` signal is exposed on the headless
+  `NgxHeadlessErrorSummary` directive if you need to replicate this gating
+  in a custom summary UI.
+
+### Dark mode: `:host-context(.dark)` heuristic removed
+
+`NgxFormFieldError` and `NgxFormFieldNotification` previously shipped a
+`:host-context(.dark)` / `:host-context(:root:not(.dark))` heuristic
+alongside their `prefers-color-scheme: dark` media query, intended to
+support class-based dark-mode toggling (e.g. Tailwind's `.dark` strategy).
+`:host-context()` is non-standard and unsupported in Firefox and Safari, so
+the three engines disagreed on the resulting colors — in some
+configurations this produced WCAG 1.4.3 contrast failures (as low as
+~1.8:1). The heuristic has been removed; built-in dark defaults are now
+driven by `prefers-color-scheme` only, consistently across all engines.
+
+- **Breaking for class-based dark-mode consumers:** if your app toggles a
+  `.dark` class instead of relying on the OS color scheme, the built-in
+  dark tokens will no longer activate. Override the public
+  `--ngx-signal-form-error-*` / `--ngx-signal-form-warning-*` /
+  `--ngx-signal-form-notification-*` custom properties yourself, scoped to
+  your `.dark` selector — see the [assistive README](../packages/toolkit/assistive/README.md#dark-mode).
 
 ---
 

--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -87,16 +87,20 @@ Grouped validation notification with an optional title.
 
 `errors` must be a signal, for example `signal<readonly ValidationError[]>([])`.
 
-| Input       | Type                                 | Description                                       |
-| ----------- | ------------------------------------ | ------------------------------------------------- |
-| `errors`    | `Signal<readonly ValidationError[]>` | Grouped validation messages to present            |
-| `fieldName` | `string`                             | Optional id base for `aria-describedby` linkage   |
-| `title`     | `string`                             | Optional title above the grouped messages         |
-| `listStyle` | `'plain' \| 'bullets'`               | Stacked paragraphs or bullet list                 |
-| `tone`      | `'auto' \| 'error' \| 'warning'`     | Resolve the card as an error/warning notification |
+| Input       | Type                                 | Description                                     |
+| ----------- | ------------------------------------ | ----------------------------------------------- |
+| `errors`    | `Signal<readonly ValidationError[]>` | Grouped validation messages to present          |
+| `fieldName` | `string`                             | Optional id base for `aria-describedby` linkage |
+| `title`     | `string`                             | Optional title above the grouped messages       |
+| `listStyle` | `'plain' \| 'bullets'`               | Stacked paragraphs or bullet list               |
+| `tone`      | `'auto' \| 'error' \| 'warning'`     | Currently a no-op — see below                   |
 
-- `tone="auto"` treats an all-warning list as a polite status notification
-- Blocking errors keep `role="alert"`
+- Tone is always **content-driven**, regardless of the `tone` value passed:
+  any blocking (non-`warn:`) error routes the group to `role="alert"`; an
+  all-warning list routes to the polite `role="status"` container.
+- The `tone` input does not currently force either outcome. It is retained
+  as a stable API surface for possible future expansion (e.g. explicit
+  tone forcing) — do not rely on it to change rendering today.
 - Intended for grouped fieldset summaries or custom headless summary cards
 
 ### NgxFormFieldErrorSummary
@@ -128,8 +132,8 @@ Helper text below inputs. Automatically linked to the input via `aria-describedb
 ```
 
 Optional `position` input (`'left' | 'right'`): alignment within the assistive
-row. When omitted, hints right-align — or left-align when a character count
-shares the row.
+row. When omitted, hints left-align by default; pass `position="right"` to
+opt into end alignment.
 
 ### NgxFormFieldCharacterCount
 
@@ -187,6 +191,16 @@ tokens when used inside `ngx-form-fieldset`.
 
 The default light-theme error surface now matches the Figma design token
 directly: `#fdebeb`.
+
+### Dark mode
+
+Built-in dark defaults are driven by the `prefers-color-scheme: dark` media
+query only — they do not detect a `.dark` class on an ancestor element.
+(`:host-context()`, which would be needed for that, is non-standard and
+unsupported in Firefox and Safari.) Apps using a class-based dark-mode
+strategy must override the public `--ngx-signal-form-error-*` /
+`--ngx-signal-form-warning-*` / `--ngx-signal-form-notification-*` custom
+properties themselves, scoped to their `.dark` selector.
 
 ## Related documentation
 

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -377,8 +377,14 @@ describe('NgxFormFieldErrorSummary', () => {
     await userEvent.click(input);
     await userEvent.tab();
 
+    // The alert shell is always mounted (WCAG 4.1.3 live region), so
+    // `findByRole('alert')` resolves as soon as the element exists — not
+    // once it actually contains the error text. Wait for the text content
+    // itself to avoid racing the update.
     const summaryAlert = await screen.findByRole('alert');
-    expect(summaryAlert.textContent).toContain('Email is required');
+    await vi.waitFor(() => {
+      expect(summaryAlert.textContent).toContain('Email is required');
+    });
 
     const focusTarget = summaryAlert.closest('ngx-form-field-error-summary');
     expect(document.activeElement).not.toBe(focusTarget);

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -83,7 +83,7 @@ describe('NgxFormFieldErrorSummary', () => {
 
     const { fixture } = await render(TestComponent);
 
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
 
     fixture.componentInstance.submittedStatus.set('submitted');
     fixture.detectChanges();
@@ -119,7 +119,7 @@ describe('NgxFormFieldErrorSummary', () => {
     const { fixture } = await render(TestComponent);
 
     // Default strategy is on-touch → no entries until a field is touched.
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
 
     fixture.componentInstance.contactForm.email().markAsTouched();
     fixture.detectChanges();
@@ -189,7 +189,7 @@ describe('NgxFormFieldErrorSummary', () => {
 
     await render(TestComponent);
 
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     expect(screen.queryAllByRole('button').length).toBe(0);
   });
 
@@ -273,9 +273,10 @@ describe('NgxFormFieldErrorSummary', () => {
 
     const { fixture } = await render(TestComponent);
 
-    // Before submit there are no entries, so the summary is hidden and
-    // focus is wherever the test framework left it (typically <body>).
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    // Before submit there are no entries, so the summary shell stays
+    // mounted (WCAG 4.1.3) but empty, and focus is wherever the test
+    // framework left it (typically <body>).
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
 
     // Submit triggers the on-submit strategy → entries appear → host
     // should receive focus on the next render pass.
@@ -337,6 +338,50 @@ describe('NgxFormFieldErrorSummary', () => {
     // Summary is visible but focus must remain on the input.
     expect(await screen.findByRole('alert')).toBeTruthy();
     expect(document.activeElement).toBe(input);
+  });
+
+  it('does not steal focus under the default on-touch strategy (WCAG 3.2.1/3.2.2)', async () => {
+    // The GOV.UK/WAI error-summary pattern moves focus to the summary after
+    // a failed *submit*. `errorStrategy` defaults to `'on-touch'`, and the
+    // root FieldTree's `touched()` aggregates children — so merely blurring
+    // the first invalid field would surface the summary. Auto-focusing here
+    // would be an unexpected context change (WCAG 3.2.1/3.2.2) while the
+    // user is still filling out the form, not the documented "arrive after
+    // a failed submit" contract.
+    @Component({
+      selector: 'ngx-test-error-summary-on-touch-no-steal',
+      imports: [FormField, NgxFormFieldErrorSummary],
+
+      template: `
+        <input
+          id="email"
+          data-testid="email-input"
+          [formField]="contactForm.email"
+        />
+        <ngx-form-field-error-summary [formTree]="contactForm" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly contactForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    await render(TestComponent);
+
+    const input = screen.getByTestId('email-input');
+    await userEvent.click(input);
+    await userEvent.tab();
+
+    const summaryAlert = await screen.findByRole('alert');
+    expect(summaryAlert.textContent).toContain('Email is required');
+
+    const focusTarget = summaryAlert.closest('ngx-form-field-error-summary');
+    expect(document.activeElement).not.toBe(focusTarget);
   });
 
   describe('dev-mode focus-failure diagnostic', () => {

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -27,10 +27,16 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
  * - Error links are focusable buttons for keyboard navigation
  * - Each entry identifies the field and the error message
  * - The summary host has `tabindex="-1"` and is **programmatically focused**
- *   the first time it appears with non-zero entries (GOV.UK / WAI tutorial
- *   pattern for WCAG 2.4.3 + 3.3.1). This guarantees screen reader users
- *   land on the summary after submit instead of being left where they were.
- *   Opt out with `[autoFocus]="false"`.
+ *   the first time it appears with non-zero entries under the resolved
+ *   `'on-submit'` strategy (GOV.UK / WAI tutorial pattern for WCAG 2.4.3 +
+ *   3.3.1). This guarantees screen reader users land on the summary after a
+ *   failed submit instead of being left where they were. Auto-focus is
+ *   intentionally skipped for `'on-touch'` / `'immediate'` strategies: the
+ *   root FieldTree's `touched()` aggregates children, so the summary can
+ *   appear the moment the user blurs the first invalid field — focusing it
+ *   then would be an unexpected mid-fill context change (WCAG 3.2.1/3.2.2),
+ *   not the documented "arrive after a failed submit" contract. Opt out of
+ *   the on-submit auto-focus with `[autoFocus]="false"`.
  *
  * ## Usage
  *
@@ -67,8 +73,24 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
     },
   ],
   template: `
-    @if (summary.shouldShow() && summary.hasErrors()) {
-      <div class="ngx-form-field-error-summary" role="alert">
+    <!--
+      The role="alert" container is rendered UNCONDITIONALLY (even when
+      empty), the same always-mounted live-region pattern NgxFormFieldError
+      and NgxFormFieldNotification use: role="alert" only fires reliably on
+      content insertion into a pre-existing live region, so inserting the
+      container and its content in the same tick risks the NVDA + Chrome
+      missed-first-announcement bug. aria-hidden/[hidden] are intentionally
+      never toggled — the @if below already guarantees zero content while
+      empty, so an empty live region announces nothing on its own.
+    -->
+    <div
+      class="ngx-form-field-error-summary"
+      [class.ngx-form-field-error-summary--empty]="
+        !(summary.shouldShow() && summary.hasErrors())
+      "
+      role="alert"
+    >
+      @if (summary.shouldShow() && summary.hasErrors()) {
         @if (summaryLabel()) {
           <p class="ngx-form-field-error-summary__label">
             {{ summaryLabel() }}
@@ -94,8 +116,8 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
             </li>
           }
         </ul>
-      </div>
-    }
+      }
+    </div>
   `,
   styles: `
     .ngx-form-field-error-summary {
@@ -104,6 +126,16 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
       padding: 1rem;
       margin-block: 1rem;
       background: var(--ngx-error-summary-bg, #fef2f2);
+    }
+
+    /* Empty live-region shell: the @if in the template guarantees zero
+     * content while empty, so we additionally zero the box model to
+     * collapse it visually — mirrors the --empty pattern in
+     * NgxFormFieldError / NgxFormFieldNotification. */
+    .ngx-form-field-error-summary--empty {
+      border-width: 0;
+      padding: 0;
+      margin-block: 0;
     }
 
     .ngx-form-field-error-summary__label {
@@ -165,13 +197,21 @@ export class NgxFormFieldErrorSummary {
 
   /**
    * Whether to programmatically focus the summary host the first time it
-   * appears with non-zero entries.
+   * appears with non-zero entries **under the resolved `'on-submit'`
+   * strategy**.
    *
    * The default (`true`) follows the GOV.UK / WAI error-summary pattern so
    * screen-reader users hear the announcement and arrive at the summary
    * after a failed submit. Set to `false` if your flow already moves focus
    * elsewhere (e.g. straight to the first invalid field) or if focus
    * theft is undesirable in your design.
+   *
+   * This input has no effect under `'on-touch'` or `'immediate'` strategies
+   * — auto-focus is always skipped for those, regardless of this value,
+   * because the summary can appear mid-fill (e.g. on blurring the first
+   * invalid field) and stealing focus then would be an unexpected context
+   * change (WCAG 3.2.1/3.2.2), not the documented "arrive after a failed
+   * submit" contract.
    *
    * @default true
    */
@@ -205,6 +245,13 @@ export class NgxFormFieldErrorSummary {
         untracked(() => {
           if (hasFocused) return;
           if (!this.autoFocus()) return;
+          // Only the resolved 'on-submit' strategy matches the documented
+          // GOV.UK/WAI "arrive at the summary after a failed submit"
+          // contract. Under 'on-touch'/'immediate' the summary can appear
+          // mid-fill (e.g. blurring the first invalid field, or on initial
+          // render for an already-invalid form) — auto-focusing there would
+          // be an unexpected context change (WCAG 3.2.1/3.2.2).
+          if (this.summary.resolvedStrategy() !== 'on-submit') return;
 
           const host = this.#host.nativeElement;
           // Defensive: in jsdom-based test environments `focus()` is

--- a/packages/toolkit/assistive/form-field-error.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.browser.spec.ts
@@ -46,11 +46,12 @@ describe('NgxFormFieldError — WCAG 4.1.3 live-region first-insertion', () => {
     const { container } = await render(TestComponent);
 
     // Before any interaction: the alert region must exist (so the first
-    // announcement is delivered) but be hidden + empty.
+    // announcement is delivered) but be empty. `aria-hidden`/`[hidden]` are
+    // intentionally never toggled — see the class-level docs.
     const alertEl = container.querySelector('[role="alert"]');
     expect(alertEl).toBeTruthy();
-    expect(alertEl?.hasAttribute('hidden')).toBe(true);
-    expect(alertEl?.getAttribute('aria-hidden')).toBe('true');
+    expect(alertEl?.hasAttribute('hidden')).toBe(false);
+    expect(alertEl?.hasAttribute('aria-hidden')).toBe(false);
     expect(alertEl?.textContent?.trim()).toBe('');
   });
 
@@ -83,7 +84,7 @@ describe('NgxFormFieldError — WCAG 4.1.3 live-region first-insertion', () => {
 
     const alertBefore = container.querySelector('[role="alert"]');
     expect(alertBefore).toBeTruthy();
-    expect(alertBefore?.hasAttribute('hidden')).toBe(true);
+    expect(alertBefore?.hasAttribute('hidden')).toBe(false);
 
     // Touch + blur to satisfy the on-touch strategy.
     const input = container.querySelector<HTMLInputElement>('input#email')!;
@@ -133,11 +134,11 @@ describe('NgxFormFieldError — WCAG 4.1.3 live-region first-insertion', () => {
     const { container } = await render(TestComponent);
 
     // Before any value: status region must exist (so the first
-    // announcement is delivered) but be hidden + empty.
+    // announcement is delivered) but be empty.
     const statusBefore = container.querySelector('[role="status"]');
     expect(statusBefore).toBeTruthy();
-    expect(statusBefore?.hasAttribute('hidden')).toBe(true);
-    expect(statusBefore?.getAttribute('aria-hidden')).toBe('true');
+    expect(statusBefore?.hasAttribute('hidden')).toBe(false);
+    expect(statusBefore?.hasAttribute('aria-hidden')).toBe(false);
     expect(statusBefore?.textContent?.trim()).toBe('');
 
     // Type a short password to trigger the `warn:weak-password` warning.

--- a/packages/toolkit/assistive/form-field-error.cross-surface.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.cross-surface.spec.ts
@@ -91,8 +91,9 @@ describe('cross-surface: NgxFormFieldError vs NgxHeadlessErrorState', () => {
 
     await render(TestComponent);
 
-    // Before touch: neither surface should show errors
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    // Before touch: neither surface should show errors. The alert shell
+    // stays mounted (WCAG 4.1.3) but must be empty.
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     expect(screen.queryByTestId('custom-error')).toBeFalsy();
 
     // Touch the field to trigger on-touch strategy
@@ -151,8 +152,9 @@ describe('cross-surface: NgxFormFieldError vs NgxHeadlessErrorState', () => {
     // Type a valid value
     await userEvent.type(screen.getByRole('textbox'), 'John');
 
-    // Both surfaces clear together
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    // Both surfaces clear together. The alert shell stays mounted (WCAG
+    // 4.1.3) but must be empty.
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     expect(screen.queryByTestId('custom-error')).toBeFalsy();
   });
 
@@ -205,10 +207,10 @@ describe('cross-surface: NgxFormFieldError vs NgxHeadlessErrorState', () => {
 
     const { container } = await render(TestEmptyDirectErrorsComponent);
 
-    // Live region stays in DOM (WCAG 4.1.3) but is hidden + empty
+    // Live region stays in DOM (WCAG 4.1.3) but is empty
     const alertEl = container.querySelector('[role="alert"]');
     expect(alertEl).toBeTruthy();
-    expect(alertEl?.hasAttribute('hidden')).toBe(true);
+    expect(alertEl?.hasAttribute('hidden')).toBe(false);
     expect(alertEl?.textContent?.trim()).toBe('');
   });
 

--- a/packages/toolkit/assistive/form-field-error.css
+++ b/packages/toolkit/assistive/form-field-error.css
@@ -97,21 +97,20 @@
   margin-top: var(--_error-margin-top);
 }
 
+/* Dark-mode defaults are driven by `prefers-color-scheme` only. An earlier
+ * revision also tried to special-case a `.dark` class ancestor via
+ * `:host-context()`, but that selector is non-standard and unsupported in
+ * Firefox and Safari — the three engines disagreed on the resulting colors
+ * (see the v1.0.0 accessibility audit), risking WCAG 1.4.3 contrast
+ * failures. Class-based ("`.dark` on `<html>`/`<body>`") theming strategies
+ * are not detectable in plain CSS without `:host-context()`; apps using that
+ * strategy must override the public `--ngx-signal-form-error-color` /
+ * `--ngx-signal-form-warning-color` custom properties directly (see README). */
 @media (prefers-color-scheme: dark) {
   :host {
     --_error-clr-danger: var(--_error-clr-danger-dark);
     --_error-clr-warning: var(--_error-clr-warning-dark);
   }
-
-  :host-context(:root:not(.dark)) {
-    --_error-clr-danger: #db1818;
-    --_error-clr-warning: #a16207;
-  }
-}
-
-:host-context(.dark) {
-  --_error-clr-danger: var(--_error-clr-danger-dark);
-  --_error-clr-warning: var(--_error-clr-warning-dark);
 }
 
 .ngx-form-field-error {
@@ -145,13 +144,14 @@
 }
 
 /* Empty live-region shell: the role="alert" / role="status" containers stay
- * mounted (with `aria-hidden="true"` and `[hidden]`) so AT picks up the
- * live region on first content insertion (WCAG 4.1.3). The element is
- * already removed from layout flow by `[hidden]`, but we also clear
- * padding/border/margin defensively in case a consumer overrides the
- * default `display:none` styling (e.g. with `display: contents` for a
- * flex/grid layout) — the empty shell must contribute zero visual
- * footprint regardless of how it is reflowed. */
+ * mounted and exposed (no `aria-hidden`/`[hidden]` toggling — see the
+ * class-level template docs) so AT picks up the live region on first
+ * content insertion (WCAG 4.1.3). The `@if` in the template guarantees zero
+ * content while empty, so the flex container naturally collapses to zero
+ * size; we also clear padding/border/margin defensively in case a consumer
+ * overrides layout (e.g. `display: contents` for a flex/grid layout) — the
+ * empty shell must contribute zero visual footprint regardless of how it is
+ * reflowed. */
 .ngx-form-field-error--empty {
   padding: var(--_error-space-0);
   border-width: var(--_error-space-0);

--- a/packages/toolkit/assistive/form-field-error.integration.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.integration.spec.ts
@@ -43,8 +43,10 @@ describe('NgxFormFieldError (integration)', () => {
 
     await render(TestFormErrorComponent);
 
+    // The alert shell stays mounted (WCAG 4.1.3, always-mounted live
+    // region) but must render no error text.
     const alert = screen.queryByRole('alert');
-    expect(alert).toBeFalsy();
+    expect(alert?.textContent?.trim() ?? '').toBe('');
   });
 
   /**

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -59,7 +59,7 @@ describe('NgxFormFieldError', () => {
 
       // Field is invalid but untouched, no error should be visible
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should NOT show errors when form is unsubmitted and field untouched (on-submit strategy)', async () => {
@@ -91,7 +91,7 @@ describe('NgxFormFieldError', () => {
       await render(TestComponent);
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
   });
 
@@ -182,7 +182,7 @@ describe('NgxFormFieldError', () => {
       await user.tab();
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should not render errors when field is invalid but not touched (on-touch strategy)', async () => {
@@ -215,7 +215,7 @@ describe('NgxFormFieldError', () => {
 
       // Don't touch the field
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should render multiple errors', async () => {
@@ -390,7 +390,7 @@ describe('NgxFormFieldError', () => {
 
       // No error yet (on-submit strategy)
       let alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
 
       // After submission
       fixture.componentInstance.submittedStatus.set('submitted');
@@ -432,7 +432,7 @@ describe('NgxFormFieldError', () => {
 
       // submittedStatus is ignored for on-touch - field must be touched
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should NOT show errors during async submission if not touched (on-touch strategy)', async () => {
@@ -467,7 +467,7 @@ describe('NgxFormFieldError', () => {
 
       // submittedStatus is ignored for on-touch - field must be touched
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should show errors during async submission (on-submit strategy)', async () => {
@@ -533,7 +533,7 @@ describe('NgxFormFieldError', () => {
 
       // Initially no errors (not submitted)
       let alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
 
       // During submission - errors should appear
       fixture.componentInstance.submittedStatus.set('submitting');
@@ -592,8 +592,13 @@ describe('NgxFormFieldError', () => {
        * region. If the alert container itself is added to the DOM at the
        * same moment as the first error, the very first announcement can be
        * silently dropped. v1 keeps the role="alert" container always
-       * mounted (and aria-hidden="true" while empty) so that timing
-       * edge case never trips screen readers.
+       * mounted so that timing edge case never trips screen readers. It
+       * does NOT toggle `aria-hidden`/`[hidden]` while empty — doing so
+       * would prune the node from the accessibility tree and then expose it
+       * at the same tick the first error is inserted, which is functionally
+       * equivalent to a fresh live-region insertion and reintroduces the
+       * same missed-first-announcement bug the always-mounted container
+       * exists to avoid.
        */
       @Component({
         selector: 'ngx-test-empty-live-region',
@@ -626,23 +631,21 @@ describe('NgxFormFieldError', () => {
       // but the live-region container itself MUST already be in the DOM
       // with role="alert" so a future insertion fires the announcement.
       // The container carries the `--empty` marker class so CSS can
-      // collapse it visually; `aria-hidden="true"` keeps AT silent until
-      // content arrives, and `[hidden]` removes the empty shell from
-      // layout flow.
+      // collapse it visually. `aria-hidden`/`[hidden]` are intentionally
+      // absent — toggling them off at the same tick content is inserted
+      // would defeat the always-mounted pattern (see class-level docs).
       const alertContainer = container.querySelector('[role="alert"]');
       expect(alertContainer).toBeTruthy();
       expect(
         alertContainer?.classList.contains('ngx-form-field-error--empty'),
       ).toBe(true);
-      expect(alertContainer?.getAttribute('aria-hidden')).toBe('true');
-      expect(alertContainer?.hasAttribute('hidden')).toBe(true);
+      expect(alertContainer?.hasAttribute('aria-hidden')).toBe(false);
+      expect(alertContainer?.hasAttribute('hidden')).toBe(false);
       // No id leaks while empty — aria-describedby targets must not point
-      // at an element with no message text. Angular renders `null`
-      // bindings as either a missing attribute or the literal string
-      // "null" depending on the jsdom path; what matters here is that
-      // the auto-generated `*-error` id is not exposed.
-      const idAttr = alertContainer?.getAttribute('id') ?? null;
-      expect(idAttr === null || idAttr === '' || idAttr === 'null').toBe(true);
+      // at an element with no message text. `[attr.id]` removes the
+      // attribute entirely for a `null` binding (unlike the property
+      // binding `[id]`, which would coerce to the literal string "null").
+      expect(alertContainer?.hasAttribute('id')).toBe(false);
       // No error text either.
       expect(alertContainer?.textContent?.trim()).toBe('');
 
@@ -652,8 +655,8 @@ describe('NgxFormFieldError', () => {
       expect(
         statusContainer?.classList.contains('ngx-form-field-error--empty'),
       ).toBe(true);
-      expect(statusContainer?.getAttribute('aria-hidden')).toBe('true');
-      expect(statusContainer?.hasAttribute('hidden')).toBe(true);
+      expect(statusContainer?.hasAttribute('aria-hidden')).toBe(false);
+      expect(statusContainer?.hasAttribute('hidden')).toBe(false);
     });
 
     it('should rely on role="alert" implicit semantics (no redundant aria-live/aria-atomic)', async () => {
@@ -794,7 +797,7 @@ describe('NgxFormFieldError', () => {
       await user.tab();
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should handle empty errors array', async () => {
@@ -827,7 +830,7 @@ describe('NgxFormFieldError', () => {
       await user.tab();
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     // Regression: when both `[formField]` and `[errors]` are bound, the
@@ -1052,12 +1055,9 @@ describe('NgxFormFieldError', () => {
         // Without a field name the auto-generated id would look like
         // `-error` / `-warning`, which is a broken aria-describedby
         // target. The v1 contract is simply: no resolvable field name →
-        // no id chain exposed. We accept any "empty-ish" id value here
-        // (null, "", or literally "null" which some JSDOM pathways emit
-        // when binding null) — the important assertion is that no
-        // `*-error` id leaks into the DOM.
-        const idAttr = alert.getAttribute('id');
-        expect(idAttr?.endsWith('-error') ?? false).toBe(false);
+        // no id chain exposed. `[attr.id]` removes the attribute entirely
+        // for a `null` binding, so the id attribute must be absent.
+        expect(alert.hasAttribute('id')).toBe(false);
         expect(alert.textContent).toContain('Email is required');
 
         expect(errorSpy).toHaveBeenCalled();
@@ -1180,7 +1180,7 @@ describe('NgxFormFieldError', () => {
       expect(status.textContent).toContain('Consider 8+ characters');
 
       // Errors stay hidden — only the warning is visible.
-      expect(screen.queryByRole('alert')).toBeFalsy();
+      expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     });
 
     it('gates warnings behind touch when warningStrategy is on-touch', async () => {
@@ -1189,7 +1189,7 @@ describe('NgxFormFieldError', () => {
       fixture.detectChanges();
 
       // Untouched: warning hidden.
-      expect(screen.queryByRole('status')).toBeFalsy();
+      expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
 
       // Touching the field surfaces the warning.
       fixture.componentInstance.contactForm.password().markAsTouched();
@@ -1207,7 +1207,7 @@ describe('NgxFormFieldError', () => {
       // Unsubmitted: warning hidden even when touched.
       fixture.componentInstance.contactForm.password().markAsTouched();
       fixture.detectChanges();
-      expect(screen.queryByRole('status')).toBeFalsy();
+      expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
 
       // After submit, warning surfaces.
       fixture.componentInstance.submittedStatus.set('submitted');
@@ -1231,7 +1231,7 @@ describe('NgxFormFieldError', () => {
       expect(status.textContent).toContain('Consider 8+ characters');
 
       // Errors still gated by submit.
-      expect(screen.queryByRole('alert')).toBeFalsy();
+      expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     });
   });
 });

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -114,17 +114,21 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
       pre-existing live region — works the very first time an error appears.
       This satisfies WCAG 4.1.3 (Status Messages) and avoids the NVDA + Chrome
       timing edge case where a freshly-inserted live region misses its first
-      announcement. We mark the container as aria-hidden="true" while empty
-      so it is invisible to AT and contributes no whitespace text to the
-      accessibility tree, but never toggle the role attribute itself.
+      announcement. We intentionally do NOT toggle aria-hidden/[hidden]
+      while empty: the @if below already guarantees zero content (including
+      whitespace text) when empty, so an empty live region announces nothing
+      on its own — flipping aria-hidden off at the same tick the first
+      error is inserted would prune-then-immediately-expose the node, which
+      is functionally equivalent to inserting a brand-new live region and
+      reintroduces the very missed-first-announcement bug this pattern exists
+      to avoid. Visual collapse while empty is handled by the --empty CSS
+      class alone.
     -->
     <div
-      [id]="errorContainerVisible() ? errorId() : null"
+      [attr.id]="errorContainerVisible() ? errorId() : null"
       class="ngx-form-field-error ngx-form-field-error--error"
       [class.ngx-form-field-error--empty]="!errorContainerVisible()"
       role="alert"
-      [attr.aria-hidden]="errorContainerVisible() ? null : 'true'"
-      [hidden]="!errorContainerVisible()"
     >
       @if (errorContainerVisible()) {
         @if (usesBulletList()) {
@@ -159,15 +163,13 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
       Non-blocking Warnings: role="status" implies aria-live="polite" and
       aria-atomic="true"; the explicit attributes are intentionally omitted
       to avoid duplicate AT announcements. Same empty-live-region pattern as
-      the alert container above.
+      the alert container above (no aria-hidden/[hidden] toggling).
     -->
     <div
-      [id]="warningContainerVisible() ? warningId() : null"
+      [attr.id]="warningContainerVisible() ? warningId() : null"
       class="ngx-form-field-error ngx-form-field-error--warning"
       [class.ngx-form-field-error--empty]="!warningContainerVisible()"
       role="status"
-      [attr.aria-hidden]="warningContainerVisible() ? null : 'true'"
-      [hidden]="!warningContainerVisible()"
     >
       @if (warningContainerVisible()) {
         @if (usesBulletList()) {

--- a/packages/toolkit/assistive/form-field-notification.cross-surface.spec.ts
+++ b/packages/toolkit/assistive/form-field-notification.cross-surface.spec.ts
@@ -178,7 +178,7 @@ describe('cross-surface: NgxFormFieldNotification vs NgxHeadlessNotification', (
     expect(screen.queryByTestId('custom-warning')).toBeFalsy();
   });
 
-  it('empty error list keeps both live regions hidden but in DOM (WCAG 4.1.3)', async () => {
+  it('empty error list keeps both live regions empty but in DOM (WCAG 4.1.3)', async () => {
     @Component({
       selector: 'test-notification-cross-surface-empty',
       imports: [NgxFormFieldNotification],
@@ -197,7 +197,7 @@ describe('cross-surface: NgxFormFieldNotification vs NgxHeadlessNotification', (
     const statusEl = container.querySelector('[role="status"]');
     expect(alertEl).toBeTruthy();
     expect(statusEl).toBeTruthy();
-    expect(alertEl?.hasAttribute('hidden')).toBe(true);
-    expect(statusEl?.hasAttribute('hidden')).toBe(true);
+    expect(alertEl?.hasAttribute('hidden')).toBe(false);
+    expect(statusEl?.hasAttribute('hidden')).toBe(false);
   });
 });

--- a/packages/toolkit/assistive/form-field-notification.css
+++ b/packages/toolkit/assistive/form-field-notification.css
@@ -155,6 +155,15 @@
   display: block;
 }
 
+/* Dark-mode defaults are driven by `prefers-color-scheme` only. An earlier
+ * revision also tried to special-case a `.dark` class ancestor via
+ * `:host-context()`, but that selector is non-standard and unsupported in
+ * Firefox and Safari — the three engines disagreed on the resulting colors
+ * (see the v1.0.0 accessibility audit), risking WCAG 1.4.3 contrast
+ * failures. Class-based ("`.dark` on `<html>`/`<body>`") theming strategies
+ * are not detectable in plain CSS without `:host-context()`; apps using that
+ * strategy must override the public `--ngx-signal-form-notification-*`
+ * custom properties directly (see README). */
 @media (prefers-color-scheme: dark) {
   :host {
     --_notification-clr-danger: var(--_notification-clr-danger-dark);
@@ -162,24 +171,6 @@
     --_notification-clr-warning: var(--_notification-clr-warning-dark);
     --_notification-bg-warning-light: var(--_notification-bg-warning-dark);
   }
-
-  :host-context(:root:not(.dark)) {
-    --_notification-clr-danger: #db1818;
-    --_notification-clr-danger-soft: #fdebeb;
-    --_notification-clr-warning: #a16207;
-    --_notification-bg-warning-light: color-mix(
-      in srgb,
-      var(--_notification-clr-warning) 10%,
-      white
-    );
-  }
-}
-
-:host-context(.dark) {
-  --_notification-clr-danger: var(--_notification-clr-danger-dark);
-  --_notification-clr-danger-soft: var(--_notification-bg-danger-dark);
-  --_notification-clr-warning: var(--_notification-clr-warning-dark);
-  --_notification-bg-warning-light: var(--_notification-bg-warning-dark);
 }
 
 .ngx-form-field-notification {

--- a/packages/toolkit/assistive/form-field-notification.spec.ts
+++ b/packages/toolkit/assistive/form-field-notification.spec.ts
@@ -86,9 +86,10 @@ describe('NgxFormFieldNotification', () => {
       },
     );
 
-    // Mixed lists resolve to error: blocking wins over warnings.
+    // Mixed lists resolve to error: blocking wins over warnings. The
+    // status shell stays mounted (WCAG 4.1.3) but must be empty.
     expect(screen.getByRole('alert')).toBeTruthy();
-    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
     expect(container.querySelector('#mixed-group-error')).toBeTruthy();
     expect(container.querySelector('#mixed-group-warning')).toBeNull();
   });
@@ -112,7 +113,7 @@ describe('NgxFormFieldNotification', () => {
     );
 
     expect(screen.getByRole('status')).toBeTruthy();
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
   });
 
   it('keeps alert semantics for blocking errors even when tone="warning"', async () => {
@@ -134,7 +135,7 @@ describe('NgxFormFieldNotification', () => {
     );
 
     expect(screen.getByRole('alert')).toBeTruthy();
-    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
   });
 
   it('keeps the error container id while blocking errors exist, regardless of tone', async () => {
@@ -187,7 +188,7 @@ describe('NgxFormFieldNotification', () => {
     expect(container.querySelector('#static-field-error')).toBeTruthy();
   });
 
-  it('keeps an empty shell mounted with aria-hidden and no id when errors are undefined', async () => {
+  it('keeps an empty shell mounted with no id when errors are undefined', async () => {
     const { container } = await render(
       `<ngx-form-field-notification fieldName="empty-shell" />`,
       { imports: [NgxFormFieldNotification] },
@@ -198,12 +199,14 @@ describe('NgxFormFieldNotification', () => {
     expect(
       shell?.classList.contains('ngx-form-field-notification--empty'),
     ).toBe(true);
-    expect(shell?.getAttribute('aria-hidden')).toBe('true');
+    // `aria-hidden`/`[hidden]` are intentionally never toggled — see the
+    // class-level docs on the always-mounted live-region pattern.
+    expect(shell?.hasAttribute('aria-hidden')).toBe(false);
     expect(shell?.id).toBe('');
     expect(container.querySelector('#empty-shell-error')).toBeNull();
   });
 
-  it('keeps an empty shell mounted with aria-hidden when errors is an empty array', async () => {
+  it('keeps an empty shell mounted with no id when errors is an empty array', async () => {
     const errors = signal<readonly { kind: string; message: string }[]>([]);
 
     const { container } = await render(
@@ -221,7 +224,7 @@ describe('NgxFormFieldNotification', () => {
     expect(
       shell?.classList.contains('ngx-form-field-notification--empty'),
     ).toBe(true);
-    expect(shell?.getAttribute('aria-hidden')).toBe('true');
+    expect(shell?.hasAttribute('aria-hidden')).toBe(false);
     expect(shell?.id).toBe('');
   });
 

--- a/packages/toolkit/assistive/form-field-notification.ts
+++ b/packages/toolkit/assistive/form-field-notification.ts
@@ -59,7 +59,12 @@ export type NgxFormFieldNotificationTone = NgxNotificationTone;
       role is never re-assigned at the same tick as content insertion. Toggling
       role between alert and status when the first message arrives is the same
       bug class NgxFormFieldError works around (NVDA + Chrome miss the very
-      first announcement when role and content arrive together).
+      first announcement when role and content arrive together). We also do
+      NOT toggle aria-hidden/[hidden] while empty — the @if below already
+      guarantees zero content, and flipping aria-hidden off in the same tick
+      content is inserted is functionally equivalent to a fresh live-region
+      insertion, reintroducing the same missed-first-announcement bug. Visual
+      collapse while empty is handled by the --empty CSS class alone.
     -->
     <div
       class="ngx-form-field-notification ngx-form-field-notification--error"
@@ -70,8 +75,6 @@ export type NgxFormFieldNotificationTone = NgxNotificationTone;
         headless.showErrorContainer() ? headless.errorContainerId() : null
       "
       role="alert"
-      [attr.aria-hidden]="headless.showErrorContainer() ? null : 'true'"
-      [hidden]="!headless.showErrorContainer()"
     >
       @if (headless.showErrorContainer()) {
         @if (title()) {
@@ -113,8 +116,6 @@ export type NgxFormFieldNotificationTone = NgxNotificationTone;
         headless.showWarningContainer() ? headless.warningContainerId() : null
       "
       role="status"
-      [attr.aria-hidden]="headless.showWarningContainer() ? null : 'true'"
-      [hidden]="!headless.showWarningContainer()"
     >
       @if (headless.showWarningContainer()) {
         @if (title()) {

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -159,6 +159,7 @@ describe('NgxFormFieldset', () => {
     /// stays mounted (WCAG 4.1.3, always-mounted live region) but must be
     /// empty.
     const warnings = screen.queryAllByRole('status');
+    expect(warnings).not.toHaveLength(0);
     for (const warning of warnings) {
       expect(warning.textContent?.trim() ?? '').toBe('');
     }

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -155,9 +155,13 @@ describe('NgxFormFieldset', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]?.textContent).toContain('City required');
 
-    /// Warning should be suppressed when error is shown
+    /// Warning should be suppressed when error is shown. The status shell
+    /// stays mounted (WCAG 4.1.3, always-mounted live region) but must be
+    /// empty.
     const warnings = screen.queryAllByRole('status');
-    expect(warnings).toHaveLength(0);
+    for (const warning of warnings) {
+      expect(warning.textContent?.trim() ?? '').toBe('');
+    }
   });
 
   it('shows warnings when no blocking errors exist', async () => {

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -2,8 +2,11 @@ import { computed, Directive, inject, input, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   createErrorVisibility,
+  injectFormContext,
+  resolveStrategyFromContext,
   splitByKind,
   type ErrorDisplayStrategy,
+  type ResolvedErrorDisplayStrategy,
   type SubmittedStatus,
 } from '@ngx-signal-forms/toolkit';
 import {
@@ -40,6 +43,14 @@ export interface ErrorSummarySignals {
   readonly hasWarnings: Signal<boolean>;
   /** Whether the summary should be visible based on strategy */
   readonly shouldShow: Signal<boolean>;
+  /**
+   * The fully-resolved error display strategy: explicit `strategy` input →
+   * form context → `'on-touch'` default. Consumers that need to distinguish
+   * a submit-driven appearance (e.g. to decide whether to move focus) from
+   * an on-touch/immediate one should read this rather than the raw
+   * `strategy` input, which may be `undefined`.
+   */
+  readonly resolvedStrategy: Signal<ResolvedErrorDisplayStrategy>;
   /** Focus the control for the first error entry */
   readonly focusFirst: () => void;
 }
@@ -61,14 +72,19 @@ export interface ErrorSummarySignals {
  *
  * ## Usage
  *
+ * The `role="alert"` container should be rendered UNCONDITIONALLY (even
+ * while empty) rather than inserted together with its content — the same
+ * always-mounted live-region pattern `NgxFormFieldError` and
+ * `NgxFormFieldNotification` use. `role="alert"` only reliably fires on
+ * content insertion into a *pre-existing* live region; mounting the
+ * container and its content in the same tick risks the NVDA + Chrome
+ * missed-first-announcement bug. Gate only the inner content on
+ * `shouldShow()`/`hasErrors()`, not the container itself:
+ *
  * ```html
- * <div
- *   ngxHeadlessErrorSummary
- *   #summary="errorSummary"
- *   [formTree]="myForm"
- * >
- *   @if (summary.shouldShow() && summary.hasErrors()) {
- *     <ul role="alert">
+ * <div ngxHeadlessErrorSummary #summary="errorSummary" [formTree]="myForm">
+ *   <ul role="alert">
+ *     @if (summary.shouldShow() && summary.hasErrors()) {
  *       @for (entry of summary.entries(); track entry.kind + entry.fieldName) {
  *         <li>
  *           <button type="button" (click)="entry.focus()">
@@ -76,8 +92,8 @@ export interface ErrorSummarySignals {
  *           </button>
  *         </li>
  *       }
- *     </ul>
- *   }
+ *     }
+ *   </ul>
  * </div>
  * ```
  */
@@ -92,6 +108,7 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
   readonly #labelResolver = inject(NGX_FIELD_LABEL_RESOLVER, {
     optional: true,
   });
+  readonly #formContext = injectFormContext();
 
   /**
    * The root form FieldTree to aggregate errors from.
@@ -109,6 +126,10 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
    * If not provided, inherits from form context.
    */
   readonly submittedStatus = input<SubmittedStatus | undefined>();
+
+  readonly resolvedStrategy = computed(() =>
+    resolveStrategyFromContext(this.strategy(), this.#formContext),
+  );
 
   readonly #fieldState = computed(() => this.formTree()());
 


### PR DESCRIPTION
Closes #163

Fixes 6 of 7 verified blocker findings from the assistive audit (#141); one is resolved as a documentation-only fix rather than an API removal (see below).

## Fixes

1. **`id="null"` leak (bug)** — `NgxFormFieldError`'s error/warning containers used a *property* binding (`[id]`), which coerces `null` to the DOM string `"null"`. Switched to `[attr.id]` (matching `NgxFormFieldNotification`) so `null` removes the attribute entirely. Tightened the existing spec assertions accordingly.

2. **Error summary `autoFocus` stealing focus mid-fill (a11y)** — `NgxFormFieldErrorSummary`'s `autoFocus` fired on every 0→N entries transition, including under the default `'on-touch'` strategy, silently stealing focus (WCAG 3.2.1/3.2.2) and contradicting the documented "focus after a failed submit" contract. `autoFocus` now only fires when the resolved strategy is `'on-submit'`. Added a `resolvedStrategy` signal to `NgxHeadlessErrorSummary` (headless) so custom summary UIs can replicate the gating. Added a regression test for the on-touch case (failed before the fix, passes after).

3. **Error summary inserting `role="alert"` with its content (a11y)** — the summary's live-region container was only mounted once there were entries, risking the NVDA+Chrome missed-first-announcement bug on the first submit. It's now rendered unconditionally (empty shell), matching `NgxFormFieldError`/`NgxFormFieldNotification`. Updated the `NgxHeadlessErrorSummary` usage-doc example to show the same pattern.

4. **`aria-hidden`/`[hidden]` toggling defeating the always-mounted pattern (a11y)** — flipping `aria-hidden` off in the same tick the first error/warning/entry is inserted is functionally equivalent to inserting a brand-new live region. Dropped `aria-hidden`/`[hidden]` toggling from `NgxFormFieldError` and `NgxFormFieldNotification`; the existing `@if` already guarantees zero content while empty, and the `--empty` CSS class handles visual collapse. Updated every spec that asserted "no alert/status element" for empty regions to instead assert on empty text content (the container is now always present).

5. **`tone` documented as functional but is a no-op (api-design)** — `NgxHeadlessNotification.tone` is already honestly documented as a no-op in its own JSDoc ("retained as a stable API surface for future expansion"). The only inaccuracy was the assistive README implying `tone="error"`/`tone="warning"` forces the rendered tone. **Chose the documentation-fix option** over removing the input: removal would require redesigning/retesting the headless entry point's own tested contract (5 tests + its own README table), which is a bigger cross-area change than this ticket's scope. Corrected the assistive README table/description to say tone is content-driven.

6. **Dark mode via non-standard `:host-context(.dark)` (a11y)** — unsupported in Firefox/Safari, causing the three engines to disagree on colors (including WCAG 1.4.3 contrast failures in some configurations). Removed the `:host-context()` heuristic from `form-field-error.css` / `form-field-notification.css`; dark defaults are now driven by `prefers-color-scheme` only. Documented the override path (public `--ngx-signal-form-*` custom properties) in the assistive README and migration guide.

7. **README hint-alignment default wrong (docs)** — README said hints right-align by default; the implementation default is left. Corrected the README.

## Bonus fix

Found and fixed a pre-existing syntax error in `form-field-error.ts`/`form-field-notification.ts`: literal backticks inside the `template: \`...\`` JS template literals (left over from an interrupted prior attempt at fixes #1/#4) were silently breaking the whole toolkit test suite's compile step. Confirmed the full suite is green after the fix.

## Breaking changes (documented in `docs/MIGRATING_BETA_TO_V1.md` §6)

- `[id]` → `[attr.id]`: the `id` attribute is now absent instead of `"null"` when unresolvable.
- Empty live regions no longer carry `aria-hidden`/`[hidden]`; role-based queries (e.g. Testing Library) now always find the container — assert on content instead of presence.
- `NgxFormFieldErrorSummary`'s `autoFocus` no longer fires under `'on-touch'`/`'immediate'` strategies.
- Dark mode no longer detects a `.dark` ancestor class via `:host-context()` — class-based dark-mode apps must override the public `--ngx-signal-form-*` custom properties directly.

## Verification

- `pnpm nx run-many -t test,lint,build --projects=toolkit` — green (71 test files / 1169 tests, no lint errors, build succeeds), run 3x with `--skip-nx-cache` to confirm no flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)