### PR TITLE
fix(form-field): resolve v1.0.0 audit blockers

### DIFF
--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -533,7 +533,9 @@ A custom renderer is a component referenced through
 `*ngComponentOutlet` and binds inputs depending on the call site:
 
 - `NgxFormFieldWrapper` (and any wrapper following this guide) binds
-  `{ formField, strategy, submittedStatus }`.
+  `{ formField, strategy, submittedStatus, warningStrategy, fieldName }`.
+  `warningStrategy` and `fieldName` are extras beyond the minimal contract —
+  see the id contract below for why `fieldName` matters.
 - `NgxFormFieldset` binds
   `{ errors, fieldName, strategy, submittedStatus, listStyle }`.
 
@@ -541,6 +543,20 @@ Inputs the renderer doesn't declare are dropped silently by
 `*ngComponentOutlet`; extra inputs the renderer declares are unaffected.
 A renderer that targets both call sites must accept the union (or declare a
 generic `inputs` signature).
+
+### The id contract
+
+Independently of which renderer is mounted, both call sites compose the
+bound control's `aria-describedby` from `${fieldName}-error` /
+`${fieldName}-warning` whenever errors/warnings are visible. **Your renderer
+must render a matching element** — `id="${fieldName}-error"` whenever it
+displays blocking errors, `id="${fieldName}-warning"` whenever it displays
+warnings — or the composed `aria-describedby` dangles (an axe
+`aria-valid-attr-value` violation on every invalid field). Read `fieldName`
+from the input the wrapper passes rather than re-injecting
+`NGX_SIGNAL_FORM_FIELD_CONTEXT` yourself when it's available (`NgxFormFieldset`
+always passes it; `NgxFormFieldWrapper` passes it as of the input listed
+above). See `NgxFormFieldError` for the reference implementation.
 
 ## Checklist before shipping
 
@@ -558,7 +574,11 @@ generic `inputs` signature).
       `{ optional: true }`, falls back to `NgxFormFieldError`, and renders
       the resolved component via `*ngComponentOutlet`.
 - [ ] The computed feeding `*ngComponentOutlet` inputs binds
-      `{ formField, strategy, submittedStatus }` so any compliant renderer works.
+      `{ formField, strategy, submittedStatus }` (plus `fieldName`,
+      recommended — see the id contract above) so any compliant renderer works.
+- [ ] Custom error/warning renderers satisfy the
+      [id contract](#the-id-contract): `id="${fieldName}-error"` /
+      `id="${fieldName}-warning"` on the elements that display each kind.
 - [ ] Wrapper does **not** write `aria-invalid`, `aria-required`, or
       `aria-describedby` on its host element — those belong on the bound
       control and are owned by `NgxSignalFormAutoAria`.

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -758,3 +758,124 @@ reasoning. If you are already on Angular 22, no migration action is required.
   aggregation and error summary usage.
 - [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md) — the warning
   convention and message resolution order.
+
+---
+
+## 9. `form-field` v1.0.0 audit blockers
+
+The `form-field` entry point (`NgxFormFieldWrapper`, `NgxFormFieldset`) and
+its `NgxFormFieldError` collaborator shipped several defects fixed as part
+of the v1.0.0 release audit. Most are non-breaking bug fixes; the ones with
+observable behavior changes are called out below.
+
+### New: `warningStrategy` input on `NgxFormFieldWrapper`
+
+The wrapper previously only mounted its projected error/warning renderer
+when the **blocking-error** strategy (`strategy`, default `'on-touch'`)
+said errors should show — so a warnings-only field never rendered anything
+until the field was touched (or submitted), even though `NgxFormFieldError`
+defaults its own warning timing to `'immediate'`. The wrapper now exposes a
+`warningStrategy` input (forwarded to the renderer) and mounts the renderer
+whenever errors **or** warnings should be visible, matching the
+already-documented "warning timing is independent of error timing"
+contract. Non-breaking / additive — no action required unless you want to
+override the new input.
+
+### Breaking (a11y fix): warnings no longer render alongside a visible blocking error
+
+`NgxFormFieldError`'s warning live region (`role="status"`) previously
+rendered even while the error live region (`role="alert"`) was also
+visible for the same field — assertive **and** polite announcements firing
+for one field at once. It now suppresses the warning region whenever a
+blocking error is visible, matching `NgxFormFieldset`'s existing
+"warnings hidden while errors present" behavior and the form-field
+`README`'s documented contract. The corresponding `${fieldName}-warning`
+id is also dropped from the composed `aria-describedby` in that state (see
+`createAriaDescribedBySignal`) so nothing dangles.
+
+- If a test asserted both a populated `role="alert"` and a populated
+  `role="status"` for the same mixed error+warning field, update it to
+  expect the `role="status"` container to be empty (it stays mounted per
+  WCAG 4.1.3, just without an `id` or content) while errors are visible.
+
+### Fix: dev-mode "could not resolve field name" diagnostics no longer fire spuriously
+
+Both `NgxFormFieldWrapper.resolvedFieldName` and `NgxFormFieldError`'s
+internal field-name resolution used to log their one-shot `console.error`
+from inside a `computed()`. Projected children (`NgxFormFieldHint`,
+`NgxFormFieldError` itself when nested in the wrapper) read that computed
+via `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the wrapper's first
+change-detection pass — before `afterEveryRender` had populated the
+resolved name — so the diagnostic fired even for correctly configured
+fields (input with an `id`, no explicit `fieldName`). Both diagnostics now
+fire from `afterEveryRender` once the DOM state has settled instead.
+
+- If a unit test asserted `console.error` was called by reading
+  `resolvedFieldName()` (or rendering) without ever running change
+  detection, it now needs a render + `fixture.detectChanges()` /
+  `await fixture.whenStable()` pass before the diagnostic fires. (Any
+  test exercised through `@testing-library/angular`'s `render()` already
+  gets this for free.)
+
+### Fix: `[hidden]` on the wrapper host now actually hides the field
+
+`ngx-form-field-wrapper`'s `:host { display: flex }` rule is author-origin
+CSS, which beats the (non-`!important`) UA-stylesheet `[hidden] { display:
+none }` rule regardless of specificity — so a field marked `hidden()` by
+Angular Signal Forms kept rendering fully visible and focusable despite
+carrying the `hidden` attribute. `:host([hidden]) { display: none
+!important; }` has been added so the documented safety net actually works.
+If you were relying on the old (broken) behavior to keep a `hidden()`
+field visible, add your own `@if` instead of the `hidden()` schema logic.
+
+### Fix: bound-control discovery no longer misroutes to a `[prefix]`/label-slot decoy
+
+The wrapper's fallback DOM probe (used for plain controls without their
+own `[formField]` binding, mocked field states, and the pre-init render
+window) queried the whole wrapper host with one selector, which returns
+the first match in **document order** — not by resolution tier. An
+id-bearing `[prefix]`/label-slot element (e.g. a password-visibility
+toggle button) could therefore outrank the real control in the `__main`
+slot, silently misrouting `fieldName`, `data-signal-field`, semantics, and
+required-detection. The probe now checks `__main` first and only falls
+back to a whole-host scan when `__main` has no match (preserving the
+implicit-label pattern, `<label>Email <input id="email"></label>`).
+Non-breaking unless you had markup relying on the old mis-routing.
+
+### Fix: author-supplied `aria-labelledby` / `aria-describedby` preserved instead of clobbered
+
+`NgxFormFieldWrapper` (non-cluster mode) and `NgxFormFieldset` used to
+bind `[attr.aria-labelledby]` / `[attr.aria-describedby]` unconditionally
+to their internally-managed value (`null` in most cases), which silently
+removed any value an author bound directly on the host element (e.g.
+`<fieldset ngxFormFieldset aria-describedby="pw-rules">`). Both now merge
+with (rather than replace) any author-supplied value captured at
+construction — the same preservation rule auto-aria already applies to the
+bound control itself.
+
+### New: custom error-renderer `id` contract documented; `fieldName` passed through
+
+`NgxFormFieldErrorRenderer` (`core/tokens.ts`) now documents that a custom
+renderer **must** render `id="${fieldName}-error"` / `id="${fieldName}-warning"`
+on the elements displaying each kind — the composed `aria-describedby`
+references those ids regardless of which renderer is mounted, so a
+renderer that doesn't satisfy this produces dangling references (an axe
+`aria-valid-attr-value` violation). `NgxFormFieldWrapper` now also passes
+`fieldName` directly to the renderer (in addition to
+`{formField, strategy, submittedStatus, warningStrategy}`) so a custom
+renderer can satisfy the contract without injecting
+`NGX_SIGNAL_FORM_FIELD_CONTEXT` itself. See
+[`docs/CUSTOM_WRAPPERS.md`](./CUSTOM_WRAPPERS.md#the-id-contract).
+
+### New: `NgxFormField` bundle now includes `NgxSignalFormControlSemanticsDirective`
+
+The wrapper's own "could not infer a control kind" dev warning instructs
+authors to declare semantics via `ngxSignalFormControl="..."` — but that
+attribute was inert for consumers who imported only the `NgxFormField`
+convenience bundle (not the full `NgxSignalFormToolkit`), since the
+directive that reads it was never declared. Worse, `ngxSignalFormControlAria="manual"`
+was silently ignored while `NgxSignalFormAutoAria` (which the bundle does
+include) kept managing ARIA anyway via its CSS attribute selector — actively
+overriding what the author opted out of. `NgxFormField` now includes
+`NgxSignalFormControlSemanticsDirective`; it's selector-gated and inert for
+consumers who never add the attribute.

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -317,6 +317,72 @@ describe('NgxFormFieldError', () => {
       expect(list?.tagName).toBe('UL');
       expect(list?.querySelectorAll('li')).toHaveLength(2);
     });
+
+    it('suppresses the warning live region while a blocking error is also visible', async () => {
+      // README's "Warning support" section documents "blocking errors
+      // present → warnings hidden", and NgxFormFieldset already enforces
+      // this. Without a guard, both the role="alert" and role="status"
+      // containers render at once for a field with mixed errors/warnings —
+      // an assertive AND a polite announcement for the same field.
+      @Component({
+        selector: 'ngx-test-mixed-error-warning',
+        imports: [NgxFormFieldError],
+
+        template: `
+          <ngx-form-field-error fieldName="password" [errors]="errors" />
+        `,
+      })
+      class TestComponent {
+        readonly errors = signal([
+          { kind: 'required', message: 'Password is required' },
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ]);
+      }
+
+      const { container } = await render(TestComponent);
+
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain('Password is required');
+
+      // Query the container directly (not via `screen.getByRole`): the
+      // empty-container pattern also marks it `[hidden]`/`aria-hidden`,
+      // which testing-library's accessibility-tree-aware queries exclude.
+      // The status container stays mounted (WCAG 4.1.3 first-insertion
+      // semantics) but must not expose the `-warning` id or render the
+      // warning text — otherwise `aria-describedby="password-warning"`
+      // would dangle.
+      const status = container.querySelector('[role="status"]');
+      expect(status).toBeTruthy();
+      expect(status?.getAttribute('id')).not.toBe('password-warning');
+      expect(status?.textContent?.trim()).toBe('');
+      expect(container.textContent).not.toContain('Consider 8+ characters');
+    });
+
+    it('shows the warning live region when no blocking error is present', async () => {
+      @Component({
+        selector: 'ngx-test-warning-only',
+        imports: [NgxFormFieldError],
+
+        template: `
+          <ngx-form-field-error fieldName="password" [errors]="errors" />
+        `,
+      })
+      class TestComponent {
+        readonly errors = signal([
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ]);
+      }
+
+      const { container } = await render(TestComponent);
+
+      const status = screen.getByRole('status');
+      expect(status.getAttribute('id')).toBe('password-warning');
+      expect(status.textContent).toContain('Consider 8+ characters');
+
+      const alert = container.querySelector('[role="alert"]');
+      expect(alert?.getAttribute('id')).not.toBe('password-error');
+      expect(alert?.textContent?.trim()).toBe('');
+    });
   });
 
   describe('strategy switching', () => {

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -1,4 +1,11 @@
-import { Component, computed, inject, input, isDevMode } from '@angular/core';
+import {
+  afterEveryRender,
+  Component,
+  computed,
+  inject,
+  input,
+  isDevMode,
+} from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   injectFormContext,
@@ -265,15 +272,6 @@ export class NgxFormFieldError {
    */
   readonly listStyle = input<NgxFormFieldListStyle>('plain');
 
-  constructor() {
-    // Bridge the `formField` class input to the headless directive so it can
-    // compute strategy-based showErrors and split errors/warnings.
-    // Cannot use `hostDirectives` input forwarding for `formField` because
-    // Angular's FormField directive has selector `[formField]` and would try
-    // to apply to this component, losing the `passThroughInput` guard.
-    this.headless.connectFieldState(computed(() => this.formField()?.()));
-  }
-
   /**
    * Reactive accessor to the underlying field state, derived from the same
    * `[formField]` input the headless directive consumes. Used to drive the
@@ -305,24 +303,48 @@ export class NgxFormFieldError {
   });
 
   // ── Field name / ID resolution ────────────────────────────────────────
+  //
+  // Pure by design: when nested inside `ngx-form-field-wrapper`,
+  // `this.#fieldContext.fieldName()` is the wrapper's own `resolvedFieldName`
+  // signal, which starts out `null` and only picks up the bound control's
+  // `id` once the wrapper's `afterEveryRender` write phase runs (see
+  // form-field-wrapper.ts). This component's template (`errorId()` /
+  // `warningId()`, both derived from `#resolvedFieldName`) can render on
+  // that very first pass whenever errors are already visible (e.g.
+  // `strategy="immediate"`), which used to fire this component's own
+  // `console.error` purely because of the one-render race — even for a
+  // correctly configured field. The diagnostic is emitted from
+  // `afterEveryRender` below instead, once the wrapper (if any) has had a
+  // chance to settle.
   readonly #resolvedFieldName = computed<string | null>(() => {
-    const resolvedFieldName = resolveFieldNameFromCandidates(
+    return resolveFieldNameFromCandidates(
       this.fieldName(),
       this.#fieldContext?.fieldName(),
     );
-    if (resolvedFieldName !== null) {
-      return resolvedFieldName;
-    }
-
-    if (isDevMode() && !this.#warnedMissingName) {
-      this.#warnedMissingName = true;
-      // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
-      console.error(
-        '[ngx-signal-forms] ngx-form-field-error requires an explicit `fieldName` input or a parent ngx-form-field-wrapper context. The component will render without id/aria-describedby linking until one is provided.',
-      );
-    }
-    return null;
   });
+
+  constructor() {
+    // Bridge the `formField` class input to the headless directive so it can
+    // compute strategy-based showErrors and split errors/warnings.
+    // Cannot use `hostDirectives` input forwarding for `formField` because
+    // Angular's FormField directive has selector `[formField]` and would try
+    // to apply to this component, losing the `passThroughInput` guard.
+    this.headless.connectFieldState(computed(() => this.formField()?.()));
+
+    afterEveryRender(() => {
+      if (
+        isDevMode() &&
+        !this.#warnedMissingName &&
+        this.#resolvedFieldName() === null
+      ) {
+        this.#warnedMissingName = true;
+        // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
+        console.error(
+          '[ngx-signal-forms] ngx-form-field-error requires an explicit `fieldName` input or a parent ngx-form-field-wrapper context. The component will render without id/aria-describedby linking until one is provided.',
+        );
+      }
+    });
+  }
 
   /**
    * Computed error / warning IDs for aria-describedby linking. Both return
@@ -380,9 +402,23 @@ export class NgxFormFieldError {
 
   /**
    * Same as `errorContainerVisible` but for the warnings live region.
+   *
+   * Guarded by `!errorContainerVisible()` — the README's "Warning support"
+   * section documents "blocking errors present → warnings hidden", and
+   * `NgxFormFieldset` already enforces this ("UX best practice", see
+   * `filteredErrorsSignal`). Without the guard, a field with both blocking
+   * errors and warnings would render BOTH the `role="alert"` and
+   * `role="status"` containers at once — an assertive *and* a polite
+   * announcement for the same field — and `createAriaDescribedBySignal`
+   * would still compose `${fieldName}-warning` into a control's
+   * `aria-describedby` even while this container is visible, so the two
+   * are guarded in lockstep.
    */
   protected readonly warningContainerVisible = computed(
-    () => this.showWarnings() && this.headless.hasWarnings(),
+    () =>
+      this.showWarnings() &&
+      this.headless.hasWarnings() &&
+      !this.errorContainerVisible(),
   );
 
   // ── Resolved messages (delegate to the public createErrorMessageSignal) ──

--- a/packages/toolkit/core/tokens.ts
+++ b/packages/toolkit/core/tokens.ts
@@ -194,7 +194,8 @@ export const NGX_SIGNAL_FORM_HINT_REGISTRY =
  * Renderer contract for the form-field error slot. Two consumers bind this
  * renderer:
  *
- * - `NgxFormFieldWrapper` binds inputs `{formField, strategy, submittedStatus}`.
+ * - `NgxFormFieldWrapper` binds inputs
+ *   `{formField, strategy, submittedStatus, warningStrategy, fieldName}`.
  * - `NgxFormFieldset` binds inputs `{errors, fieldName, strategy, submittedStatus, listStyle}`.
  *
  * The wrapper instantiates the configured component via `*ngComponentOutlet`
@@ -210,6 +211,23 @@ export const NGX_SIGNAL_FORM_HINT_REGISTRY =
  * fieldset instantiate it via `*ngComponentOutlet` without supplying
  * `ngComponentOutletNgModule`, so module-declared components are not
  * supported.
+ *
+ * ## id contract (required for valid `aria-describedby`)
+ *
+ * Both call sites compose the bound control's `aria-describedby` from
+ * `${fieldName}-error` / `${fieldName}-warning` whenever errors/warnings are
+ * visible (see `createAriaDescribedBySignal` and the wrapper's
+ * selection-cluster host binding) — this composition happens independently
+ * of which renderer is mounted. A custom renderer **must** render an element
+ * with `id="${fieldName}-error"` whenever it displays blocking errors, and
+ * `id="${fieldName}-warning"` whenever it displays warnings (using the
+ * `fieldName` input above, or by injecting `NGX_SIGNAL_FORM_FIELD_CONTEXT`
+ * itself when the wrapper doesn't pass it — e.g. `NgxFormFieldset`'s
+ * contract predates the `fieldName` addition here but already binds it
+ * explicitly). A renderer that doesn't satisfy this produces dangling
+ * `aria-describedby` references — an axe `aria-valid-attr-value` violation
+ * on every invalid field. See `NgxFormFieldError` for the reference
+ * implementation and `docs/CUSTOM_WRAPPERS.md` for the full checklist.
  *
  * @public
  */

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.spec.ts
@@ -116,7 +116,13 @@ describe('createAriaDescribedBySignal', () => {
     expect(ariaDescribedBy()).toBe('password-warning');
   });
 
-  it('appends both error and warning IDs when both kinds are present and visible', () => {
+  it('appends ONLY the error ID (not warning) when both kinds are present and visible', () => {
+    // The default `NgxFormFieldError` renderer suppresses its warning live
+    // region whenever a blocking error is also visible (mixed error+warning
+    // case) — matching README's documented "blocking errors present →
+    // warnings hidden" contract and `NgxFormFieldset`'s existing behavior.
+    // No `${fieldName}-warning` element exists in the DOM in that state, so
+    // composing it into `aria-describedby` here would dangle.
     const fieldState = fieldStateSignal([
       { kind: 'required', message: 'Required' },
       warningError('weak-password'),
@@ -132,10 +138,10 @@ describe('createAriaDescribedBySignal', () => {
       fieldName: () => 'password',
     });
 
-    expect(ariaDescribedBy()).toBe('password-error password-warning');
+    expect(ariaDescribedBy()).toBe('password-error');
   });
 
-  it('composes preserved + hint + error + warning IDs in that order', () => {
+  it('composes preserved + hint + error IDs (warning omitted) when a blocking error is also present', () => {
     const fieldState = fieldStateSignal([
       { kind: 'required', message: 'Required' },
       warningError('weak-password'),
@@ -152,7 +158,7 @@ describe('createAriaDescribedBySignal', () => {
     });
 
     expect(ariaDescribedBy()).toBe(
-      'password-description password-hint password-error password-warning',
+      'password-description password-hint password-error',
     );
   });
 

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
@@ -122,15 +122,22 @@ export function createAriaDescribedBySignal(
 
     if (state && isVisible) {
       const errors = state.errors();
+      const hasBlockingError = errors.some(isBlockingError);
 
-      if (errors.some(isBlockingError)) {
+      if (hasBlockingError) {
         const errorId = generateErrorId(resolvedFieldName);
         if (!parts.includes(errorId)) {
           parts.push(errorId);
         }
       }
 
-      if (errors.some(isWarningError)) {
+      // Blocking errors take visual AND announcement priority: the default
+      // `NgxFormFieldError` renderer suppresses its warning live region
+      // whenever a blocking error is also visible (mixed error+warning
+      // case), so no `${fieldName}-warning` element exists in the DOM at
+      // that point. Compose the id here too or `aria-describedby` dangles —
+      // an axe `aria-valid-attr-value` violation.
+      if (!hasBlockingError && errors.some(isWarningError)) {
         const warningId = generateWarningId(resolvedFieldName);
         if (!parts.includes(warningId)) {
           parts.push(warningId);

--- a/packages/toolkit/core/utilities/find-bound-control.ts
+++ b/packages/toolkit/core/utilities/find-bound-control.ts
@@ -1,19 +1,30 @@
 /**
  * CSS selector used to discover a bound control inside a wrapper host.
  *
- * Resolution order (the first match wins):
+ * Candidate branches (each may match a bound control):
  *
- * 1. `input[id], textarea[id], select[id], button[type="button"][id]` —
- *    native controls with an `id`. This is the canonical case and works in
- *    both dev and prod builds.
- * 2. `[id][formField]` — the Signal Forms host binding on a custom control.
- * 3. `[id][ng-reflect-form-field]` — Angular's dev-mode reflection
- *    attribute. Populated only in dev builds and only when the `formField`
- *    input serializes to a string, so it's safe to ignore in production.
- * 4. `[id][data-ngx-signal-form-control]` — the stable attribute written
- *    by `NgxSignalFormControlSemanticsDirective`. Recommended fallback for
- *    custom control hosts that don't carry a native `[formField]` binding
- *    themselves.
+ * - `input[id], textarea[id], select[id], button[type="button"][id]` —
+ *   native controls with an `id`. This is the canonical case and works in
+ *   both dev and prod builds.
+ * - `[id][formField]` — the Signal Forms host binding on a custom control.
+ * - `[id][ng-reflect-form-field]` — Angular's dev-mode reflection
+ *   attribute. Populated only in dev builds and only when the `formField`
+ *   input serializes to a string, so it's safe to ignore in production.
+ * - `[id][data-ngx-signal-form-control]` — the stable attribute written
+ *   by `NgxSignalFormControlSemanticsDirective`. Recommended fallback for
+ *   custom control hosts that don't carry a native `[formField]` binding
+ *   themselves.
+ *
+ * **Not a tiered resolution order.** This is one comma-separated selector
+ * passed to a single `querySelector` call, which returns the first match in
+ * *document order* across the whole subtree — not the first branch above
+ * that has a match. A `[prefix]`/label-slot element that happens to satisfy
+ * any branch (e.g. `<button prefix type="button" id="toggle">`) can
+ * therefore win over the real control found elsewhere in the subtree.
+ * Callers that care about this (`NgxFormFieldWrapper`, via
+ * `readFormFieldWrapperDomSnapshot`) scope the element passed to
+ * {@link findBoundControl} to the region that can only contain the real
+ * control (its `__main` slot) rather than the whole wrapper host.
  *
  * Centralized here (rather than co-located with the form-field wrapper) so
  * `NgxFieldIdentity` and any future surface that needs to discover a bound
@@ -27,6 +38,9 @@ export const BOUND_CONTROL_SELECTOR =
  *
  * Returns `null` when no match is found or when the first match isn't an
  * `HTMLElement` (guards against exotic host node types).
+ *
+ * `hostEl` should already be scoped to the region that can only contain the
+ * real control — see the document-order caveat on {@link BOUND_CONTROL_SELECTOR}.
  */
 export function findBoundControl(
   // oxlint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- DOM APIs operate on mutable HTMLElement instances.

--- a/packages/toolkit/form-field/README.md
+++ b/packages/toolkit/form-field/README.md
@@ -189,10 +189,12 @@ Warnings (errors with `kind` starting with `warn:`) display automatically:
 - Errors use `role="alert"`, warnings use `role="status"` (relying on the
   implicit live-region semantics of those roles — no explicit `aria-live`)
 
-Warning **display timing** is independent from error timing. The projected
-`NgxFormFieldError` accepts a `warningStrategy` input (default
-`'immediate'`) so advisory messages stay visible even when errors are gated
-by `'on-touch'` or `'on-submit'`. See
+Warning **display timing** is independent from error timing. The wrapper
+exposes a `warningStrategy` input (default `'immediate'`, forwarded to the
+projected `NgxFormFieldError`) so advisory messages stay visible even when
+errors are gated by `'on-touch'` or `'on-submit'` — the wrapper mounts its
+error/warning renderer whenever either should be visible, not just on the
+blocking-error timing. See
 [`WARNINGS_SUPPORT.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/WARNINGS_SUPPORT.md#when-warnings-appear--warningstrategy).
 
 ## Fieldset component

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -495,6 +495,21 @@
   block-size: fit-content; /* Prevent stretching in grid/flex rows */
 }
 
+/*
+ * `[attr.hidden]` is bound on the host as a defensive net (see
+ * `isFieldHidden()` in form-field-wrapper.ts) so a `hidden()` field stays
+ * out of the accessibility tree and off-screen even if the consumer forgets
+ * `@if`. The UA stylesheet's `[hidden] { display: none }` rule is *not*
+ * `!important` and author-origin styles beat UA-origin styles regardless of
+ * specificity, so the `:host { display: flex }` rule above silently wins
+ * and the "hidden" field stays fully visible. This rule restores the
+ * intended behavior for every appearance/layout variant (they all
+ * ultimately set `display` on `:host`).
+ */
+:host([hidden]) {
+  display: none !important;
+}
+
 :host(.ngx-signal-form-field-wrapper--selection-group) {
   --_gap: var(--_field-space-xs);
 }

--- a/packages/toolkit/form-field/form-field-wrapper.hidden.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.hidden.browser.spec.ts
@@ -1,0 +1,73 @@
+import { signal } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldWrapper } from './form-field-wrapper';
+
+/**
+ * Regression coverage for the `[attr.hidden]` safety net documented at
+ * form-field-wrapper.ts (`isFieldHidden`): the wrapper binds `hidden` on the
+ * host whenever the bound field's `hidden()` schema logic reports `true`, as
+ * a defensive net so a `hidden()` field stays out of the accessibility tree
+ * and off-screen even if the consumer forgets `@if`.
+ *
+ * That net was silently defeated: `:host { display: flex }` is an
+ * author-origin rule, and author-origin styles beat the UA stylesheet's
+ * (non-`!important`) `[hidden] { display: none }` regardless of specificity.
+ * jsdom does not implement the UA stylesheet cascade, so this can only be
+ * caught in a real browser — hence a `.browser.spec.ts` rather than the
+ * jsdom suite in `form-field-wrapper.spec.ts` (which already asserts the
+ * `hidden` *attribute* is present, but not that it actually hides anything).
+ */
+describe('NgxFormFieldWrapper — [hidden] safety net (rendered display)', () => {
+  it('renders with display:none when the bound field reports hidden() === true', async () => {
+    const hiddenField = signal({
+      invalid: () => false,
+      touched: () => false,
+      hidden: () => true,
+      errors: () => [],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field" fieldName="secret">
+        <label for="secret">Secret</label>
+        <input id="secret" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: hiddenField },
+      },
+    );
+
+    const wrapper = container.querySelector<HTMLElement>(
+      'ngx-form-field-wrapper',
+    );
+    expect(wrapper).toHaveAttribute('hidden', '');
+    expect(getComputedStyle(wrapper!).display).toBe('none');
+  });
+
+  it('keeps display:flex when the bound field reports hidden() === false', async () => {
+    const visibleField = signal({
+      invalid: () => false,
+      touched: () => false,
+      hidden: () => false,
+      errors: () => [],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field" fieldName="visible">
+        <label for="visible">Visible</label>
+        <input id="visible" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: visibleField },
+      },
+    );
+
+    const wrapper = container.querySelector<HTMLElement>(
+      'ngx-form-field-wrapper',
+    );
+    expect(wrapper).not.toHaveAttribute('hidden');
+    expect(getComputedStyle(wrapper!).display).not.toBe('none');
+  });
+});

--- a/packages/toolkit/form-field/form-field-wrapper.renderer-seam.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.renderer-seam.spec.ts
@@ -27,7 +27,13 @@ const addressSchema = schema<AddressModel>((path) => {
  */
 @Component({
   selector: 'stub-error-renderer',
-  template: `<span data-testid="stub-error">STUB-ERR:{{ errorCount() }}</span>`,
+  template: `
+    <span data-testid="stub-error">STUB-ERR:{{ errorCount() }}</span>
+    <span data-testid="stub-field-name">{{ fieldName() ?? 'null' }}</span>
+    <span data-testid="stub-warning-strategy">{{
+      warningStrategy() ?? 'unset'
+    }}</span>
+  `,
   standalone: true,
 })
 class StubErrorRenderer {
@@ -39,6 +45,13 @@ class StubErrorRenderer {
   readonly listStyle = input<unknown>();
   readonly strategy = input<unknown>();
   readonly submittedStatus = input<unknown>();
+  /**
+   * `NgxFormFieldWrapper` forwards its `warningStrategy` input here — an
+   * extra beyond the minimal `{formField, strategy, submittedStatus}`
+   * contract — so a custom renderer can honor independent warning timing
+   * without its own DI lookup.
+   */
+  readonly warningStrategy = input<unknown>();
 
   protected readonly errorCount = computed(() => {
     const errorsSignal = this.errors();
@@ -89,6 +102,51 @@ describe('form-field wrapper renderer seam', () => {
     // FieldTree through the renderer contract correctly.
     const stub = await screen.findByTestId('stub-error');
     expect(stub.textContent?.trim()).toBe('STUB-ERR:1');
+  });
+
+  it('forwards fieldName and warningStrategy to a custom renderer without requiring DI context lookups', async () => {
+    // Regression coverage: a custom error-renderer contract previously only
+    // documented `{formField, strategy, submittedStatus}`. A renderer that
+    // needs to satisfy the `${fieldName}-error`/`-warning` id contract (see
+    // NgxFormFieldErrorRenderer in core/tokens.ts) had to inject
+    // NGX_SIGNAL_FORM_FIELD_CONTEXT itself to learn the field name — the
+    // wrapper now passes it (and `warningStrategy`) directly as inputs.
+    @Component({
+      selector: 'host-component-fieldname-passthrough',
+      standalone: true,
+      imports: [NgxFormFieldWrapper],
+      template: `
+        <ngx-form-field-wrapper
+          [formField]="contactForm.email"
+          fieldName="email"
+          strategy="immediate"
+          warningStrategy="on-touch"
+        >
+          <label for="email">Email</label>
+          <input id="email" type="email" [formField]="contactForm.email" />
+        </ngx-form-field-wrapper>
+      `,
+    })
+    class HostComponent {
+      readonly contactForm = form(
+        signal<ContactModel>({ email: '' }),
+        contactSchema,
+      );
+    }
+
+    await render(HostComponent, {
+      providers: [
+        provideFormFieldErrorRenderer({ component: StubErrorRenderer }),
+      ],
+    });
+
+    const fieldNameEl = await screen.findByTestId('stub-field-name');
+    expect(fieldNameEl.textContent?.trim()).toBe('email');
+
+    const warningStrategyEl = await screen.findByTestId(
+      'stub-warning-strategy',
+    );
+    expect(warningStrategyEl.textContent?.trim()).toBe('on-touch');
   });
 });
 

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -63,10 +63,19 @@ const createMockFieldState = () =>
     errors: () => [],
   });
 
-const createWrapperComponent = (
+/**
+ * Renders a bare `NgxFormFieldWrapper` and lets its `afterEveryRender` write
+ * phase settle before returning the instance. The unresolved-field-name
+ * diagnostic fires from that write phase (not synchronously from the
+ * `resolvedFieldName` computed — see the class-level doc comment), so
+ * callers asserting on `console.error` must await a real render here rather
+ * than reading `resolvedFieldName()` off a freshly constructed, never
+ * change-detected fixture.
+ */
+const createWrapperComponent = async (
   field: ReturnType<typeof createMockFieldState> = createMockFieldState(),
   fieldName?: string,
-): NgxSignalFormWrapperComponent => {
+): Promise<NgxSignalFormWrapperComponent> => {
   const bindings = [inputBinding('formField', () => field)];
 
   if (fieldName !== undefined) {
@@ -76,6 +85,9 @@ const createWrapperComponent = (
   const fixture = TestBed.createComponent(NgxSignalFormWrapperComponent, {
     bindings,
   });
+
+  fixture.detectChanges();
+  await fixture.whenStable();
 
   return fixture.componentInstance;
 };
@@ -113,7 +125,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(errorContainer).toBeTruthy();
     });
 
-    it('should return null and log a dev-mode error when neither fieldName nor bound control id is provided', () => {
+    it('should return null and log a dev-mode error when neither fieldName nor bound control id is provided', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -124,7 +136,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField);
+      const component = await createWrapperComponent(invalidField);
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -217,7 +229,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(container.querySelector('[id="password-error"]')).toBeTruthy();
     });
 
-    it('should handle empty string fieldName by returning null and logging in dev mode', () => {
+    it('should handle empty string fieldName by returning null and logging in dev mode', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -228,7 +240,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField, '');
+      const component = await createWrapperComponent(invalidField, '');
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -1413,6 +1425,110 @@ describe('NgxSignalFormWrapperComponent', () => {
       ).toBeTruthy();
     });
 
+    it('merges an author-supplied aria-describedby with the cluster-managed error id instead of clobbering it', async () => {
+      // Regression guard: `[attr.aria-describedby]` on the host is always
+      // active (Angular host bindings can't be conditionally applied at
+      // runtime), so an author-supplied value on
+      // `<ngx-form-field-wrapper aria-describedby="…">` used to be nulled
+      // out whenever the wrapper wasn't in selection-cluster mode, and
+      // replaced outright (not merged) when it was.
+      const invalidField = signal({
+        invalid: () => true,
+        touched: () => true,
+        errors: () => [
+          { kind: 'required', message: 'Preferred contact method is required' },
+        ],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="delivery-method"
+          aria-describedby="delivery-hint"
+        >
+          <span ngxFormFieldLabel>Delivery option *</span>
+          <div>
+            <label>
+              <input id="delivery-standard" type="radio" value="standard" />
+              Standard
+            </label>
+            <label>
+              <input id="delivery-express" type="radio" value="express" />
+              Express
+            </label>
+          </div>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: invalidField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute(
+        'aria-describedby',
+        'delivery-hint delivery-method-error',
+      );
+    });
+
+    it('preserves an author-supplied aria-describedby on a non-cluster wrapper instead of nulling it out', async () => {
+      const invalidField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="email"
+          aria-describedby="email-hint"
+        >
+          <label for="email">Email</label>
+          <input id="email" type="email" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: invalidField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('aria-describedby', 'email-hint');
+    });
+
+    it('preserves an author-supplied aria-labelledby on a non-cluster wrapper instead of nulling it out', async () => {
+      const invalidField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="email"
+          aria-labelledby="email-label"
+        >
+          <label for="email">Email</label>
+          <input id="email" type="email" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: invalidField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('aria-labelledby', 'email-label');
+    });
+
     it('should keep explicit labels associated to single controls while using neutral headings for grouped controls', async () => {
       const invalidField = signal({
         invalid: () => true,
@@ -2095,6 +2211,19 @@ describe('NgxSignalFormWrapperComponent', () => {
       const errorContainer = container.querySelector('[role="alert"]');
       expect(errorContainer).toBeTruthy();
       expect(errorContainer?.textContent).toContain('Password is required');
+
+      // Warnings are suppressed while a blocking error is visible — README's
+      // "Warning support" section documents this, and `NgxFormFieldset`
+      // already enforces it. Rendering both would double-announce the same
+      // field (an assertive role="alert" AND a polite role="status" at
+      // once). The role="status" container stays mounted (WCAG 4.1.3
+      // first-insertion semantics) but must not expose an id or content.
+      const warningContainer = container.querySelector('[role="status"]');
+      expect(warningContainer?.getAttribute('id')).not.toBe('password-warning');
+      expect(warningContainer?.textContent?.trim()).toBe('');
+      expect(container.textContent).not.toContain(
+        'Consider a stronger password',
+      );
     });
 
     it('should handle multiple warnings', async () => {
@@ -2261,6 +2390,119 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(
         formField?.classList.contains('ngx-signal-form-field-wrapper--warning'),
       ).toBe(false);
+    });
+  });
+
+  describe('Warning-only fields render independently of the blocking-error strategy', () => {
+    // Regression coverage: the wrapper used to gate mounting the projected
+    // error renderer entirely on `shouldShowErrors()`, which runs the
+    // blocking-error strategy (default 'on-touch') even when the field's
+    // only messages are warnings. A warnings-only, UNTOUCHED field would
+    // therefore never mount `NgxFormFieldError` at all, so its own
+    // `warningStrategy` default of 'immediate' never got a chance to run —
+    // the README's documented "warning timing is independent of error
+    // timing" was unreachable through the wrapper. `shouldRenderErrorSlot`
+    // now mounts the renderer whenever errors OR warnings should show.
+    it('renders the warning immediately on an untouched field under the default on-touch error strategy', async () => {
+      const untouchedWarningField = signal({
+        invalid: () => true,
+        touched: () => false,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" fieldName="password">
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: untouchedWarningField },
+        },
+      );
+
+      const status = container.querySelector('[role="status"]');
+      expect(status?.getAttribute('id')).toBe('password-warning');
+      expect(status?.textContent).toContain('Consider 8+ characters');
+      // No blocking error, so the alert container stays empty/unlinked.
+      const alert = container.querySelector('[role="alert"]');
+      expect(alert?.getAttribute('id')).not.toBe('password-error');
+    });
+
+    it('respects an explicit strategy="on-submit" for a warnings-only field with the immediate warningStrategy default', async () => {
+      const unsubmittedWarningField = signal({
+        invalid: () => true,
+        touched: () => true,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="password"
+          strategy="on-submit"
+        >
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: unsubmittedWarningField },
+        },
+      );
+
+      // Warning is visible immediately even though the field hasn't been
+      // submitted — 'immediate' is the warningStrategy default, and it is
+      // NOT the same signal as the wrapper's own (on-submit) `strategy`.
+      const status = container.querySelector('[role="status"]');
+      expect(status?.getAttribute('id')).toBe('password-warning');
+      expect(status?.textContent).toContain('Consider 8+ characters');
+    });
+
+    it('gates the warning behind on-touch when an explicit warningStrategy is bound through the wrapper', async () => {
+      const untouchedWarningField = signal({
+        invalid: () => true,
+        touched: () => false,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+
+      const { container, fixture } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="password"
+          warningStrategy="on-touch"
+        >
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: untouchedWarningField },
+        },
+      );
+
+      // Untouched: warningStrategy="on-touch" keeps the warning hidden, and
+      // no renderer should even mount (no errors, no visible warnings).
+      expect(container.querySelector('ngx-form-field-error')).toBeNull();
+
+      untouchedWarningField.set({
+        invalid: () => true,
+        touched: () => true,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const status = container.querySelector('[role="status"]');
+      expect(status?.textContent).toContain('Consider 8+ characters');
     });
   });
 
@@ -2566,7 +2808,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(customError).toBeFalsy();
     });
 
-    it('should return null and log a dev-mode error when custom control has no id', () => {
+    it('should return null and log a dev-mode error when custom control has no id', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -2577,7 +2819,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField);
+      const component = await createWrapperComponent(invalidField);
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -2675,7 +2917,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(container.querySelector('[id="first-error"]')).toBeTruthy();
     });
 
-    it('should return null and log a dev-mode error when no input has id attribute and no fieldName is provided', () => {
+    it('should return null and log a dev-mode error when no input has id attribute and no fieldName is provided', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -2686,7 +2928,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField);
+      const component = await createWrapperComponent(invalidField);
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -3569,6 +3811,91 @@ describe('NgxSignalFormWrapperComponent', () => {
       const wrapper = container.querySelector('ngx-form-field-wrapper');
       expect(wrapper).not.toHaveAttribute('hidden');
       expect(container.querySelector('ngx-form-field-error')).toBeTruthy();
+    });
+  });
+
+  describe('Field-name resolution race (spurious console.error)', () => {
+    // Regression coverage for the bug where `resolvedFieldName()` logged a
+    // one-shot `console.error` from *inside* a `computed()`. Projected
+    // children (`NgxFormFieldHint`, `NgxFormFieldError`) read that computed
+    // via `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the wrapper's FIRST
+    // change-detection pass — before `afterEveryRender`'s write phase has
+    // ever populated `#inputElementId` — so the diagnostic fired even for
+    // correctly configured fields (input WITH an id). See
+    // form-field-wrapper.ts `resolvedFieldName` for the fix (diagnostic
+    // moved to the write phase).
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        // Swallow dev-mode diagnostics; assertions inspect the spy directly.
+      });
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not log when a projected hint reads the field name on first render', async () => {
+      const field = createMockFieldState();
+
+      await render(
+        `<ngx-form-field-wrapper [formField]="field">
+          <label for="username">Username</label>
+          <input id="username" type="text" />
+          <ngx-form-field-hint>Pick something memorable</ngx-form-field-hint>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent, NgxFormFieldHint],
+          componentProperties: { field },
+        },
+      );
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not log when the error renderer is visible on first render (strategy="immediate")', async () => {
+      const invalidField = signal({
+        invalid: () => true,
+        touched: () => false,
+        errors: () => [{ kind: 'required', message: 'Username is required' }],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" strategy="immediate">
+          <label for="username2">Username</label>
+          <input id="username2" type="text" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: invalidField },
+        },
+      );
+
+      // Sanity: the error renderer really did mount on the first pass.
+      expect(container.querySelector('[id="username2-error"]')).toBeTruthy();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('still logs exactly once when the field genuinely has no id and no fieldName', async () => {
+      const field = createMockFieldState();
+
+      const { fixture } = await render(
+        `<ngx-form-field-wrapper [formField]="field">
+          <input type="text" />
+          <ngx-form-field-hint>No id on this control</ngx-form-field-hint>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent, NgxFormFieldHint],
+          componentProperties: { field },
+        },
+      );
+      await fixture.whenStable();
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy.mock.calls[0]?.[0]).toMatch(
+        /Could not resolve a deterministic field name/u,
+      );
     });
   });
 

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -37,6 +37,7 @@ import {
   readDirectErrors,
   type ResolvedNgxSignalFormControlSemantics,
   resolveErrorDisplayStrategy,
+  resolveStrategyFromContext,
 } from '@ngx-signal-forms/toolkit';
 import {
   NGX_SIGNAL_FORM_HINT_REGISTRY,
@@ -259,7 +260,7 @@ import {
       }
     </div>
 
-    @if (isTopPlacement() && shouldShowErrors()) {
+    @if (isTopPlacement() && shouldRenderErrorSlot()) {
       <div class="ngx-signal-form-field-wrapper__messages">
         <ng-container
           *ngComponentOutlet="
@@ -291,7 +292,7 @@ import {
     <!-- Assistive row: fixed-height container prevents layout shift -->
     <div class="ngx-signal-form-field-wrapper__assistive">
       <div class="ngx-signal-form-field-wrapper__assistive-left">
-        @if (!isTopPlacement() && shouldShowErrors()) {
+        @if (!isTopPlacement() && shouldRenderErrorSlot()) {
           <ng-container
             *ngComponentOutlet="
               errorRendererComponent();
@@ -299,7 +300,7 @@ import {
             "
           />
         }
-        <div [style.display]="shouldShowErrors() ? 'none' : 'contents'">
+        <div [style.display]="shouldRenderErrorSlot() ? 'none' : 'contents'">
           <ng-content select="ngx-form-field-hint" />
         </div>
       </div>
@@ -371,6 +372,20 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * @default Inherited from form context or 'on-touch'
    */
   readonly strategy = input<ErrorDisplayStrategy | null>(null);
+
+  /**
+   * Warning display strategy, passed through to the projected error
+   * renderer (`NgxFormFieldError` by default). Decoupled from {@link strategy}
+   * so warnings can stay visible even while blocking errors are gated by
+   * `'on-touch'` / `'on-submit'`.
+   *
+   * The wrapper also uses this to decide whether to mount the error
+   * renderer at all: it renders whenever blocking errors OR warnings
+   * should be visible, not just on the blocking-error timing.
+   *
+   * @default `'immediate'`
+   */
+  readonly warningStrategy = input<ErrorDisplayStrategy | undefined>();
 
   /**
    * Placement of the automatic error or warning messages.
@@ -457,12 +472,24 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * Inputs map passed to `*ngComponentOutlet` for the error renderer. Custom
    * error renderers must accept `formField`, `strategy`, and `submittedStatus`;
    * any extra inputs the consumer's renderer declares are unaffected.
+   *
+   * `warningStrategy` and `fieldName` are extras beyond that minimal
+   * contract: `warningStrategy` forwards this input's value (`undefined`
+   * when unset, which is a no-op for the default `NgxFormFieldError`'s own
+   * `'immediate'` fallback) so consumers can override warning timing
+   * through the wrapper instead of only through a directly-projected
+   * `NgxFormFieldError`. `fieldName` lets a custom renderer satisfy the
+   * `${fieldName}-error` / `${fieldName}-warning` id contract (see
+   * `NgxFormFieldErrorRenderer`) without needing to inject
+   * `NGX_SIGNAL_FORM_FIELD_CONTEXT` itself.
    */
   protected readonly errorRendererInputs = computed<Record<string, unknown>>(
     () => ({
       formField: this.formField(),
       strategy: this.effectiveStrategy(),
       submittedStatus: this.submittedStatus(),
+      warningStrategy: this.warningStrategy(),
+      fieldName: this.resolvedFieldName(),
     }),
   );
 
@@ -482,6 +509,23 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * Reference to the host element for DOM queries.
    */
   readonly #elementRef = inject(ElementRef<HTMLElement>);
+
+  /**
+   * Author-supplied `aria-labelledby` / `aria-describedby`, captured at
+   * construction. `selectionClusterLabelledBy` / `selectionClusterDescribedBy`
+   * below return `null` for non-cluster wrappers (the vast majority), and
+   * `[attr.aria-labelledby]` / `[attr.aria-describedby]` on the host would
+   * otherwise strip any value an author bound directly on
+   * `<ngx-form-field-wrapper aria-describedby="…">` — the host bindings are
+   * always active regardless of cluster mode, so there is no way to simply
+   * "not bind" them for the common case. Falling back to (and merging with)
+   * these preserves author-supplied values the same way auto-aria already
+   * does for the bound control itself.
+   */
+  readonly #initialAriaLabelledby =
+    this.#elementRef.nativeElement.getAttribute('aria-labelledby');
+  readonly #initialAriaDescribedby =
+    this.#elementRef.nativeElement.getAttribute('aria-describedby');
 
   /**
    * Signal holding the input element's ID attribute.
@@ -747,11 +791,21 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * 1. Explicit `fieldName` input (highest priority)
    * 2. Input element's `id` attribute (automatic, recommended)
    *
-   * Returns `null` when neither source is available. A dev-mode
-   * `console.error` is emitted once per instance so the misconfiguration
-   * is surfaced loudly without crashing the render tree. Downstream
-   * consumers (auto-ARIA, hint registry, projected error component)
-   * handle `null` by skipping the `aria-describedby` wiring.
+   * Returns `null` when neither source is available. Downstream consumers
+   * (auto-ARIA, hint registry, projected error component) handle `null` by
+   * skipping the `aria-describedby` wiring.
+   *
+   * **Pure by design**: this computed performs no side effects. Projected
+   * children (`NgxFormFieldHint`, `NgxFormFieldError`) read it via
+   * `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the *first* change-detection
+   * pass — before `#inputElementId` is populated by the `afterEveryRender`
+   * write phase below — so a `console.error` fired from in here would fire
+   * once, permanently, on every correctly configured field (id set, no
+   * `fieldName` input) purely because of that one-render race. The
+   * unresolved-name diagnostic instead lives in the `afterEveryRender`
+   * write callback, which runs after the DOM snapshot for the current
+   * render has been applied — i.e. only once the state has actually
+   * settled.
    *
    * @remarks
    * This signal is public to allow child components to access the resolved field name
@@ -775,13 +829,6 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     const idFromInput = this.#inputElementId();
     if (idFromInput) {
       return idFromInput;
-    }
-
-    if (isDevMode() && !this.#warnedUnresolvedFieldName) {
-      this.#warnedUnresolvedFieldName = true;
-      console.error(
-        '[ngx-signal-forms] Could not resolve a deterministic field name for ngx-form-field-wrapper. Add an explicit `fieldName` input or an `id` attribute to the bound control. ARIA wiring will be skipped until a name is available.',
-      );
     }
 
     return null;
@@ -921,6 +968,58 @@ export class NgxFormFieldWrapper<TValue = unknown> {
   });
 
   /**
+   * Effective warning display strategy. Defaults to `'immediate'` (mirrors
+   * `NgxFormFieldError`'s own default) so advisory messages stay visible
+   * even when blocking errors are gated by `'on-touch'` / `'on-submit'` —
+   * unlike {@link effectiveStrategy}, an unset {@link warningStrategy} does
+   * NOT fall back to the form context or global config default, matching
+   * the projected error renderer's contract exactly.
+   */
+  protected readonly effectiveWarningStrategy = computed<ErrorDisplayStrategy>(
+    () => {
+      const explicit = this.warningStrategy();
+      if (explicit !== undefined) {
+        return resolveStrategyFromContext(explicit, this.#formContext);
+      }
+      return 'immediate';
+    },
+  );
+
+  /**
+   * Visibility-timing computed for warnings, independent of
+   * {@link effectiveStrategy} (which only governs blocking errors).
+   */
+  readonly #showWarningsByStrategy = createShowErrorsComputed(
+    this.#fieldState,
+    this.effectiveWarningStrategy,
+    this.submittedStatus,
+  );
+
+  /**
+   * Whether the error renderer should mount to show warnings, evaluated
+   * independently of {@link shouldShowErrors}. Without this, a warnings-only
+   * field would never render `NgxFormFieldError` at all when
+   * {@link effectiveStrategy} (e.g. `'on-touch'`) gates the blocking-error
+   * timing — the renderer's own `warningStrategy` default of `'immediate'`
+   * never gets a chance to run because the `@if` around the outlet in the
+   * template never mounts it. See README "Warning support".
+   */
+  protected readonly shouldShowWarnings = computed(() => {
+    if (this.isFieldHidden()) return false;
+    if (!this.hasWarnings()) return false;
+    return this.#showWarningsByStrategy();
+  });
+
+  /**
+   * Whether the projected error renderer should be mounted at all — either
+   * because blocking errors should show, or because warnings should show
+   * under their own (independent) strategy timing.
+   */
+  protected readonly shouldRenderErrorSlot = computed(() => {
+    return this.shouldShowErrors() || this.shouldShowWarnings();
+  });
+
+  /**
    * Whether to apply warning styling to the form field container.
    * Warning styling is shown only when:
    * 1. Field has warnings
@@ -944,40 +1043,62 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     return this.#controlKind() === 'radio-group' ? 'radiogroup' : 'group';
   });
 
+  /**
+   * Falls back to (never replaces) `#initialAriaLabelledby` for non-cluster
+   * wrappers — see the field doc comment on `#initialAriaLabelledby` for why
+   * the host binding can't simply be left unbound instead.
+   */
   protected readonly selectionClusterLabelledBy = computed<string | null>(
     () => {
       if (!this.isSelectionCluster()) {
-        return null;
+        return this.#initialAriaLabelledby;
       }
 
-      return this.#selectionClusterLabelId();
+      return this.#selectionClusterLabelId() ?? this.#initialAriaLabelledby;
     },
   );
 
+  /**
+   * Merges the author-supplied `#initialAriaDescribedby` with the
+   * cluster-managed error/warning id rather than replacing it — same
+   * preservation rule auto-aria already applies to the bound control itself.
+   */
   protected readonly selectionClusterDescribedBy = computed<string | null>(
     () => {
-      if (!this.isSelectionCluster()) {
+      const managedId = ((): string | null => {
+        if (!this.isSelectionCluster()) {
+          return null;
+        }
+
+        const fieldName = this.resolvedFieldName();
+        if (fieldName === null) {
+          return null;
+        }
+
+        if (this.showInvalidState()) {
+          return `${fieldName}-error`;
+        }
+
+        // `shouldShowWarnings()` gates whether the projected error renderer's
+        // warning live region is in the DOM (see `shouldRenderErrorSlot` /
+        // `NgxFormFieldError.warningContainerVisible`). Guard
+        // `aria-describedby` on the same signal to avoid dangling references
+        // for warning-only clusters gated by a non-'immediate'
+        // `warningStrategy`.
+        if (this.showWarningState() && this.shouldShowWarnings()) {
+          return `${fieldName}-warning`;
+        }
+
         return null;
+      })();
+
+      if (managedId === null) {
+        return this.#initialAriaDescribedby;
       }
 
-      const fieldName = this.resolvedFieldName();
-      if (fieldName === null) {
-        return null;
-      }
-
-      if (this.showInvalidState()) {
-        return `${fieldName}-error`;
-      }
-
-      // `shouldShowErrors()` gates the `<ngx-form-field-error>` template, so
-      // the `${fieldName}-warning` id only exists in the DOM when that branch
-      // renders. Guard `aria-describedby` on the same signal to avoid dangling
-      // references for warning-only clusters with `showErrors="false"`.
-      if (this.showWarningState() && this.shouldShowErrors()) {
-        return `${fieldName}-warning`;
-      }
-
-      return null;
+      return this.#initialAriaDescribedby
+        ? `${this.#initialAriaDescribedby} ${managedId}`
+        : managedId;
     },
   );
 
@@ -1125,6 +1246,28 @@ export class NgxFormFieldWrapper<TValue = unknown> {
         // Angular runs CD, which is when wrappers see the change anyway.
         // Keep order: name → element → visible → hints.
         const resolvedFieldName = this.resolvedFieldName();
+
+        // Fire the unresolved-name diagnostic here — after the DOM snapshot
+        // for *this* render has already been written to `#inputElementId`
+        // above — rather than inside the `resolvedFieldName` computed. By
+        // this point the state has genuinely settled: either the bound
+        // control still has no `id` (and no explicit `fieldName` was given)
+        // or no control was found at all. Checking post-write avoids the
+        // false positive where projected content (`NgxFormFieldHint`,
+        // `NgxFormFieldError`) reads `resolvedFieldName()` through
+        // `NGX_SIGNAL_FORM_FIELD_CONTEXT` on the first change-detection
+        // pass, before this write phase has ever run.
+        if (
+          isDevMode() &&
+          !this.#warnedUnresolvedFieldName &&
+          resolvedFieldName === null
+        ) {
+          this.#warnedUnresolvedFieldName = true;
+          console.error(
+            '[ngx-signal-forms] Could not resolve a deterministic field name for ngx-form-field-wrapper. Add an explicit `fieldName` input or an `id` attribute to the bound control. ARIA wiring will be skipped until a name is available.',
+          );
+        }
+
         this.#fieldIdentity.setFieldName(resolvedFieldName);
         this.#fieldIdentity.setControlElement(inputEl);
         this.#fieldIdentity.setControlVisible(

--- a/packages/toolkit/form-field/form-field.utils.spec.ts
+++ b/packages/toolkit/form-field/form-field.utils.spec.ts
@@ -186,6 +186,53 @@ describe('readFormFieldWrapperDomSnapshot — native-vs-fallback precedence', ()
     expect(snapshot.inputEl).toBe(probeMatch);
     expect(snapshot.inputId).toBe('probe-match');
   });
+
+  it('does not let an id-bearing [prefix]/label-slot element outrank the real control in __main', () => {
+    // Regression guard: `findBoundControl`'s selector is one comma-separated
+    // `querySelector`, which returns the first match in *document order*
+    // across the whole host, not "the real control" specifically. An
+    // `id`-bearing element projected before `__main` (label slot, [prefix]
+    // slot) used to win the fallback probe purely by being earlier in the
+    // DOM — even though it isn't a form control at all. The probe must be
+    // scoped to `__main` so only the real control can match.
+    const host = document.createElement('div');
+
+    const label = document.createElement('div');
+    label.className = 'ngx-signal-form-field-wrapper__label';
+    // A native <button type="button"> with an id satisfies
+    // BOUND_CONTROL_SELECTOR and sits before `__main` in document order.
+    const decoyToggle = document.createElement('button');
+    decoyToggle.type = 'button';
+    decoyToggle.id = 'decoy-toggle';
+    label.append(decoyToggle);
+
+    const content = document.createElement('div');
+    content.className = 'ngx-signal-form-field-wrapper__content';
+    const prefix = document.createElement('div');
+    prefix.className = 'ngx-signal-form-field-wrapper__prefix';
+    const decoyPrefixInput = document.createElement('input');
+    decoyPrefixInput.id = 'decoy-prefix';
+    prefix.append(decoyPrefixInput);
+
+    const main = document.createElement('div');
+    main.className = 'ngx-signal-form-field-wrapper__main';
+    const realControl = document.createElement('input');
+    realControl.id = 'real-control';
+    main.append(realControl);
+
+    content.append(prefix, main);
+    host.append(label, content);
+
+    const snapshot = readFormFieldWrapperDomSnapshot(
+      host,
+      null,
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS,
+      null,
+    );
+
+    expect(snapshot.inputEl).toBe(realControl);
+    expect(snapshot.inputId).toBe('real-control');
+  });
 });
 
 describe('null (unresolved) control kind fallback', () => {

--- a/packages/toolkit/form-field/form-field.utils.ts
+++ b/packages/toolkit/form-field/form-field.utils.ts
@@ -89,6 +89,28 @@ export function readFormFieldWrapperDomSnapshot(
     cachedControl?.isConnected &&
     hostEl.contains(cachedControl) &&
     cachedControl.hasAttribute('id');
+  // `findBoundControl`'s selector is a single comma-separated `querySelector`,
+  // which returns the first match in *document order* across whatever root
+  // it's given, not by resolution tier. Scanning `hostEl` directly lets a
+  // `[prefix]`/label-slot element that happens to match the selector (a
+  // `<button prefix type="button" id="toggle">`, or a second, unrelated
+  // `<input id>` sitting in a projected label) win over the real control in
+  // `__main` — `__label` renders before `__content` in the template, and
+  // `__prefix` before `__main` inside it, so both slots are checked first in
+  // document order.
+  //
+  // Probe `__main` first — the region `selectionControlCount` below also
+  // scans — since that's where a wrapper's real control lives whenever it's
+  // projected as a standalone sibling. Only fall back to scanning the whole
+  // host when `__main` has no match: the implicit-label pattern
+  // (`<label>Email <input id="email"></label>`) projects the control AS PART
+  // OF the label into `__label`, not `__main`, so a real, singly-nested
+  // control legitimately has no `__main` match to find.
+  const mainSlot = hostEl.querySelector<HTMLElement>(
+    ':scope > .ngx-signal-form-field-wrapper__content > .ngx-signal-form-field-wrapper__main',
+  );
+  const probedControl =
+    (mainSlot && findBoundControl(mainSlot)) ?? findBoundControl(hostEl);
   // `nativeControl` wins when present. The native-vs-fallback invariant
   // (PR #92: native and CSS-selector paths must produce identical output) is
   // upheld upstream in `resolveBoundControlFromBindings`, which only returns a
@@ -96,8 +118,7 @@ export function readFormFieldWrapperDomSnapshot(
   // `findBoundControl` selector enforces. An id-less `[formField]` host
   // therefore arrives here as `nativeControl === null` and falls through to the
   // probe, which still finds the inner `<input id>`.
-  const inputEl =
-    nativeControl ?? (cacheHit ? cachedControl : findBoundControl(hostEl));
+  const inputEl = nativeControl ?? (cacheHit ? cachedControl : probedControl);
 
   return {
     inputEl,
@@ -109,13 +130,9 @@ export function readFormFieldWrapperDomSnapshot(
     // mode. The `__main` slot is always rendered by the wrapper template;
     // the `?? 0` is defense-in-depth against unexpected DOM trees.
     selectionControlCount:
-      hostEl
-        .querySelector(
-          ':scope > .ngx-signal-form-field-wrapper__content > .ngx-signal-form-field-wrapper__main',
-        )
-        ?.querySelectorAll(
-          "input[type='radio'], input[type='checkbox']:not([role='switch']), [role='radio'], [role='checkbox']",
-        ).length ?? 0,
+      mainSlot?.querySelectorAll(
+        "input[type='radio'], input[type='checkbox']:not([role='switch']), [role='radio'], [role='checkbox']",
+      ).length ?? 0,
     label: hostEl.querySelector(
       ':scope > .ngx-signal-form-field-wrapper__label :is(label, [ngxFormFieldLabel])',
     ),

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -254,6 +254,57 @@ describe('NgxFormFieldset', () => {
     expect(host).toHaveAttribute('aria-describedby', 'address-error');
   });
 
+  it('preserves an author-supplied aria-describedby instead of clobbering it', async () => {
+    // Regression guard: the `[attr.aria-describedby]` host binding used to
+    // return only the managed error/warning id (or `null`), which nulled
+    // out any author-supplied value — a common pattern being
+    // `<fieldset ngxFormFieldset aria-describedby="pw-rules">` pointing at a
+    // sibling hint element the fieldset doesn't own.
+    const fieldset = createFieldsetState({
+      errors: () => [{ kind: 'required', message: 'Required' }],
+      errorSummary: () => [{ kind: 'required', message: 'Required' }],
+    });
+
+    const { container } = await render(
+      `<ngx-form-fieldset
+        [fieldsetField]="fieldset"
+        fieldsetId="address"
+        aria-describedby="pw-rules"
+      >
+        <div>Content</div>
+      </ngx-form-fieldset>`,
+      {
+        imports: [NgxFormFieldset],
+        componentProperties: { fieldset },
+      },
+    );
+
+    const host = container.querySelector('ngx-form-fieldset');
+    expect(host).toHaveAttribute('aria-describedby', 'pw-rules address-error');
+  });
+
+  it('falls back to the author-supplied aria-describedby alone when no messages are shown', async () => {
+    const fieldset = createFieldsetState({
+      invalid: () => false,
+      valid: () => true,
+      errors: () => [],
+      errorSummary: () => [],
+    });
+
+    const { container } = await render(
+      `<ngx-form-fieldset [fieldsetField]="fieldset" aria-describedby="pw-rules">
+        <div>Content</div>
+      </ngx-form-fieldset>`,
+      {
+        imports: [NgxFormFieldset],
+        componentProperties: { fieldset },
+      },
+    );
+
+    const host = container.querySelector('ngx-form-fieldset');
+    expect(host).toHaveAttribute('aria-describedby', 'pw-rules');
+  });
+
   it('renders aggregated messages below content by default', async () => {
     const fieldset = createFieldsetState({
       errors: () => [{ kind: 'required', message: 'Required' }],

--- a/packages/toolkit/form-field/form-fieldset.ts
+++ b/packages/toolkit/form-field/form-fieldset.ts
@@ -214,6 +214,13 @@ export class NgxFormFieldset {
     this.#elementRef.nativeElement.getAttribute('aria-labelledby');
   readonly #initialAriaLabel =
     this.#elementRef.nativeElement.getAttribute('aria-label');
+  // Same preservation rule for `aria-describedby`: `describedByIds()` below
+  // used to return the managed error/warning id (or `null`) unconditionally,
+  // clobbering an author-supplied value (a common pattern:
+  // `<fieldset ngxFormFieldset aria-describedby="pw-rules">`). Capture it
+  // here and prepend it in `describedByIds()`.
+  readonly #initialAriaDescribedby =
+    this.#elementRef.nativeElement.getAttribute('aria-describedby');
   // `<fieldset>` natively implies role="group" and associates a child <legend>.
   // Any other host tag (custom element `<ngx-form-fieldset>` or a bare
   // `[ngxFormFieldset]` attribute target) needs an explicit group role so the
@@ -488,13 +495,18 @@ export class NgxFormFieldset {
   });
 
   protected readonly describedByIds = computed(() => {
+    // Preserve any author-supplied `aria-describedby` — same rule as
+    // `#initialAriaLabelledby` above. Every `return` below merges the
+    // managed id onto this instead of replacing it outright.
+    const initial = this.#initialAriaDescribedby;
+
     // The rendered notification/error component strips its `id` attribute
     // whenever `displayedMessagesSignal` is empty, which happens when the user
     // passes `showErrors="false"` even on an invalid fieldset. Mirror that
     // gating here so `aria-describedby` never points to an element without a
     // matching id in the DOM.
     if (!this.showMessages()) {
-      return null;
+      return initial;
     }
 
     const fieldsetId = this.fieldset.resolvedFieldsetId();
@@ -503,14 +515,16 @@ export class NgxFormFieldset {
     // `filteredErrorsSignal`), so only reference the id that is actually in
     // the DOM.
     if (this.fieldset.shouldShowErrors()) {
-      return `${fieldsetId}-error`;
+      return initial ? `${initial} ${fieldsetId}-error` : `${fieldsetId}-error`;
     }
 
     if (this.fieldset.shouldShowWarnings()) {
-      return `${fieldsetId}-warning`;
+      return initial
+        ? `${initial} ${fieldsetId}-warning`
+        : `${fieldsetId}-warning`;
     }
 
-    return null;
+    return initial;
   });
 
   constructor() {

--- a/packages/toolkit/form-field/index.spec.ts
+++ b/packages/toolkit/form-field/index.spec.ts
@@ -1,0 +1,74 @@
+import { signal } from '@angular/core';
+import { FormField } from '@angular/forms/signals';
+import {
+  NgxSignalFormAutoAria,
+  NgxSignalFormControlSemanticsDirective,
+} from '@ngx-signal-forms/toolkit';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormField } from './index';
+import { NgxFormFieldWrapper } from './form-field-wrapper';
+
+/**
+ * Stability + behavior contract for the `NgxFormField` convenience bundle.
+ *
+ * Regression coverage for the finding that `NgxFormField` included
+ * `NgxSignalFormAutoAria` but not `NgxSignalFormControlSemanticsDirective` —
+ * the very directive the wrapper's own dev-mode "could not infer a control
+ * kind" warning instructs authors to use via `ngxSignalFormControl="..."`.
+ * A consumer importing only `NgxFormField` (not the full
+ * `NgxSignalFormToolkit`) and following that instruction got: the warning
+ * kept firing (kind stayed unresolved), and worse,
+ * `ngxSignalFormControlAria="manual"` was silently ignored while
+ * `NgxSignalFormAutoAria` kept managing ARIA anyway via its CSS attribute
+ * selector — actively overriding what the author opted out of.
+ */
+describe('NgxFormField bundle', () => {
+  it('includes NgxSignalFormAutoAria and NgxSignalFormControlSemanticsDirective', () => {
+    expect(NgxFormField).toContain(NgxSignalFormAutoAria);
+    expect(NgxFormField).toContain(NgxSignalFormControlSemanticsDirective);
+  });
+
+  it('includes NgxFormFieldWrapper', () => {
+    expect(NgxFormField).toContain(NgxFormFieldWrapper);
+  });
+
+  it('resolves ngxSignalFormControl semantics when only NgxFormField is imported (no NgxSignalFormToolkit)', async () => {
+    const invalidField = signal({
+      invalid: () => true,
+      touched: () => true,
+      required: () => false,
+      errors: () => [{ kind: 'required', message: 'Email updates required' }],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field">
+        <label for="emailUpdates">Email updates</label>
+        <input
+          id="emailUpdates"
+          type="checkbox"
+          ngxSignalFormControl="switch"
+        />
+      </ngx-form-field-wrapper>`,
+      {
+        // `FormField` is Angular's own directive — required so `[formField]`
+        // provides the `FORM_FIELD` token `NgxSignalFormAutoAria` (part of
+        // the bundle) injects. `NgxFormField` is the only toolkit import:
+        // not `NgxSignalFormControlSemanticsDirective` directly, and not
+        // `NgxSignalFormToolkit`. Before the fix, the `ngxSignalFormControl`
+        // attribute was inert here — the directive that reads it and writes
+        // the `data-ngx-signal-form-control-*` attributes was never
+        // declared, so the wrapper's control-kind resolution never saw it
+        // and fell back to `kind: null`.
+        imports: [FormField, NgxFormField],
+        componentProperties: { field: invalidField },
+      },
+    );
+
+    const wrapper = container.querySelector('ngx-form-field-wrapper');
+    expect(wrapper).toHaveAttribute(
+      'data-ngx-signal-form-control-kind',
+      'switch',
+    );
+  });
+});

--- a/packages/toolkit/form-field/index.ts
+++ b/packages/toolkit/form-field/index.ts
@@ -7,7 +7,10 @@ export * from './form-fieldset';
 // moved to the core barrel during v1 hardening.
 export type { NgxFormFieldErrorPlacement } from '@ngx-signal-forms/toolkit';
 
-import { NgxSignalFormAutoAria } from '@ngx-signal-forms/toolkit';
+import {
+  NgxSignalFormAutoAria,
+  NgxSignalFormControlSemanticsDirective,
+} from '@ngx-signal-forms/toolkit';
 import {
   NgxFormFieldCharacterCount,
   NgxFormFieldError,
@@ -24,6 +27,19 @@ import { NgxFormFieldset } from './form-fieldset';
  * `aria-describedby` even when consumers don't separately import
  * `NgxSignalFormToolkit`. The directive is idempotent — importing it twice
  * (e.g. via both bundles) is safe.
+ *
+ * Also includes `NgxSignalFormControlSemanticsDirective` so the
+ * `ngxSignalFormControl="..."` / `ngxSignalFormControlAria="manual"`
+ * attributes the wrapper's own dev-mode warning instructs authors to add
+ * (see the "unresolved control kind" diagnostic in `NgxFormFieldWrapper`)
+ * actually do something when a consumer imports only this bundle. Without
+ * it, `ngxSignalFormControl` was inert — the control's kind stayed
+ * unresolved (the warning kept firing) and, worse, `ariaMode="manual"` was
+ * silently ignored while `NgxSignalFormAutoAria` kept managing ARIA via its
+ * CSS attribute selector, actively overriding what the author opted out of.
+ * The directive is selector-gated (`[ngxSignalFormControl]`) and inert when
+ * unused, so including it here is a no-op for consumers who never add the
+ * attribute.
  *
  * @example
  * ```typescript
@@ -46,6 +62,7 @@ import { NgxFormFieldset } from './form-fieldset';
  */
 export const NgxFormField = [
   NgxSignalFormAutoAria,
+  NgxSignalFormControlSemanticsDirective,
   NgxFormFieldWrapper,
   NgxFormFieldHint,
   NgxFormFieldCharacterCount,


### PR DESCRIPTION
Closes #160

## Summary

Fixes all 8 verified blocker findings from audit #138 (form-field area). None were invalid — all 8 were reproduced and fixed with a regression test first (TDD).

1. **Spurious dev console.error (race)** — `NgxFormFieldWrapper.resolvedFieldName` fired a one-shot `console.error` from inside a `computed()`. Projected children (`NgxFormFieldHint`, `NgxFormFieldError`) read that computed via `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the wrapper's first change-detection pass — before `afterEveryRender` had populated the resolved name — so the diagnostic fired even for correctly configured fields. Moved the diagnostic into the `afterEveryRender` write phase (state has settled by then). `NgxFormFieldError` had the exact same pattern (same finding called it out) and double-logged in the immediate-errors case; fixed the same way.
2. **`[hidden]` didn't actually hide fields** — `:host { display: flex }` (author-origin) silently beat the UA stylesheet's non-`!important` `[hidden] { display: none }` rule. Added `:host([hidden]) { display: none !important; }`.
3. **Warnings-only fields never rendered under the default `'on-touch'` error strategy** — the wrapper only mounted the error/warning renderer when the *blocking-error* strategy said errors should show. Added a `warningStrategy` input + a `shouldRenderErrorSlot` computed (errors OR warnings) so a warnings-only field renders under its own (independent, default-`'immediate'`) timing, matching the README's documented contract.
4. **Warnings rendered alongside a visible blocking error** — `NgxFormFieldError.warningContainerVisible` had no `!hasErrors()` guard, so mixed error+warning fields fired both an assertive `role="alert"` and a polite `role="status"` announcement at once. Added the guard (matches `NgxFormFieldset`'s existing behavior + the README) and dropped the now-absent `${fieldName}-warning` id from `createAriaDescribedBySignal`'s composition in that state.
5. **Bound-control probe could misroute to a `[prefix]`/label-slot decoy** — `findBoundControl`'s selector returns the first DOM-order match across the whole host, not by resolution tier. Scoped the fallback probe to the `__main` slot first, falling back to a whole-host scan only when `__main` has no match (preserves the implicit-label pattern, `<label>Email <input id="email"></label>`).
6. **Custom error-renderer `id` contract undocumented** — documented that a renderer must render `id="${fieldName}-error"` / `id="${fieldName}-warning"` (in `NgxFormFieldErrorRenderer` JSDoc and `CUSTOM_WRAPPERS.md`); the wrapper now also passes `fieldName` directly to the renderer so it doesn't need to inject `NGX_SIGNAL_FORM_FIELD_CONTEXT` itself.
7. **Host `aria-labelledby`/`aria-describedby` clobbered author-supplied values** — `NgxFormFieldWrapper` (non-cluster mode) and `NgxFormFieldset` bound these unconditionally to the internally-managed value (`null` in most cases), nulling out anything an author bound directly on the host. Both now capture the initial value at construction and merge with it, mirroring the preservation rule auto-aria already applies to the bound control.
8. **`NgxFormField` bundle missing `NgxSignalFormControlSemanticsDirective`** — the wrapper's own dev warning tells authors to use `ngxSignalFormControl="..."`, but that attribute was inert for consumers who only imported the `NgxFormField` convenience bundle. Added the directive to the bundle (selector-gated, inert when unused).

No findings were invalid.

## Breaking changes

Documented in `docs/MIGRATING_BETA_TO_V1.md` (new section 9, appended at the end to minimize conflicts with sibling audit PRs #184–#188). Summary:

- Warnings no longer render alongside a visible blocking error for the same field (`NgxFormFieldError`) — a test asserting both live regions populated simultaneously needs updating.
- The "could not resolve field name" `console.error` diagnostics (wrapper + `NgxFormFieldError`) now fire from `afterEveryRender` instead of synchronously — tests asserting them without ever running change detection need a render pass first.
- `[hidden]` on the wrapper host now actually sets `display: none`.
- The bound-control fallback probe no longer matches decoy elements outside `__main`.
- Author-supplied `aria-labelledby`/`aria-describedby` on the wrapper/fieldset host are now preserved (merged) instead of being replaced.

## Cross-cutting touches (noted per ticket instructions)

Findings #1 and #4 explicitly called out the same root-cause bugs present in `packages/toolkit/assistive/form-field-error.ts` and `packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts`. Fixed both alongside the primary `form-field` fixes since they're the same defect, with matching regression tests.

## Test plan

- [x] `pnpm nx run-many -t test,lint,build --projects=toolkit` — 72 files / 1186 tests, lint, and build all pass
- [x] `pnpm nx run toolkit:test-browser` — 6 files / 20 tests pass (covers the CSS `[hidden]` fix, which jsdom can't catch)
- [x] Verified each new regression test fails without its corresponding fix (spot-checked #1, #8, #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)