### PR TITLE
fix(headless): resolve v1.0.0 audit blockers

### DIFF
--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -44,6 +44,9 @@ releases will not include any of the renames below.
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
+- **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§9](#9-headless-audit-fixes-v100))
+- **BREAKING: `CharacterCountResult` members are now typed `Signal<T>`** (was the looser `ReadSignal<T>` alias); a new `hasLimit` member was added — compile-time tightening only, no runtime change
+- **Bug fix** — error summary no longer drops a second field's error when two different fields share the same kind + message-less default; `NgxHeadlessNotification` no longer leaks the internal `warn:` prefix; `createErrorMessageSignal`'s ID fallback strips Angular's internal `{appId}.form{n}.` prefix; required `Date`/`File`/`Map`-valued leaves no longer vanish from field-optionality summaries
 
 ---
 
@@ -693,6 +696,92 @@ queried the attributes in tests — switch tests to assert `role` instead.
 Peer dependencies now constrain `@angular/core` and `@angular/forms` to
 `>=22.0.0 <23.0.0`. See [`COMPATIBILITY.md`](../COMPATIBILITY.md) for the
 reasoning. If you are already on Angular 22, no migration action is required.
+
+---
+
+## 9. Headless audit fixes (v1.0.0)
+
+A pre-1.0 audit of `@ngx-signal-forms/toolkit/headless` found a handful of
+correctness and API-surface issues. Fixes shipped together; the API-affecting
+ones are called out here.
+
+### `ErrorSummarySignals.shouldShowWarnings` (new, breaking for interface implementers)
+
+`NgxHeadlessErrorSummary.shouldShow` gates `entries()` on `strategy &&
+hasErrors()`. That gate can never reveal `warningEntries()` on a warnings-only
+form, because `hasErrors()` is permanently `false` when there are no blocking
+errors. `ErrorSummarySignals` now declares a dedicated
+`shouldShowWarnings: Signal<boolean>` (`strategy && hasWarnings()`) — gate
+`warningEntries()` on this instead of `shouldShow()`:
+
+```html
+<!-- before — warnings could never render -->
+@if (summary.shouldShow()) { @for (e of summary.warningEntries(); track e.kind)
+{ … } }
+
+<!-- after -->
+@if (summary.shouldShowWarnings()) { @for (e of summary.warningEntries(); track
+e.kind) { … } }
+```
+
+If you implement `ErrorSummarySignals` yourself (e.g. a custom summary
+directive), add the new member.
+
+### `CharacterCountResult` — real `Signal<T>` typing + `hasLimit`
+
+`createCharacterCount()`'s return type previously typed every member as the
+looser `ReadSignal<T>` (`= () => T`) alias, even though every member was
+already a real `computed()` at runtime. Members are now typed `Signal<T>`,
+matching `NgxHeadlessCharacterCount`'s own `CharacterCountStateSignals`. A new
+`hasLimit: Signal<boolean>` member was added (always `true` — `maxLength` is
+required — kept for symmetry with the directive's `hasLimit`). This is a
+compile-time tightening with no runtime change; it only affects code that
+assigned the factory's return values to a hand-rolled `() => T`-shaped type
+that isn't a real `Signal`.
+
+### Error summary: per-field deduplication
+
+`NgxHeadlessErrorSummary` deduplicated entries by `kind + message` only. Two
+different fields both failing `required()` with no custom `message` (Angular's
+default `ValidationError.message` is `undefined`) shared the same dedupe key
+and the second field's error was silently dropped from the summary — a WCAG
+3.3.1 violation. Deduplication is now per-field. If your tests asserted the
+old (buggy) collapsed count for a summary with multiple message-less errors on
+distinct fields, update the expected entry count.
+
+`NgxHeadlessFieldset`'s grouped-message dedupe (a documented feature, not a
+bug) is unchanged.
+
+### `NgxHeadlessNotification` — warning messages no longer leak `warn:`
+
+Message-less warnings with an unknown kind (e.g. `warningError('weak_password')`)
+previously rendered as `warn:weak password` inside the notification's warning
+live region because the internal `warn:` prefix wasn't stripped. It now
+resolves to `weak password`, consistent with every other headless surface
+(`NgxHeadlessErrorState`, `NgxHeadlessErrorSummary`,
+`createErrorMessageSignal`). Update any test/snapshot asserting the old
+`warn:`-prefixed text.
+
+### `createErrorMessageSignal` — ID fallback strips the Angular-internal prefix
+
+When `options.fieldName` is omitted, the per-error DOM id fallback previously
+used `FieldState.name()` raw — which is Angular-internal-prefixed
+(`${APP_ID}.form${n}.path`, e.g. `ng.form0.email`) and varies per form
+instance. IDs are now derived from the stripped path (`email-error-required`),
+matching the ids the in-tree wrapper and other consumers derive from the same
+field. This restores the documented "lockstep" ID guarantee; pass an explicit
+`fieldName` if you need to keep a specific id shape.
+
+### Field-optionality — `Date` / `File` / `Map`-valued required leaves
+
+`summarizeFieldOptionality()` / `createFieldOptionalitySummary()` walked the
+`FieldTree` using "is this node iterable?" as a container check. Angular gives
+any field whose _current_ value is a non-null object (including `Date`,
+`File`, `Map`) an iterator, so a required `Date | null` field flipped out of
+the walk — and lost its `hasRequired` contribution — the moment it was
+populated. The walk now distinguishes genuine structural containers (plain
+objects / arrays) from boxed leaf values, so a required `Date`/`File`/`Map`
+leaf is counted consistently whether it's `null` or populated.
 
 ---
 

--- a/packages/toolkit/core/utilities/humanize-field-path.ts
+++ b/packages/toolkit/core/utilities/humanize-field-path.ts
@@ -1,9 +1,14 @@
-const ANGULAR_FORM_NAME_PREFIX = /^ng\.form\d+\./u;
+// Angular's real prefix is `${APP_ID}.form{n}.` — APP_ID defaults to `'ng'`
+// in production but is configurable (e.g. `provideAppId()`) and differs in
+// test environments (`BrowserTestingModule` uses `'a'`). Match any app-id
+// segment (no dots) rather than hardcoding `ng`, or the prefix silently
+// survives stripping whenever APP_ID isn't the production default.
+const ANGULAR_FORM_NAME_PREFIX = /^[^.]+\.form\d+\./u;
 
 /**
- * Strips the Angular internal form prefix (`ng.form0.`) from a field path,
- * splits camelCase, capitalizes each segment, and joins nested paths with
- * ` / `.
+ * Strips the Angular internal form prefix (`{appId}.form0.`) from a field
+ * path, splits camelCase, capitalizes each segment, and joins nested paths
+ * with ` / `.
  *
  * This is the default field-label resolver used by error summaries. Override
  * it globally via `provideFieldLabels()` or `NGX_FIELD_LABEL_RESOLVER`.
@@ -50,9 +55,11 @@ export function humanizeFieldPath(fieldName: string): string {
 /**
  * Strips the Angular internal form prefix from a raw field name.
  *
- * Resolver functions receive the stripped path, not the raw `ng.form0.*` name.
+ * Resolver functions receive the stripped path, not the raw `{appId}.form0.*`
+ * name.
  *
- * @param rawName - Raw field name that may include Angular's `ng.form{n}.` prefix
+ * @param rawName - Raw field name that may include Angular's
+ *   `{appId}.form{n}.` prefix
  * @returns Field name with the Angular internal form prefix removed
  *
  * @packageInternal Used only within `@ngx-signal-forms/toolkit` package entries.

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -102,12 +102,13 @@ Selector: `[ngxHeadlessErrorState]` · Export: `errorState`
 
 Exposes error state signals for custom error display.
 
-| Input             | Type                        | Description                                                                              |
-| ----------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
-| `field`           | `FieldTree` (required)      | The field to track                                                                       |
-| `fieldName`       | `string \| null` (required) | Field name for ID generation. Pass `null` to disable id generation until a name resolves |
-| `strategy`        | `ErrorDisplayStrategy`      | Override (inherits from context)                                                         |
-| `submittedStatus` | `SubmittedStatus`           | Override for `'on-submit'` strategy                                                      |
+| Input             | Type                                            | Description                                                                                                                                                   |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `field`           | `FieldTree` (optional)                          | The field to track. Omit when using `errorsOverride` or the host `connectFieldState()` bridge                                                                 |
+| `fieldName`       | `string \| null` (optional, default `null`)     | Field name for ID generation. Pass `null` (or omit) to disable id generation until a name resolves                                                            |
+| `errorsOverride`  | `Signal<readonly ValidationError[]>` (optional) | Pre-aggregated errors that replace field-based extraction (e.g. for fieldsets). When provided, `field` is not required and `showErrors` always returns `true` |
+| `strategy`        | `ErrorDisplayStrategy`                          | Override (inherits from context)                                                                                                                              |
+| `submittedStatus` | `SubmittedStatus`                               | Override for `'on-submit'` strategy                                                                                                                           |
 
 Signals: `showErrors()`, `showWarnings()`, `hasErrors()`, `hasWarnings()`, `errors()`, `warnings()`, `resolvedErrors()`, `resolvedWarnings()`, `errorId` (nullable), `warningId` (nullable).
 
@@ -123,7 +124,9 @@ Aggregates all errors from a form tree. Each entry has a `focus()` method that c
 | `strategy`        | `ErrorDisplayStrategy` | Override (inherits from context)    |
 | `submittedStatus` | `SubmittedStatus`      | Override for `'on-submit'` strategy |
 
-Signals: `entries()`, `warningEntries()`, `hasErrors()`, `hasWarnings()`, `shouldShow()`, `focusFirst()`.
+Signals: `entries()`, `warningEntries()`, `hasErrors()`, `hasWarnings()`, `shouldShow()`, `shouldShowWarnings()`, `focusFirst()`.
+
+`shouldShow()` gates `entries()` (strategy && `hasErrors()`); `shouldShowWarnings()` gates `warningEntries()` (strategy && `hasWarnings()`) — a warnings-only form has no blocking errors, so `shouldShow()` alone can never reveal warnings.
 
 ### NgxHeadlessCharacterCount
 
@@ -131,12 +134,12 @@ Selector: `[ngxHeadlessCharacterCount]` · Export: `characterCount`
 
 Provides character count signals with progressive limit states.
 
-| Input              | Type                | Default  | Description     |
-| ------------------ | ------------------- | -------- | --------------- |
-| `field`            | `FieldTree<string>` | required | String field    |
-| `maxLength`        | `number`            | required | Character limit |
-| `warningThreshold` | `number`            | `0.8`    | Warning at 80%  |
-| `dangerThreshold`  | `number`            | `0.95`   | Danger at 95%   |
+| Input              | Type                             | Default  | Description                                              |
+| ------------------ | -------------------------------- | -------- | -------------------------------------------------------- |
+| `field`            | `FieldTree<CharacterCountValue>` | required | `string \| readonly string[] \| null \| undefined` field |
+| `maxLength`        | `number`                         | required | Character limit                                          |
+| `warningThreshold` | `number`                         | `0.8`    | Warning at 80%                                           |
+| `dangerThreshold`  | `number`                         | `0.95`   | Danger at 95%                                            |
 
 Signals: `currentLength()`, `resolvedMaxLength()`, `remaining()`, `limitState()` (`'ok' | 'warning' | 'danger' | 'exceeded'`), `hasLimit()`, `isExceeded()`, `percentUsed()`.
 
@@ -252,7 +255,7 @@ humanizeFieldPath('address.postalCode'); // 'Address / Postal code'
 createUniqueId('field'); // 'field-1', 'field-2', ...
 
 // Error-summary building blocks (what NgxHeadlessErrorSummary uses internally)
-toErrorSummaryEntry(data); // ErrorSummaryEntryData → entry with focus()
+toErrorSummaryEntry(error); // ValidationError → ErrorSummaryEntryData with focus()
 focusBoundControlFromError(error); // focus the control bound to an error
 
 // Required/optional leaf summary for a form tree (drives marking legends)

--- a/packages/toolkit/headless/src/lib/character-count.ts
+++ b/packages/toolkit/headless/src/lib/character-count.ts
@@ -82,8 +82,8 @@ export const DEFAULT_DANGER_THRESHOLD = 0.95;
  * The limit state transitions based on configurable thresholds:
  * - **ok**: Under warning threshold (default < 80%)
  * - **warning**: At/above warning, under danger (default 80-94%)
- * - **danger**: At/above danger, under exceeded (default 95-99%)
- * - **exceeded**: At or above 100%
+ * - **danger**: At/above danger, up to and including 100% (default 95-100%)
+ * - **exceeded**: Over 100%
  *
  * @example Custom thresholds
  * ```html

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
@@ -1,10 +1,17 @@
 import {
+  Component,
   Injector,
   runInInjectionContext,
   signal,
   type Signal,
 } from '@angular/core';
-import type { ValidationError } from '@angular/forms/signals';
+import { TestBed } from '@angular/core/testing';
+import {
+  form,
+  required,
+  schema,
+  type ValidationError,
+} from '@angular/forms/signals';
 import {
   NGX_ERROR_MESSAGES,
   type ErrorMessageRegistry,
@@ -472,5 +479,40 @@ describe('createErrorMessageSignal — edge cases', () => {
     );
 
     expect(result()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real FieldTree name() fallback — no `fieldName` option supplied
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — name() fallback on a real field', () => {
+  it('strips the Angular-internal `ng.formN.` prefix from the field name fallback', () => {
+    // Angular's real `FieldState.name()` is `${APP_ID}.form${n}.path`, e.g.
+    // `ng.form0.email` — not the bare path segment the mocked specs above
+    // use. When `fieldName` is omitted, the per-error DOM id must still be
+    // derived from the bare path so it matches the ids the in-tree wrapper
+    // (and any other consumer deriving ids from the same field name) builds.
+    @Component({ template: '' })
+    class Host {
+      readonly form = form(
+        signal({ email: '' }),
+        schema<{ email: string }>((path) => {
+          required(path.email);
+        }),
+      );
+      readonly resolved = createErrorMessageSignal(() => this.form.email(), {
+        strategy: 'immediate',
+      });
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { resolved, form: contactForm } = fixture.componentInstance;
+
+    // Sanity-check the assumption this regression test relies on: Angular's
+    // real field name is prefixed.
+    expect(contactForm.email().name()).toMatch(/^\w+\.form\d+\.email$/);
+
+    expect(resolved()[0]?.id).toBe('email-error-required');
   });
 });

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.ts
@@ -7,6 +7,7 @@ import {
   NGX_ERROR_MESSAGES,
   readDirectErrors,
   splitByKind,
+  stripAngularFormPrefix,
   type CreateErrorVisibilityOptions,
   type ErrorDisplayStrategy,
   type ErrorMessageRegistry,
@@ -296,5 +297,10 @@ function readNameFromField(accessor: FieldStateAccessor): string | null {
   const state = accessor();
   if (!state || typeof state !== 'object') return null;
   const name = state.name;
-  return typeof name === 'function' ? name() : null;
+  if (typeof name !== 'function') return null;
+  // Angular's real `FieldState.name()` is Angular-internal-prefixed
+  // (`${APP_ID}.form${n}.path`, e.g. `a.form0.email`) and varies per form
+  // instance. Strip it so the fallback ID matches the bare-path IDs the
+  // in-tree wrapper and other consumers derive from the same field name.
+  return stripAngularFormPrefix(name());
 }

--- a/packages/toolkit/headless/src/lib/error-summary.spec.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.spec.ts
@@ -1,4 +1,5 @@
-import { Component, signal } from '@angular/core';
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import {
   disabled,
   form,
@@ -6,6 +7,7 @@ import {
   hidden,
   required,
   schema,
+  validate,
 } from '@angular/forms/signals';
 import { render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
@@ -134,6 +136,56 @@ describe('NgxHeadlessErrorSummary', () => {
       const nameError = screen.getByText('Name is required');
       expect(nameError).toBeTruthy();
     });
+
+    it('keeps a separate entry per field when two fields share kind and the framework-default (message-less) error', async () => {
+      // Both fields fail `required()` with no custom `message`, so
+      // `ValidationError.message` is `undefined` for both — a message-blind
+      // dedupe key (`kind::message`) collapses them to a single entry and
+      // silently drops the second field from the summary (WCAG 3.3.1).
+      @Component({
+        selector: 'ngx-test-summary-shared-key',
+        imports: [FormField, NgxHeadlessErrorSummary],
+
+        template: `
+          <div>
+            <input id="email" [formField]="contactForm.email" />
+            <input id="name" [formField]="contactForm.name" />
+            <div
+              ngxHeadlessErrorSummary
+              #summary="errorSummary"
+              [formTree]="contactForm"
+              strategy="immediate"
+            >
+              <span data-testid="entry-count">{{
+                summary.entries().length
+              }}</span>
+              @for (
+                entry of summary.entries();
+                track entry.kind + entry.fieldName
+              ) {
+                <span [attr.data-testid]="'field-' + entry.fieldName"></span>
+              }
+            </div>
+          </div>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '', name: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email);
+            required(path.name);
+          }),
+        );
+      }
+
+      await render(TestComponent);
+
+      expect(screen.getByTestId('entry-count')).toHaveTextContent('2');
+      expect(screen.queryByTestId('field-Email')).toBeTruthy();
+      expect(screen.queryByTestId('field-Name')).toBeTruthy();
+    });
   });
 
   describe('strategy-aware visibility', () => {
@@ -220,6 +272,64 @@ describe('NgxHeadlessErrorSummary', () => {
       await user.tab();
 
       expect(screen.getByTestId('visible-summary')).toBeTruthy();
+    });
+  });
+
+  describe('shouldShowWarnings', () => {
+    it('gates a warnings-only form independently of shouldShow', async () => {
+      // A warnings-only form never has blocking errors, so `hasErrors()` is
+      // permanently `false` and `shouldShow()` (strategy && hasErrors) can
+      // never gate `warningEntries()`. `shouldShowWarnings` (strategy &&
+      // hasWarnings) is the dedicated gate consumers must use instead.
+      @Component({
+        selector: 'ngx-test-summary-should-show-warnings',
+        imports: [FormField, NgxHeadlessErrorSummary],
+
+        template: `
+          <div>
+            <input id="street" [formField]="addressForm.street" />
+            <div
+              ngxHeadlessErrorSummary
+              #summary="errorSummary"
+              [formTree]="addressForm"
+              strategy="immediate"
+            >
+              <span data-testid="should-show">{{ summary.shouldShow() }}</span>
+              <span data-testid="should-show-warnings">{{
+                summary.shouldShowWarnings()
+              }}</span>
+              <span data-testid="warning-count">{{
+                summary.warningEntries().length
+              }}</span>
+            </div>
+          </div>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ street: '' });
+        readonly addressForm = form(
+          this.#model,
+          schema((path) => {
+            validate(path.street, (ctx) =>
+              ctx.value()
+                ? null
+                : { kind: 'warn:street-optional', message: 'Optional' },
+            );
+          }),
+        );
+      }
+
+      const { fixture } = await render(TestComponent);
+
+      fixture.componentInstance.addressForm.street().markAsTouched();
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(screen.getByTestId('warning-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('should-show')).toHaveTextContent('false');
+      expect(screen.getByTestId('should-show-warnings')).toHaveTextContent(
+        'true',
+      );
     });
   });
 

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -12,7 +12,7 @@ import {
 } from '@ngx-signal-forms/toolkit/core';
 
 import {
-  dedupeValidationErrors,
+  dedupeValidationErrorsByField,
   isErrorOnInteractiveField,
   readErrors,
   toErrorSummaryEntry,
@@ -40,6 +40,15 @@ export interface ErrorSummarySignals {
   readonly hasWarnings: Signal<boolean>;
   /** Whether the summary should be visible based on strategy */
   readonly shouldShow: Signal<boolean>;
+  /**
+   * Whether the warning list should be visible based on strategy.
+   *
+   * Independent of {@link shouldShow}: a warnings-only form (no blocking
+   * errors) has `hasErrors() === false`, so `shouldShow()` never gates
+   * `warningEntries()`. Consumers rendering `warningEntries()` should gate
+   * on this signal instead of `shouldShow()`.
+   */
+  readonly shouldShowWarnings: Signal<boolean>;
   /** Focus the control for the first error entry */
   readonly focusFirst: () => void;
 }
@@ -127,12 +136,17 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
    *
    * `readonly()` is intentionally **not** filtered: the field is visible and
    * focusable, and its error is usually still meaningful to the user.
+   *
+   * Deduplication is per-field (see {@link dedupeValidationErrorsByField}):
+   * unlike `NgxHeadlessFieldset`'s grouped-message dedupe, two different
+   * fields sharing the same kind/message (e.g. two `required()` fields with
+   * no custom message) must both keep their own summary entry.
    */
   readonly #split = computed(() => {
     const visibleErrors = readErrors(this.#fieldState()).filter(
       (error: ValidationError) => isErrorOnInteractiveField(error),
     );
-    return splitByKind(dedupeValidationErrors(visibleErrors));
+    return splitByKind(dedupeValidationErrorsByField(visibleErrors));
   });
 
   readonly entries = computed(() =>
@@ -162,6 +176,10 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
 
   readonly shouldShow = computed(
     () => this.#showErrorsSignal() && this.hasErrors(),
+  );
+
+  readonly shouldShowWarnings = computed(
+    () => this.#showErrorsSignal() && this.hasWarnings(),
   );
 
   readonly focusFirst = (): void => {

--- a/packages/toolkit/headless/src/lib/field-optionality.spec.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.spec.ts
@@ -115,6 +115,41 @@ describe('summarizeFieldOptionality', () => {
       hasOptional: false,
     });
   });
+
+  it('treats a Date-valued leaf as a control leaf, not a container, across a null → Date transition', () => {
+    // Angular's FieldTree proxy grows a Symbol.iterator whenever the field's
+    // *current* value is any non-null object (Date/File/Map included) — for
+    // a Date that iterator yields zero entries. A naive "is it iterable?"
+    // container check would treat the populated field as an empty container
+    // and silently drop its `required()` state from the walk.
+    @Component({ template: '' })
+    class Host {
+      readonly model = signal<{ birthDate: Date | null }>({ birthDate: null });
+      readonly tree = form(
+        this.model,
+        schema<{ birthDate: Date | null }>((path) => {
+          required(path.birthDate);
+        }),
+      );
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { tree, model } = fixture.componentInstance;
+
+    // While null, the leaf is unambiguous — required is read normally.
+    expect(summarizeFieldOptionality(tree)).toEqual({
+      hasRequired: true,
+      hasOptional: false,
+    });
+
+    // Once populated with a real Date, the field must still count as the
+    // same required leaf, not vanish from the walk.
+    model.set({ birthDate: new Date('2000-01-01') });
+    expect(summarizeFieldOptionality(tree)).toEqual({
+      hasRequired: true,
+      hasOptional: false,
+    });
+  });
 });
 
 describe('createFieldOptionalitySummary', () => {
@@ -151,6 +186,28 @@ describe('createFieldOptionalitySummary', () => {
 
     // Flip the predicate → the field becomes required and the summary updates.
     wantsEmail.set(true);
+    expect(summary.hasRequired()).toBe(true);
+  });
+
+  it('does not flip hasRequired to false when a required Date leaf gains a value', () => {
+    @Component({ template: '' })
+    class Host {
+      readonly model = signal<{ birthDate: Date | null }>({ birthDate: null });
+      readonly tree = form(
+        this.model,
+        schema<{ birthDate: Date | null }>((path) => {
+          required(path.birthDate);
+        }),
+      );
+      readonly summary = createFieldOptionalitySummary(() => this.tree);
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { summary, model } = fixture.componentInstance;
+
+    expect(summary.hasRequired()).toBe(true);
+
+    model.set({ birthDate: new Date('2000-01-01') });
     expect(summary.hasRequired()).toBe(true);
   });
 

--- a/packages/toolkit/headless/src/lib/field-optionality.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.ts
@@ -32,6 +32,51 @@ function isIterableNode(node: unknown): node is Iterable<unknown> {
 }
 
 /**
+ * Whether `value` is a plain data object — `{ ... }` object-literal shape or
+ * `null`-prototype object — as opposed to a boxed/branded value (`Date`,
+ * `File`, `Map`, a custom class instance, ...).
+ */
+function isPlainObject(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Whether a `FieldTree` node should be descended into as a structural
+ * container, rather than read as a leaf.
+ *
+ * Angular's `FieldTree` proxy grows a `[Symbol.iterator]` whenever the
+ * field's *current* value is any non-null object — this includes genuine
+ * schema containers (object subfields, arrays) but also boxed leaf values
+ * like `Date`, `File`, or `Map`, whose iteration yields zero entries. Relying
+ * on iterability alone would treat a populated `Date | null` leaf as an
+ * "empty container" the moment it gets a value, silently dropping its
+ * `required()` state from the walk. Genuine containers always hold a plain
+ * object or array (that's what the schema's object/array shape lowers to),
+ * so checking the value's prototype disambiguates the two.
+ *
+ * Known caveat: a leaf whose value is itself a custom class instance
+ * declared as an object-shaped model field (rather than a scalar) would be
+ * misread as a leaf here — the same class of edge case as the documented
+ * `string[]`-as-container caveat below.
+ */
+function isContainerNode(
+  node: AnyFieldTree,
+): node is AnyFieldTree & Iterable<unknown> {
+  if (!isIterableNode(node)) return false;
+
+  const state = node() as { value?: () => unknown } | null | undefined;
+  if (!state || typeof state.value !== 'function') return true;
+
+  const value = state.value();
+  if (Array.isArray(value)) return true;
+  if (value !== null && typeof value === 'object') return isPlainObject(value);
+
+  return true;
+}
+
+/**
  * Yield every leaf (control) `FieldTree` reachable from `node`, depth-first.
  *
  * Container nodes are descended into and never yielded themselves; only leaves
@@ -46,12 +91,12 @@ function isIterableNode(node: unknown): node is Iterable<unknown> {
  * @yields Each leaf (control) `FieldTree` in depth-first order.
  */
 function* walkLeaves(node: AnyFieldTree): Generator<AnyFieldTree> {
-  if (!isIterableNode(node)) {
+  if (!isContainerNode(node)) {
     yield node;
     return;
   }
 
-  for (const entry of node as Iterable<unknown>) {
+  for (const entry of node) {
     // Array-like nodes yield the child FieldTree (a callable) directly; object
     // subfields yield `[key, childTree]` tuples.
     const child: AnyFieldTree | undefined =

--- a/packages/toolkit/headless/src/lib/notification.spec.ts
+++ b/packages/toolkit/headless/src/lib/notification.spec.ts
@@ -29,6 +29,9 @@ describe('NgxHeadlessNotification', () => {
           [tone]="tone()"
         >
           <span data-testid="resolved-tone">{{ n.resolvedTone() }}</span>
+          <span data-testid="resolved-message">{{
+            n.resolvedMessages()[0]?.message
+          }}</span>
           @if (n.showErrorContainer()) {
             <div
               data-testid="error-container"
@@ -103,6 +106,23 @@ describe('NgxHeadlessNotification', () => {
       await setup({ errors: [], fieldName: 'address', tone: 'warning' });
 
       expect(screen.getByTestId('resolved-tone').textContent).toBe('error');
+    });
+  });
+
+  describe('resolvedMessages', () => {
+    it('strips the internal "warn:" prefix from a message-less warning kind', async () => {
+      // Angular's `ValidationError.message` is `undefined` by default. With
+      // no validator-supplied message and no registry entry for the kind,
+      // the fallback message is derived from the kind itself — the `warn:`
+      // marker prefix must never leak into the rendered warning text.
+      await setup({
+        errors: [{ kind: 'warn:weak_password' }],
+        fieldName: 'password',
+      });
+
+      const message = screen.getByTestId('resolved-message').textContent;
+      expect(message).not.toContain('warn:');
+      expect(message).toBe('weak password');
     });
   });
 

--- a/packages/toolkit/headless/src/lib/notification.ts
+++ b/packages/toolkit/headless/src/lib/notification.ts
@@ -1,14 +1,13 @@
 import { computed, Directive, inject, input, type Signal } from '@angular/core';
 import type { ValidationError } from '@angular/forms/signals';
-import {
-  isWarningError,
-  resolveValidationErrorMessage,
-} from '@ngx-signal-forms/toolkit';
+import { isWarningError } from '@ngx-signal-forms/toolkit';
 import {
   createFieldMessageIdSignals,
   NGX_ERROR_MESSAGES,
   normalizeFieldName,
 } from '@ngx-signal-forms/toolkit/core';
+
+import { resolveErrorMessage } from './utilities';
 
 /**
  * Visual / ARIA tone for grouped notifications.
@@ -165,10 +164,11 @@ export class NgxHeadlessNotification implements NotificationStateSignals {
     () =>
       this.#resolvedErrors().map((error) => ({
         kind: error.kind,
-        message: resolveValidationErrorMessage(
-          error,
-          this.#errorMessagesRegistry,
-        ),
+        // `stripWarningPrefix` defaults to `true` here (see `resolveErrorMessage`)
+        // because this directive is precisely the warning-tone surface — a
+        // message-less `warn:*` kind must never leak the internal `warn:`
+        // prefix into the rendered warning live region.
+        message: resolveErrorMessage(error, this.#errorMessagesRegistry),
       })),
   );
 }

--- a/packages/toolkit/headless/src/lib/utilities.spec.ts
+++ b/packages/toolkit/headless/src/lib/utilities.spec.ts
@@ -520,6 +520,16 @@ describe('Headless Utilities', () => {
       );
     });
 
+    it('should strip the form prefix regardless of the configured APP_ID', () => {
+      // Angular's real prefix is `${APP_ID}.form{n}.`, not hardcoded `ng.`.
+      // `BrowserTestingModule` (and any app with a custom `provideAppId`)
+      // uses a different APP_ID — e.g. `a.form0.email` in TestBed specs.
+      expect(humanizeFieldPath('a.form0.email')).toBe('Email');
+      expect(humanizeFieldPath('my-app.form3.address.city')).toBe(
+        'Address / City',
+      );
+    });
+
     it('should handle underscores and hyphens', () => {
       expect(humanizeFieldPath('first_name')).toBe('First name');
       expect(humanizeFieldPath('last-name')).toBe('Last name');

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -114,9 +114,7 @@ export interface FieldStateFlags {
  * Eliminates the repeated pattern of 5 individual `readFieldFlag` computeds
  * found in fieldset directives and components.
  *
- * @remarks Must be called in an injection context (constructor, field
- * initializer, or `runInInjectionContext`) because it creates `computed`
- * signals internally.
+ * @remarks Does not require an injection context (only creates `computed`s).
  *
  * @param fieldState - A signal/computed that returns the field state object
  * @returns Object with computed signals for each boolean flag
@@ -357,10 +355,16 @@ export interface ErrorStateResult {
  *
  * ```typescript
  * const formData = signal({ email: '' });
- * const emailField = form(formData, { validators: [Validators.required, Validators.email] });
+ * const contactForm = form(
+ *   formData,
+ *   schema((path) => {
+ *     required(path.email);
+ *     email(path.email);
+ *   }),
+ * );
  *
  * const errorState = createErrorState({
- *   field: emailField,
+ *   field: contactForm.email,
  *   fieldName: 'email',
  * });
  *
@@ -466,17 +470,21 @@ export interface CreateCharacterCountOptions {
  */
 export interface CharacterCountResult {
   /** Current value length */
-  readonly currentLength: ReadSignal<number>;
+  readonly currentLength: Signal<number>;
   /** Resolved maximum length */
-  readonly resolvedMaxLength: ReadSignal<number>;
+  readonly resolvedMaxLength: Signal<number>;
   /** Remaining characters until limit */
-  readonly remaining: ReadSignal<number>;
+  readonly remaining: Signal<number>;
   /** Current limit state */
-  readonly limitState: ReadSignal<CharacterCountLimitState>;
+  readonly limitState: Signal<CharacterCountLimitState>;
+  /** Whether a limit is configured. `maxLength` is required, so this is
+   * always `true` — retained for API symmetry with
+   * `NgxHeadlessCharacterCount.hasLimit`. */
+  readonly hasLimit: Signal<boolean>;
   /** Whether the limit has been exceeded */
-  readonly isExceeded: ReadSignal<boolean>;
+  readonly isExceeded: Signal<boolean>;
   /** Percentage of limit used (0-100+) */
-  readonly percentUsed: ReadSignal<number>;
+  readonly percentUsed: Signal<number>;
 }
 
 /**
@@ -485,15 +493,14 @@ export interface CharacterCountResult {
  * This utility provides the same state management as NgxHeadlessCharacterCount
  * but as standalone signals for programmatic use.
  *
- * @remarks Must be called in an injection context (constructor, field
- * initializer, or `runInInjectionContext`) because it creates `computed()`
- * signals internally.
+ * @remarks Does not require an injection context (only creates `computed()`
+ * signals internally).
  *
  * ## Usage
  *
  * ```typescript
  * const formData = signal({ bio: '' });
- * const bioField = form(formData, { validators: [] });
+ * const bioField = form(formData).bio;
  *
  * const charCount = createCharacterCount({
  *   field: bioField,
@@ -592,11 +599,16 @@ export function createCharacterCount(
     return 'ok';
   });
 
+  // `maxLength` is a required option, so a limit is always configured.
+  // See the `hasLimit` doc above for why this member exists at all.
+  const hasLimit = computed(() => true);
+
   return {
     currentLength,
     resolvedMaxLength,
     remaining,
     limitState,
+    hasLimit,
     isExceeded,
     percentUsed,
   };
@@ -636,6 +648,58 @@ type ValidationErrorWithFieldTree = ValidationError & {
       }
     | undefined;
 };
+
+/**
+ * Deduplicate validation errors **per originating field** by kind + message
+ * + field identity.
+ *
+ * This is deliberately distinct from {@link dedupeValidationErrors}, which
+ * `NgxHeadlessFieldset` uses to collapse the *same* message repeated across
+ * a group into one grouped entry — a documented feature, not a bug. An
+ * error-summary entry, by contrast, represents one field's error; two
+ * different fields that both fail `required()` with no custom message
+ * (Angular's default `ValidationError.message` is `undefined`) share the
+ * key `'required::'` under a message-blind dedupe and one of them would be
+ * silently dropped from the summary, violating WCAG 3.3.1 (the dropped
+ * field's error is never listed and never reachable via `focus()`).
+ *
+ * Errors without a resolvable `fieldTree` (e.g. from custom validators)
+ * fall back to the field-blind key so they still dedupe sensibly among
+ * themselves.
+ *
+ * @param errors - Array of ValidationError to deduplicate
+ * @returns Deduplicated array preserving first occurrence order
+ *
+ * @internal
+ */
+export function dedupeValidationErrorsByField(
+  errors: readonly ValidationError[],
+): ValidationError[] {
+  const seen = new Set<string>();
+  const result: ValidationError[] = [];
+
+  for (const error of errors) {
+    const key = `${fieldIdentityKey(error)}::${error.kind}::${error.message ?? ''}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(error);
+  }
+
+  return result;
+}
+
+function fieldIdentityKey(error: ValidationError): string {
+  const e = error as ValidationErrorWithFieldTree;
+  if (typeof e.fieldTree === 'function') {
+    const fieldState = e.fieldTree();
+    if (fieldState && typeof fieldState.name === 'function') {
+      return fieldState.name();
+    }
+  }
+  return '';
+}
 
 /**
  * Resolve the field name from a `ValidationError` via duck-typed access


### PR DESCRIPTION
Closes #161

## Summary

Fixes 10 of the 11 verified blocker findings from audit #139 (headless).

1. **Error summary drops errors from distinct fields sharing kind+message** — `NgxHeadlessErrorSummary` now dedupes per-field (kind + message + field identity via `dedupeValidationErrorsByField`) instead of message-blind, so two fields both failing `required()` with no custom message both keep their summary entry (WCAG 3.3.1). `NgxHeadlessFieldset`'s grouped-message dedupe (a documented feature) is untouched.
2. **NgxHeadlessNotification leaked the internal `warn:` prefix** — `resolvedMessages` now goes through the shared `resolveErrorMessage` (default `stripWarningPrefix: true`), matching every other headless surface.
3. **createErrorMessageSignal's name() fallback emitted Angular-internal `ng.form0.`-prefixed DOM IDs** — the fallback now strips the prefix via `stripAngularFormPrefix` before generating IDs. Also broadened `stripAngularFormPrefix`'s regex (in `/core`) to match any app id, not just the `'ng'` default, since it previously silently failed to strip for any non-default `APP_ID`.
4. **field-optionality dropped required Date/File/Map leaves once populated** — the walker now distinguishes genuine structural containers (plain objects/arrays) from boxed leaf values, so a required `Date | null` field no longer flip-flops out of the summary the moment it's populated.
5. **Inconsistent/incomplete visibility-signal semantics** — added `ErrorSummarySignals.shouldShowWarnings` (`strategy && hasWarnings()`) so warnings-only forms can gate and render their warning list, independent of `shouldShow` (`strategy && hasErrors()`).
6. **createCharacterCount returned unbranded types** — `CharacterCountResult` members are now typed `Signal<T>` (were the looser `ReadSignal<T>` alias) and gained a `hasLimit` member for symmetry with the directive.
7. **Doc examples used a nonexistent `form({ validators })` API** — rewritten with the real schema-function API for both `createErrorState` and `createCharacterCount`.
8. **False "must be called in an injection context" claims** — removed from `createFieldStateFlags`/`createCharacterCount` (they only call `computed()`, never `inject()`).
9. **README documented `field`/`fieldName` as required and omitted `errorsOverride`** — corrected the `NgxHeadlessErrorState` and `NgxHeadlessCharacterCount` input tables, and fixed the `toErrorSummaryEntry` usage comment direction.
10. **Character-count class-level doc contradicted the actual `>1` "exceeded" boundary** — fixed to match the member-level doc in the same file.

### Skipped

**#11 — `NgxHeadlessNotification`'s `tone` input is a documented no-op.** Confirmed in code: the `assistive` package's own test suite already deliberately locks in "content wins over explicit tone in both directions" (an a11y-safety invariant — a real blocking error can never be downgraded to a status role, and an all-warning list can never be upgraded to an alert role). Given that, there is no remaining scenario where `tone` could take effect without changing that already-tested behavior — a real fix is a public-API removal on `NgxHeadlessNotification.tone` that cascades into the `assistive` entry point's `hostDirectives` forwarding (`NgxFormFieldNotification`) and its test suite. That's out of scope for the headless area and overlaps with the in-flight `fix/assistive-v1-blockers` work. Recommend a coordinated follow-up across both entry points.

## Breaking changes

- `ErrorSummarySignals` gained a required `shouldShowWarnings: Signal<boolean>` member — implementers of the interface must add it.
- `CharacterCountResult` member types tightened from `ReadSignal<T>` (`= () => T`) to `Signal<T>`; added `hasLimit`. Compile-time only, no runtime change.
- Behavior fixes that change previously-buggy output: error-summary entry counts (more entries now shown), notification warning text (no more `warn:` prefix), `createErrorMessageSignal` fallback IDs (no more `ng.form0.` prefix), and field-optionality results for `Date`/`File`/`Map` leaves.

All documented in `docs/MIGRATING_BETA_TO_V1.md` §9 (plus "At a glance" bullets).

## Test plan

- [x] `pnpm nx run-many -t test,lint,build --projects=toolkit` — all green (71 test files / 1175 tests, lint, build)
- [x] `pnpm nx run toolkit:test-browser` — all green (5 files / 18 tests)
- [x] Regression tests added first (TDD) for findings 1-4 and the `shouldShowWarnings` gate (finding 5), matching existing vitest/testing-library spec style

🤖 Generated with [Claude Code](https://claude.com/claude-code)