### PR TITLE
fix: resolve all v1.0.0 audit blockers (#159–#164)

### DIFF
--- a/.agents/skills/ngx-signal-forms/vest/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/vest/SKILL.md
@@ -6,7 +6,7 @@ description: Sub-skill of ngx-signal-forms for the @ngx-signal-forms/toolkit/ves
 
 Implements the `@ngx-signal-forms/toolkit/vest` entry point.
 
-Requires `vest@^6.0.0`. Vest 5 and earlier are not supported. Prefer `vest@6.2.7` or `>=6.3.1`; `6.3.0` is excluded because of an upstream packaging/runtime break.
+Requires `vest@>=6.0.0`. Vest 5 and earlier are not supported.
 
 ## When to Use Vest vs Angular Validators
 

--- a/.github/instructions/ngx-signal-forms-toolkit.instructions.md
+++ b/.github/instructions/ngx-signal-forms-toolkit.instructions.md
@@ -563,7 +563,7 @@ Public directives and helpers include:
 
 Use `@ngx-signal-forms/toolkit/vest` when validation logic reads more like business policy than field rules — eligibility, conditional rules, async server-backed checks, or reusable rule sets outside Angular forms.
 
-Requires `vest` `>=6.0.0 <6.3.0 || >=6.3.1` as an **optional** peer dependency. Prefer `vest@6.2.7` or `>=6.3.1`; `6.3.0` is excluded because of an upstream packaging break.
+Requires `vest` `>=6.0.0` as an **optional** peer dependency.
 
 Current public exports:
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,7 +9,7 @@ This document describes the compatibility contract for
 - Current peer dependencies:
   - `@angular/core >=22.0.0 <23.0.0`
   - `@angular/forms >=22.0.0 <23.0.0`
-  - `vest >=6.0.0 <6.3.0 || >=6.3.1` (optional)
+  - `vest >=6.0.0` (optional)
 
 ## Angular compatibility
 
@@ -46,11 +46,9 @@ That means:
 The Vest adapter is optional and only required when importing
 `@ngx-signal-forms/toolkit/vest`.
 
-| Vest version    | Status        | Notes                                           |
-| --------------- | ------------- | ----------------------------------------------- |
-| `6.0.0 - 6.2.x` | Supported     | Standard Schema-compatible                      |
-| `6.3.0`         | Not supported | Excluded because of an upstream packaging issue |
-| `>=6.3.1`       | Supported     | Supported by the current peer range             |
+| Vest version | Status    | Notes                       |
+| ------------ | --------- | --------------------------- |
+| `>=6.0.0`    | Supported | Standard Schema-compatible. |
 
 ## Runtime and tooling baseline
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -55,8 +55,9 @@ The Vest adapter is optional and only required when importing
 ## Runtime and tooling baseline
 
 The toolkit's `engines.node` matches the Angular 22 toolchain used in this repo:
-`^20.19.0 || ^22.12.0 || >=24.0.0`. Consumers should use an active LTS Node
-version compatible with Angular 22 and their package manager/tooling stack.
+`^22.22.3 || ^24.15.0 || >=26.0.0` (mirrors `@angular/core@22`'s own `engines`
+field). Consumers should use an active LTS Node version compatible with
+Angular 22 and their package manager/tooling stack.
 
 The repository currently validates and publishes with the following Node
 versions:

--- a/apps/demo-e2e/src/page-objects/fieldset-appearance.page.ts
+++ b/apps/demo-e2e/src/page-objects/fieldset-appearance.page.ts
@@ -149,7 +149,13 @@ export class FieldsetAppearancePage extends BaseFormPage {
   }
 
   getGroupedAlert(fieldset: Locator): Locator {
-    return this.getGroupedMessages(fieldset).getByRole('alert').first();
+    // The role="alert" live-region shell is now always mounted (empty) so AT
+    // reliably announces on first content insertion; filter to a contentful
+    // alert so "no grouped error" still reads as zero matches.
+    return this.getGroupedMessages(fieldset)
+      .getByRole('alert')
+      .filter({ hasText: /\S/ })
+      .first();
   }
 
   getNotificationTitle(fieldset: Locator): Locator {

--- a/apps/demo/src/styles.scss
+++ b/apps/demo/src/styles.scss
@@ -80,6 +80,21 @@
   --spacing-12: 3rem;
 }
 
+/* Signal-forms error/warning colors.
+ *
+ * The toolkit drives its dark-mode error colors from `prefers-color-scheme`
+ * only; it no longer detects a `.dark` ancestor class (that relied on the
+ * non-standard `:host-context()`, unsupported in Firefox/Safari — see the
+ * v1.0.0 accessibility audit). Because this demo themes via a `.dark` class
+ * toggled independently of the OS preference, it must set the public
+ * `--ngx-signal-form-error-color` / `--ngx-signal-form-warning-color`
+ * custom properties per theme, otherwise an explicit-light UI on an
+ * OS-prefers-dark machine would show dark-mode error colors. */
+:root {
+  --ngx-signal-form-error-color: #db1818;
+  --ngx-signal-form-warning-color: #a16207;
+}
+
 /* Dark theme variable overrides (activated via .dark class) */
 .dark {
   --color-bg: var(--color-gray-900);
@@ -88,6 +103,8 @@
   --color-text-muted: var(--color-gray-400);
   --color-border: var(--color-gray-700);
   --color-border-focus: var(--color-brand-end);
+  --ngx-signal-form-error-color: #fca5a5;
+  --ngx-signal-form-warning-color: #fcd34d;
 }
 
 /* Base layer: global resets */

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -533,7 +533,9 @@ A custom renderer is a component referenced through
 `*ngComponentOutlet` and binds inputs depending on the call site:
 
 - `NgxFormFieldWrapper` (and any wrapper following this guide) binds
-  `{ formField, strategy, submittedStatus }`.
+  `{ formField, strategy, submittedStatus, warningStrategy, fieldName }`.
+  `warningStrategy` and `fieldName` are extras beyond the minimal contract —
+  see the id contract below for why `fieldName` matters.
 - `NgxFormFieldset` binds
   `{ errors, fieldName, strategy, submittedStatus, listStyle }`.
 
@@ -541,6 +543,20 @@ Inputs the renderer doesn't declare are dropped silently by
 `*ngComponentOutlet`; extra inputs the renderer declares are unaffected.
 A renderer that targets both call sites must accept the union (or declare a
 generic `inputs` signature).
+
+### The id contract
+
+Independently of which renderer is mounted, both call sites compose the
+bound control's `aria-describedby` from `${fieldName}-error` /
+`${fieldName}-warning` whenever errors/warnings are visible. **Your renderer
+must render a matching element** — `id="${fieldName}-error"` whenever it
+displays blocking errors, `id="${fieldName}-warning"` whenever it displays
+warnings — or the composed `aria-describedby` dangles (an axe
+`aria-valid-attr-value` violation on every invalid field). Read `fieldName`
+from the input the wrapper passes rather than re-injecting
+`NGX_SIGNAL_FORM_FIELD_CONTEXT` yourself when it's available (`NgxFormFieldset`
+always passes it; `NgxFormFieldWrapper` passes it as of the input listed
+above). See `NgxFormFieldError` for the reference implementation.
 
 ## Checklist before shipping
 
@@ -558,7 +574,11 @@ generic `inputs` signature).
       `{ optional: true }`, falls back to `NgxFormFieldError`, and renders
       the resolved component via `*ngComponentOutlet`.
 - [ ] The computed feeding `*ngComponentOutlet` inputs binds
-      `{ formField, strategy, submittedStatus }` so any compliant renderer works.
+      `{ formField, strategy, submittedStatus }` (plus `fieldName`,
+      recommended — see the id contract above) so any compliant renderer works.
+- [ ] Custom error/warning renderers satisfy the
+      [id contract](#the-id-contract): `id="${fieldName}-error"` /
+      `id="${fieldName}-warning"` on the elements that display each kind.
 - [ ] Wrapper does **not** write `aria-invalid`, `aria-required`, or
       `aria-describedby` on its host element — those belong on the bound
       control and are owned by `NgxSignalFormAutoAria`.

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -43,6 +43,9 @@ releases will not include any of the renames below.
 - **BREAKING: `ErrorMessageRegistry` is now strongly typed per built-in kind** — factory params for built-in kinds (`minLength`, `min`, `pattern`, …) are typed; custom kinds stay `any` (see [§5b](#5b-error-message-registry-is-now-strongly-typed))
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
+- **A11y fix** — assistive live-region containers no longer toggle `aria-hidden`/`[hidden]` while empty, and `NgxFormFieldError`'s `id` binding no longer emits the literal string `"null"` (see [§6](#6-v100-audit-blockers-live-region-focus-and-dark-mode-fixes))
+- **A11y fix** — `NgxFormFieldErrorSummary`'s `autoFocus` now only fires under the resolved `'on-submit'` strategy, never `'on-touch'`/`'immediate'` (see [§6](#6-v100-audit-blockers-live-region-focus-and-dark-mode-fixes))
+- **BREAKING (a11y fix)** — dark mode no longer detects a `.dark` ancestor class via `:host-context()` (non-standard, unsupported in Firefox/Safari); class-based dark-mode apps must override the public `--ngx-signal-form-*` custom properties directly (see [§6](#6-v100-audit-blockers-live-region-focus-and-dark-mode-fixes))
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
 
 ---
@@ -560,6 +563,99 @@ import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
   `,
 })
 ```
+
+---
+
+## 6. v1.0.0 audit blockers: live-region, focus, and dark-mode fixes
+
+The `assistive` entry point (`NgxFormFieldError`, `NgxFormFieldNotification`,
+`NgxFormFieldErrorSummary`) shipped a handful of accessibility defects that
+were fixed as part of the v1.0.0 release audit. None of these rename or
+remove an input/output, but they change runtime DOM/behavior in ways some
+consumers (especially tests) may depend on.
+
+### `id` binding no longer emits the literal string `"null"`
+
+`NgxFormFieldError`'s error/warning containers used a **property** binding
+(`[id]`) for their generated id. Binding `null` to the DOM `id` property
+coerces to the string `"null"` (WebIDL `DOMString`), so every empty
+container in the document ended up with `id="null"` — a real duplicate-id
+bug. This is now an **attribute** binding (`[attr.id]`), matching
+`NgxFormFieldNotification`, so a `null`/unresolvable id removes the
+attribute entirely instead of emitting `"null"`.
+
+- **Before:** `id="null"` could appear on empty error/warning containers.
+- **After:** the `id` attribute is simply absent.
+- If any test asserted `element.getAttribute('id') === 'null'`, update it to
+  assert `element.hasAttribute('id') === false`.
+
+### Empty live regions no longer toggle `aria-hidden` / `[hidden]`
+
+`NgxFormFieldError`, `NgxFormFieldNotification`, and
+`NgxFormFieldErrorSummary` previously toggled `aria-hidden="true"` and
+`[hidden]` on their live-region containers while empty, removing them from
+the DOM once the first error/warning/entry arrived. Flipping `aria-hidden`
+off in the same change-detection pass that inserts the first message is
+functionally equivalent to inserting a brand-new live region — which
+reintroduces the exact NVDA + Chrome "missed first announcement" bug the
+always-mounted container pattern exists to avoid.
+
+The containers now stay mounted **and exposed** at all times; the `@if` in
+each template already guarantees zero content (including whitespace) while
+empty, and visual collapse is handled entirely by the existing `--empty`
+CSS class.
+
+- **Before:** `screen.queryByRole('alert')` (and `'status'`) returned `null`
+  while there were no errors/warnings/entries, because the empty container
+  carried `aria-hidden`/`[hidden]` and Testing Library's accessible-role
+  queries exclude hidden elements by default.
+- **After:** the container is always found by role; assert on its content
+  instead — e.g. `expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('')`.
+- `NgxFormFieldErrorSummary`'s `role="alert"` container is now also
+  rendered unconditionally (previously it was only added to the DOM once
+  there were entries, which risked the same missed-first-announcement
+  timing bug on the very first submit).
+
+### `NgxFormFieldErrorSummary` `autoFocus` no longer fires under `'on-touch'` / `'immediate'`
+
+`autoFocus` (default `true`) is documented as implementing the GOV.UK/WAI
+pattern of moving focus to the summary "after a failed submit." Previously
+it fired on _any_ 0 → N entries transition, including under the default
+`'on-touch'` strategy — so blurring the first invalid field mid-fill (or,
+under `'immediate'`, simply loading an already-invalid form) silently
+stole focus. This violated WCAG 3.2.1/3.2.2 and contradicted the documented
+contract.
+
+`autoFocus` now only moves focus when the resolved strategy (explicit
+`strategy` input → form context → `'on-touch'` default) is `'on-submit'`.
+Under `'on-touch'`/`'immediate'`, focus is never moved automatically,
+regardless of the `autoFocus` value.
+
+- If you depended on the old on-touch/immediate auto-focus behavior, move
+  focus yourself (e.g. in a submit handler) or switch the summary's
+  `strategy` to `'on-submit'`.
+- The new `resolvedStrategy` signal is exposed on the headless
+  `NgxHeadlessErrorSummary` directive if you need to replicate this gating
+  in a custom summary UI.
+
+### Dark mode: `:host-context(.dark)` heuristic removed
+
+`NgxFormFieldError` and `NgxFormFieldNotification` previously shipped a
+`:host-context(.dark)` / `:host-context(:root:not(.dark))` heuristic
+alongside their `prefers-color-scheme: dark` media query, intended to
+support class-based dark-mode toggling (e.g. Tailwind's `.dark` strategy).
+`:host-context()` is non-standard and unsupported in Firefox and Safari, so
+the three engines disagreed on the resulting colors — in some
+configurations this produced WCAG 1.4.3 contrast failures (as low as
+~1.8:1). The heuristic has been removed; built-in dark defaults are now
+driven by `prefers-color-scheme` only, consistently across all engines.
+
+- **Breaking for class-based dark-mode consumers:** if your app toggles a
+  `.dark` class instead of relying on the OS color scheme, the built-in
+  dark tokens will no longer activate. Override the public
+  `--ngx-signal-form-error-*` / `--ngx-signal-form-warning-*` /
+  `--ngx-signal-form-notification-*` custom properties yourself, scoped to
+  your `.dark` selector — see the [assistive README](../packages/toolkit/assistive/README.md#dark-mode).
 
 ---
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -44,6 +44,9 @@ releases will not include any of the renames below.
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
+- **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§9](#9-headless-audit-fixes-v100))
+- **BREAKING: `CharacterCountResult` members are now typed `Signal<T>`** (was the looser `ReadSignal<T>` alias); a new `hasLimit` member was added — compile-time tightening only, no runtime change
+- **Bug fix** — error summary no longer drops a second field's error when two different fields share the same kind + message-less default; `NgxHeadlessNotification` no longer leaks the internal `warn:` prefix; `createErrorMessageSignal`'s ID fallback strips Angular's internal `{appId}.form{n}.` prefix; required `Date`/`File`/`Map`-valued leaves no longer vanish from field-optionality summaries
 
 ---
 
@@ -693,6 +696,92 @@ queried the attributes in tests — switch tests to assert `role` instead.
 Peer dependencies now constrain `@angular/core` and `@angular/forms` to
 `>=22.0.0 <23.0.0`. See [`COMPATIBILITY.md`](../COMPATIBILITY.md) for the
 reasoning. If you are already on Angular 22, no migration action is required.
+
+---
+
+## 9. Headless audit fixes (v1.0.0)
+
+A pre-1.0 audit of `@ngx-signal-forms/toolkit/headless` found a handful of
+correctness and API-surface issues. Fixes shipped together; the API-affecting
+ones are called out here.
+
+### `ErrorSummarySignals.shouldShowWarnings` (new, breaking for interface implementers)
+
+`NgxHeadlessErrorSummary.shouldShow` gates `entries()` on `strategy &&
+hasErrors()`. That gate can never reveal `warningEntries()` on a warnings-only
+form, because `hasErrors()` is permanently `false` when there are no blocking
+errors. `ErrorSummarySignals` now declares a dedicated
+`shouldShowWarnings: Signal<boolean>` (`strategy && hasWarnings()`) — gate
+`warningEntries()` on this instead of `shouldShow()`:
+
+```html
+<!-- before — warnings could never render -->
+@if (summary.shouldShow()) { @for (e of summary.warningEntries(); track e.kind)
+{ … } }
+
+<!-- after -->
+@if (summary.shouldShowWarnings()) { @for (e of summary.warningEntries(); track
+e.kind) { … } }
+```
+
+If you implement `ErrorSummarySignals` yourself (e.g. a custom summary
+directive), add the new member.
+
+### `CharacterCountResult` — real `Signal<T>` typing + `hasLimit`
+
+`createCharacterCount()`'s return type previously typed every member as the
+looser `ReadSignal<T>` (`= () => T`) alias, even though every member was
+already a real `computed()` at runtime. Members are now typed `Signal<T>`,
+matching `NgxHeadlessCharacterCount`'s own `CharacterCountStateSignals`. A new
+`hasLimit: Signal<boolean>` member was added (always `true` — `maxLength` is
+required — kept for symmetry with the directive's `hasLimit`). This is a
+compile-time tightening with no runtime change; it only affects code that
+assigned the factory's return values to a hand-rolled `() => T`-shaped type
+that isn't a real `Signal`.
+
+### Error summary: per-field deduplication
+
+`NgxHeadlessErrorSummary` deduplicated entries by `kind + message` only. Two
+different fields both failing `required()` with no custom `message` (Angular's
+default `ValidationError.message` is `undefined`) shared the same dedupe key
+and the second field's error was silently dropped from the summary — a WCAG
+3.3.1 violation. Deduplication is now per-field. If your tests asserted the
+old (buggy) collapsed count for a summary with multiple message-less errors on
+distinct fields, update the expected entry count.
+
+`NgxHeadlessFieldset`'s grouped-message dedupe (a documented feature, not a
+bug) is unchanged.
+
+### `NgxHeadlessNotification` — warning messages no longer leak `warn:`
+
+Message-less warnings with an unknown kind (e.g. `warningError('weak_password')`)
+previously rendered as `warn:weak password` inside the notification's warning
+live region because the internal `warn:` prefix wasn't stripped. It now
+resolves to `weak password`, consistent with every other headless surface
+(`NgxHeadlessErrorState`, `NgxHeadlessErrorSummary`,
+`createErrorMessageSignal`). Update any test/snapshot asserting the old
+`warn:`-prefixed text.
+
+### `createErrorMessageSignal` — ID fallback strips the Angular-internal prefix
+
+When `options.fieldName` is omitted, the per-error DOM id fallback previously
+used `FieldState.name()` raw — which is Angular-internal-prefixed
+(`${APP_ID}.form${n}.path`, e.g. `ng.form0.email`) and varies per form
+instance. IDs are now derived from the stripped path (`email-error-required`),
+matching the ids the in-tree wrapper and other consumers derive from the same
+field. This restores the documented "lockstep" ID guarantee; pass an explicit
+`fieldName` if you need to keep a specific id shape.
+
+### Field-optionality — `Date` / `File` / `Map`-valued required leaves
+
+`summarizeFieldOptionality()` / `createFieldOptionalitySummary()` walked the
+`FieldTree` using "is this node iterable?" as a container check. Angular gives
+any field whose _current_ value is a non-null object (including `Date`,
+`File`, `Map`) an iterator, so a required `Date | null` field flipped out of
+the walk — and lost its `hasRequired` contribution — the moment it was
+populated. The walk now distinguishes genuine structural containers (plain
+objects / arrays) from boxed leaf values, so a required `Date`/`File`/`Map`
+leaf is counted consistently whether it's `null` or populated.
 
 ---
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -44,6 +44,8 @@ releases will not include any of the renames below.
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
+- **BREAKING: `canSubmitWithWarnings()` now reads `errorSummary()`** — child-path blocking errors now correctly disable submission (see [§5c](#5c-cansubmitwithwarnings-now-aggregates-descendant-errors))
+- **BREAKING: `injectFieldControl()` validates the resolved value against the runtime `FieldTree` contract** — an id resolving to a non-`FieldTree` property now throws instead of silently returning an unsound cast (see [§5d](#5d-injectfieldcontrol-validates-the-resolved-fieldtree))
 
 ---
 
@@ -470,6 +472,54 @@ What changed for migrators:
   string.
 - **No runtime behavior change** for existing string entries or correctly typed
   factories — this is a compile-time tightening only.
+
+## 5c. `canSubmitWithWarnings()` now aggregates descendant errors
+
+`canSubmitWithWarnings()` previously gated on `formTree().errors()`, which
+only reports the root field's **own** errors. Validators are almost always
+placed on child paths (`path.email`, not `path`), so a blocking `required`
+error on a child field left the root's `errors()` empty and
+`canSubmitWithWarnings()` returned `true` — while its sibling helper
+`submitWithWarnings()` already correctly gated on `errorSummary()` (which
+aggregates descendant errors) and silently refused to submit. That mismatch
+produced a dead click: the submit button computed "submittable" while the
+actual submit call was a no-op.
+
+`canSubmitWithWarnings()` now reads `formTree().errorSummary()`, matching
+`submitWithWarnings()`.
+
+**Action:** If you built a form whose only blocking validators live at the
+form root (uncommon) and were relying on child-path errors being ignored by
+`canSubmitWithWarnings()`, that form's submit button will now correctly stay
+disabled until the child error clears. This is the intended fix — no code
+changes are needed unless you were compensating for the bug elsewhere (e.g.
+manually re-checking `errorSummary()` before calling `submitWithWarnings()`).
+
+## 5d. `injectFieldControl()` validates the resolved `FieldTree`
+
+`injectFieldControl()` previously validated only `isRecord(control) && part
+in control` while walking the dotted id path, then cast the final value to
+`FieldTree<TValue>` unconditionally. Any property reachable by the path —
+including one that happens to collide with non-control data on the form
+object — passed silently and was returned as though it were a real
+`FieldTree`, deferring the failure to a confusing error at the first
+downstream call site.
+
+`injectFieldControl()` now validates the resolved value with the existing
+`isFieldTree()` runtime guard and throws the same descriptive
+`"Field "…" not found in form"` error immediately when it fails the check.
+
+**Action:** No change needed for real Angular `form()` trees — they always
+satisfy the `FieldTree` contract. If you were passing a hand-rolled mock form
+into toolkit-consuming code under test, make sure the mocked leaf values are
+callable and resolve to an object exposing `value`, `touched`, `errors`,
+`errorSummary`, `submitting`, and `markAsTouched` as functions, plus a
+`fieldTree` back-reference to the callable itself (mirrors what
+`walkFieldTreeEntries()` already requires).
+
+Resolution also remains a **one-shot, non-reactive** lookup — the form
+instance and the element's `id` are both read once, at call time. This was
+previously undocumented; see the updated `injectFieldControl()` JSDoc.
 
 ### Control semantics contract — `ngxSignalFormControl`
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -44,6 +44,7 @@ releases will not include any of the renames below.
 - **A11y** — removed explicit `aria-live` / `aria-atomic`; role semantics now authoritative
 - **Behavior** — missing `fieldName` / `id` now logs (dev mode) instead of throwing
 - **Compatibility** — Angular peer-dep is `>=22.0.0 <23.0.0`
+- **BREAKING: `@angular/common` is now a declared peer dependency** — it was always required at runtime (form-field wrapper/fieldset use `NgComponentOutlet`/`NgTemplateOutlet`) but was previously undeclared
 
 ---
 
@@ -693,6 +694,21 @@ queried the attributes in tests — switch tests to assert `role` instead.
 Peer dependencies now constrain `@angular/core` and `@angular/forms` to
 `>=22.0.0 <23.0.0`. See [`COMPATIBILITY.md`](../COMPATIBILITY.md) for the
 reasoning. If you are already on Angular 22, no migration action is required.
+
+### `@angular/common` is now a declared peer dependency
+
+`NgxFormFieldWrapper` and `NgxFormFieldset` have always imported
+`NgComponentOutlet` / `NgTemplateOutlet` from `@angular/common` at runtime,
+but the package previously declared `@angular/common` as a devDependency
+only, not a peer dependency. This worked by accident whenever a consuming
+app already depended on `@angular/common` (virtually all Angular apps do),
+but strict installers and dependency audits correctly flagged it as an
+undeclared dependency. `package.json` now lists
+`"@angular/common": ">=22.0.0 <23.0.0"` under `peerDependencies`, matching
+the `@angular/core` / `@angular/forms` range. No action is required for
+apps that already have `@angular/common` installed (every Angular app
+does); package managers with strict peer resolution will now correctly
+surface it instead of silently allowing the gap.
 
 ---
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -758,3 +758,124 @@ reasoning. If you are already on Angular 22, no migration action is required.
   aggregation and error summary usage.
 - [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md) — the warning
   convention and message resolution order.
+
+---
+
+## 9. `form-field` v1.0.0 audit blockers
+
+The `form-field` entry point (`NgxFormFieldWrapper`, `NgxFormFieldset`) and
+its `NgxFormFieldError` collaborator shipped several defects fixed as part
+of the v1.0.0 release audit. Most are non-breaking bug fixes; the ones with
+observable behavior changes are called out below.
+
+### New: `warningStrategy` input on `NgxFormFieldWrapper`
+
+The wrapper previously only mounted its projected error/warning renderer
+when the **blocking-error** strategy (`strategy`, default `'on-touch'`)
+said errors should show — so a warnings-only field never rendered anything
+until the field was touched (or submitted), even though `NgxFormFieldError`
+defaults its own warning timing to `'immediate'`. The wrapper now exposes a
+`warningStrategy` input (forwarded to the renderer) and mounts the renderer
+whenever errors **or** warnings should be visible, matching the
+already-documented "warning timing is independent of error timing"
+contract. Non-breaking / additive — no action required unless you want to
+override the new input.
+
+### Breaking (a11y fix): warnings no longer render alongside a visible blocking error
+
+`NgxFormFieldError`'s warning live region (`role="status"`) previously
+rendered even while the error live region (`role="alert"`) was also
+visible for the same field — assertive **and** polite announcements firing
+for one field at once. It now suppresses the warning region whenever a
+blocking error is visible, matching `NgxFormFieldset`'s existing
+"warnings hidden while errors present" behavior and the form-field
+`README`'s documented contract. The corresponding `${fieldName}-warning`
+id is also dropped from the composed `aria-describedby` in that state (see
+`createAriaDescribedBySignal`) so nothing dangles.
+
+- If a test asserted both a populated `role="alert"` and a populated
+  `role="status"` for the same mixed error+warning field, update it to
+  expect the `role="status"` container to be empty (it stays mounted per
+  WCAG 4.1.3, just without an `id` or content) while errors are visible.
+
+### Fix: dev-mode "could not resolve field name" diagnostics no longer fire spuriously
+
+Both `NgxFormFieldWrapper.resolvedFieldName` and `NgxFormFieldError`'s
+internal field-name resolution used to log their one-shot `console.error`
+from inside a `computed()`. Projected children (`NgxFormFieldHint`,
+`NgxFormFieldError` itself when nested in the wrapper) read that computed
+via `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the wrapper's first
+change-detection pass — before `afterEveryRender` had populated the
+resolved name — so the diagnostic fired even for correctly configured
+fields (input with an `id`, no explicit `fieldName`). Both diagnostics now
+fire from `afterEveryRender` once the DOM state has settled instead.
+
+- If a unit test asserted `console.error` was called by reading
+  `resolvedFieldName()` (or rendering) without ever running change
+  detection, it now needs a render + `fixture.detectChanges()` /
+  `await fixture.whenStable()` pass before the diagnostic fires. (Any
+  test exercised through `@testing-library/angular`'s `render()` already
+  gets this for free.)
+
+### Fix: `[hidden]` on the wrapper host now actually hides the field
+
+`ngx-form-field-wrapper`'s `:host { display: flex }` rule is author-origin
+CSS, which beats the (non-`!important`) UA-stylesheet `[hidden] { display:
+none }` rule regardless of specificity — so a field marked `hidden()` by
+Angular Signal Forms kept rendering fully visible and focusable despite
+carrying the `hidden` attribute. `:host([hidden]) { display: none
+!important; }` has been added so the documented safety net actually works.
+If you were relying on the old (broken) behavior to keep a `hidden()`
+field visible, add your own `@if` instead of the `hidden()` schema logic.
+
+### Fix: bound-control discovery no longer misroutes to a `[prefix]`/label-slot decoy
+
+The wrapper's fallback DOM probe (used for plain controls without their
+own `[formField]` binding, mocked field states, and the pre-init render
+window) queried the whole wrapper host with one selector, which returns
+the first match in **document order** — not by resolution tier. An
+id-bearing `[prefix]`/label-slot element (e.g. a password-visibility
+toggle button) could therefore outrank the real control in the `__main`
+slot, silently misrouting `fieldName`, `data-signal-field`, semantics, and
+required-detection. The probe now checks `__main` first and only falls
+back to a whole-host scan when `__main` has no match (preserving the
+implicit-label pattern, `<label>Email <input id="email"></label>`).
+Non-breaking unless you had markup relying on the old mis-routing.
+
+### Fix: author-supplied `aria-labelledby` / `aria-describedby` preserved instead of clobbered
+
+`NgxFormFieldWrapper` (non-cluster mode) and `NgxFormFieldset` used to
+bind `[attr.aria-labelledby]` / `[attr.aria-describedby]` unconditionally
+to their internally-managed value (`null` in most cases), which silently
+removed any value an author bound directly on the host element (e.g.
+`<fieldset ngxFormFieldset aria-describedby="pw-rules">`). Both now merge
+with (rather than replace) any author-supplied value captured at
+construction — the same preservation rule auto-aria already applies to the
+bound control itself.
+
+### New: custom error-renderer `id` contract documented; `fieldName` passed through
+
+`NgxFormFieldErrorRenderer` (`core/tokens.ts`) now documents that a custom
+renderer **must** render `id="${fieldName}-error"` / `id="${fieldName}-warning"`
+on the elements displaying each kind — the composed `aria-describedby`
+references those ids regardless of which renderer is mounted, so a
+renderer that doesn't satisfy this produces dangling references (an axe
+`aria-valid-attr-value` violation). `NgxFormFieldWrapper` now also passes
+`fieldName` directly to the renderer (in addition to
+`{formField, strategy, submittedStatus, warningStrategy}`) so a custom
+renderer can satisfy the contract without injecting
+`NGX_SIGNAL_FORM_FIELD_CONTEXT` itself. See
+[`docs/CUSTOM_WRAPPERS.md`](./CUSTOM_WRAPPERS.md#the-id-contract).
+
+### New: `NgxFormField` bundle now includes `NgxSignalFormControlSemanticsDirective`
+
+The wrapper's own "could not infer a control kind" dev warning instructs
+authors to declare semantics via `ngxSignalFormControl="..."` — but that
+attribute was inert for consumers who imported only the `NgxFormField`
+convenience bundle (not the full `NgxSignalFormToolkit`), since the
+directive that reads it was never declared. Worse, `ngxSignalFormControlAria="manual"`
+was silently ignored while `NgxSignalFormAutoAria` (which the bundle does
+include) kept managing ARIA anyway via its CSS attribute selector — actively
+overriding what the author opted out of. `NgxFormField` now includes
+`NgxSignalFormControlSemanticsDirective`; it's selector-gated and inert for
+consumers who never add the attribute.

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -667,6 +667,49 @@ import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 See [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#suite-lifecycle)
 for the full suite-lifecycle discussion.
 
+### Vest v1.0.0 audit fixes (non-breaking)
+
+These are bug fixes, not public API changes — no consumer code changes are
+required. Listed here because they change previously-broken observable
+behavior:
+
+- **Fixed: a superseded focused run could leave a field permanently
+  `pending()`.** Vest 6 tracks a single resolver per suite instance, so two
+  registrations of the same suite on different fields (e.g. two
+  `focusCurrentField` validators) could steal each other's resolver, leaving
+  the earlier field's async validation stuck pending forever. The adapter now
+  falls back to the suite's `subscribe`/`get` API (when available) to detect
+  settlement independently of the stolen resolver. `VestRunnableSuite` gained
+  two new **optional** members, `subscribe` and `get`, to support this —
+  existing suite shapes that omit them keep working unchanged.
+- **Fixed: cross-field error mis-attribution for subfield-bound validators.**
+  A `focusCurrentField`-bound validator (e.g. bound to `path.email`) could
+  surface an unrelated field's retained Vest failure (e.g. `password`) as if
+  it belonged to its own bound field, because Vest's `only()` mode retains
+  other fields' previous failures in the same result. Validators bound to a
+  specific field now only map entries for that field (or its descendants).
+- **Fixed: a sync Vest warning could permanently suppress a blocking async
+  Vest error on the same field.** Angular's `validateAsync` only schedules its
+  resource when the bound subtree has zero sync errors, and toolkit warnings
+  are ordinary `ValidationError`s. A sync `warn()` result therefore silently
+  prevented the async phase (and any blocking async check, e.g. a
+  "username already taken" check) from ever running. The adapter now defers
+  surfacing a sync warning only while the suite has pending async tests, and
+  re-surfaces it together with the settled result — so an advisory warning
+  can no longer hide a blocking async error. If you inspect warnings
+  synchronously (without waiting for `whenStable()`/the async result), a
+  warning may now appear one tick later than before while async tests are
+  in flight.
+
+### Vest peer dependency range widened
+
+`vest@6.3.0` was previously excluded from the `vest` peer range
+(`>=6.0.0 <6.3.0 || >=6.3.1`) over an unverified packaging-defect claim, and
+the `>=6.3.1` half of that range pointed at a version that was never
+published as stable (only `6.3.2` was). The peer range is now simply
+`>=6.0.0` — see [`COMPATIBILITY.md`](../COMPATIBILITY.md#vest-compatibility).
+This is a relaxation, not a breaking change.
+
 ### Null-safe field-name resolution
 
 The wrapper, error, and headless field-name directives previously threw when

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -488,12 +488,14 @@ actual submit call was a no-op.
 `canSubmitWithWarnings()` now reads `formTree().errorSummary()`, matching
 `submitWithWarnings()`.
 
-**Action:** If you built a form whose only blocking validators live at the
-form root (uncommon) and were relying on child-path errors being ignored by
-`canSubmitWithWarnings()`, that form's submit button will now correctly stay
-disabled until the child error clears. This is the intended fix — no code
-changes are needed unless you were compensating for the bug elsewhere (e.g.
-manually re-checking `errorSummary()` before calling `submitWithWarnings()`).
+**Action:** This affects forms with blocking validators on descendant paths
+(the common case, e.g. `path.email`) — previously, `canSubmitWithWarnings()`
+ignored those child-path errors, so such a form's submit button could appear
+submittable even while a child field was invalid. After this fix, that
+button will now correctly stay disabled until the child error clears. This
+is the intended fix — no code changes are needed unless you were
+compensating for the bug elsewhere (e.g. manually re-checking
+`errorSummary()` before calling `submitWithWarnings()`).
 
 ## 5d. `injectFieldControl()` validates the resolved `FieldTree`
 

--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -87,16 +87,20 @@ Grouped validation notification with an optional title.
 
 `errors` must be a signal, for example `signal<readonly ValidationError[]>([])`.
 
-| Input       | Type                                 | Description                                       |
-| ----------- | ------------------------------------ | ------------------------------------------------- |
-| `errors`    | `Signal<readonly ValidationError[]>` | Grouped validation messages to present            |
-| `fieldName` | `string`                             | Optional id base for `aria-describedby` linkage   |
-| `title`     | `string`                             | Optional title above the grouped messages         |
-| `listStyle` | `'plain' \| 'bullets'`               | Stacked paragraphs or bullet list                 |
-| `tone`      | `'auto' \| 'error' \| 'warning'`     | Resolve the card as an error/warning notification |
+| Input       | Type                                 | Description                                     |
+| ----------- | ------------------------------------ | ----------------------------------------------- |
+| `errors`    | `Signal<readonly ValidationError[]>` | Grouped validation messages to present          |
+| `fieldName` | `string`                             | Optional id base for `aria-describedby` linkage |
+| `title`     | `string`                             | Optional title above the grouped messages       |
+| `listStyle` | `'plain' \| 'bullets'`               | Stacked paragraphs or bullet list               |
+| `tone`      | `'auto' \| 'error' \| 'warning'`     | Currently a no-op — see below                   |
 
-- `tone="auto"` treats an all-warning list as a polite status notification
-- Blocking errors keep `role="alert"`
+- Tone is always **content-driven**, regardless of the `tone` value passed:
+  any blocking (non-`warn:`) error routes the group to `role="alert"`; an
+  all-warning list routes to the polite `role="status"` container.
+- The `tone` input does not currently force either outcome. It is retained
+  as a stable API surface for possible future expansion (e.g. explicit
+  tone forcing) — do not rely on it to change rendering today.
 - Intended for grouped fieldset summaries or custom headless summary cards
 
 ### NgxFormFieldErrorSummary
@@ -128,8 +132,8 @@ Helper text below inputs. Automatically linked to the input via `aria-describedb
 ```
 
 Optional `position` input (`'left' | 'right'`): alignment within the assistive
-row. When omitted, hints right-align — or left-align when a character count
-shares the row.
+row. When omitted, hints left-align by default; pass `position="right"` to
+opt into end alignment.
 
 ### NgxFormFieldCharacterCount
 
@@ -187,6 +191,16 @@ tokens when used inside `ngx-form-fieldset`.
 
 The default light-theme error surface now matches the Figma design token
 directly: `#fdebeb`.
+
+### Dark mode
+
+Built-in dark defaults are driven by the `prefers-color-scheme: dark` media
+query only — they do not detect a `.dark` class on an ancestor element.
+(`:host-context()`, which would be needed for that, is non-standard and
+unsupported in Firefox and Safari.) Apps using a class-based dark-mode
+strategy must override the public `--ngx-signal-form-error-*` /
+`--ngx-signal-form-warning-*` / `--ngx-signal-form-notification-*` custom
+properties themselves, scoped to their `.dark` selector.
 
 ## Related documentation
 

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -377,8 +377,14 @@ describe('NgxFormFieldErrorSummary', () => {
     await userEvent.click(input);
     await userEvent.tab();
 
+    // The alert shell is always mounted (WCAG 4.1.3 live region), so
+    // `findByRole('alert')` resolves as soon as the element exists — not
+    // once it actually contains the error text. Wait for the text content
+    // itself to avoid racing the update.
     const summaryAlert = await screen.findByRole('alert');
-    expect(summaryAlert.textContent).toContain('Email is required');
+    await vi.waitFor(() => {
+      expect(summaryAlert.textContent).toContain('Email is required');
+    });
 
     const focusTarget = summaryAlert.closest('ngx-form-field-error-summary');
     expect(document.activeElement).not.toBe(focusTarget);

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -83,7 +83,7 @@ describe('NgxFormFieldErrorSummary', () => {
 
     const { fixture } = await render(TestComponent);
 
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
 
     fixture.componentInstance.submittedStatus.set('submitted');
     fixture.detectChanges();
@@ -119,7 +119,7 @@ describe('NgxFormFieldErrorSummary', () => {
     const { fixture } = await render(TestComponent);
 
     // Default strategy is on-touch → no entries until a field is touched.
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
 
     fixture.componentInstance.contactForm.email().markAsTouched();
     fixture.detectChanges();
@@ -189,7 +189,7 @@ describe('NgxFormFieldErrorSummary', () => {
 
     await render(TestComponent);
 
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     expect(screen.queryAllByRole('button').length).toBe(0);
   });
 
@@ -273,9 +273,10 @@ describe('NgxFormFieldErrorSummary', () => {
 
     const { fixture } = await render(TestComponent);
 
-    // Before submit there are no entries, so the summary is hidden and
-    // focus is wherever the test framework left it (typically <body>).
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    // Before submit there are no entries, so the summary shell stays
+    // mounted (WCAG 4.1.3) but empty, and focus is wherever the test
+    // framework left it (typically <body>).
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
 
     // Submit triggers the on-submit strategy → entries appear → host
     // should receive focus on the next render pass.
@@ -337,6 +338,50 @@ describe('NgxFormFieldErrorSummary', () => {
     // Summary is visible but focus must remain on the input.
     expect(await screen.findByRole('alert')).toBeTruthy();
     expect(document.activeElement).toBe(input);
+  });
+
+  it('does not steal focus under the default on-touch strategy (WCAG 3.2.1/3.2.2)', async () => {
+    // The GOV.UK/WAI error-summary pattern moves focus to the summary after
+    // a failed *submit*. `errorStrategy` defaults to `'on-touch'`, and the
+    // root FieldTree's `touched()` aggregates children — so merely blurring
+    // the first invalid field would surface the summary. Auto-focusing here
+    // would be an unexpected context change (WCAG 3.2.1/3.2.2) while the
+    // user is still filling out the form, not the documented "arrive after
+    // a failed submit" contract.
+    @Component({
+      selector: 'ngx-test-error-summary-on-touch-no-steal',
+      imports: [FormField, NgxFormFieldErrorSummary],
+
+      template: `
+        <input
+          id="email"
+          data-testid="email-input"
+          [formField]="contactForm.email"
+        />
+        <ngx-form-field-error-summary [formTree]="contactForm" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly contactForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    await render(TestComponent);
+
+    const input = screen.getByTestId('email-input');
+    await userEvent.click(input);
+    await userEvent.tab();
+
+    const summaryAlert = await screen.findByRole('alert');
+    expect(summaryAlert.textContent).toContain('Email is required');
+
+    const focusTarget = summaryAlert.closest('ngx-form-field-error-summary');
+    expect(document.activeElement).not.toBe(focusTarget);
   });
 
   describe('dev-mode focus-failure diagnostic', () => {

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -27,10 +27,16 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
  * - Error links are focusable buttons for keyboard navigation
  * - Each entry identifies the field and the error message
  * - The summary host has `tabindex="-1"` and is **programmatically focused**
- *   the first time it appears with non-zero entries (GOV.UK / WAI tutorial
- *   pattern for WCAG 2.4.3 + 3.3.1). This guarantees screen reader users
- *   land on the summary after submit instead of being left where they were.
- *   Opt out with `[autoFocus]="false"`.
+ *   the first time it appears with non-zero entries under the resolved
+ *   `'on-submit'` strategy (GOV.UK / WAI tutorial pattern for WCAG 2.4.3 +
+ *   3.3.1). This guarantees screen reader users land on the summary after a
+ *   failed submit instead of being left where they were. Auto-focus is
+ *   intentionally skipped for `'on-touch'` / `'immediate'` strategies: the
+ *   root FieldTree's `touched()` aggregates children, so the summary can
+ *   appear the moment the user blurs the first invalid field — focusing it
+ *   then would be an unexpected mid-fill context change (WCAG 3.2.1/3.2.2),
+ *   not the documented "arrive after a failed submit" contract. Opt out of
+ *   the on-submit auto-focus with `[autoFocus]="false"`.
  *
  * ## Usage
  *
@@ -67,8 +73,24 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
     },
   ],
   template: `
-    @if (summary.shouldShow() && summary.hasErrors()) {
-      <div class="ngx-form-field-error-summary" role="alert">
+    <!--
+      The role="alert" container is rendered UNCONDITIONALLY (even when
+      empty), the same always-mounted live-region pattern NgxFormFieldError
+      and NgxFormFieldNotification use: role="alert" only fires reliably on
+      content insertion into a pre-existing live region, so inserting the
+      container and its content in the same tick risks the NVDA + Chrome
+      missed-first-announcement bug. aria-hidden/[hidden] are intentionally
+      never toggled — the @if below already guarantees zero content while
+      empty, so an empty live region announces nothing on its own.
+    -->
+    <div
+      class="ngx-form-field-error-summary"
+      [class.ngx-form-field-error-summary--empty]="
+        !(summary.shouldShow() && summary.hasErrors())
+      "
+      role="alert"
+    >
+      @if (summary.shouldShow() && summary.hasErrors()) {
         @if (summaryLabel()) {
           <p class="ngx-form-field-error-summary__label">
             {{ summaryLabel() }}
@@ -94,8 +116,8 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
             </li>
           }
         </ul>
-      </div>
-    }
+      }
+    </div>
   `,
   styles: `
     .ngx-form-field-error-summary {
@@ -104,6 +126,16 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
       padding: 1rem;
       margin-block: 1rem;
       background: var(--ngx-error-summary-bg, #fef2f2);
+    }
+
+    /* Empty live-region shell: the @if in the template guarantees zero
+     * content while empty, so we additionally zero the box model to
+     * collapse it visually — mirrors the --empty pattern in
+     * NgxFormFieldError / NgxFormFieldNotification. */
+    .ngx-form-field-error-summary--empty {
+      border-width: 0;
+      padding: 0;
+      margin-block: 0;
     }
 
     .ngx-form-field-error-summary__label {
@@ -165,13 +197,21 @@ export class NgxFormFieldErrorSummary {
 
   /**
    * Whether to programmatically focus the summary host the first time it
-   * appears with non-zero entries.
+   * appears with non-zero entries **under the resolved `'on-submit'`
+   * strategy**.
    *
    * The default (`true`) follows the GOV.UK / WAI error-summary pattern so
    * screen-reader users hear the announcement and arrive at the summary
    * after a failed submit. Set to `false` if your flow already moves focus
    * elsewhere (e.g. straight to the first invalid field) or if focus
    * theft is undesirable in your design.
+   *
+   * This input has no effect under `'on-touch'` or `'immediate'` strategies
+   * — auto-focus is always skipped for those, regardless of this value,
+   * because the summary can appear mid-fill (e.g. on blurring the first
+   * invalid field) and stealing focus then would be an unexpected context
+   * change (WCAG 3.2.1/3.2.2), not the documented "arrive after a failed
+   * submit" contract.
    *
    * @default true
    */
@@ -205,6 +245,13 @@ export class NgxFormFieldErrorSummary {
         untracked(() => {
           if (hasFocused) return;
           if (!this.autoFocus()) return;
+          // Only the resolved 'on-submit' strategy matches the documented
+          // GOV.UK/WAI "arrive at the summary after a failed submit"
+          // contract. Under 'on-touch'/'immediate' the summary can appear
+          // mid-fill (e.g. blurring the first invalid field, or on initial
+          // render for an already-invalid form) — auto-focusing there would
+          // be an unexpected context change (WCAG 3.2.1/3.2.2).
+          if (this.summary.resolvedStrategy() !== 'on-submit') return;
 
           const host = this.#host.nativeElement;
           // Defensive: in jsdom-based test environments `focus()` is

--- a/packages/toolkit/assistive/form-field-error.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.browser.spec.ts
@@ -46,11 +46,12 @@ describe('NgxFormFieldError — WCAG 4.1.3 live-region first-insertion', () => {
     const { container } = await render(TestComponent);
 
     // Before any interaction: the alert region must exist (so the first
-    // announcement is delivered) but be hidden + empty.
+    // announcement is delivered) but be empty. `aria-hidden`/`[hidden]` are
+    // intentionally never toggled — see the class-level docs.
     const alertEl = container.querySelector('[role="alert"]');
     expect(alertEl).toBeTruthy();
-    expect(alertEl?.hasAttribute('hidden')).toBe(true);
-    expect(alertEl?.getAttribute('aria-hidden')).toBe('true');
+    expect(alertEl?.hasAttribute('hidden')).toBe(false);
+    expect(alertEl?.hasAttribute('aria-hidden')).toBe(false);
     expect(alertEl?.textContent?.trim()).toBe('');
   });
 
@@ -83,7 +84,7 @@ describe('NgxFormFieldError — WCAG 4.1.3 live-region first-insertion', () => {
 
     const alertBefore = container.querySelector('[role="alert"]');
     expect(alertBefore).toBeTruthy();
-    expect(alertBefore?.hasAttribute('hidden')).toBe(true);
+    expect(alertBefore?.hasAttribute('hidden')).toBe(false);
 
     // Touch + blur to satisfy the on-touch strategy.
     const input = container.querySelector<HTMLInputElement>('input#email')!;
@@ -133,11 +134,11 @@ describe('NgxFormFieldError — WCAG 4.1.3 live-region first-insertion', () => {
     const { container } = await render(TestComponent);
 
     // Before any value: status region must exist (so the first
-    // announcement is delivered) but be hidden + empty.
+    // announcement is delivered) but be empty.
     const statusBefore = container.querySelector('[role="status"]');
     expect(statusBefore).toBeTruthy();
-    expect(statusBefore?.hasAttribute('hidden')).toBe(true);
-    expect(statusBefore?.getAttribute('aria-hidden')).toBe('true');
+    expect(statusBefore?.hasAttribute('hidden')).toBe(false);
+    expect(statusBefore?.hasAttribute('aria-hidden')).toBe(false);
     expect(statusBefore?.textContent?.trim()).toBe('');
 
     // Type a short password to trigger the `warn:weak-password` warning.

--- a/packages/toolkit/assistive/form-field-error.cross-surface.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.cross-surface.spec.ts
@@ -91,8 +91,9 @@ describe('cross-surface: NgxFormFieldError vs NgxHeadlessErrorState', () => {
 
     await render(TestComponent);
 
-    // Before touch: neither surface should show errors
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    // Before touch: neither surface should show errors. The alert shell
+    // stays mounted (WCAG 4.1.3) but must be empty.
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     expect(screen.queryByTestId('custom-error')).toBeFalsy();
 
     // Touch the field to trigger on-touch strategy
@@ -151,8 +152,9 @@ describe('cross-surface: NgxFormFieldError vs NgxHeadlessErrorState', () => {
     // Type a valid value
     await userEvent.type(screen.getByRole('textbox'), 'John');
 
-    // Both surfaces clear together
-    expect(screen.queryByRole('alert')).toBeFalsy();
+    // Both surfaces clear together. The alert shell stays mounted (WCAG
+    // 4.1.3) but must be empty.
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     expect(screen.queryByTestId('custom-error')).toBeFalsy();
   });
 
@@ -205,10 +207,10 @@ describe('cross-surface: NgxFormFieldError vs NgxHeadlessErrorState', () => {
 
     const { container } = await render(TestEmptyDirectErrorsComponent);
 
-    // Live region stays in DOM (WCAG 4.1.3) but is hidden + empty
+    // Live region stays in DOM (WCAG 4.1.3) but is empty
     const alertEl = container.querySelector('[role="alert"]');
     expect(alertEl).toBeTruthy();
-    expect(alertEl?.hasAttribute('hidden')).toBe(true);
+    expect(alertEl?.hasAttribute('hidden')).toBe(false);
     expect(alertEl?.textContent?.trim()).toBe('');
   });
 

--- a/packages/toolkit/assistive/form-field-error.css
+++ b/packages/toolkit/assistive/form-field-error.css
@@ -97,21 +97,20 @@
   margin-top: var(--_error-margin-top);
 }
 
+/* Dark-mode defaults are driven by `prefers-color-scheme` only. An earlier
+ * revision also tried to special-case a `.dark` class ancestor via
+ * `:host-context()`, but that selector is non-standard and unsupported in
+ * Firefox and Safari — the three engines disagreed on the resulting colors
+ * (see the v1.0.0 accessibility audit), risking WCAG 1.4.3 contrast
+ * failures. Class-based ("`.dark` on `<html>`/`<body>`") theming strategies
+ * are not detectable in plain CSS without `:host-context()`; apps using that
+ * strategy must override the public `--ngx-signal-form-error-color` /
+ * `--ngx-signal-form-warning-color` custom properties directly (see README). */
 @media (prefers-color-scheme: dark) {
   :host {
     --_error-clr-danger: var(--_error-clr-danger-dark);
     --_error-clr-warning: var(--_error-clr-warning-dark);
   }
-
-  :host-context(:root:not(.dark)) {
-    --_error-clr-danger: #db1818;
-    --_error-clr-warning: #a16207;
-  }
-}
-
-:host-context(.dark) {
-  --_error-clr-danger: var(--_error-clr-danger-dark);
-  --_error-clr-warning: var(--_error-clr-warning-dark);
 }
 
 .ngx-form-field-error {
@@ -145,13 +144,14 @@
 }
 
 /* Empty live-region shell: the role="alert" / role="status" containers stay
- * mounted (with `aria-hidden="true"` and `[hidden]`) so AT picks up the
- * live region on first content insertion (WCAG 4.1.3). The element is
- * already removed from layout flow by `[hidden]`, but we also clear
- * padding/border/margin defensively in case a consumer overrides the
- * default `display:none` styling (e.g. with `display: contents` for a
- * flex/grid layout) — the empty shell must contribute zero visual
- * footprint regardless of how it is reflowed. */
+ * mounted and exposed (no `aria-hidden`/`[hidden]` toggling — see the
+ * class-level template docs) so AT picks up the live region on first
+ * content insertion (WCAG 4.1.3). The `@if` in the template guarantees zero
+ * content while empty, so the flex container naturally collapses to zero
+ * size; we also clear padding/border/margin defensively in case a consumer
+ * overrides layout (e.g. `display: contents` for a flex/grid layout) — the
+ * empty shell must contribute zero visual footprint regardless of how it is
+ * reflowed. */
 .ngx-form-field-error--empty {
   padding: var(--_error-space-0);
   border-width: var(--_error-space-0);

--- a/packages/toolkit/assistive/form-field-error.integration.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.integration.spec.ts
@@ -43,8 +43,10 @@ describe('NgxFormFieldError (integration)', () => {
 
     await render(TestFormErrorComponent);
 
+    // The alert shell stays mounted (WCAG 4.1.3, always-mounted live
+    // region) but must render no error text.
     const alert = screen.queryByRole('alert');
-    expect(alert).toBeFalsy();
+    expect(alert?.textContent?.trim() ?? '').toBe('');
   });
 
   /**

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -317,6 +317,72 @@ describe('NgxFormFieldError', () => {
       expect(list?.tagName).toBe('UL');
       expect(list?.querySelectorAll('li')).toHaveLength(2);
     });
+
+    it('suppresses the warning live region while a blocking error is also visible', async () => {
+      // README's "Warning support" section documents "blocking errors
+      // present → warnings hidden", and NgxFormFieldset already enforces
+      // this. Without a guard, both the role="alert" and role="status"
+      // containers render at once for a field with mixed errors/warnings —
+      // an assertive AND a polite announcement for the same field.
+      @Component({
+        selector: 'ngx-test-mixed-error-warning',
+        imports: [NgxFormFieldError],
+
+        template: `
+          <ngx-form-field-error fieldName="password" [errors]="errors" />
+        `,
+      })
+      class TestComponent {
+        readonly errors = signal([
+          { kind: 'required', message: 'Password is required' },
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ]);
+      }
+
+      const { container } = await render(TestComponent);
+
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toContain('Password is required');
+
+      // Query the container directly (not via `screen.getByRole`): the
+      // empty-container pattern also marks it `[hidden]`/`aria-hidden`,
+      // which testing-library's accessibility-tree-aware queries exclude.
+      // The status container stays mounted (WCAG 4.1.3 first-insertion
+      // semantics) but must not expose the `-warning` id or render the
+      // warning text — otherwise `aria-describedby="password-warning"`
+      // would dangle.
+      const status = container.querySelector('[role="status"]');
+      expect(status).toBeTruthy();
+      expect(status?.getAttribute('id')).not.toBe('password-warning');
+      expect(status?.textContent?.trim()).toBe('');
+      expect(container.textContent).not.toContain('Consider 8+ characters');
+    });
+
+    it('shows the warning live region when no blocking error is present', async () => {
+      @Component({
+        selector: 'ngx-test-warning-only',
+        imports: [NgxFormFieldError],
+
+        template: `
+          <ngx-form-field-error fieldName="password" [errors]="errors" />
+        `,
+      })
+      class TestComponent {
+        readonly errors = signal([
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ]);
+      }
+
+      const { container } = await render(TestComponent);
+
+      const status = screen.getByRole('status');
+      expect(status.getAttribute('id')).toBe('password-warning');
+      expect(status.textContent).toContain('Consider 8+ characters');
+
+      const alert = container.querySelector('[role="alert"]');
+      expect(alert?.getAttribute('id')).not.toBe('password-error');
+      expect(alert?.textContent?.trim()).toBe('');
+    });
   });
 
   describe('strategy switching', () => {

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -59,7 +59,7 @@ describe('NgxFormFieldError', () => {
 
       // Field is invalid but untouched, no error should be visible
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should NOT show errors when form is unsubmitted and field untouched (on-submit strategy)', async () => {
@@ -91,7 +91,7 @@ describe('NgxFormFieldError', () => {
       await render(TestComponent);
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
   });
 
@@ -182,7 +182,7 @@ describe('NgxFormFieldError', () => {
       await user.tab();
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should not render errors when field is invalid but not touched (on-touch strategy)', async () => {
@@ -215,7 +215,7 @@ describe('NgxFormFieldError', () => {
 
       // Don't touch the field
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should render multiple errors', async () => {
@@ -390,7 +390,7 @@ describe('NgxFormFieldError', () => {
 
       // No error yet (on-submit strategy)
       let alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
 
       // After submission
       fixture.componentInstance.submittedStatus.set('submitted');
@@ -432,7 +432,7 @@ describe('NgxFormFieldError', () => {
 
       // submittedStatus is ignored for on-touch - field must be touched
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should NOT show errors during async submission if not touched (on-touch strategy)', async () => {
@@ -467,7 +467,7 @@ describe('NgxFormFieldError', () => {
 
       // submittedStatus is ignored for on-touch - field must be touched
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should show errors during async submission (on-submit strategy)', async () => {
@@ -533,7 +533,7 @@ describe('NgxFormFieldError', () => {
 
       // Initially no errors (not submitted)
       let alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
 
       // During submission - errors should appear
       fixture.componentInstance.submittedStatus.set('submitting');
@@ -592,8 +592,13 @@ describe('NgxFormFieldError', () => {
        * region. If the alert container itself is added to the DOM at the
        * same moment as the first error, the very first announcement can be
        * silently dropped. v1 keeps the role="alert" container always
-       * mounted (and aria-hidden="true" while empty) so that timing
-       * edge case never trips screen readers.
+       * mounted so that timing edge case never trips screen readers. It
+       * does NOT toggle `aria-hidden`/`[hidden]` while empty — doing so
+       * would prune the node from the accessibility tree and then expose it
+       * at the same tick the first error is inserted, which is functionally
+       * equivalent to a fresh live-region insertion and reintroduces the
+       * same missed-first-announcement bug the always-mounted container
+       * exists to avoid.
        */
       @Component({
         selector: 'ngx-test-empty-live-region',
@@ -626,23 +631,21 @@ describe('NgxFormFieldError', () => {
       // but the live-region container itself MUST already be in the DOM
       // with role="alert" so a future insertion fires the announcement.
       // The container carries the `--empty` marker class so CSS can
-      // collapse it visually; `aria-hidden="true"` keeps AT silent until
-      // content arrives, and `[hidden]` removes the empty shell from
-      // layout flow.
+      // collapse it visually. `aria-hidden`/`[hidden]` are intentionally
+      // absent — toggling them off at the same tick content is inserted
+      // would defeat the always-mounted pattern (see class-level docs).
       const alertContainer = container.querySelector('[role="alert"]');
       expect(alertContainer).toBeTruthy();
       expect(
         alertContainer?.classList.contains('ngx-form-field-error--empty'),
       ).toBe(true);
-      expect(alertContainer?.getAttribute('aria-hidden')).toBe('true');
-      expect(alertContainer?.hasAttribute('hidden')).toBe(true);
+      expect(alertContainer?.hasAttribute('aria-hidden')).toBe(false);
+      expect(alertContainer?.hasAttribute('hidden')).toBe(false);
       // No id leaks while empty — aria-describedby targets must not point
-      // at an element with no message text. Angular renders `null`
-      // bindings as either a missing attribute or the literal string
-      // "null" depending on the jsdom path; what matters here is that
-      // the auto-generated `*-error` id is not exposed.
-      const idAttr = alertContainer?.getAttribute('id') ?? null;
-      expect(idAttr === null || idAttr === '' || idAttr === 'null').toBe(true);
+      // at an element with no message text. `[attr.id]` removes the
+      // attribute entirely for a `null` binding (unlike the property
+      // binding `[id]`, which would coerce to the literal string "null").
+      expect(alertContainer?.hasAttribute('id')).toBe(false);
       // No error text either.
       expect(alertContainer?.textContent?.trim()).toBe('');
 
@@ -652,8 +655,8 @@ describe('NgxFormFieldError', () => {
       expect(
         statusContainer?.classList.contains('ngx-form-field-error--empty'),
       ).toBe(true);
-      expect(statusContainer?.getAttribute('aria-hidden')).toBe('true');
-      expect(statusContainer?.hasAttribute('hidden')).toBe(true);
+      expect(statusContainer?.hasAttribute('aria-hidden')).toBe(false);
+      expect(statusContainer?.hasAttribute('hidden')).toBe(false);
     });
 
     it('should rely on role="alert" implicit semantics (no redundant aria-live/aria-atomic)', async () => {
@@ -794,7 +797,7 @@ describe('NgxFormFieldError', () => {
       await user.tab();
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     it('should handle empty errors array', async () => {
@@ -827,7 +830,7 @@ describe('NgxFormFieldError', () => {
       await user.tab();
 
       const alert = screen.queryByRole('alert');
-      expect(alert).toBeFalsy();
+      expect(alert?.textContent?.trim() ?? '').toBe('');
     });
 
     // Regression: when both `[formField]` and `[errors]` are bound, the
@@ -1052,12 +1055,9 @@ describe('NgxFormFieldError', () => {
         // Without a field name the auto-generated id would look like
         // `-error` / `-warning`, which is a broken aria-describedby
         // target. The v1 contract is simply: no resolvable field name →
-        // no id chain exposed. We accept any "empty-ish" id value here
-        // (null, "", or literally "null" which some JSDOM pathways emit
-        // when binding null) — the important assertion is that no
-        // `*-error` id leaks into the DOM.
-        const idAttr = alert.getAttribute('id');
-        expect(idAttr?.endsWith('-error') ?? false).toBe(false);
+        // no id chain exposed. `[attr.id]` removes the attribute entirely
+        // for a `null` binding, so the id attribute must be absent.
+        expect(alert.hasAttribute('id')).toBe(false);
         expect(alert.textContent).toContain('Email is required');
 
         expect(errorSpy).toHaveBeenCalled();
@@ -1180,7 +1180,7 @@ describe('NgxFormFieldError', () => {
       expect(status.textContent).toContain('Consider 8+ characters');
 
       // Errors stay hidden — only the warning is visible.
-      expect(screen.queryByRole('alert')).toBeFalsy();
+      expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     });
 
     it('gates warnings behind touch when warningStrategy is on-touch', async () => {
@@ -1189,7 +1189,7 @@ describe('NgxFormFieldError', () => {
       fixture.detectChanges();
 
       // Untouched: warning hidden.
-      expect(screen.queryByRole('status')).toBeFalsy();
+      expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
 
       // Touching the field surfaces the warning.
       fixture.componentInstance.contactForm.password().markAsTouched();
@@ -1207,7 +1207,7 @@ describe('NgxFormFieldError', () => {
       // Unsubmitted: warning hidden even when touched.
       fixture.componentInstance.contactForm.password().markAsTouched();
       fixture.detectChanges();
-      expect(screen.queryByRole('status')).toBeFalsy();
+      expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
 
       // After submit, warning surfaces.
       fixture.componentInstance.submittedStatus.set('submitted');
@@ -1231,7 +1231,7 @@ describe('NgxFormFieldError', () => {
       expect(status.textContent).toContain('Consider 8+ characters');
 
       // Errors still gated by submit.
-      expect(screen.queryByRole('alert')).toBeFalsy();
+      expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
     });
   });
 });

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -114,17 +114,21 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
       pre-existing live region — works the very first time an error appears.
       This satisfies WCAG 4.1.3 (Status Messages) and avoids the NVDA + Chrome
       timing edge case where a freshly-inserted live region misses its first
-      announcement. We mark the container as aria-hidden="true" while empty
-      so it is invisible to AT and contributes no whitespace text to the
-      accessibility tree, but never toggle the role attribute itself.
+      announcement. We intentionally do NOT toggle aria-hidden/[hidden]
+      while empty: the @if below already guarantees zero content (including
+      whitespace text) when empty, so an empty live region announces nothing
+      on its own — flipping aria-hidden off at the same tick the first
+      error is inserted would prune-then-immediately-expose the node, which
+      is functionally equivalent to inserting a brand-new live region and
+      reintroduces the very missed-first-announcement bug this pattern exists
+      to avoid. Visual collapse while empty is handled by the --empty CSS
+      class alone.
     -->
     <div
-      [id]="errorContainerVisible() ? errorId() : null"
+      [attr.id]="errorContainerVisible() ? errorId() : null"
       class="ngx-form-field-error ngx-form-field-error--error"
       [class.ngx-form-field-error--empty]="!errorContainerVisible()"
       role="alert"
-      [attr.aria-hidden]="errorContainerVisible() ? null : 'true'"
-      [hidden]="!errorContainerVisible()"
     >
       @if (errorContainerVisible()) {
         @if (usesBulletList()) {
@@ -159,15 +163,13 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
       Non-blocking Warnings: role="status" implies aria-live="polite" and
       aria-atomic="true"; the explicit attributes are intentionally omitted
       to avoid duplicate AT announcements. Same empty-live-region pattern as
-      the alert container above.
+      the alert container above (no aria-hidden/[hidden] toggling).
     -->
     <div
-      [id]="warningContainerVisible() ? warningId() : null"
+      [attr.id]="warningContainerVisible() ? warningId() : null"
       class="ngx-form-field-error ngx-form-field-error--warning"
       [class.ngx-form-field-error--empty]="!warningContainerVisible()"
       role="status"
-      [attr.aria-hidden]="warningContainerVisible() ? null : 'true'"
-      [hidden]="!warningContainerVisible()"
     >
       @if (warningContainerVisible()) {
         @if (usesBulletList()) {

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -1,4 +1,11 @@
-import { Component, computed, inject, input, isDevMode } from '@angular/core';
+import {
+  afterEveryRender,
+  Component,
+  computed,
+  inject,
+  input,
+  isDevMode,
+} from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   injectFormContext,
@@ -265,15 +272,6 @@ export class NgxFormFieldError {
    */
   readonly listStyle = input<NgxFormFieldListStyle>('plain');
 
-  constructor() {
-    // Bridge the `formField` class input to the headless directive so it can
-    // compute strategy-based showErrors and split errors/warnings.
-    // Cannot use `hostDirectives` input forwarding for `formField` because
-    // Angular's FormField directive has selector `[formField]` and would try
-    // to apply to this component, losing the `passThroughInput` guard.
-    this.headless.connectFieldState(computed(() => this.formField()?.()));
-  }
-
   /**
    * Reactive accessor to the underlying field state, derived from the same
    * `[formField]` input the headless directive consumes. Used to drive the
@@ -305,24 +303,48 @@ export class NgxFormFieldError {
   });
 
   // ── Field name / ID resolution ────────────────────────────────────────
+  //
+  // Pure by design: when nested inside `ngx-form-field-wrapper`,
+  // `this.#fieldContext.fieldName()` is the wrapper's own `resolvedFieldName`
+  // signal, which starts out `null` and only picks up the bound control's
+  // `id` once the wrapper's `afterEveryRender` write phase runs (see
+  // form-field-wrapper.ts). This component's template (`errorId()` /
+  // `warningId()`, both derived from `#resolvedFieldName`) can render on
+  // that very first pass whenever errors are already visible (e.g.
+  // `strategy="immediate"`), which used to fire this component's own
+  // `console.error` purely because of the one-render race — even for a
+  // correctly configured field. The diagnostic is emitted from
+  // `afterEveryRender` below instead, once the wrapper (if any) has had a
+  // chance to settle.
   readonly #resolvedFieldName = computed<string | null>(() => {
-    const resolvedFieldName = resolveFieldNameFromCandidates(
+    return resolveFieldNameFromCandidates(
       this.fieldName(),
       this.#fieldContext?.fieldName(),
     );
-    if (resolvedFieldName !== null) {
-      return resolvedFieldName;
-    }
-
-    if (isDevMode() && !this.#warnedMissingName) {
-      this.#warnedMissingName = true;
-      // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
-      console.error(
-        '[ngx-signal-forms] ngx-form-field-error requires an explicit `fieldName` input or a parent ngx-form-field-wrapper context. The component will render without id/aria-describedby linking until one is provided.',
-      );
-    }
-    return null;
   });
+
+  constructor() {
+    // Bridge the `formField` class input to the headless directive so it can
+    // compute strategy-based showErrors and split errors/warnings.
+    // Cannot use `hostDirectives` input forwarding for `formField` because
+    // Angular's FormField directive has selector `[formField]` and would try
+    // to apply to this component, losing the `passThroughInput` guard.
+    this.headless.connectFieldState(computed(() => this.formField()?.()));
+
+    afterEveryRender(() => {
+      if (
+        isDevMode() &&
+        !this.#warnedMissingName &&
+        this.#resolvedFieldName() === null
+      ) {
+        this.#warnedMissingName = true;
+        // oxlint-disable-next-line no-console -- dev-mode misconfiguration signal
+        console.error(
+          '[ngx-signal-forms] ngx-form-field-error requires an explicit `fieldName` input or a parent ngx-form-field-wrapper context. The component will render without id/aria-describedby linking until one is provided.',
+        );
+      }
+    });
+  }
 
   /**
    * Computed error / warning IDs for aria-describedby linking. Both return
@@ -380,9 +402,23 @@ export class NgxFormFieldError {
 
   /**
    * Same as `errorContainerVisible` but for the warnings live region.
+   *
+   * Guarded by `!errorContainerVisible()` — the README's "Warning support"
+   * section documents "blocking errors present → warnings hidden", and
+   * `NgxFormFieldset` already enforces this ("UX best practice", see
+   * `filteredErrorsSignal`). Without the guard, a field with both blocking
+   * errors and warnings would render BOTH the `role="alert"` and
+   * `role="status"` containers at once — an assertive *and* a polite
+   * announcement for the same field — and `createAriaDescribedBySignal`
+   * would still compose `${fieldName}-warning` into a control's
+   * `aria-describedby` even while this container is visible, so the two
+   * are guarded in lockstep.
    */
   protected readonly warningContainerVisible = computed(
-    () => this.showWarnings() && this.headless.hasWarnings(),
+    () =>
+      this.showWarnings() &&
+      this.headless.hasWarnings() &&
+      !this.errorContainerVisible(),
   );
 
   // ── Resolved messages (delegate to the public createErrorMessageSignal) ──

--- a/packages/toolkit/assistive/form-field-notification.cross-surface.spec.ts
+++ b/packages/toolkit/assistive/form-field-notification.cross-surface.spec.ts
@@ -178,7 +178,7 @@ describe('cross-surface: NgxFormFieldNotification vs NgxHeadlessNotification', (
     expect(screen.queryByTestId('custom-warning')).toBeFalsy();
   });
 
-  it('empty error list keeps both live regions hidden but in DOM (WCAG 4.1.3)', async () => {
+  it('empty error list keeps both live regions empty but in DOM (WCAG 4.1.3)', async () => {
     @Component({
       selector: 'test-notification-cross-surface-empty',
       imports: [NgxFormFieldNotification],
@@ -197,7 +197,7 @@ describe('cross-surface: NgxFormFieldNotification vs NgxHeadlessNotification', (
     const statusEl = container.querySelector('[role="status"]');
     expect(alertEl).toBeTruthy();
     expect(statusEl).toBeTruthy();
-    expect(alertEl?.hasAttribute('hidden')).toBe(true);
-    expect(statusEl?.hasAttribute('hidden')).toBe(true);
+    expect(alertEl?.hasAttribute('hidden')).toBe(false);
+    expect(statusEl?.hasAttribute('hidden')).toBe(false);
   });
 });

--- a/packages/toolkit/assistive/form-field-notification.css
+++ b/packages/toolkit/assistive/form-field-notification.css
@@ -155,6 +155,15 @@
   display: block;
 }
 
+/* Dark-mode defaults are driven by `prefers-color-scheme` only. An earlier
+ * revision also tried to special-case a `.dark` class ancestor via
+ * `:host-context()`, but that selector is non-standard and unsupported in
+ * Firefox and Safari — the three engines disagreed on the resulting colors
+ * (see the v1.0.0 accessibility audit), risking WCAG 1.4.3 contrast
+ * failures. Class-based ("`.dark` on `<html>`/`<body>`") theming strategies
+ * are not detectable in plain CSS without `:host-context()`; apps using that
+ * strategy must override the public `--ngx-signal-form-notification-*`
+ * custom properties directly (see README). */
 @media (prefers-color-scheme: dark) {
   :host {
     --_notification-clr-danger: var(--_notification-clr-danger-dark);
@@ -162,24 +171,6 @@
     --_notification-clr-warning: var(--_notification-clr-warning-dark);
     --_notification-bg-warning-light: var(--_notification-bg-warning-dark);
   }
-
-  :host-context(:root:not(.dark)) {
-    --_notification-clr-danger: #db1818;
-    --_notification-clr-danger-soft: #fdebeb;
-    --_notification-clr-warning: #a16207;
-    --_notification-bg-warning-light: color-mix(
-      in srgb,
-      var(--_notification-clr-warning) 10%,
-      white
-    );
-  }
-}
-
-:host-context(.dark) {
-  --_notification-clr-danger: var(--_notification-clr-danger-dark);
-  --_notification-clr-danger-soft: var(--_notification-bg-danger-dark);
-  --_notification-clr-warning: var(--_notification-clr-warning-dark);
-  --_notification-bg-warning-light: var(--_notification-bg-warning-dark);
 }
 
 .ngx-form-field-notification {

--- a/packages/toolkit/assistive/form-field-notification.spec.ts
+++ b/packages/toolkit/assistive/form-field-notification.spec.ts
@@ -86,9 +86,10 @@ describe('NgxFormFieldNotification', () => {
       },
     );
 
-    // Mixed lists resolve to error: blocking wins over warnings.
+    // Mixed lists resolve to error: blocking wins over warnings. The
+    // status shell stays mounted (WCAG 4.1.3) but must be empty.
     expect(screen.getByRole('alert')).toBeTruthy();
-    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
     expect(container.querySelector('#mixed-group-error')).toBeTruthy();
     expect(container.querySelector('#mixed-group-warning')).toBeNull();
   });
@@ -112,7 +113,7 @@ describe('NgxFormFieldNotification', () => {
     );
 
     expect(screen.getByRole('status')).toBeTruthy();
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
   });
 
   it('keeps alert semantics for blocking errors even when tone="warning"', async () => {
@@ -134,7 +135,7 @@ describe('NgxFormFieldNotification', () => {
     );
 
     expect(screen.getByRole('alert')).toBeTruthy();
-    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByRole('status')?.textContent?.trim() ?? '').toBe('');
   });
 
   it('keeps the error container id while blocking errors exist, regardless of tone', async () => {
@@ -187,7 +188,7 @@ describe('NgxFormFieldNotification', () => {
     expect(container.querySelector('#static-field-error')).toBeTruthy();
   });
 
-  it('keeps an empty shell mounted with aria-hidden and no id when errors are undefined', async () => {
+  it('keeps an empty shell mounted with no id when errors are undefined', async () => {
     const { container } = await render(
       `<ngx-form-field-notification fieldName="empty-shell" />`,
       { imports: [NgxFormFieldNotification] },
@@ -198,12 +199,14 @@ describe('NgxFormFieldNotification', () => {
     expect(
       shell?.classList.contains('ngx-form-field-notification--empty'),
     ).toBe(true);
-    expect(shell?.getAttribute('aria-hidden')).toBe('true');
+    // `aria-hidden`/`[hidden]` are intentionally never toggled — see the
+    // class-level docs on the always-mounted live-region pattern.
+    expect(shell?.hasAttribute('aria-hidden')).toBe(false);
     expect(shell?.id).toBe('');
     expect(container.querySelector('#empty-shell-error')).toBeNull();
   });
 
-  it('keeps an empty shell mounted with aria-hidden when errors is an empty array', async () => {
+  it('keeps an empty shell mounted with no id when errors is an empty array', async () => {
     const errors = signal<readonly { kind: string; message: string }[]>([]);
 
     const { container } = await render(
@@ -221,7 +224,7 @@ describe('NgxFormFieldNotification', () => {
     expect(
       shell?.classList.contains('ngx-form-field-notification--empty'),
     ).toBe(true);
-    expect(shell?.getAttribute('aria-hidden')).toBe('true');
+    expect(shell?.hasAttribute('aria-hidden')).toBe(false);
     expect(shell?.id).toBe('');
   });
 

--- a/packages/toolkit/assistive/form-field-notification.ts
+++ b/packages/toolkit/assistive/form-field-notification.ts
@@ -59,7 +59,12 @@ export type NgxFormFieldNotificationTone = NgxNotificationTone;
       role is never re-assigned at the same tick as content insertion. Toggling
       role between alert and status when the first message arrives is the same
       bug class NgxFormFieldError works around (NVDA + Chrome miss the very
-      first announcement when role and content arrive together).
+      first announcement when role and content arrive together). We also do
+      NOT toggle aria-hidden/[hidden] while empty — the @if below already
+      guarantees zero content, and flipping aria-hidden off in the same tick
+      content is inserted is functionally equivalent to a fresh live-region
+      insertion, reintroducing the same missed-first-announcement bug. Visual
+      collapse while empty is handled by the --empty CSS class alone.
     -->
     <div
       class="ngx-form-field-notification ngx-form-field-notification--error"
@@ -70,8 +75,6 @@ export type NgxFormFieldNotificationTone = NgxNotificationTone;
         headless.showErrorContainer() ? headless.errorContainerId() : null
       "
       role="alert"
-      [attr.aria-hidden]="headless.showErrorContainer() ? null : 'true'"
-      [hidden]="!headless.showErrorContainer()"
     >
       @if (headless.showErrorContainer()) {
         @if (title()) {
@@ -113,8 +116,6 @@ export type NgxFormFieldNotificationTone = NgxNotificationTone;
         headless.showWarningContainer() ? headless.warningContainerId() : null
       "
       role="status"
-      [attr.aria-hidden]="headless.showWarningContainer() ? null : 'true'"
-      [hidden]="!headless.showWarningContainer()"
     >
       @if (headless.showWarningContainer()) {
         @if (title()) {

--- a/packages/toolkit/core/tokens.ts
+++ b/packages/toolkit/core/tokens.ts
@@ -194,7 +194,8 @@ export const NGX_SIGNAL_FORM_HINT_REGISTRY =
  * Renderer contract for the form-field error slot. Two consumers bind this
  * renderer:
  *
- * - `NgxFormFieldWrapper` binds inputs `{formField, strategy, submittedStatus}`.
+ * - `NgxFormFieldWrapper` binds inputs
+ *   `{formField, strategy, submittedStatus, warningStrategy, fieldName}`.
  * - `NgxFormFieldset` binds inputs `{errors, fieldName, strategy, submittedStatus, listStyle}`.
  *
  * The wrapper instantiates the configured component via `*ngComponentOutlet`
@@ -210,6 +211,23 @@ export const NGX_SIGNAL_FORM_HINT_REGISTRY =
  * fieldset instantiate it via `*ngComponentOutlet` without supplying
  * `ngComponentOutletNgModule`, so module-declared components are not
  * supported.
+ *
+ * ## id contract (required for valid `aria-describedby`)
+ *
+ * Both call sites compose the bound control's `aria-describedby` from
+ * `${fieldName}-error` / `${fieldName}-warning` whenever errors/warnings are
+ * visible (see `createAriaDescribedBySignal` and the wrapper's
+ * selection-cluster host binding) — this composition happens independently
+ * of which renderer is mounted. A custom renderer **must** render an element
+ * with `id="${fieldName}-error"` whenever it displays blocking errors, and
+ * `id="${fieldName}-warning"` whenever it displays warnings (using the
+ * `fieldName` input above, or by injecting `NGX_SIGNAL_FORM_FIELD_CONTEXT`
+ * itself when the wrapper doesn't pass it — e.g. `NgxFormFieldset`'s
+ * contract predates the `fieldName` addition here but already binds it
+ * explicitly). A renderer that doesn't satisfy this produces dangling
+ * `aria-describedby` references — an axe `aria-valid-attr-value` violation
+ * on every invalid field. See `NgxFormFieldError` for the reference
+ * implementation and `docs/CUSTOM_WRAPPERS.md` for the full checklist.
  *
  * @public
  */

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.spec.ts
@@ -116,7 +116,13 @@ describe('createAriaDescribedBySignal', () => {
     expect(ariaDescribedBy()).toBe('password-warning');
   });
 
-  it('appends both error and warning IDs when both kinds are present and visible', () => {
+  it('appends ONLY the error ID (not warning) when both kinds are present and visible', () => {
+    // The default `NgxFormFieldError` renderer suppresses its warning live
+    // region whenever a blocking error is also visible (mixed error+warning
+    // case) — matching README's documented "blocking errors present →
+    // warnings hidden" contract and `NgxFormFieldset`'s existing behavior.
+    // No `${fieldName}-warning` element exists in the DOM in that state, so
+    // composing it into `aria-describedby` here would dangle.
     const fieldState = fieldStateSignal([
       { kind: 'required', message: 'Required' },
       warningError('weak-password'),
@@ -132,10 +138,10 @@ describe('createAriaDescribedBySignal', () => {
       fieldName: () => 'password',
     });
 
-    expect(ariaDescribedBy()).toBe('password-error password-warning');
+    expect(ariaDescribedBy()).toBe('password-error');
   });
 
-  it('composes preserved + hint + error + warning IDs in that order', () => {
+  it('composes preserved + hint + error IDs (warning omitted) when a blocking error is also present', () => {
     const fieldState = fieldStateSignal([
       { kind: 'required', message: 'Required' },
       warningError('weak-password'),
@@ -152,7 +158,7 @@ describe('createAriaDescribedBySignal', () => {
     });
 
     expect(ariaDescribedBy()).toBe(
-      'password-description password-hint password-error password-warning',
+      'password-description password-hint password-error',
     );
   });
 

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
@@ -122,15 +122,22 @@ export function createAriaDescribedBySignal(
 
     if (state && isVisible) {
       const errors = state.errors();
+      const hasBlockingError = errors.some(isBlockingError);
 
-      if (errors.some(isBlockingError)) {
+      if (hasBlockingError) {
         const errorId = generateErrorId(resolvedFieldName);
         if (!parts.includes(errorId)) {
           parts.push(errorId);
         }
       }
 
-      if (errors.some(isWarningError)) {
+      // Blocking errors take visual AND announcement priority: the default
+      // `NgxFormFieldError` renderer suppresses its warning live region
+      // whenever a blocking error is also visible (mixed error+warning
+      // case), so no `${fieldName}-warning` element exists in the DOM at
+      // that point. Compose the id here too or `aria-describedby` dangles —
+      // an axe `aria-valid-attr-value` violation.
+      if (!hasBlockingError && errors.some(isWarningError)) {
         const warningId = generateWarningId(resolvedFieldName);
         if (!parts.includes(warningId)) {
           parts.push(warningId);

--- a/packages/toolkit/core/utilities/find-bound-control.ts
+++ b/packages/toolkit/core/utilities/find-bound-control.ts
@@ -1,19 +1,30 @@
 /**
  * CSS selector used to discover a bound control inside a wrapper host.
  *
- * Resolution order (the first match wins):
+ * Candidate branches (each may match a bound control):
  *
- * 1. `input[id], textarea[id], select[id], button[type="button"][id]` —
- *    native controls with an `id`. This is the canonical case and works in
- *    both dev and prod builds.
- * 2. `[id][formField]` — the Signal Forms host binding on a custom control.
- * 3. `[id][ng-reflect-form-field]` — Angular's dev-mode reflection
- *    attribute. Populated only in dev builds and only when the `formField`
- *    input serializes to a string, so it's safe to ignore in production.
- * 4. `[id][data-ngx-signal-form-control]` — the stable attribute written
- *    by `NgxSignalFormControlSemanticsDirective`. Recommended fallback for
- *    custom control hosts that don't carry a native `[formField]` binding
- *    themselves.
+ * - `input[id], textarea[id], select[id], button[type="button"][id]` —
+ *   native controls with an `id`. This is the canonical case and works in
+ *   both dev and prod builds.
+ * - `[id][formField]` — the Signal Forms host binding on a custom control.
+ * - `[id][ng-reflect-form-field]` — Angular's dev-mode reflection
+ *   attribute. Populated only in dev builds and only when the `formField`
+ *   input serializes to a string, so it's safe to ignore in production.
+ * - `[id][data-ngx-signal-form-control]` — the stable attribute written
+ *   by `NgxSignalFormControlSemanticsDirective`. Recommended fallback for
+ *   custom control hosts that don't carry a native `[formField]` binding
+ *   themselves.
+ *
+ * **Not a tiered resolution order.** This is one comma-separated selector
+ * passed to a single `querySelector` call, which returns the first match in
+ * *document order* across the whole subtree — not the first branch above
+ * that has a match. A `[prefix]`/label-slot element that happens to satisfy
+ * any branch (e.g. `<button prefix type="button" id="toggle">`) can
+ * therefore win over the real control found elsewhere in the subtree.
+ * Callers that care about this (`NgxFormFieldWrapper`, via
+ * `readFormFieldWrapperDomSnapshot`) scope the element passed to
+ * {@link findBoundControl} to the region that can only contain the real
+ * control (its `__main` slot) rather than the whole wrapper host.
  *
  * Centralized here (rather than co-located with the form-field wrapper) so
  * `NgxFieldIdentity` and any future surface that needs to discover a bound
@@ -27,6 +38,9 @@ export const BOUND_CONTROL_SELECTOR =
  *
  * Returns `null` when no match is found or when the first match isn't an
  * `HTMLElement` (guards against exotic host node types).
+ *
+ * `hostEl` should already be scoped to the region that can only contain the
+ * real control — see the document-order caveat on {@link BOUND_CONTROL_SELECTOR}.
  */
 export function findBoundControl(
   // oxlint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- DOM APIs operate on mutable HTMLElement instances.

--- a/packages/toolkit/core/utilities/humanize-field-path.ts
+++ b/packages/toolkit/core/utilities/humanize-field-path.ts
@@ -1,9 +1,14 @@
-const ANGULAR_FORM_NAME_PREFIX = /^ng\.form\d+\./u;
+// Angular's real prefix is `${APP_ID}.form{n}.` — APP_ID defaults to `'ng'`
+// in production but is configurable (e.g. `provideAppId()`) and differs in
+// test environments (`BrowserTestingModule` uses `'a'`). Match any app-id
+// segment (no dots) rather than hardcoding `ng`, or the prefix silently
+// survives stripping whenever APP_ID isn't the production default.
+const ANGULAR_FORM_NAME_PREFIX = /^[^.]+\.form\d+\./u;
 
 /**
- * Strips the Angular internal form prefix (`ng.form0.`) from a field path,
- * splits camelCase, capitalizes each segment, and joins nested paths with
- * ` / `.
+ * Strips the Angular internal form prefix (`{appId}.form0.`) from a field
+ * path, splits camelCase, capitalizes each segment, and joins nested paths
+ * with ` / `.
  *
  * This is the default field-label resolver used by error summaries. Override
  * it globally via `provideFieldLabels()` or `NGX_FIELD_LABEL_RESOLVER`.
@@ -50,9 +55,11 @@ export function humanizeFieldPath(fieldName: string): string {
 /**
  * Strips the Angular internal form prefix from a raw field name.
  *
- * Resolver functions receive the stripped path, not the raw `ng.form0.*` name.
+ * Resolver functions receive the stripped path, not the raw `{appId}.form0.*`
+ * name.
  *
- * @param rawName - Raw field name that may include Angular's `ng.form{n}.` prefix
+ * @param rawName - Raw field name that may include Angular's
+ *   `{appId}.form{n}.` prefix
  * @returns Field name with the Angular internal form prefix removed
  *
  * @packageInternal Used only within `@ngx-signal-forms/toolkit` package entries.

--- a/packages/toolkit/core/utilities/inject-field-control.spec.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.spec.ts
@@ -28,6 +28,42 @@ function createMockFieldTree<TValue>(value: TValue): FieldTree<TValue> {
   return fieldTree;
 }
 
+/**
+ * Callable `FieldTree`-shaped mock for a group node (e.g. `address`),
+ * matching real Angular Signal Forms more faithfully than
+ * `createMockFieldTree`'s plain-object test-fixture parents: in a real form
+ * *every* node — the form root and every intermediate group, not just
+ * leaves — is itself callable (`typeof node === 'function'`) and satisfies
+ * `isFieldTree()`. Child fields are exposed as properties directly on the
+ * callable function object (mirroring `formInstance.address.city`).
+ *
+ * This is the shape that exposed the pre-fix bug: `injectFieldControl`'s
+ * path-navigation guard only accepted `typeof value === 'object'`, so it
+ * rejected the (callable) `address` group on the second path segment of
+ * `"address.city"` — and would have rejected `formInstance` itself on the
+ * very first segment of any single-level path in a real, non-mocked form.
+ */
+function createGroupFieldTree<TValue extends Record<string, unknown>>(
+  value: TValue,
+  children: { [K in keyof TValue]: FieldTree<TValue[K]> },
+): FieldTree<TValue> {
+  let fieldTree!: FieldTree<TValue>;
+  const call = () => ({
+    value: () => value,
+    touched: () => false,
+    errors: () => [],
+    errorSummary: () => [],
+    submitting: () => false,
+    markAsTouched: () => {},
+    invalid: () => false,
+    get fieldTree() {
+      return fieldTree;
+    },
+  });
+  fieldTree = Object.assign(call, children) as unknown as FieldTree<TValue>;
+  return fieldTree;
+}
+
 describe('injectFieldControl', () => {
   it('should resolve field control from form using id attribute', () => {
     const emailControl = createMockFieldTree('');
@@ -51,6 +87,43 @@ describe('injectFieldControl', () => {
   it('should resolve nested field control using dot notation', () => {
     const cityControl = createMockFieldTree('');
     const mockForm = { address: { city: cityControl } };
+    const mockContext: NgxSignalFormContext = {
+      form: mockForm,
+      submittedStatus: () => 'unsubmitted' as SubmittedStatus,
+      errorStrategy: () => 'on-touch',
+    };
+
+    const injector = Injector.create({
+      providers: [{ provide: NGX_SIGNAL_FORM_CONTEXT, useValue: mockContext }],
+    });
+
+    const element = document.createElement('input');
+    element.setAttribute('id', 'address.city');
+
+    const result = injectFieldControl(element, injector);
+    expect(result).toBe(cityControl);
+  });
+
+  it('should resolve nested field control when every ancestor node is a callable FieldTree (real form shape)', () => {
+    // Regression for a bug where path navigation's guard only accepted
+    // `typeof value === 'object'`, rejecting real (callable) FieldTree nodes
+    // at every level above the leaf — including `formInstance` itself. Only
+    // the plain-object mocks used elsewhere in this file (e.g. `{ address:
+    // { city } }`, where `address` is a non-callable plain object) ever
+    // passed. This test uses `createGroupFieldTree` so that both the form
+    // root and the `address` group are callable, matching how Angular's
+    // real Signal Forms `FieldTree` is shaped.
+    const cityControl = createMockFieldTree('');
+    const addressGroup = createGroupFieldTree(
+      { city: '' },
+      {
+        city: cityControl,
+      },
+    );
+    const mockForm = createGroupFieldTree(
+      { address: { city: '' } },
+      { address: addressGroup },
+    );
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
       submittedStatus: () => 'unsubmitted' as SubmittedStatus,

--- a/packages/toolkit/core/utilities/inject-field-control.spec.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.spec.ts
@@ -1,13 +1,36 @@
 import { ElementRef, Injector, signal } from '@angular/core';
+import type { FieldTree } from '@angular/forms/signals';
 import { describe, expect, it } from 'vitest';
 import type { SubmittedStatus } from '../types';
 import type { NgxSignalFormContext } from '../directives/ngx-signal-form';
 import { NGX_SIGNAL_FORM_CONTEXT } from '../tokens';
 import { injectFieldControl } from './inject-field-control';
 
+/**
+ * Minimal `FieldTree`-shaped mock satisfying the runtime contract enforced by
+ * `isFieldTree()` (callable, backing `FieldState` with the required methods
+ * and a `.fieldTree` back-reference to itself).
+ */
+function createMockFieldTree<TValue>(value: TValue): FieldTree<TValue> {
+  let fieldTree!: FieldTree<TValue>;
+  fieldTree = (() => ({
+    value: () => value,
+    touched: () => false,
+    errors: () => [],
+    errorSummary: () => [],
+    submitting: () => false,
+    markAsTouched: () => {},
+    invalid: () => false,
+    get fieldTree() {
+      return fieldTree;
+    },
+  })) as FieldTree<TValue>;
+  return fieldTree;
+}
+
 describe('injectFieldControl', () => {
   it('should resolve field control from form using id attribute', () => {
-    const emailControl = signal({ value: '', invalid: () => false });
+    const emailControl = createMockFieldTree('');
     const mockForm = { email: emailControl };
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
@@ -26,7 +49,7 @@ describe('injectFieldControl', () => {
   });
 
   it('should resolve nested field control using dot notation', () => {
-    const cityControl = signal({ value: '', invalid: () => false });
+    const cityControl = createMockFieldTree('');
     const mockForm = { address: { city: cityControl } };
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
@@ -46,7 +69,7 @@ describe('injectFieldControl', () => {
   });
 
   it('should work with ElementRef', () => {
-    const emailControl = signal({ value: '', invalid: () => false });
+    const emailControl = createMockFieldTree('');
     const mockForm = { email: emailControl };
     const mockContext: NgxSignalFormContext = {
       form: mockForm,
@@ -170,5 +193,51 @@ describe('injectFieldControl', () => {
     expect(() => {
       injectFieldControl(element, injector);
     }).toThrow(/requires form context/i);
+  });
+
+  it('should throw instead of returning an unsound cast when the resolved value is not a FieldTree', () => {
+    // Regression: an id can collide with a non-field property on the form
+    // object (e.g. plain metadata, not a control). Path navigation used to
+    // validate only `isRecord(control) && part in control`, then blindly
+    // cast the result to `FieldTree`, deferring the failure to a confusing
+    // downstream call site instead of throwing here with a clear message.
+    const mockForm = { metadata: { note: 'plain data, not a FieldTree' } };
+    const mockContext: NgxSignalFormContext = {
+      form: mockForm,
+      submittedStatus: () => 'unsubmitted' as SubmittedStatus,
+      errorStrategy: () => 'on-touch',
+    };
+    const injector = Injector.create({
+      providers: [{ provide: NGX_SIGNAL_FORM_CONTEXT, useValue: mockContext }],
+    });
+
+    const element = document.createElement('input');
+    element.setAttribute('id', 'metadata');
+
+    expect(() => {
+      injectFieldControl(element, injector);
+    }).toThrow(/Field "metadata".*not.*(FieldTree|found)/is);
+  });
+
+  it('should throw when the resolved value is callable but does not satisfy the FieldState contract', () => {
+    // A callable property (e.g. a plain function living on the form object)
+    // passes a naive "is it a function" check but is not a real FieldTree —
+    // calling it does not produce a conforming FieldState.
+    const mockForm = { email: () => 'not a FieldState' };
+    const mockContext: NgxSignalFormContext = {
+      form: mockForm,
+      submittedStatus: () => 'unsubmitted' as SubmittedStatus,
+      errorStrategy: () => 'on-touch',
+    };
+    const injector = Injector.create({
+      providers: [{ provide: NGX_SIGNAL_FORM_CONTEXT, useValue: mockContext }],
+    });
+
+    const element = document.createElement('input');
+    element.setAttribute('id', 'email');
+
+    expect(() => {
+      injectFieldControl(element, injector);
+    }).toThrow(/Field "email".*not.*(FieldTree|found)/is);
   });
 });

--- a/packages/toolkit/core/utilities/inject-field-control.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.ts
@@ -3,6 +3,7 @@ import type { FieldTree } from '@angular/forms/signals';
 import { assertInjector } from './assert-injector';
 import { resolveFieldName } from './field-resolution';
 import { injectFormContext } from './inject-form-context';
+import { isFieldTree } from './walk-field-tree';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -17,7 +18,17 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  * @param element - The HTML element or ElementRef to resolve the field name from
  * @param injector - Optional injector for use outside injection context
  * @returns The resolved `FieldTree<TValue>` from the form
- * @throws Error if field cannot be resolved or form context is not found
+ * @throws Error if field cannot be resolved, the resolved value does not
+ *   satisfy the runtime `FieldTree` contract (see `isFieldTree`), or form
+ *   context is not found
+ *
+ * @remarks
+ * Resolution is a **one-shot, non-reactive** lookup: the form instance and
+ * the element's `id` are both read once, at injection/call time. Swapping
+ * the underlying form instance or assigning the element's `id` after this
+ * call resolves will NOT be reflected — the returned `FieldTree` reference
+ * is fixed for the lifetime of the caller. Re-invoke this function (e.g. in
+ * a fresh `computed()`) if you need to track a form or id that can change.
  *
  * @example
  * ```typescript
@@ -82,6 +93,13 @@ export function injectFieldControl<TValue = unknown>(
         );
       }
       control = control[part];
+    }
+
+    if (!isFieldTree(control)) {
+      throw new Error(
+        `[ngx-signal-forms] Field "${fieldName}" not found in form. ` +
+          `Resolved value does not satisfy the FieldTree contract.`,
+      );
     }
 
     return control as FieldTree<TValue>;

--- a/packages/toolkit/core/utilities/inject-field-control.ts
+++ b/packages/toolkit/core/utilities/inject-field-control.ts
@@ -5,8 +5,15 @@ import { resolveFieldName } from './field-resolution';
 import { injectFormContext } from './inject-form-context';
 import { isFieldTree } from './walk-field-tree';
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
+// Real `FieldTree` nodes are callable (`typeof` is `'function'`, not
+// `'object'`) — see `isFieldTree` in `walk-field-tree.ts`, which requires
+// every node to be invokable in order to read its `FieldState`. A guard that
+// only accepted `'object'` would reject `formInstance` itself on the very
+// first path segment for any real form, since the form root is a
+// `FieldTree`. Only plain-object mocks (not real `FieldTree`s) would ever
+// satisfy such a guard, which is why this bug shipped without failing tests.
+const isNavigable = (value: unknown): value is Record<string, unknown> =>
+  (typeof value === 'object' || typeof value === 'function') && value !== null;
 
 /**
  * Custom Inject Function (CIF) for retrieving a specific field control from the form.
@@ -86,7 +93,7 @@ export function injectFieldControl<TValue = unknown>(
     let control: unknown = formInstance;
 
     for (const part of pathParts) {
-      if (!isRecord(control) || !(part in control)) {
+      if (!isNavigable(control) || !(part in control)) {
         throw new Error(
           `[ngx-signal-forms] Field "${fieldName}" not found in form. ` +
             `Could not access property "${part}".`,

--- a/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.coverage.spec.ts
@@ -320,6 +320,42 @@ describe('canSubmitWithWarnings', () => {
     expect(canSubmit()).toBe(false);
   });
 
+  it('returns false when a blocking error lives on a CHILD path, not the root', async () => {
+    // Regression for the root-vs-descendant mismatch: a validator on
+    // `path.email` (not `path` itself) puts the blocking error on the
+    // child FieldState's `errors()`. The root FieldState's own `errors()`
+    // stays empty — only `errorSummary()` aggregates descendant errors.
+    // `canSubmitWithWarnings` must agree with `submitWithWarnings` (which
+    // already reads `errorSummary()`) or the submit button computes
+    // "submittable" while the actual submit helper silently refuses.
+    const model = signal({ email: '' });
+    const f = TestBed.runInInjectionContext(() =>
+      form(
+        model,
+        schema<{ email: string }>((path) => {
+          validate(path.email, (ctx) => {
+            const value = ctx.value();
+            if (!value) {
+              return { kind: 'required', message: 'Email is required' };
+            }
+            return null;
+          });
+        }),
+      ),
+    );
+
+    // Root's own errors() stay empty; the blocking error only surfaces via
+    // errorSummary() on the root (or errors() on the child).
+    expect(f().errors()).toEqual([]);
+
+    const canSubmit = TestBed.runInInjectionContext(() =>
+      canSubmitWithWarnings(f),
+    );
+    await flush();
+
+    expect(canSubmit()).toBe(false);
+  });
+
   it('returns false while submitting()/pending() are true (mock form)', () => {
     // canSubmitWithWarnings reads `submitting()` and `pending()` on the
     // FieldState. Use a mock to drive both signals deterministically without

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -180,7 +180,11 @@ export function canSubmitWithWarnings(
       return false;
     }
 
-    return getBlockingErrors(formState.errors()).length === 0;
+    // `errors()` only reports the field's OWN errors; validators placed on
+    // child paths (the common case) never surface here. `errorSummary()`
+    // aggregates descendant errors too, matching what `submitWithWarnings()`
+    // gates on — keeping the two helpers in agreement.
+    return getBlockingErrors(formState.errorSummary()).length === 0;
   });
 }
 

--- a/packages/toolkit/form-field/README.md
+++ b/packages/toolkit/form-field/README.md
@@ -189,10 +189,12 @@ Warnings (errors with `kind` starting with `warn:`) display automatically:
 - Errors use `role="alert"`, warnings use `role="status"` (relying on the
   implicit live-region semantics of those roles — no explicit `aria-live`)
 
-Warning **display timing** is independent from error timing. The projected
-`NgxFormFieldError` accepts a `warningStrategy` input (default
-`'immediate'`) so advisory messages stay visible even when errors are gated
-by `'on-touch'` or `'on-submit'`. See
+Warning **display timing** is independent from error timing. The wrapper
+exposes a `warningStrategy` input (default `'immediate'`, forwarded to the
+projected `NgxFormFieldError`) so advisory messages stay visible even when
+errors are gated by `'on-touch'` or `'on-submit'` — the wrapper mounts its
+error/warning renderer whenever either should be visible, not just on the
+blocking-error timing. See
 [`WARNINGS_SUPPORT.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/WARNINGS_SUPPORT.md#when-warnings-appear--warningstrategy).
 
 ## Fieldset component

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -495,6 +495,21 @@
   block-size: fit-content; /* Prevent stretching in grid/flex rows */
 }
 
+/*
+ * `[attr.hidden]` is bound on the host as a defensive net (see
+ * `isFieldHidden()` in form-field-wrapper.ts) so a `hidden()` field stays
+ * out of the accessibility tree and off-screen even if the consumer forgets
+ * `@if`. The UA stylesheet's `[hidden] { display: none }` rule is *not*
+ * `!important` and author-origin styles beat UA-origin styles regardless of
+ * specificity, so the `:host { display: flex }` rule above silently wins
+ * and the "hidden" field stays fully visible. This rule restores the
+ * intended behavior for every appearance/layout variant (they all
+ * ultimately set `display` on `:host`).
+ */
+:host([hidden]) {
+  display: none !important;
+}
+
 :host(.ngx-signal-form-field-wrapper--selection-group) {
   --_gap: var(--_field-space-xs);
 }

--- a/packages/toolkit/form-field/form-field-wrapper.hidden.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.hidden.browser.spec.ts
@@ -1,0 +1,73 @@
+import { signal } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldWrapper } from './form-field-wrapper';
+
+/**
+ * Regression coverage for the `[attr.hidden]` safety net documented at
+ * form-field-wrapper.ts (`isFieldHidden`): the wrapper binds `hidden` on the
+ * host whenever the bound field's `hidden()` schema logic reports `true`, as
+ * a defensive net so a `hidden()` field stays out of the accessibility tree
+ * and off-screen even if the consumer forgets `@if`.
+ *
+ * That net was silently defeated: `:host { display: flex }` is an
+ * author-origin rule, and author-origin styles beat the UA stylesheet's
+ * (non-`!important`) `[hidden] { display: none }` regardless of specificity.
+ * jsdom does not implement the UA stylesheet cascade, so this can only be
+ * caught in a real browser — hence a `.browser.spec.ts` rather than the
+ * jsdom suite in `form-field-wrapper.spec.ts` (which already asserts the
+ * `hidden` *attribute* is present, but not that it actually hides anything).
+ */
+describe('NgxFormFieldWrapper — [hidden] safety net (rendered display)', () => {
+  it('renders with display:none when the bound field reports hidden() === true', async () => {
+    const hiddenField = signal({
+      invalid: () => false,
+      touched: () => false,
+      hidden: () => true,
+      errors: () => [],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field" fieldName="secret">
+        <label for="secret">Secret</label>
+        <input id="secret" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: hiddenField },
+      },
+    );
+
+    const wrapper = container.querySelector<HTMLElement>(
+      'ngx-form-field-wrapper',
+    );
+    expect(wrapper).toHaveAttribute('hidden', '');
+    expect(getComputedStyle(wrapper!).display).toBe('none');
+  });
+
+  it('keeps display:flex when the bound field reports hidden() === false', async () => {
+    const visibleField = signal({
+      invalid: () => false,
+      touched: () => false,
+      hidden: () => false,
+      errors: () => [],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field" fieldName="visible">
+        <label for="visible">Visible</label>
+        <input id="visible" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: visibleField },
+      },
+    );
+
+    const wrapper = container.querySelector<HTMLElement>(
+      'ngx-form-field-wrapper',
+    );
+    expect(wrapper).not.toHaveAttribute('hidden');
+    expect(getComputedStyle(wrapper!).display).not.toBe('none');
+  });
+});

--- a/packages/toolkit/form-field/form-field-wrapper.renderer-seam.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.renderer-seam.spec.ts
@@ -27,7 +27,13 @@ const addressSchema = schema<AddressModel>((path) => {
  */
 @Component({
   selector: 'stub-error-renderer',
-  template: `<span data-testid="stub-error">STUB-ERR:{{ errorCount() }}</span>`,
+  template: `
+    <span data-testid="stub-error">STUB-ERR:{{ errorCount() }}</span>
+    <span data-testid="stub-field-name">{{ fieldName() ?? 'null' }}</span>
+    <span data-testid="stub-warning-strategy">{{
+      warningStrategy() ?? 'unset'
+    }}</span>
+  `,
   standalone: true,
 })
 class StubErrorRenderer {
@@ -39,6 +45,13 @@ class StubErrorRenderer {
   readonly listStyle = input<unknown>();
   readonly strategy = input<unknown>();
   readonly submittedStatus = input<unknown>();
+  /**
+   * `NgxFormFieldWrapper` forwards its `warningStrategy` input here — an
+   * extra beyond the minimal `{formField, strategy, submittedStatus}`
+   * contract — so a custom renderer can honor independent warning timing
+   * without its own DI lookup.
+   */
+  readonly warningStrategy = input<unknown>();
 
   protected readonly errorCount = computed(() => {
     const errorsSignal = this.errors();
@@ -89,6 +102,51 @@ describe('form-field wrapper renderer seam', () => {
     // FieldTree through the renderer contract correctly.
     const stub = await screen.findByTestId('stub-error');
     expect(stub.textContent?.trim()).toBe('STUB-ERR:1');
+  });
+
+  it('forwards fieldName and warningStrategy to a custom renderer without requiring DI context lookups', async () => {
+    // Regression coverage: a custom error-renderer contract previously only
+    // documented `{formField, strategy, submittedStatus}`. A renderer that
+    // needs to satisfy the `${fieldName}-error`/`-warning` id contract (see
+    // NgxFormFieldErrorRenderer in core/tokens.ts) had to inject
+    // NGX_SIGNAL_FORM_FIELD_CONTEXT itself to learn the field name — the
+    // wrapper now passes it (and `warningStrategy`) directly as inputs.
+    @Component({
+      selector: 'host-component-fieldname-passthrough',
+      standalone: true,
+      imports: [NgxFormFieldWrapper],
+      template: `
+        <ngx-form-field-wrapper
+          [formField]="contactForm.email"
+          fieldName="email"
+          strategy="immediate"
+          warningStrategy="on-touch"
+        >
+          <label for="email">Email</label>
+          <input id="email" type="email" [formField]="contactForm.email" />
+        </ngx-form-field-wrapper>
+      `,
+    })
+    class HostComponent {
+      readonly contactForm = form(
+        signal<ContactModel>({ email: '' }),
+        contactSchema,
+      );
+    }
+
+    await render(HostComponent, {
+      providers: [
+        provideFormFieldErrorRenderer({ component: StubErrorRenderer }),
+      ],
+    });
+
+    const fieldNameEl = await screen.findByTestId('stub-field-name');
+    expect(fieldNameEl.textContent?.trim()).toBe('email');
+
+    const warningStrategyEl = await screen.findByTestId(
+      'stub-warning-strategy',
+    );
+    expect(warningStrategyEl.textContent?.trim()).toBe('on-touch');
   });
 });
 

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -63,10 +63,19 @@ const createMockFieldState = () =>
     errors: () => [],
   });
 
-const createWrapperComponent = (
+/**
+ * Renders a bare `NgxFormFieldWrapper` and lets its `afterEveryRender` write
+ * phase settle before returning the instance. The unresolved-field-name
+ * diagnostic fires from that write phase (not synchronously from the
+ * `resolvedFieldName` computed — see the class-level doc comment), so
+ * callers asserting on `console.error` must await a real render here rather
+ * than reading `resolvedFieldName()` off a freshly constructed, never
+ * change-detected fixture.
+ */
+const createWrapperComponent = async (
   field: ReturnType<typeof createMockFieldState> = createMockFieldState(),
   fieldName?: string,
-): NgxSignalFormWrapperComponent => {
+): Promise<NgxSignalFormWrapperComponent> => {
   const bindings = [inputBinding('formField', () => field)];
 
   if (fieldName !== undefined) {
@@ -76,6 +85,9 @@ const createWrapperComponent = (
   const fixture = TestBed.createComponent(NgxSignalFormWrapperComponent, {
     bindings,
   });
+
+  fixture.detectChanges();
+  await fixture.whenStable();
 
   return fixture.componentInstance;
 };
@@ -113,7 +125,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(errorContainer).toBeTruthy();
     });
 
-    it('should return null and log a dev-mode error when neither fieldName nor bound control id is provided', () => {
+    it('should return null and log a dev-mode error when neither fieldName nor bound control id is provided', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -124,7 +136,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField);
+      const component = await createWrapperComponent(invalidField);
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -217,7 +229,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(container.querySelector('[id="password-error"]')).toBeTruthy();
     });
 
-    it('should handle empty string fieldName by returning null and logging in dev mode', () => {
+    it('should handle empty string fieldName by returning null and logging in dev mode', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -228,7 +240,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField, '');
+      const component = await createWrapperComponent(invalidField, '');
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -1413,6 +1425,110 @@ describe('NgxSignalFormWrapperComponent', () => {
       ).toBeTruthy();
     });
 
+    it('merges an author-supplied aria-describedby with the cluster-managed error id instead of clobbering it', async () => {
+      // Regression guard: `[attr.aria-describedby]` on the host is always
+      // active (Angular host bindings can't be conditionally applied at
+      // runtime), so an author-supplied value on
+      // `<ngx-form-field-wrapper aria-describedby="…">` used to be nulled
+      // out whenever the wrapper wasn't in selection-cluster mode, and
+      // replaced outright (not merged) when it was.
+      const invalidField = signal({
+        invalid: () => true,
+        touched: () => true,
+        errors: () => [
+          { kind: 'required', message: 'Preferred contact method is required' },
+        ],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="delivery-method"
+          aria-describedby="delivery-hint"
+        >
+          <span ngxFormFieldLabel>Delivery option *</span>
+          <div>
+            <label>
+              <input id="delivery-standard" type="radio" value="standard" />
+              Standard
+            </label>
+            <label>
+              <input id="delivery-express" type="radio" value="express" />
+              Express
+            </label>
+          </div>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: invalidField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute(
+        'aria-describedby',
+        'delivery-hint delivery-method-error',
+      );
+    });
+
+    it('preserves an author-supplied aria-describedby on a non-cluster wrapper instead of nulling it out', async () => {
+      const invalidField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="email"
+          aria-describedby="email-hint"
+        >
+          <label for="email">Email</label>
+          <input id="email" type="email" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: invalidField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('aria-describedby', 'email-hint');
+    });
+
+    it('preserves an author-supplied aria-labelledby on a non-cluster wrapper instead of nulling it out', async () => {
+      const invalidField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="email"
+          aria-labelledby="email-label"
+        >
+          <label for="email">Email</label>
+          <input id="email" type="email" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: invalidField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('aria-labelledby', 'email-label');
+    });
+
     it('should keep explicit labels associated to single controls while using neutral headings for grouped controls', async () => {
       const invalidField = signal({
         invalid: () => true,
@@ -2095,6 +2211,19 @@ describe('NgxSignalFormWrapperComponent', () => {
       const errorContainer = container.querySelector('[role="alert"]');
       expect(errorContainer).toBeTruthy();
       expect(errorContainer?.textContent).toContain('Password is required');
+
+      // Warnings are suppressed while a blocking error is visible — README's
+      // "Warning support" section documents this, and `NgxFormFieldset`
+      // already enforces it. Rendering both would double-announce the same
+      // field (an assertive role="alert" AND a polite role="status" at
+      // once). The role="status" container stays mounted (WCAG 4.1.3
+      // first-insertion semantics) but must not expose an id or content.
+      const warningContainer = container.querySelector('[role="status"]');
+      expect(warningContainer?.getAttribute('id')).not.toBe('password-warning');
+      expect(warningContainer?.textContent?.trim()).toBe('');
+      expect(container.textContent).not.toContain(
+        'Consider a stronger password',
+      );
     });
 
     it('should handle multiple warnings', async () => {
@@ -2261,6 +2390,119 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(
         formField?.classList.contains('ngx-signal-form-field-wrapper--warning'),
       ).toBe(false);
+    });
+  });
+
+  describe('Warning-only fields render independently of the blocking-error strategy', () => {
+    // Regression coverage: the wrapper used to gate mounting the projected
+    // error renderer entirely on `shouldShowErrors()`, which runs the
+    // blocking-error strategy (default 'on-touch') even when the field's
+    // only messages are warnings. A warnings-only, UNTOUCHED field would
+    // therefore never mount `NgxFormFieldError` at all, so its own
+    // `warningStrategy` default of 'immediate' never got a chance to run —
+    // the README's documented "warning timing is independent of error
+    // timing" was unreachable through the wrapper. `shouldRenderErrorSlot`
+    // now mounts the renderer whenever errors OR warnings should show.
+    it('renders the warning immediately on an untouched field under the default on-touch error strategy', async () => {
+      const untouchedWarningField = signal({
+        invalid: () => true,
+        touched: () => false,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" fieldName="password">
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: untouchedWarningField },
+        },
+      );
+
+      const status = container.querySelector('[role="status"]');
+      expect(status?.getAttribute('id')).toBe('password-warning');
+      expect(status?.textContent).toContain('Consider 8+ characters');
+      // No blocking error, so the alert container stays empty/unlinked.
+      const alert = container.querySelector('[role="alert"]');
+      expect(alert?.getAttribute('id')).not.toBe('password-error');
+    });
+
+    it('respects an explicit strategy="on-submit" for a warnings-only field with the immediate warningStrategy default', async () => {
+      const unsubmittedWarningField = signal({
+        invalid: () => true,
+        touched: () => true,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="password"
+          strategy="on-submit"
+        >
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: unsubmittedWarningField },
+        },
+      );
+
+      // Warning is visible immediately even though the field hasn't been
+      // submitted — 'immediate' is the warningStrategy default, and it is
+      // NOT the same signal as the wrapper's own (on-submit) `strategy`.
+      const status = container.querySelector('[role="status"]');
+      expect(status?.getAttribute('id')).toBe('password-warning');
+      expect(status?.textContent).toContain('Consider 8+ characters');
+    });
+
+    it('gates the warning behind on-touch when an explicit warningStrategy is bound through the wrapper', async () => {
+      const untouchedWarningField = signal({
+        invalid: () => true,
+        touched: () => false,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+
+      const { container, fixture } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="password"
+          warningStrategy="on-touch"
+        >
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: untouchedWarningField },
+        },
+      );
+
+      // Untouched: warningStrategy="on-touch" keeps the warning hidden, and
+      // no renderer should even mount (no errors, no visible warnings).
+      expect(container.querySelector('ngx-form-field-error')).toBeNull();
+
+      untouchedWarningField.set({
+        invalid: () => true,
+        touched: () => true,
+        errors: () => [
+          { kind: 'warn:weak-password', message: 'Consider 8+ characters' },
+        ],
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const status = container.querySelector('[role="status"]');
+      expect(status?.textContent).toContain('Consider 8+ characters');
     });
   });
 
@@ -2566,7 +2808,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(customError).toBeFalsy();
     });
 
-    it('should return null and log a dev-mode error when custom control has no id', () => {
+    it('should return null and log a dev-mode error when custom control has no id', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -2577,7 +2819,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField);
+      const component = await createWrapperComponent(invalidField);
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -2675,7 +2917,7 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(container.querySelector('[id="first-error"]')).toBeTruthy();
     });
 
-    it('should return null and log a dev-mode error when no input has id attribute and no fieldName is provided', () => {
+    it('should return null and log a dev-mode error when no input has id attribute and no fieldName is provided', async () => {
       const invalidField = signal({
         invalid: () => true,
         touched: () => true,
@@ -2686,7 +2928,7 @@ describe('NgxSignalFormWrapperComponent', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
 
-      const component = createWrapperComponent(invalidField);
+      const component = await createWrapperComponent(invalidField);
 
       expect(component.resolvedFieldName()).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
@@ -3569,6 +3811,91 @@ describe('NgxSignalFormWrapperComponent', () => {
       const wrapper = container.querySelector('ngx-form-field-wrapper');
       expect(wrapper).not.toHaveAttribute('hidden');
       expect(container.querySelector('ngx-form-field-error')).toBeTruthy();
+    });
+  });
+
+  describe('Field-name resolution race (spurious console.error)', () => {
+    // Regression coverage for the bug where `resolvedFieldName()` logged a
+    // one-shot `console.error` from *inside* a `computed()`. Projected
+    // children (`NgxFormFieldHint`, `NgxFormFieldError`) read that computed
+    // via `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the wrapper's FIRST
+    // change-detection pass — before `afterEveryRender`'s write phase has
+    // ever populated `#inputElementId` — so the diagnostic fired even for
+    // correctly configured fields (input WITH an id). See
+    // form-field-wrapper.ts `resolvedFieldName` for the fix (diagnostic
+    // moved to the write phase).
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        // Swallow dev-mode diagnostics; assertions inspect the spy directly.
+      });
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not log when a projected hint reads the field name on first render', async () => {
+      const field = createMockFieldState();
+
+      await render(
+        `<ngx-form-field-wrapper [formField]="field">
+          <label for="username">Username</label>
+          <input id="username" type="text" />
+          <ngx-form-field-hint>Pick something memorable</ngx-form-field-hint>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent, NgxFormFieldHint],
+          componentProperties: { field },
+        },
+      );
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not log when the error renderer is visible on first render (strategy="immediate")', async () => {
+      const invalidField = signal({
+        invalid: () => true,
+        touched: () => false,
+        errors: () => [{ kind: 'required', message: 'Username is required' }],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" strategy="immediate">
+          <label for="username2">Username</label>
+          <input id="username2" type="text" />
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: invalidField },
+        },
+      );
+
+      // Sanity: the error renderer really did mount on the first pass.
+      expect(container.querySelector('[id="username2-error"]')).toBeTruthy();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('still logs exactly once when the field genuinely has no id and no fieldName', async () => {
+      const field = createMockFieldState();
+
+      const { fixture } = await render(
+        `<ngx-form-field-wrapper [formField]="field">
+          <input type="text" />
+          <ngx-form-field-hint>No id on this control</ngx-form-field-hint>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent, NgxFormFieldHint],
+          componentProperties: { field },
+        },
+      );
+      await fixture.whenStable();
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy.mock.calls[0]?.[0]).toMatch(
+        /Could not resolve a deterministic field name/u,
+      );
     });
   });
 

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -37,6 +37,7 @@ import {
   readDirectErrors,
   type ResolvedNgxSignalFormControlSemantics,
   resolveErrorDisplayStrategy,
+  resolveStrategyFromContext,
 } from '@ngx-signal-forms/toolkit';
 import {
   NGX_SIGNAL_FORM_HINT_REGISTRY,
@@ -259,7 +260,7 @@ import {
       }
     </div>
 
-    @if (isTopPlacement() && shouldShowErrors()) {
+    @if (isTopPlacement() && shouldRenderErrorSlot()) {
       <div class="ngx-signal-form-field-wrapper__messages">
         <ng-container
           *ngComponentOutlet="
@@ -291,7 +292,7 @@ import {
     <!-- Assistive row: fixed-height container prevents layout shift -->
     <div class="ngx-signal-form-field-wrapper__assistive">
       <div class="ngx-signal-form-field-wrapper__assistive-left">
-        @if (!isTopPlacement() && shouldShowErrors()) {
+        @if (!isTopPlacement() && shouldRenderErrorSlot()) {
           <ng-container
             *ngComponentOutlet="
               errorRendererComponent();
@@ -299,7 +300,7 @@ import {
             "
           />
         }
-        <div [style.display]="shouldShowErrors() ? 'none' : 'contents'">
+        <div [style.display]="shouldRenderErrorSlot() ? 'none' : 'contents'">
           <ng-content select="ngx-form-field-hint" />
         </div>
       </div>
@@ -371,6 +372,20 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * @default Inherited from form context or 'on-touch'
    */
   readonly strategy = input<ErrorDisplayStrategy | null>(null);
+
+  /**
+   * Warning display strategy, passed through to the projected error
+   * renderer (`NgxFormFieldError` by default). Decoupled from {@link strategy}
+   * so warnings can stay visible even while blocking errors are gated by
+   * `'on-touch'` / `'on-submit'`.
+   *
+   * The wrapper also uses this to decide whether to mount the error
+   * renderer at all: it renders whenever blocking errors OR warnings
+   * should be visible, not just on the blocking-error timing.
+   *
+   * @default `'immediate'`
+   */
+  readonly warningStrategy = input<ErrorDisplayStrategy | undefined>();
 
   /**
    * Placement of the automatic error or warning messages.
@@ -457,12 +472,24 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * Inputs map passed to `*ngComponentOutlet` for the error renderer. Custom
    * error renderers must accept `formField`, `strategy`, and `submittedStatus`;
    * any extra inputs the consumer's renderer declares are unaffected.
+   *
+   * `warningStrategy` and `fieldName` are extras beyond that minimal
+   * contract: `warningStrategy` forwards this input's value (`undefined`
+   * when unset, which is a no-op for the default `NgxFormFieldError`'s own
+   * `'immediate'` fallback) so consumers can override warning timing
+   * through the wrapper instead of only through a directly-projected
+   * `NgxFormFieldError`. `fieldName` lets a custom renderer satisfy the
+   * `${fieldName}-error` / `${fieldName}-warning` id contract (see
+   * `NgxFormFieldErrorRenderer`) without needing to inject
+   * `NGX_SIGNAL_FORM_FIELD_CONTEXT` itself.
    */
   protected readonly errorRendererInputs = computed<Record<string, unknown>>(
     () => ({
       formField: this.formField(),
       strategy: this.effectiveStrategy(),
       submittedStatus: this.submittedStatus(),
+      warningStrategy: this.warningStrategy(),
+      fieldName: this.resolvedFieldName(),
     }),
   );
 
@@ -482,6 +509,23 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * Reference to the host element for DOM queries.
    */
   readonly #elementRef = inject(ElementRef<HTMLElement>);
+
+  /**
+   * Author-supplied `aria-labelledby` / `aria-describedby`, captured at
+   * construction. `selectionClusterLabelledBy` / `selectionClusterDescribedBy`
+   * below return `null` for non-cluster wrappers (the vast majority), and
+   * `[attr.aria-labelledby]` / `[attr.aria-describedby]` on the host would
+   * otherwise strip any value an author bound directly on
+   * `<ngx-form-field-wrapper aria-describedby="…">` — the host bindings are
+   * always active regardless of cluster mode, so there is no way to simply
+   * "not bind" them for the common case. Falling back to (and merging with)
+   * these preserves author-supplied values the same way auto-aria already
+   * does for the bound control itself.
+   */
+  readonly #initialAriaLabelledby =
+    this.#elementRef.nativeElement.getAttribute('aria-labelledby');
+  readonly #initialAriaDescribedby =
+    this.#elementRef.nativeElement.getAttribute('aria-describedby');
 
   /**
    * Signal holding the input element's ID attribute.
@@ -747,11 +791,21 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * 1. Explicit `fieldName` input (highest priority)
    * 2. Input element's `id` attribute (automatic, recommended)
    *
-   * Returns `null` when neither source is available. A dev-mode
-   * `console.error` is emitted once per instance so the misconfiguration
-   * is surfaced loudly without crashing the render tree. Downstream
-   * consumers (auto-ARIA, hint registry, projected error component)
-   * handle `null` by skipping the `aria-describedby` wiring.
+   * Returns `null` when neither source is available. Downstream consumers
+   * (auto-ARIA, hint registry, projected error component) handle `null` by
+   * skipping the `aria-describedby` wiring.
+   *
+   * **Pure by design**: this computed performs no side effects. Projected
+   * children (`NgxFormFieldHint`, `NgxFormFieldError`) read it via
+   * `NGX_SIGNAL_FORM_FIELD_CONTEXT` during the *first* change-detection
+   * pass — before `#inputElementId` is populated by the `afterEveryRender`
+   * write phase below — so a `console.error` fired from in here would fire
+   * once, permanently, on every correctly configured field (id set, no
+   * `fieldName` input) purely because of that one-render race. The
+   * unresolved-name diagnostic instead lives in the `afterEveryRender`
+   * write callback, which runs after the DOM snapshot for the current
+   * render has been applied — i.e. only once the state has actually
+   * settled.
    *
    * @remarks
    * This signal is public to allow child components to access the resolved field name
@@ -775,13 +829,6 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     const idFromInput = this.#inputElementId();
     if (idFromInput) {
       return idFromInput;
-    }
-
-    if (isDevMode() && !this.#warnedUnresolvedFieldName) {
-      this.#warnedUnresolvedFieldName = true;
-      console.error(
-        '[ngx-signal-forms] Could not resolve a deterministic field name for ngx-form-field-wrapper. Add an explicit `fieldName` input or an `id` attribute to the bound control. ARIA wiring will be skipped until a name is available.',
-      );
     }
 
     return null;
@@ -921,6 +968,58 @@ export class NgxFormFieldWrapper<TValue = unknown> {
   });
 
   /**
+   * Effective warning display strategy. Defaults to `'immediate'` (mirrors
+   * `NgxFormFieldError`'s own default) so advisory messages stay visible
+   * even when blocking errors are gated by `'on-touch'` / `'on-submit'` —
+   * unlike {@link effectiveStrategy}, an unset {@link warningStrategy} does
+   * NOT fall back to the form context or global config default, matching
+   * the projected error renderer's contract exactly.
+   */
+  protected readonly effectiveWarningStrategy = computed<ErrorDisplayStrategy>(
+    () => {
+      const explicit = this.warningStrategy();
+      if (explicit !== undefined) {
+        return resolveStrategyFromContext(explicit, this.#formContext);
+      }
+      return 'immediate';
+    },
+  );
+
+  /**
+   * Visibility-timing computed for warnings, independent of
+   * {@link effectiveStrategy} (which only governs blocking errors).
+   */
+  readonly #showWarningsByStrategy = createShowErrorsComputed(
+    this.#fieldState,
+    this.effectiveWarningStrategy,
+    this.submittedStatus,
+  );
+
+  /**
+   * Whether the error renderer should mount to show warnings, evaluated
+   * independently of {@link shouldShowErrors}. Without this, a warnings-only
+   * field would never render `NgxFormFieldError` at all when
+   * {@link effectiveStrategy} (e.g. `'on-touch'`) gates the blocking-error
+   * timing — the renderer's own `warningStrategy` default of `'immediate'`
+   * never gets a chance to run because the `@if` around the outlet in the
+   * template never mounts it. See README "Warning support".
+   */
+  protected readonly shouldShowWarnings = computed(() => {
+    if (this.isFieldHidden()) return false;
+    if (!this.hasWarnings()) return false;
+    return this.#showWarningsByStrategy();
+  });
+
+  /**
+   * Whether the projected error renderer should be mounted at all — either
+   * because blocking errors should show, or because warnings should show
+   * under their own (independent) strategy timing.
+   */
+  protected readonly shouldRenderErrorSlot = computed(() => {
+    return this.shouldShowErrors() || this.shouldShowWarnings();
+  });
+
+  /**
    * Whether to apply warning styling to the form field container.
    * Warning styling is shown only when:
    * 1. Field has warnings
@@ -944,40 +1043,62 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     return this.#controlKind() === 'radio-group' ? 'radiogroup' : 'group';
   });
 
+  /**
+   * Falls back to (never replaces) `#initialAriaLabelledby` for non-cluster
+   * wrappers — see the field doc comment on `#initialAriaLabelledby` for why
+   * the host binding can't simply be left unbound instead.
+   */
   protected readonly selectionClusterLabelledBy = computed<string | null>(
     () => {
       if (!this.isSelectionCluster()) {
-        return null;
+        return this.#initialAriaLabelledby;
       }
 
-      return this.#selectionClusterLabelId();
+      return this.#selectionClusterLabelId() ?? this.#initialAriaLabelledby;
     },
   );
 
+  /**
+   * Merges the author-supplied `#initialAriaDescribedby` with the
+   * cluster-managed error/warning id rather than replacing it — same
+   * preservation rule auto-aria already applies to the bound control itself.
+   */
   protected readonly selectionClusterDescribedBy = computed<string | null>(
     () => {
-      if (!this.isSelectionCluster()) {
+      const managedId = ((): string | null => {
+        if (!this.isSelectionCluster()) {
+          return null;
+        }
+
+        const fieldName = this.resolvedFieldName();
+        if (fieldName === null) {
+          return null;
+        }
+
+        if (this.showInvalidState()) {
+          return `${fieldName}-error`;
+        }
+
+        // `shouldShowWarnings()` gates whether the projected error renderer's
+        // warning live region is in the DOM (see `shouldRenderErrorSlot` /
+        // `NgxFormFieldError.warningContainerVisible`). Guard
+        // `aria-describedby` on the same signal to avoid dangling references
+        // for warning-only clusters gated by a non-'immediate'
+        // `warningStrategy`.
+        if (this.showWarningState() && this.shouldShowWarnings()) {
+          return `${fieldName}-warning`;
+        }
+
         return null;
+      })();
+
+      if (managedId === null) {
+        return this.#initialAriaDescribedby;
       }
 
-      const fieldName = this.resolvedFieldName();
-      if (fieldName === null) {
-        return null;
-      }
-
-      if (this.showInvalidState()) {
-        return `${fieldName}-error`;
-      }
-
-      // `shouldShowErrors()` gates the `<ngx-form-field-error>` template, so
-      // the `${fieldName}-warning` id only exists in the DOM when that branch
-      // renders. Guard `aria-describedby` on the same signal to avoid dangling
-      // references for warning-only clusters with `showErrors="false"`.
-      if (this.showWarningState() && this.shouldShowErrors()) {
-        return `${fieldName}-warning`;
-      }
-
-      return null;
+      return this.#initialAriaDescribedby
+        ? `${this.#initialAriaDescribedby} ${managedId}`
+        : managedId;
     },
   );
 
@@ -1125,6 +1246,28 @@ export class NgxFormFieldWrapper<TValue = unknown> {
         // Angular runs CD, which is when wrappers see the change anyway.
         // Keep order: name → element → visible → hints.
         const resolvedFieldName = this.resolvedFieldName();
+
+        // Fire the unresolved-name diagnostic here — after the DOM snapshot
+        // for *this* render has already been written to `#inputElementId`
+        // above — rather than inside the `resolvedFieldName` computed. By
+        // this point the state has genuinely settled: either the bound
+        // control still has no `id` (and no explicit `fieldName` was given)
+        // or no control was found at all. Checking post-write avoids the
+        // false positive where projected content (`NgxFormFieldHint`,
+        // `NgxFormFieldError`) reads `resolvedFieldName()` through
+        // `NGX_SIGNAL_FORM_FIELD_CONTEXT` on the first change-detection
+        // pass, before this write phase has ever run.
+        if (
+          isDevMode() &&
+          !this.#warnedUnresolvedFieldName &&
+          resolvedFieldName === null
+        ) {
+          this.#warnedUnresolvedFieldName = true;
+          console.error(
+            '[ngx-signal-forms] Could not resolve a deterministic field name for ngx-form-field-wrapper. Add an explicit `fieldName` input or an `id` attribute to the bound control. ARIA wiring will be skipped until a name is available.',
+          );
+        }
+
         this.#fieldIdentity.setFieldName(resolvedFieldName);
         this.#fieldIdentity.setControlElement(inputEl);
         this.#fieldIdentity.setControlVisible(

--- a/packages/toolkit/form-field/form-field.utils.spec.ts
+++ b/packages/toolkit/form-field/form-field.utils.spec.ts
@@ -186,6 +186,53 @@ describe('readFormFieldWrapperDomSnapshot — native-vs-fallback precedence', ()
     expect(snapshot.inputEl).toBe(probeMatch);
     expect(snapshot.inputId).toBe('probe-match');
   });
+
+  it('does not let an id-bearing [prefix]/label-slot element outrank the real control in __main', () => {
+    // Regression guard: `findBoundControl`'s selector is one comma-separated
+    // `querySelector`, which returns the first match in *document order*
+    // across the whole host, not "the real control" specifically. An
+    // `id`-bearing element projected before `__main` (label slot, [prefix]
+    // slot) used to win the fallback probe purely by being earlier in the
+    // DOM — even though it isn't a form control at all. The probe must be
+    // scoped to `__main` so only the real control can match.
+    const host = document.createElement('div');
+
+    const label = document.createElement('div');
+    label.className = 'ngx-signal-form-field-wrapper__label';
+    // A native <button type="button"> with an id satisfies
+    // BOUND_CONTROL_SELECTOR and sits before `__main` in document order.
+    const decoyToggle = document.createElement('button');
+    decoyToggle.type = 'button';
+    decoyToggle.id = 'decoy-toggle';
+    label.append(decoyToggle);
+
+    const content = document.createElement('div');
+    content.className = 'ngx-signal-form-field-wrapper__content';
+    const prefix = document.createElement('div');
+    prefix.className = 'ngx-signal-form-field-wrapper__prefix';
+    const decoyPrefixInput = document.createElement('input');
+    decoyPrefixInput.id = 'decoy-prefix';
+    prefix.append(decoyPrefixInput);
+
+    const main = document.createElement('div');
+    main.className = 'ngx-signal-form-field-wrapper__main';
+    const realControl = document.createElement('input');
+    realControl.id = 'real-control';
+    main.append(realControl);
+
+    content.append(prefix, main);
+    host.append(label, content);
+
+    const snapshot = readFormFieldWrapperDomSnapshot(
+      host,
+      null,
+      DEFAULT_NGX_SIGNAL_FORM_CONTROL_PRESETS,
+      null,
+    );
+
+    expect(snapshot.inputEl).toBe(realControl);
+    expect(snapshot.inputId).toBe('real-control');
+  });
 });
 
 describe('null (unresolved) control kind fallback', () => {

--- a/packages/toolkit/form-field/form-field.utils.ts
+++ b/packages/toolkit/form-field/form-field.utils.ts
@@ -89,6 +89,28 @@ export function readFormFieldWrapperDomSnapshot(
     cachedControl?.isConnected &&
     hostEl.contains(cachedControl) &&
     cachedControl.hasAttribute('id');
+  // `findBoundControl`'s selector is a single comma-separated `querySelector`,
+  // which returns the first match in *document order* across whatever root
+  // it's given, not by resolution tier. Scanning `hostEl` directly lets a
+  // `[prefix]`/label-slot element that happens to match the selector (a
+  // `<button prefix type="button" id="toggle">`, or a second, unrelated
+  // `<input id>` sitting in a projected label) win over the real control in
+  // `__main` — `__label` renders before `__content` in the template, and
+  // `__prefix` before `__main` inside it, so both slots are checked first in
+  // document order.
+  //
+  // Probe `__main` first — the region `selectionControlCount` below also
+  // scans — since that's where a wrapper's real control lives whenever it's
+  // projected as a standalone sibling. Only fall back to scanning the whole
+  // host when `__main` has no match: the implicit-label pattern
+  // (`<label>Email <input id="email"></label>`) projects the control AS PART
+  // OF the label into `__label`, not `__main`, so a real, singly-nested
+  // control legitimately has no `__main` match to find.
+  const mainSlot = hostEl.querySelector<HTMLElement>(
+    ':scope > .ngx-signal-form-field-wrapper__content > .ngx-signal-form-field-wrapper__main',
+  );
+  const probedControl =
+    (mainSlot && findBoundControl(mainSlot)) ?? findBoundControl(hostEl);
   // `nativeControl` wins when present. The native-vs-fallback invariant
   // (PR #92: native and CSS-selector paths must produce identical output) is
   // upheld upstream in `resolveBoundControlFromBindings`, which only returns a
@@ -96,8 +118,7 @@ export function readFormFieldWrapperDomSnapshot(
   // `findBoundControl` selector enforces. An id-less `[formField]` host
   // therefore arrives here as `nativeControl === null` and falls through to the
   // probe, which still finds the inner `<input id>`.
-  const inputEl =
-    nativeControl ?? (cacheHit ? cachedControl : findBoundControl(hostEl));
+  const inputEl = nativeControl ?? (cacheHit ? cachedControl : probedControl);
 
   return {
     inputEl,
@@ -109,13 +130,9 @@ export function readFormFieldWrapperDomSnapshot(
     // mode. The `__main` slot is always rendered by the wrapper template;
     // the `?? 0` is defense-in-depth against unexpected DOM trees.
     selectionControlCount:
-      hostEl
-        .querySelector(
-          ':scope > .ngx-signal-form-field-wrapper__content > .ngx-signal-form-field-wrapper__main',
-        )
-        ?.querySelectorAll(
-          "input[type='radio'], input[type='checkbox']:not([role='switch']), [role='radio'], [role='checkbox']",
-        ).length ?? 0,
+      mainSlot?.querySelectorAll(
+        "input[type='radio'], input[type='checkbox']:not([role='switch']), [role='radio'], [role='checkbox']",
+      ).length ?? 0,
     label: hostEl.querySelector(
       ':scope > .ngx-signal-form-field-wrapper__label :is(label, [ngxFormFieldLabel])',
     ),

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -159,6 +159,7 @@ describe('NgxFormFieldset', () => {
     /// stays mounted (WCAG 4.1.3, always-mounted live region) but must be
     /// empty.
     const warnings = screen.queryAllByRole('status');
+    expect(warnings).not.toHaveLength(0);
     for (const warning of warnings) {
       expect(warning.textContent?.trim() ?? '').toBe('');
     }

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -155,9 +155,13 @@ describe('NgxFormFieldset', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]?.textContent).toContain('City required');
 
-    /// Warning should be suppressed when error is shown
+    /// Warning should be suppressed when error is shown. The status shell
+    /// stays mounted (WCAG 4.1.3, always-mounted live region) but must be
+    /// empty.
     const warnings = screen.queryAllByRole('status');
-    expect(warnings).toHaveLength(0);
+    for (const warning of warnings) {
+      expect(warning.textContent?.trim() ?? '').toBe('');
+    }
   });
 
   it('shows warnings when no blocking errors exist', async () => {

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -254,6 +254,57 @@ describe('NgxFormFieldset', () => {
     expect(host).toHaveAttribute('aria-describedby', 'address-error');
   });
 
+  it('preserves an author-supplied aria-describedby instead of clobbering it', async () => {
+    // Regression guard: the `[attr.aria-describedby]` host binding used to
+    // return only the managed error/warning id (or `null`), which nulled
+    // out any author-supplied value — a common pattern being
+    // `<fieldset ngxFormFieldset aria-describedby="pw-rules">` pointing at a
+    // sibling hint element the fieldset doesn't own.
+    const fieldset = createFieldsetState({
+      errors: () => [{ kind: 'required', message: 'Required' }],
+      errorSummary: () => [{ kind: 'required', message: 'Required' }],
+    });
+
+    const { container } = await render(
+      `<ngx-form-fieldset
+        [fieldsetField]="fieldset"
+        fieldsetId="address"
+        aria-describedby="pw-rules"
+      >
+        <div>Content</div>
+      </ngx-form-fieldset>`,
+      {
+        imports: [NgxFormFieldset],
+        componentProperties: { fieldset },
+      },
+    );
+
+    const host = container.querySelector('ngx-form-fieldset');
+    expect(host).toHaveAttribute('aria-describedby', 'pw-rules address-error');
+  });
+
+  it('falls back to the author-supplied aria-describedby alone when no messages are shown', async () => {
+    const fieldset = createFieldsetState({
+      invalid: () => false,
+      valid: () => true,
+      errors: () => [],
+      errorSummary: () => [],
+    });
+
+    const { container } = await render(
+      `<ngx-form-fieldset [fieldsetField]="fieldset" aria-describedby="pw-rules">
+        <div>Content</div>
+      </ngx-form-fieldset>`,
+      {
+        imports: [NgxFormFieldset],
+        componentProperties: { fieldset },
+      },
+    );
+
+    const host = container.querySelector('ngx-form-fieldset');
+    expect(host).toHaveAttribute('aria-describedby', 'pw-rules');
+  });
+
   it('renders aggregated messages below content by default', async () => {
     const fieldset = createFieldsetState({
       errors: () => [{ kind: 'required', message: 'Required' }],

--- a/packages/toolkit/form-field/form-fieldset.ts
+++ b/packages/toolkit/form-field/form-fieldset.ts
@@ -214,6 +214,13 @@ export class NgxFormFieldset {
     this.#elementRef.nativeElement.getAttribute('aria-labelledby');
   readonly #initialAriaLabel =
     this.#elementRef.nativeElement.getAttribute('aria-label');
+  // Same preservation rule for `aria-describedby`: `describedByIds()` below
+  // used to return the managed error/warning id (or `null`) unconditionally,
+  // clobbering an author-supplied value (a common pattern:
+  // `<fieldset ngxFormFieldset aria-describedby="pw-rules">`). Capture it
+  // here and prepend it in `describedByIds()`.
+  readonly #initialAriaDescribedby =
+    this.#elementRef.nativeElement.getAttribute('aria-describedby');
   // `<fieldset>` natively implies role="group" and associates a child <legend>.
   // Any other host tag (custom element `<ngx-form-fieldset>` or a bare
   // `[ngxFormFieldset]` attribute target) needs an explicit group role so the
@@ -488,13 +495,18 @@ export class NgxFormFieldset {
   });
 
   protected readonly describedByIds = computed(() => {
+    // Preserve any author-supplied `aria-describedby` — same rule as
+    // `#initialAriaLabelledby` above. Every `return` below merges the
+    // managed id onto this instead of replacing it outright.
+    const initial = this.#initialAriaDescribedby;
+
     // The rendered notification/error component strips its `id` attribute
     // whenever `displayedMessagesSignal` is empty, which happens when the user
     // passes `showErrors="false"` even on an invalid fieldset. Mirror that
     // gating here so `aria-describedby` never points to an element without a
     // matching id in the DOM.
     if (!this.showMessages()) {
-      return null;
+      return initial;
     }
 
     const fieldsetId = this.fieldset.resolvedFieldsetId();
@@ -503,14 +515,16 @@ export class NgxFormFieldset {
     // `filteredErrorsSignal`), so only reference the id that is actually in
     // the DOM.
     if (this.fieldset.shouldShowErrors()) {
-      return `${fieldsetId}-error`;
+      return initial ? `${initial} ${fieldsetId}-error` : `${fieldsetId}-error`;
     }
 
     if (this.fieldset.shouldShowWarnings()) {
-      return `${fieldsetId}-warning`;
+      return initial
+        ? `${initial} ${fieldsetId}-warning`
+        : `${fieldsetId}-warning`;
     }
 
-    return null;
+    return initial;
   });
 
   constructor() {

--- a/packages/toolkit/form-field/index.spec.ts
+++ b/packages/toolkit/form-field/index.spec.ts
@@ -1,0 +1,74 @@
+import { signal } from '@angular/core';
+import { FormField } from '@angular/forms/signals';
+import {
+  NgxSignalFormAutoAria,
+  NgxSignalFormControlSemanticsDirective,
+} from '@ngx-signal-forms/toolkit';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormField } from './index';
+import { NgxFormFieldWrapper } from './form-field-wrapper';
+
+/**
+ * Stability + behavior contract for the `NgxFormField` convenience bundle.
+ *
+ * Regression coverage for the finding that `NgxFormField` included
+ * `NgxSignalFormAutoAria` but not `NgxSignalFormControlSemanticsDirective` —
+ * the very directive the wrapper's own dev-mode "could not infer a control
+ * kind" warning instructs authors to use via `ngxSignalFormControl="..."`.
+ * A consumer importing only `NgxFormField` (not the full
+ * `NgxSignalFormToolkit`) and following that instruction got: the warning
+ * kept firing (kind stayed unresolved), and worse,
+ * `ngxSignalFormControlAria="manual"` was silently ignored while
+ * `NgxSignalFormAutoAria` kept managing ARIA anyway via its CSS attribute
+ * selector — actively overriding what the author opted out of.
+ */
+describe('NgxFormField bundle', () => {
+  it('includes NgxSignalFormAutoAria and NgxSignalFormControlSemanticsDirective', () => {
+    expect(NgxFormField).toContain(NgxSignalFormAutoAria);
+    expect(NgxFormField).toContain(NgxSignalFormControlSemanticsDirective);
+  });
+
+  it('includes NgxFormFieldWrapper', () => {
+    expect(NgxFormField).toContain(NgxFormFieldWrapper);
+  });
+
+  it('resolves ngxSignalFormControl semantics when only NgxFormField is imported (no NgxSignalFormToolkit)', async () => {
+    const invalidField = signal({
+      invalid: () => true,
+      touched: () => true,
+      required: () => false,
+      errors: () => [{ kind: 'required', message: 'Email updates required' }],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field">
+        <label for="emailUpdates">Email updates</label>
+        <input
+          id="emailUpdates"
+          type="checkbox"
+          ngxSignalFormControl="switch"
+        />
+      </ngx-form-field-wrapper>`,
+      {
+        // `FormField` is Angular's own directive — required so `[formField]`
+        // provides the `FORM_FIELD` token `NgxSignalFormAutoAria` (part of
+        // the bundle) injects. `NgxFormField` is the only toolkit import:
+        // not `NgxSignalFormControlSemanticsDirective` directly, and not
+        // `NgxSignalFormToolkit`. Before the fix, the `ngxSignalFormControl`
+        // attribute was inert here — the directive that reads it and writes
+        // the `data-ngx-signal-form-control-*` attributes was never
+        // declared, so the wrapper's control-kind resolution never saw it
+        // and fell back to `kind: null`.
+        imports: [FormField, NgxFormField],
+        componentProperties: { field: invalidField },
+      },
+    );
+
+    const wrapper = container.querySelector('ngx-form-field-wrapper');
+    expect(wrapper).toHaveAttribute(
+      'data-ngx-signal-form-control-kind',
+      'switch',
+    );
+  });
+});

--- a/packages/toolkit/form-field/index.ts
+++ b/packages/toolkit/form-field/index.ts
@@ -7,7 +7,10 @@ export * from './form-fieldset';
 // moved to the core barrel during v1 hardening.
 export type { NgxFormFieldErrorPlacement } from '@ngx-signal-forms/toolkit';
 
-import { NgxSignalFormAutoAria } from '@ngx-signal-forms/toolkit';
+import {
+  NgxSignalFormAutoAria,
+  NgxSignalFormControlSemanticsDirective,
+} from '@ngx-signal-forms/toolkit';
 import {
   NgxFormFieldCharacterCount,
   NgxFormFieldError,
@@ -24,6 +27,19 @@ import { NgxFormFieldset } from './form-fieldset';
  * `aria-describedby` even when consumers don't separately import
  * `NgxSignalFormToolkit`. The directive is idempotent — importing it twice
  * (e.g. via both bundles) is safe.
+ *
+ * Also includes `NgxSignalFormControlSemanticsDirective` so the
+ * `ngxSignalFormControl="..."` / `ngxSignalFormControlAria="manual"`
+ * attributes the wrapper's own dev-mode warning instructs authors to add
+ * (see the "unresolved control kind" diagnostic in `NgxFormFieldWrapper`)
+ * actually do something when a consumer imports only this bundle. Without
+ * it, `ngxSignalFormControl` was inert — the control's kind stayed
+ * unresolved (the warning kept firing) and, worse, `ariaMode="manual"` was
+ * silently ignored while `NgxSignalFormAutoAria` kept managing ARIA via its
+ * CSS attribute selector, actively overriding what the author opted out of.
+ * The directive is selector-gated (`[ngxSignalFormControl]`) and inert when
+ * unused, so including it here is a no-op for consumers who never add the
+ * attribute.
  *
  * @example
  * ```typescript
@@ -46,6 +62,7 @@ import { NgxFormFieldset } from './form-fieldset';
  */
 export const NgxFormField = [
   NgxSignalFormAutoAria,
+  NgxSignalFormControlSemanticsDirective,
   NgxFormFieldWrapper,
   NgxFormFieldHint,
   NgxFormFieldCharacterCount,

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -102,12 +102,13 @@ Selector: `[ngxHeadlessErrorState]` · Export: `errorState`
 
 Exposes error state signals for custom error display.
 
-| Input             | Type                        | Description                                                                              |
-| ----------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
-| `field`           | `FieldTree` (required)      | The field to track                                                                       |
-| `fieldName`       | `string \| null` (required) | Field name for ID generation. Pass `null` to disable id generation until a name resolves |
-| `strategy`        | `ErrorDisplayStrategy`      | Override (inherits from context)                                                         |
-| `submittedStatus` | `SubmittedStatus`           | Override for `'on-submit'` strategy                                                      |
+| Input             | Type                                            | Description                                                                                                                                                   |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `field`           | `FieldTree` (optional)                          | The field to track. Omit when using `errorsOverride` or the host `connectFieldState()` bridge                                                                 |
+| `fieldName`       | `string \| null` (optional, default `null`)     | Field name for ID generation. Pass `null` (or omit) to disable id generation until a name resolves                                                            |
+| `errorsOverride`  | `Signal<readonly ValidationError[]>` (optional) | Pre-aggregated errors that replace field-based extraction (e.g. for fieldsets). When provided, `field` is not required and `showErrors` always returns `true` |
+| `strategy`        | `ErrorDisplayStrategy`                          | Override (inherits from context)                                                                                                                              |
+| `submittedStatus` | `SubmittedStatus`                               | Override for `'on-submit'` strategy                                                                                                                           |
 
 Signals: `showErrors()`, `showWarnings()`, `hasErrors()`, `hasWarnings()`, `errors()`, `warnings()`, `resolvedErrors()`, `resolvedWarnings()`, `errorId` (nullable), `warningId` (nullable).
 
@@ -123,7 +124,9 @@ Aggregates all errors from a form tree. Each entry has a `focus()` method that c
 | `strategy`        | `ErrorDisplayStrategy` | Override (inherits from context)    |
 | `submittedStatus` | `SubmittedStatus`      | Override for `'on-submit'` strategy |
 
-Signals: `entries()`, `warningEntries()`, `hasErrors()`, `hasWarnings()`, `shouldShow()`, `focusFirst()`.
+Signals: `entries()`, `warningEntries()`, `hasErrors()`, `hasWarnings()`, `shouldShow()`, `shouldShowWarnings()`, `focusFirst()`.
+
+`shouldShow()` gates `entries()` (strategy && `hasErrors()`); `shouldShowWarnings()` gates `warningEntries()` (strategy && `hasWarnings()`) — a warnings-only form has no blocking errors, so `shouldShow()` alone can never reveal warnings.
 
 ### NgxHeadlessCharacterCount
 
@@ -131,12 +134,12 @@ Selector: `[ngxHeadlessCharacterCount]` · Export: `characterCount`
 
 Provides character count signals with progressive limit states.
 
-| Input              | Type                | Default  | Description     |
-| ------------------ | ------------------- | -------- | --------------- |
-| `field`            | `FieldTree<string>` | required | String field    |
-| `maxLength`        | `number`            | required | Character limit |
-| `warningThreshold` | `number`            | `0.8`    | Warning at 80%  |
-| `dangerThreshold`  | `number`            | `0.95`   | Danger at 95%   |
+| Input              | Type                             | Default  | Description                                              |
+| ------------------ | -------------------------------- | -------- | -------------------------------------------------------- |
+| `field`            | `FieldTree<CharacterCountValue>` | required | `string \| readonly string[] \| null \| undefined` field |
+| `maxLength`        | `number`                         | required | Character limit                                          |
+| `warningThreshold` | `number`                         | `0.8`    | Warning at 80%                                           |
+| `dangerThreshold`  | `number`                         | `0.95`   | Danger at 95%                                            |
 
 Signals: `currentLength()`, `resolvedMaxLength()`, `remaining()`, `limitState()` (`'ok' | 'warning' | 'danger' | 'exceeded'`), `hasLimit()`, `isExceeded()`, `percentUsed()`.
 
@@ -252,7 +255,7 @@ humanizeFieldPath('address.postalCode'); // 'Address / Postal code'
 createUniqueId('field'); // 'field-1', 'field-2', ...
 
 // Error-summary building blocks (what NgxHeadlessErrorSummary uses internally)
-toErrorSummaryEntry(data); // ErrorSummaryEntryData → entry with focus()
+toErrorSummaryEntry(error); // ValidationError → ErrorSummaryEntryData with focus()
 focusBoundControlFromError(error); // focus the control bound to an error
 
 // Required/optional leaf summary for a form tree (drives marking legends)

--- a/packages/toolkit/headless/src/lib/character-count.ts
+++ b/packages/toolkit/headless/src/lib/character-count.ts
@@ -82,8 +82,8 @@ export const DEFAULT_DANGER_THRESHOLD = 0.95;
  * The limit state transitions based on configurable thresholds:
  * - **ok**: Under warning threshold (default < 80%)
  * - **warning**: At/above warning, under danger (default 80-94%)
- * - **danger**: At/above danger, under exceeded (default 95-99%)
- * - **exceeded**: At or above 100%
+ * - **danger**: At/above danger, up to and including 100% (default 95-100%)
+ * - **exceeded**: Over 100%
  *
  * @example Custom thresholds
  * ```html

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
@@ -1,10 +1,17 @@
 import {
+  Component,
   Injector,
   runInInjectionContext,
   signal,
   type Signal,
 } from '@angular/core';
-import type { ValidationError } from '@angular/forms/signals';
+import { TestBed } from '@angular/core/testing';
+import {
+  form,
+  required,
+  schema,
+  type ValidationError,
+} from '@angular/forms/signals';
 import {
   NGX_ERROR_MESSAGES,
   type ErrorMessageRegistry,
@@ -472,5 +479,40 @@ describe('createErrorMessageSignal — edge cases', () => {
     );
 
     expect(result()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real FieldTree name() fallback — no `fieldName` option supplied
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — name() fallback on a real field', () => {
+  it('strips the Angular-internal `ng.formN.` prefix from the field name fallback', () => {
+    // Angular's real `FieldState.name()` is `${APP_ID}.form${n}.path`, e.g.
+    // `ng.form0.email` — not the bare path segment the mocked specs above
+    // use. When `fieldName` is omitted, the per-error DOM id must still be
+    // derived from the bare path so it matches the ids the in-tree wrapper
+    // (and any other consumer deriving ids from the same field name) builds.
+    @Component({ template: '' })
+    class Host {
+      readonly form = form(
+        signal({ email: '' }),
+        schema<{ email: string }>((path) => {
+          required(path.email);
+        }),
+      );
+      readonly resolved = createErrorMessageSignal(() => this.form.email(), {
+        strategy: 'immediate',
+      });
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { resolved, form: contactForm } = fixture.componentInstance;
+
+    // Sanity-check the assumption this regression test relies on: Angular's
+    // real field name is prefixed.
+    expect(contactForm.email().name()).toMatch(/^\w+\.form\d+\.email$/);
+
+    expect(resolved()[0]?.id).toBe('email-error-required');
   });
 });

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.ts
@@ -7,6 +7,7 @@ import {
   NGX_ERROR_MESSAGES,
   readDirectErrors,
   splitByKind,
+  stripAngularFormPrefix,
   type CreateErrorVisibilityOptions,
   type ErrorDisplayStrategy,
   type ErrorMessageRegistry,
@@ -296,5 +297,10 @@ function readNameFromField(accessor: FieldStateAccessor): string | null {
   const state = accessor();
   if (!state || typeof state !== 'object') return null;
   const name = state.name;
-  return typeof name === 'function' ? name() : null;
+  if (typeof name !== 'function') return null;
+  // Angular's real `FieldState.name()` is Angular-internal-prefixed
+  // (`${APP_ID}.form${n}.path`, e.g. `a.form0.email`) and varies per form
+  // instance. Strip it so the fallback ID matches the bare-path IDs the
+  // in-tree wrapper and other consumers derive from the same field name.
+  return stripAngularFormPrefix(name());
 }

--- a/packages/toolkit/headless/src/lib/error-summary.spec.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.spec.ts
@@ -1,4 +1,5 @@
-import { Component, signal } from '@angular/core';
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import {
   disabled,
   form,
@@ -6,6 +7,7 @@ import {
   hidden,
   required,
   schema,
+  validate,
 } from '@angular/forms/signals';
 import { render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
@@ -134,6 +136,56 @@ describe('NgxHeadlessErrorSummary', () => {
       const nameError = screen.getByText('Name is required');
       expect(nameError).toBeTruthy();
     });
+
+    it('keeps a separate entry per field when two fields share kind and the framework-default (message-less) error', async () => {
+      // Both fields fail `required()` with no custom `message`, so
+      // `ValidationError.message` is `undefined` for both — a message-blind
+      // dedupe key (`kind::message`) collapses them to a single entry and
+      // silently drops the second field from the summary (WCAG 3.3.1).
+      @Component({
+        selector: 'ngx-test-summary-shared-key',
+        imports: [FormField, NgxHeadlessErrorSummary],
+
+        template: `
+          <div>
+            <input id="email" [formField]="contactForm.email" />
+            <input id="name" [formField]="contactForm.name" />
+            <div
+              ngxHeadlessErrorSummary
+              #summary="errorSummary"
+              [formTree]="contactForm"
+              strategy="immediate"
+            >
+              <span data-testid="entry-count">{{
+                summary.entries().length
+              }}</span>
+              @for (
+                entry of summary.entries();
+                track entry.kind + entry.fieldName
+              ) {
+                <span [attr.data-testid]="'field-' + entry.fieldName"></span>
+              }
+            </div>
+          </div>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '', name: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email);
+            required(path.name);
+          }),
+        );
+      }
+
+      await render(TestComponent);
+
+      expect(screen.getByTestId('entry-count')).toHaveTextContent('2');
+      expect(screen.queryByTestId('field-Email')).toBeTruthy();
+      expect(screen.queryByTestId('field-Name')).toBeTruthy();
+    });
   });
 
   describe('strategy-aware visibility', () => {
@@ -220,6 +272,64 @@ describe('NgxHeadlessErrorSummary', () => {
       await user.tab();
 
       expect(screen.getByTestId('visible-summary')).toBeTruthy();
+    });
+  });
+
+  describe('shouldShowWarnings', () => {
+    it('gates a warnings-only form independently of shouldShow', async () => {
+      // A warnings-only form never has blocking errors, so `hasErrors()` is
+      // permanently `false` and `shouldShow()` (strategy && hasErrors) can
+      // never gate `warningEntries()`. `shouldShowWarnings` (strategy &&
+      // hasWarnings) is the dedicated gate consumers must use instead.
+      @Component({
+        selector: 'ngx-test-summary-should-show-warnings',
+        imports: [FormField, NgxHeadlessErrorSummary],
+
+        template: `
+          <div>
+            <input id="street" [formField]="addressForm.street" />
+            <div
+              ngxHeadlessErrorSummary
+              #summary="errorSummary"
+              [formTree]="addressForm"
+              strategy="immediate"
+            >
+              <span data-testid="should-show">{{ summary.shouldShow() }}</span>
+              <span data-testid="should-show-warnings">{{
+                summary.shouldShowWarnings()
+              }}</span>
+              <span data-testid="warning-count">{{
+                summary.warningEntries().length
+              }}</span>
+            </div>
+          </div>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ street: '' });
+        readonly addressForm = form(
+          this.#model,
+          schema((path) => {
+            validate(path.street, (ctx) =>
+              ctx.value()
+                ? null
+                : { kind: 'warn:street-optional', message: 'Optional' },
+            );
+          }),
+        );
+      }
+
+      const { fixture } = await render(TestComponent);
+
+      fixture.componentInstance.addressForm.street().markAsTouched();
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(screen.getByTestId('warning-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('should-show')).toHaveTextContent('false');
+      expect(screen.getByTestId('should-show-warnings')).toHaveTextContent(
+        'true',
+      );
     });
   });
 

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -2,8 +2,11 @@ import { computed, Directive, inject, input, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   createErrorVisibility,
+  injectFormContext,
+  resolveStrategyFromContext,
   splitByKind,
   type ErrorDisplayStrategy,
+  type ResolvedErrorDisplayStrategy,
   type SubmittedStatus,
 } from '@ngx-signal-forms/toolkit';
 import {
@@ -40,6 +43,14 @@ export interface ErrorSummarySignals {
   readonly hasWarnings: Signal<boolean>;
   /** Whether the summary should be visible based on strategy */
   readonly shouldShow: Signal<boolean>;
+  /**
+   * The fully-resolved error display strategy: explicit `strategy` input →
+   * form context → `'on-touch'` default. Consumers that need to distinguish
+   * a submit-driven appearance (e.g. to decide whether to move focus) from
+   * an on-touch/immediate one should read this rather than the raw
+   * `strategy` input, which may be `undefined`.
+   */
+  readonly resolvedStrategy: Signal<ResolvedErrorDisplayStrategy>;
   /** Focus the control for the first error entry */
   readonly focusFirst: () => void;
 }
@@ -61,14 +72,19 @@ export interface ErrorSummarySignals {
  *
  * ## Usage
  *
+ * The `role="alert"` container should be rendered UNCONDITIONALLY (even
+ * while empty) rather than inserted together with its content — the same
+ * always-mounted live-region pattern `NgxFormFieldError` and
+ * `NgxFormFieldNotification` use. `role="alert"` only reliably fires on
+ * content insertion into a *pre-existing* live region; mounting the
+ * container and its content in the same tick risks the NVDA + Chrome
+ * missed-first-announcement bug. Gate only the inner content on
+ * `shouldShow()`/`hasErrors()`, not the container itself:
+ *
  * ```html
- * <div
- *   ngxHeadlessErrorSummary
- *   #summary="errorSummary"
- *   [formTree]="myForm"
- * >
- *   @if (summary.shouldShow() && summary.hasErrors()) {
- *     <ul role="alert">
+ * <div ngxHeadlessErrorSummary #summary="errorSummary" [formTree]="myForm">
+ *   <ul role="alert">
+ *     @if (summary.shouldShow() && summary.hasErrors()) {
  *       @for (entry of summary.entries(); track entry.kind + entry.fieldName) {
  *         <li>
  *           <button type="button" (click)="entry.focus()">
@@ -76,8 +92,8 @@ export interface ErrorSummarySignals {
  *           </button>
  *         </li>
  *       }
- *     </ul>
- *   }
+ *     }
+ *   </ul>
  * </div>
  * ```
  */
@@ -92,6 +108,7 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
   readonly #labelResolver = inject(NGX_FIELD_LABEL_RESOLVER, {
     optional: true,
   });
+  readonly #formContext = injectFormContext();
 
   /**
    * The root form FieldTree to aggregate errors from.
@@ -109,6 +126,10 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
    * If not provided, inherits from form context.
    */
   readonly submittedStatus = input<SubmittedStatus | undefined>();
+
+  readonly resolvedStrategy = computed(() =>
+    resolveStrategyFromContext(this.strategy(), this.#formContext),
+  );
 
   readonly #fieldState = computed(() => this.formTree()());
 

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -12,7 +12,7 @@ import {
 } from '@ngx-signal-forms/toolkit/core';
 
 import {
-  dedupeValidationErrors,
+  dedupeValidationErrorsByField,
   isErrorOnInteractiveField,
   readErrors,
   toErrorSummaryEntry,
@@ -40,6 +40,15 @@ export interface ErrorSummarySignals {
   readonly hasWarnings: Signal<boolean>;
   /** Whether the summary should be visible based on strategy */
   readonly shouldShow: Signal<boolean>;
+  /**
+   * Whether the warning list should be visible based on strategy.
+   *
+   * Independent of {@link shouldShow}: a warnings-only form (no blocking
+   * errors) has `hasErrors() === false`, so `shouldShow()` never gates
+   * `warningEntries()`. Consumers rendering `warningEntries()` should gate
+   * on this signal instead of `shouldShow()`.
+   */
+  readonly shouldShowWarnings: Signal<boolean>;
   /** Focus the control for the first error entry */
   readonly focusFirst: () => void;
 }
@@ -127,12 +136,17 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
    *
    * `readonly()` is intentionally **not** filtered: the field is visible and
    * focusable, and its error is usually still meaningful to the user.
+   *
+   * Deduplication is per-field (see {@link dedupeValidationErrorsByField}):
+   * unlike `NgxHeadlessFieldset`'s grouped-message dedupe, two different
+   * fields sharing the same kind/message (e.g. two `required()` fields with
+   * no custom message) must both keep their own summary entry.
    */
   readonly #split = computed(() => {
     const visibleErrors = readErrors(this.#fieldState()).filter(
       (error: ValidationError) => isErrorOnInteractiveField(error),
     );
-    return splitByKind(dedupeValidationErrors(visibleErrors));
+    return splitByKind(dedupeValidationErrorsByField(visibleErrors));
   });
 
   readonly entries = computed(() =>
@@ -162,6 +176,10 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
 
   readonly shouldShow = computed(
     () => this.#showErrorsSignal() && this.hasErrors(),
+  );
+
+  readonly shouldShowWarnings = computed(
+    () => this.#showErrorsSignal() && this.hasWarnings(),
   );
 
   readonly focusFirst = (): void => {

--- a/packages/toolkit/headless/src/lib/field-optionality.spec.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.spec.ts
@@ -115,6 +115,41 @@ describe('summarizeFieldOptionality', () => {
       hasOptional: false,
     });
   });
+
+  it('treats a Date-valued leaf as a control leaf, not a container, across a null → Date transition', () => {
+    // Angular's FieldTree proxy grows a Symbol.iterator whenever the field's
+    // *current* value is any non-null object (Date/File/Map included) — for
+    // a Date that iterator yields zero entries. A naive "is it iterable?"
+    // container check would treat the populated field as an empty container
+    // and silently drop its `required()` state from the walk.
+    @Component({ template: '' })
+    class Host {
+      readonly model = signal<{ birthDate: Date | null }>({ birthDate: null });
+      readonly tree = form(
+        this.model,
+        schema<{ birthDate: Date | null }>((path) => {
+          required(path.birthDate);
+        }),
+      );
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { tree, model } = fixture.componentInstance;
+
+    // While null, the leaf is unambiguous — required is read normally.
+    expect(summarizeFieldOptionality(tree)).toEqual({
+      hasRequired: true,
+      hasOptional: false,
+    });
+
+    // Once populated with a real Date, the field must still count as the
+    // same required leaf, not vanish from the walk.
+    model.set({ birthDate: new Date('2000-01-01') });
+    expect(summarizeFieldOptionality(tree)).toEqual({
+      hasRequired: true,
+      hasOptional: false,
+    });
+  });
 });
 
 describe('createFieldOptionalitySummary', () => {
@@ -151,6 +186,28 @@ describe('createFieldOptionalitySummary', () => {
 
     // Flip the predicate → the field becomes required and the summary updates.
     wantsEmail.set(true);
+    expect(summary.hasRequired()).toBe(true);
+  });
+
+  it('does not flip hasRequired to false when a required Date leaf gains a value', () => {
+    @Component({ template: '' })
+    class Host {
+      readonly model = signal<{ birthDate: Date | null }>({ birthDate: null });
+      readonly tree = form(
+        this.model,
+        schema<{ birthDate: Date | null }>((path) => {
+          required(path.birthDate);
+        }),
+      );
+      readonly summary = createFieldOptionalitySummary(() => this.tree);
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { summary, model } = fixture.componentInstance;
+
+    expect(summary.hasRequired()).toBe(true);
+
+    model.set({ birthDate: new Date('2000-01-01') });
     expect(summary.hasRequired()).toBe(true);
   });
 

--- a/packages/toolkit/headless/src/lib/field-optionality.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.ts
@@ -32,6 +32,51 @@ function isIterableNode(node: unknown): node is Iterable<unknown> {
 }
 
 /**
+ * Whether `value` is a plain data object — `{ ... }` object-literal shape or
+ * `null`-prototype object — as opposed to a boxed/branded value (`Date`,
+ * `File`, `Map`, a custom class instance, ...).
+ */
+function isPlainObject(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Whether a `FieldTree` node should be descended into as a structural
+ * container, rather than read as a leaf.
+ *
+ * Angular's `FieldTree` proxy grows a `[Symbol.iterator]` whenever the
+ * field's *current* value is any non-null object — this includes genuine
+ * schema containers (object subfields, arrays) but also boxed leaf values
+ * like `Date`, `File`, or `Map`, whose iteration yields zero entries. Relying
+ * on iterability alone would treat a populated `Date | null` leaf as an
+ * "empty container" the moment it gets a value, silently dropping its
+ * `required()` state from the walk. Genuine containers always hold a plain
+ * object or array (that's what the schema's object/array shape lowers to),
+ * so checking the value's prototype disambiguates the two.
+ *
+ * Known caveat: a leaf whose value is itself a custom class instance
+ * declared as an object-shaped model field (rather than a scalar) would be
+ * misread as a leaf here — the same class of edge case as the documented
+ * `string[]`-as-container caveat below.
+ */
+function isContainerNode(
+  node: AnyFieldTree,
+): node is AnyFieldTree & Iterable<unknown> {
+  if (!isIterableNode(node)) return false;
+
+  const state = node() as { value?: () => unknown } | null | undefined;
+  if (!state || typeof state.value !== 'function') return true;
+
+  const value = state.value();
+  if (Array.isArray(value)) return true;
+  if (value !== null && typeof value === 'object') return isPlainObject(value);
+
+  return true;
+}
+
+/**
  * Yield every leaf (control) `FieldTree` reachable from `node`, depth-first.
  *
  * Container nodes are descended into and never yielded themselves; only leaves
@@ -46,12 +91,12 @@ function isIterableNode(node: unknown): node is Iterable<unknown> {
  * @yields Each leaf (control) `FieldTree` in depth-first order.
  */
 function* walkLeaves(node: AnyFieldTree): Generator<AnyFieldTree> {
-  if (!isIterableNode(node)) {
+  if (!isContainerNode(node)) {
     yield node;
     return;
   }
 
-  for (const entry of node as Iterable<unknown>) {
+  for (const entry of node) {
     // Array-like nodes yield the child FieldTree (a callable) directly; object
     // subfields yield `[key, childTree]` tuples.
     const child: AnyFieldTree | undefined =

--- a/packages/toolkit/headless/src/lib/notification.spec.ts
+++ b/packages/toolkit/headless/src/lib/notification.spec.ts
@@ -29,6 +29,9 @@ describe('NgxHeadlessNotification', () => {
           [tone]="tone()"
         >
           <span data-testid="resolved-tone">{{ n.resolvedTone() }}</span>
+          <span data-testid="resolved-message">{{
+            n.resolvedMessages()[0]?.message
+          }}</span>
           @if (n.showErrorContainer()) {
             <div
               data-testid="error-container"
@@ -103,6 +106,23 @@ describe('NgxHeadlessNotification', () => {
       await setup({ errors: [], fieldName: 'address', tone: 'warning' });
 
       expect(screen.getByTestId('resolved-tone').textContent).toBe('error');
+    });
+  });
+
+  describe('resolvedMessages', () => {
+    it('strips the internal "warn:" prefix from a message-less warning kind', async () => {
+      // Angular's `ValidationError.message` is `undefined` by default. With
+      // no validator-supplied message and no registry entry for the kind,
+      // the fallback message is derived from the kind itself — the `warn:`
+      // marker prefix must never leak into the rendered warning text.
+      await setup({
+        errors: [{ kind: 'warn:weak_password' }],
+        fieldName: 'password',
+      });
+
+      const message = screen.getByTestId('resolved-message').textContent;
+      expect(message).not.toContain('warn:');
+      expect(message).toBe('weak password');
     });
   });
 

--- a/packages/toolkit/headless/src/lib/notification.ts
+++ b/packages/toolkit/headless/src/lib/notification.ts
@@ -1,14 +1,13 @@
 import { computed, Directive, inject, input, type Signal } from '@angular/core';
 import type { ValidationError } from '@angular/forms/signals';
-import {
-  isWarningError,
-  resolveValidationErrorMessage,
-} from '@ngx-signal-forms/toolkit';
+import { isWarningError } from '@ngx-signal-forms/toolkit';
 import {
   createFieldMessageIdSignals,
   NGX_ERROR_MESSAGES,
   normalizeFieldName,
 } from '@ngx-signal-forms/toolkit/core';
+
+import { resolveErrorMessage } from './utilities';
 
 /**
  * Visual / ARIA tone for grouped notifications.
@@ -165,10 +164,11 @@ export class NgxHeadlessNotification implements NotificationStateSignals {
     () =>
       this.#resolvedErrors().map((error) => ({
         kind: error.kind,
-        message: resolveValidationErrorMessage(
-          error,
-          this.#errorMessagesRegistry,
-        ),
+        // `stripWarningPrefix` defaults to `true` here (see `resolveErrorMessage`)
+        // because this directive is precisely the warning-tone surface — a
+        // message-less `warn:*` kind must never leak the internal `warn:`
+        // prefix into the rendered warning live region.
+        message: resolveErrorMessage(error, this.#errorMessagesRegistry),
       })),
   );
 }

--- a/packages/toolkit/headless/src/lib/utilities.spec.ts
+++ b/packages/toolkit/headless/src/lib/utilities.spec.ts
@@ -520,6 +520,16 @@ describe('Headless Utilities', () => {
       );
     });
 
+    it('should strip the form prefix regardless of the configured APP_ID', () => {
+      // Angular's real prefix is `${APP_ID}.form{n}.`, not hardcoded `ng.`.
+      // `BrowserTestingModule` (and any app with a custom `provideAppId`)
+      // uses a different APP_ID — e.g. `a.form0.email` in TestBed specs.
+      expect(humanizeFieldPath('a.form0.email')).toBe('Email');
+      expect(humanizeFieldPath('my-app.form3.address.city')).toBe(
+        'Address / City',
+      );
+    });
+
     it('should handle underscores and hyphens', () => {
       expect(humanizeFieldPath('first_name')).toBe('First name');
       expect(humanizeFieldPath('last-name')).toBe('Last name');

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -114,9 +114,7 @@ export interface FieldStateFlags {
  * Eliminates the repeated pattern of 5 individual `readFieldFlag` computeds
  * found in fieldset directives and components.
  *
- * @remarks Must be called in an injection context (constructor, field
- * initializer, or `runInInjectionContext`) because it creates `computed`
- * signals internally.
+ * @remarks Does not require an injection context (only creates `computed`s).
  *
  * @param fieldState - A signal/computed that returns the field state object
  * @returns Object with computed signals for each boolean flag
@@ -357,10 +355,16 @@ export interface ErrorStateResult {
  *
  * ```typescript
  * const formData = signal({ email: '' });
- * const emailField = form(formData, { validators: [Validators.required, Validators.email] });
+ * const contactForm = form(
+ *   formData,
+ *   schema((path) => {
+ *     required(path.email);
+ *     email(path.email);
+ *   }),
+ * );
  *
  * const errorState = createErrorState({
- *   field: emailField,
+ *   field: contactForm.email,
  *   fieldName: 'email',
  * });
  *
@@ -466,17 +470,21 @@ export interface CreateCharacterCountOptions {
  */
 export interface CharacterCountResult {
   /** Current value length */
-  readonly currentLength: ReadSignal<number>;
+  readonly currentLength: Signal<number>;
   /** Resolved maximum length */
-  readonly resolvedMaxLength: ReadSignal<number>;
+  readonly resolvedMaxLength: Signal<number>;
   /** Remaining characters until limit */
-  readonly remaining: ReadSignal<number>;
+  readonly remaining: Signal<number>;
   /** Current limit state */
-  readonly limitState: ReadSignal<CharacterCountLimitState>;
+  readonly limitState: Signal<CharacterCountLimitState>;
+  /** Whether a limit is configured. `maxLength` is required, so this is
+   * always `true` — retained for API symmetry with
+   * `NgxHeadlessCharacterCount.hasLimit`. */
+  readonly hasLimit: Signal<boolean>;
   /** Whether the limit has been exceeded */
-  readonly isExceeded: ReadSignal<boolean>;
+  readonly isExceeded: Signal<boolean>;
   /** Percentage of limit used (0-100+) */
-  readonly percentUsed: ReadSignal<number>;
+  readonly percentUsed: Signal<number>;
 }
 
 /**
@@ -485,15 +493,14 @@ export interface CharacterCountResult {
  * This utility provides the same state management as NgxHeadlessCharacterCount
  * but as standalone signals for programmatic use.
  *
- * @remarks Must be called in an injection context (constructor, field
- * initializer, or `runInInjectionContext`) because it creates `computed()`
- * signals internally.
+ * @remarks Does not require an injection context (only creates `computed()`
+ * signals internally).
  *
  * ## Usage
  *
  * ```typescript
  * const formData = signal({ bio: '' });
- * const bioField = form(formData, { validators: [] });
+ * const bioField = form(formData).bio;
  *
  * const charCount = createCharacterCount({
  *   field: bioField,
@@ -592,11 +599,16 @@ export function createCharacterCount(
     return 'ok';
   });
 
+  // `maxLength` is a required option, so a limit is always configured.
+  // See the `hasLimit` doc above for why this member exists at all.
+  const hasLimit = computed(() => true);
+
   return {
     currentLength,
     resolvedMaxLength,
     remaining,
     limitState,
+    hasLimit,
     isExceeded,
     percentUsed,
   };
@@ -636,6 +648,58 @@ type ValidationErrorWithFieldTree = ValidationError & {
       }
     | undefined;
 };
+
+/**
+ * Deduplicate validation errors **per originating field** by kind + message
+ * + field identity.
+ *
+ * This is deliberately distinct from {@link dedupeValidationErrors}, which
+ * `NgxHeadlessFieldset` uses to collapse the *same* message repeated across
+ * a group into one grouped entry — a documented feature, not a bug. An
+ * error-summary entry, by contrast, represents one field's error; two
+ * different fields that both fail `required()` with no custom message
+ * (Angular's default `ValidationError.message` is `undefined`) share the
+ * key `'required::'` under a message-blind dedupe and one of them would be
+ * silently dropped from the summary, violating WCAG 3.3.1 (the dropped
+ * field's error is never listed and never reachable via `focus()`).
+ *
+ * Errors without a resolvable `fieldTree` (e.g. from custom validators)
+ * fall back to the field-blind key so they still dedupe sensibly among
+ * themselves.
+ *
+ * @param errors - Array of ValidationError to deduplicate
+ * @returns Deduplicated array preserving first occurrence order
+ *
+ * @internal
+ */
+export function dedupeValidationErrorsByField(
+  errors: readonly ValidationError[],
+): ValidationError[] {
+  const seen = new Set<string>();
+  const result: ValidationError[] = [];
+
+  for (const error of errors) {
+    const key = `${fieldIdentityKey(error)}::${error.kind}::${error.message ?? ''}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(error);
+  }
+
+  return result;
+}
+
+function fieldIdentityKey(error: ValidationError): string {
+  const e = error as ValidationErrorWithFieldTree;
+  if (typeof e.fieldTree === 'function') {
+    const fieldState = e.fieldTree();
+    if (fieldState && typeof fieldState.name === 'function') {
+      return fieldState.name();
+    }
+  }
+  return '';
+}
 
 /**
  * Resolve the field name from a `ValidationError` via duck-typed access

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -25,6 +25,7 @@
     "provenance": true
   },
   "peerDependencies": {
+    "@angular/common": ">=22.0.0 <23.0.0",
     "@angular/core": ">=22.0.0 <23.0.0",
     "@angular/forms": ">=22.0.0 <23.0.0",
     "vest": ">=6.0.0 <6.3.0 || >=6.3.1"

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@angular/core": ">=22.0.0 <23.0.0",
     "@angular/forms": ">=22.0.0 <23.0.0",
-    "vest": ">=6.0.0 <6.3.0 || >=6.3.1"
+    "vest": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "vest": {

--- a/packages/toolkit/project.json
+++ b/packages/toolkit/project.json
@@ -34,6 +34,7 @@
         "commands": [
           "mkdir -p dist/packages/toolkit",
           "cp README.md dist/packages/toolkit/README.md",
+          "cp LICENSE dist/packages/toolkit/LICENSE",
           "node packages/toolkit/scripts/strip-internal-exports.mjs"
         ],
         "parallel": false,

--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Regression tests for packaging concerns that only surface once the
+// package is actually installed/published — undeclared peer deps, missing
+// license text in the tarball, and stale compatibility docs. These read the
+// checked-in source of truth directly rather than the built dist output.
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+) as {
+  peerDependencies?: Record<string, string>;
+  engines?: { node?: string };
+};
+
+const projectJson = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../project.json'), 'utf8'),
+) as {
+  targets: { 'post-build': { options: { commands: string[] } } };
+};
+
+describe('packages/toolkit/package.json', () => {
+  it('declares @angular/common as a peer dependency', () => {
+    // form-field-wrapper.ts and form-fieldset.ts import NgComponentOutlet /
+    // NgTemplateOutlet from '@angular/common' at runtime — the built fesm
+    // bundle contains a genuine top-level import of it, so it must be a
+    // declared peer dependency, not just a devDependency.
+    expect(packageJson.peerDependencies).toHaveProperty('@angular/common');
+  });
+});
+
+describe('packages/toolkit/project.json post-build target', () => {
+  it('copies LICENSE into the publish root alongside README.md', () => {
+    const commands = projectJson.targets['post-build'].options.commands;
+    const copiesLicense = commands.some((command) =>
+      /\bcp\b.*\bLICENSE\b.*dist\/packages\/toolkit/.test(command),
+    );
+    expect(copiesLicense).toBe(true);
+  });
+});
+
+describe('COMPATIBILITY.md', () => {
+  it('documents the same engines.node range as package.json', () => {
+    const compatibilityMd = readFileSync(
+      resolve(import.meta.dirname, '../../../COMPATIBILITY.md'),
+      'utf8',
+    );
+    expect(packageJson.engines?.node).toBeTruthy();
+    expect(compatibilityMd).toContain(packageJson.engines?.node);
+  });
+});

--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -21,12 +21,18 @@ const projectJson = JSON.parse(
 };
 
 describe('packages/toolkit/package.json', () => {
-  it('declares @angular/common as a peer dependency', () => {
+  it('declares @angular/common as a peer dependency with the same range as @angular/core', () => {
     // form-field-wrapper.ts and form-fieldset.ts import NgComponentOutlet /
     // NgTemplateOutlet from '@angular/common' at runtime — the built fesm
     // bundle contains a genuine top-level import of it, so it must be a
-    // declared peer dependency, not just a devDependency.
+    // declared peer dependency, not just a devDependency. It must also track
+    // the same Angular major/minor range as @angular/core — a drifted range
+    // would let a consumer install a common/core version pair that the
+    // package was never validated against.
     expect(packageJson.peerDependencies).toHaveProperty('@angular/common');
+    expect(packageJson.peerDependencies?.['@angular/common']).toBe(
+      packageJson.peerDependencies?.['@angular/core'],
+    );
   });
 });
 

--- a/packages/toolkit/scripts/strip-internal-exports.mjs
+++ b/packages/toolkit/scripts/strip-internal-exports.mjs
@@ -37,7 +37,10 @@ const pkgJsonPath = join(distRoot, 'package.json');
 
 const PACKAGE_CORE_SPECIFIER = '@ngx-signal-forms/toolkit/core';
 const RELATIVE_MJS_SPECIFIER = './ngx-signal-forms-toolkit-core.mjs';
-const RELATIVE_DTS_SPECIFIER = './ngx-signal-forms-toolkit-core';
+// TypeScript's node16/nodenext module resolution requires an explicit
+// extension on relative ESM specifiers in declaration files; `.js` maps to
+// the sibling `.d.ts` file.
+const RELATIVE_DTS_SPECIFIER = './ngx-signal-forms-toolkit-core.js';
 const CORE_FESM_BASENAME = 'ngx-signal-forms-toolkit-core.mjs';
 const CORE_DTS_BASENAME = 'ngx-signal-forms-toolkit-core.d.ts';
 

--- a/packages/toolkit/scripts/strip-internal-exports.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-exports.spec.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Regression test for the post-build hardening script that hides the
+// build-time-only `/core` entry point from the published package. The
+// script rewrites sibling bundles' `'@ngx-signal-forms/toolkit/core'`
+// specifiers to relative paths pointing at the co-located `core` bundle.
+//
+// `.d.ts` files are ESM under `"type": "module"`, so under TypeScript's
+// node16/nodenext module resolution a relative specifier in a declaration
+// file must carry an explicit extension. A specifier like
+// `'./ngx-signal-forms-toolkit-core'` (no extension) breaks consumers using
+// nodenext resolution (SSR, tsc builds, Jest/Vitest with nodenext) with
+// TS2307, even though Angular CLI's bundler resolution masks the problem.
+
+const scriptPath = resolve(import.meta.dirname, './strip-internal-exports.mjs');
+
+describe('strip-internal-exports.mjs', () => {
+  let workDir: string;
+
+  afterEach(() => {
+    if (workDir) rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('rewrites .d.ts core specifiers to an extension-carrying relative path', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'strip-internal-exports-'));
+    const distRoot = join(workDir, 'dist/packages/toolkit');
+    const fesmDir = join(distRoot, 'fesm2022');
+    const typesDir = join(distRoot, 'types');
+    await mkdir(fesmDir, { recursive: true });
+    await mkdir(typesDir, { recursive: true });
+
+    // Sibling entry that re-exports the internal /core entry, plus the core
+    // bundle itself (which must be left untouched, not self-rewritten).
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      `export * from '@ngx-signal-forms/toolkit/core';\n`,
+    );
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit-core.mjs'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      `export * from '@ngx-signal-forms/toolkit/core';\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(distRoot, 'package.json'),
+      JSON.stringify({
+        exports: {
+          '.': './fesm2022/ngx-signal-forms-toolkit.mjs',
+          './core': './fesm2022/ngx-signal-forms-toolkit-core.mjs',
+        },
+      }),
+    );
+
+    execFileSync(process.execPath, [scriptPath], { cwd: workDir });
+
+    const dts = readFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      'utf8',
+    );
+    const mjs = readFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      'utf8',
+    );
+
+    // The .mjs rewrite already carries an extension and must be unaffected.
+    expect(mjs).toContain(`from './ngx-signal-forms-toolkit-core.mjs'`);
+
+    // The .d.ts rewrite must carry an explicit extension for node16/nodenext
+    // consumers to resolve it — the bare (extensionless) specifier must be
+    // gone entirely, not just supplemented.
+    expect(dts).not.toMatch(/'\.\/ngx-signal-forms-toolkit-core'/);
+    expect(dts).toContain(`from './ngx-signal-forms-toolkit-core.js'`);
+  });
+});

--- a/packages/toolkit/scripts/strip-internal-exports.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-exports.spec.ts
@@ -20,10 +20,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 const scriptPath = resolve(import.meta.dirname, './strip-internal-exports.mjs');
 
 describe('strip-internal-exports.mjs', () => {
-  let workDir: string;
+  let workDir: string | undefined;
 
   afterEach(() => {
-    if (workDir) rmSync(workDir, { recursive: true, force: true });
+    if (workDir !== undefined)
+      rmSync(workDir, { recursive: true, force: true });
   });
 
   it('rewrites .d.ts core specifiers to an extension-carrying relative path', async () => {

--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -33,17 +33,13 @@ The adapter reads Vest's full `run()` result, mapping blocking errors **and** `w
 
 ## Installation
 
-Vest is an optional peer dependency (`>=6.0.0 <6.3.0 || >=6.3.1`). Install it only when using this entry point.
+Vest is an optional peer dependency (`>=6.0.0`). Install it only when using this entry point.
 
 ```bash
-pnpm add @ngx-signal-forms/toolkit vest@6.2.7
+pnpm add @ngx-signal-forms/toolkit vest
 ```
 
 > **Vest v6+ required.** Standard Schema support was introduced in Vest 6.
-> `vest@6.3.0` is excluded because that release ships a broken `package.json`
-> `exports` map that prevents Angular's build tooling from resolving the
-> library. Use any `6.2.x` release or upgrade to `>=6.3.1`, where the
-> regression was fixed.
 
 If you are migrating from `ngx-vest-forms`, see [`docs/MIGRATING_FROM_NGX_VEST_FORMS.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/MIGRATING_FROM_NGX_VEST_FORMS.md) and the official [Vest 6 upgrade guide](https://vestjs.dev/docs/upgrade_guide).
 
@@ -359,6 +355,15 @@ validateVest(path, signupSuite, { resetOnDestroy: false }); // opt out of teardo
 - Only the **latest** run's result surfaces to Signal Forms. Rapid value
   changes cancel pending work via Angular's async validator contract; stale
   results never reach the field's `errors()` signal.
+- **Warnings vs. pending async tests.** Angular's `validateAsync` only
+  schedules its resource when the bound subtree has zero sync errors, and a
+  toolkit `warn:vest:*` result is an ordinary `ValidationError`. To avoid a
+  sync warning silently suppressing a blocking async check on the same field,
+  the adapter defers surfacing a warning while the suite still has pending
+  async tests, and re-surfaces it together with the settled result once they
+  finish. In practice this means a warning can appear one tick later than a
+  blocking sync error while async validation is in flight — it does not
+  change what surfaces once the field settles.
 
 ### Focused `only()` runs
 

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { create, enforce, group, only, test, warn } from 'vest';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type VestResultLike,
   VEST_ERROR_KIND_PREFIX,
   VEST_WARNING_KIND_PREFIX,
   validateVest,
@@ -1085,8 +1086,9 @@ describe('validateVest', () => {
     // via a second `focusCurrentField` registration on a different field)
     // steals the first run's resolver. The first run's promise then never
     // settles. Without a settlement fallback that does not depend on the
-    // superseded run's own resolver, `password` would stay pending() forever
-    // even after its own async test body resolves.
+    // superseded run's own resolver, `email` (the earlier registration,
+    // whose resolver gets stolen by `password`'s later run) would stay
+    // pending() forever even after its own async test body resolves.
     const deferred = new Map<string, () => void>();
     const awaitField = (field: string) =>
       new Promise<void>((resolve) => {
@@ -1143,6 +1145,73 @@ describe('validateVest', () => {
 
     expect(fixture.componentInstance.f.email().pending()).toBe(false);
     expect(fixture.componentInstance.f.password().pending()).toBe(false);
+  });
+
+  it('does not throw a TDZ ReferenceError when suite.subscribe fires its callback synchronously', async () => {
+    // Regression: the settlement race in `awaitVestRunSettlement` captured
+    // `subscribe(...)`'s return value in a `const unsubscribe`, then called
+    // `unsubscribe()` from inside the subscribe callback itself. If a suite's
+    // `subscribe` implementation invokes that callback SYNCHRONOUSLY (before
+    // `subscribe()` returns — e.g. because nothing was left pending by the
+    // time this run's settlement race subscribed), `unsubscribe` was still in
+    // its temporal dead zone, throwing a `ReferenceError` and leaving the
+    // run — and the field — pending forever.
+    const baseSuite = create((data: { email: string }) => {
+      test('email', 'Email is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+
+    const suite = {
+      ...baseSuite,
+      run(value: { email: string }) {
+        // Wrap in a genuinely fresh native Promise (rather than
+        // `Promise.resolve(...)`, which returns the SAME dual-shaped
+        // Vest result unchanged and would keep this on the synchronous
+        // path) so the adapter treats this as a raw thenable with no sync
+        // `SuiteResult` — forcing it through the async settlement race
+        // (and therefore through `suite.subscribe`) every time.
+        return new Promise<VestResultLike>((resolve, reject) => {
+          Promise.resolve(baseSuite.run(value)).then(resolve, reject);
+        });
+      },
+      subscribe(_event: 'ALL_RUNNING_TESTS_FINISHED', callback: () => void) {
+        // Real event buses typically isolate each listener's errors (so one
+        // bad subscriber cannot break the emit loop for the others), which
+        // is exactly what turns the TDZ `ReferenceError` into a silent,
+        // permanently-unsettled run rather than a visible crash. Swallow the
+        // exception here to reproduce that isolation faithfully — without
+        // the guard in `awaitVestRunSettlement`, this line hides the
+        // `ReferenceError` and the assertions below hang/fail.
+        try {
+          callback();
+        } catch {
+          // Intentionally swallowed — see comment above.
+        }
+        return () => {};
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-vest-sync-subscribe',
+      imports: [FormField],
+
+      template: `<input [formField]="signupForm.email" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly signupForm = form(this.model, (path) => {
+        validateVest(path, suite);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.signupForm.email().pending()).toBe(false);
+    const errors = fixture.componentInstance.signupForm.email().errors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe('Email is required');
   });
 
   it('does not cross-attach another field’s retained Vest failure onto a focusCurrentField-bound field', async () => {

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { create, enforce, group, only, test, warn } from 'vest';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   VEST_ERROR_KIND_PREFIX,
   VEST_WARNING_KIND_PREFIX,
@@ -1077,5 +1077,188 @@ describe('validateVest', () => {
     expect(alphaErrors).toHaveLength(1);
     expect(bravoErrors).toHaveLength(1);
     expect(alphaErrors[0]?.kind).not.toBe(bravoErrors[0]?.kind);
+  });
+
+  it('does not leave an earlier focusCurrentField registration permanently pending when a later registration on the same suite supersedes its run', async () => {
+    // Regression: Vest 6 only tracks ONE resolver per suite root isolate, so
+    // calling `suite.run()` a second time for the SAME suite instance (here,
+    // via a second `focusCurrentField` registration on a different field)
+    // steals the first run's resolver. The first run's promise then never
+    // settles. Without a settlement fallback that does not depend on the
+    // superseded run's own resolver, `password` would stay pending() forever
+    // even after its own async test body resolves.
+    const deferred = new Map<string, () => void>();
+    const awaitField = (field: string) =>
+      new Promise<void>((resolve) => {
+        deferred.set(field, resolve);
+      });
+
+    const suite = create(
+      (data: { email: string; password: string }, field?: string) => {
+        only(field);
+        test('email', 'Email check failed', async () => {
+          await awaitField('email');
+          enforce(data.email).isNotBlank();
+        });
+        test('password', 'Password check failed', async () => {
+          await awaitField('password');
+          enforce(data.password).isNotBlank();
+        });
+      },
+    );
+
+    @Component({
+      selector: 'ngx-test-vest-superseded-run',
+      imports: [FormField],
+
+      template: `
+        <input id="email" [formField]="f.email" />
+        <input id="password" [formField]="f.password" />
+      `,
+    })
+    class TestComponent {
+      readonly model = signal({ email: 'a', password: 'b' });
+      readonly f = form(this.model, (path) => {
+        // Two focusCurrentField registrations sharing ONE suite instance —
+        // the documented per-field pattern from the README.
+        validateVest(path.email, suite, { focusCurrentField: true });
+        validateVest(path.password, suite, { focusCurrentField: true });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    // Both focused runs are in-flight (their async test bodies are awaiting
+    // `awaitField`); the `password` run supersedes the `email` run's resolver.
+    // Do NOT await whenStable() here — that blocks forever while a resource
+    // is deliberately parked on the gate.
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.f.email().pending()).toBe(true);
+      expect(fixture.componentInstance.f.password().pending()).toBe(true);
+    });
+
+    deferred.get('email')?.();
+    deferred.get('password')?.();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.f.email().pending()).toBe(false);
+    expect(fixture.componentInstance.f.password().pending()).toBe(false);
+  });
+
+  it('does not cross-attach another field’s retained Vest failure onto a focusCurrentField-bound field', async () => {
+    // Regression: `mapVestValidationResult` used to map the WHOLE
+    // `getErrors()`/`getWarnings()` map regardless of which field the
+    // validator was bound to. Vest is stateful — fields excluded by `only()`
+    // retain their previous failures — so once BOTH fields have failed at
+    // least once, each focusCurrentField-bound validator's fallback
+    // resolution attached the OTHER field's retained message onto its own
+    // bound field.
+    const suite = create(
+      (data: { email: string; password: string }, field?: string) => {
+        only(field);
+        test('email', 'Email is required', () => {
+          enforce(data.email).isNotBlank();
+        });
+        test('password', 'Password is required', () => {
+          enforce(data.password).isNotBlank();
+        });
+      },
+    );
+
+    @Component({
+      selector: 'ngx-test-vest-no-cross-attach',
+      imports: [FormField],
+
+      template: `
+        <input id="email" [formField]="f.email" />
+        <input id="password" [formField]="f.password" />
+      `,
+    })
+    class TestComponent {
+      readonly model = signal({ email: '', password: '' });
+      readonly f = form(this.model, (path) => {
+        validateVest(path.email, suite, { focusCurrentField: true });
+        validateVest(path.password, suite, { focusCurrentField: true });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // Trigger the password field's focused run too, so both fields now have
+    // a retained failure in the suite's stateful result.
+    fixture.componentInstance.model.set({ email: '', password: '' });
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const emailErrors = fixture.componentInstance.f.email().errors();
+    const passwordErrors = fixture.componentInstance.f.password().errors();
+
+    expect(emailErrors.some((e) => e.message === 'Password is required')).toBe(
+      false,
+    );
+    expect(passwordErrors.some((e) => e.message === 'Email is required')).toBe(
+      false,
+    );
+    expect(emailErrors.some((e) => e.message === 'Email is required')).toBe(
+      true,
+    );
+    expect(
+      passwordErrors.some((e) => e.message === 'Password is required'),
+    ).toBe(true);
+  });
+
+  it('does not let a sync Vest warning suppress a blocking async Vest error on the same field', async () => {
+    // Regression: Angular skips a `validateAsync` resource whenever the
+    // bound node's `syncValid()` is false, and toolkit warnings are ordinary
+    // `ValidationError`s (`warn:vest:*`). A sync `warn()` result surfaced by
+    // the adapter's `validateTree` pass therefore made `syncValid()` false
+    // and silently prevented the async phase (and any blocking async Vest
+    // error, e.g. a "username already taken" check) from ever running.
+    let releaseAsyncCheck: (() => void) | undefined;
+    const asyncCheckGate = new Promise<void>((resolve) => {
+      releaseAsyncCheck = resolve;
+    });
+
+    const suite = create((data: { username: string }) => {
+      test('username', 'Usernames should be lowercase', () => {
+        warn();
+        enforce(data.username).matches(/^[a-z]+$/);
+      });
+      test('username', 'Username is already taken', async () => {
+        await asyncCheckGate;
+        enforce(data.username.toLowerCase() !== 'admin').isTruthy();
+      });
+    });
+
+    @Component({
+      selector: 'ngx-test-vest-warning-does-not-block-async',
+      imports: [FormField],
+
+      template: `<input id="username" [formField]="f.username" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ username: 'ADMIN' });
+      readonly f = form(this.model, (path) => {
+        validateVest(path, suite, { includeWarnings: true });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    // The sync warning (uppercase 'ADMIN' fails the lowercase check) must not
+    // prevent the async blocking check from being scheduled. Do NOT await
+    // whenStable() here — that blocks forever while the resource is
+    // deliberately parked on `asyncCheckGate`.
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.f.username().pending()).toBe(true);
+    });
+
+    releaseAsyncCheck?.();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const errors = fixture.componentInstance.f.username().errors();
+    expect(errors.some((e) => e.message === 'Username is already taken')).toBe(
+      true,
+    );
   });
 });

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -30,6 +30,10 @@ export interface ValidateVestOptions<TValue = unknown> {
    * objects with a `kind` prefixed by `warn:` so existing toolkit components
    * render them as non-blocking guidance.
    *
+   * While the suite has pending async tests, a sync warning is deferred (not
+   * yet surfaced) and re-emitted together with the settled result once they
+   * finish — see the vest README's "Async caveats" section for why.
+   *
    * @default false
    */
   includeWarnings?: boolean;

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -427,13 +427,19 @@ function awaitVestRunSettlement<TValue>(
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    // Declared as `let` (not `const subscribe(...)` return) and guarded with
+    // `?.()`: some suites invoke the `subscribe` callback SYNCHRONOUSLY (e.g.
+    // if all tests already finished before this call), which would otherwise
+    // try to read `unsubscribe` before its initializer has run — a TDZ
+    // `ReferenceError` that would leave this promise unsettled forever.
+    let unsubscribe: (() => void) | undefined;
 
     const settle = (fn: (value: unknown) => void, value: unknown): void => {
       if (settled) {
         return;
       }
       settled = true;
-      unsubscribe();
+      unsubscribe?.();
       fn(value);
     };
 
@@ -448,9 +454,17 @@ function awaitVestRunSettlement<TValue>(
       },
     );
 
-    const unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+    unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
       settle(resolve, get());
     });
+
+    // If the callback above fired synchronously (during the `subscribe()`
+    // call itself), `settle()` ran before `unsubscribe` was assigned, so its
+    // `unsubscribe?.()` was a no-op. Clean up the now-stale subscription here
+    // instead, now that we hold a reference to it.
+    if (settled) {
+      unsubscribe();
+    }
   });
 }
 

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -440,9 +440,11 @@ function awaitVestRunSettlement<TValue>(
     Promise.resolve(runResult).then(
       (value) => {
         settle(resolve, value);
+        return undefined;
       },
       (error: unknown) => {
         settle(reject, error);
+        return undefined;
       },
     );
 

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -107,6 +107,22 @@ export interface VestRunnableSuite<TValue> {
   ): VestResultLike | PromiseLike<VestResultLike>;
   reset?: () => void;
   only?: (field: string | string[]) => Pick<VestRunnableSuite<TValue>, 'run'>;
+  /**
+   * Optional Vest bus subscription (`suite.subscribe`). Used alongside {@link
+   * get} to recover from a superseded run — see
+   * {@link awaitVestRunSettlement}. Suites created via Vest's `create()`
+   * expose this; hand-rolled suite shapes may omit it.
+   */
+  subscribe?: (
+    event: 'ALL_RUNNING_TESTS_FINISHED',
+    callback: () => void,
+  ) => () => void;
+  /**
+   * Optional synchronous accessor for the suite's current accumulated result
+   * (`suite.get`). Used alongside {@link subscribe} to recover from a
+   * superseded run — see {@link awaitVestRunSettlement}.
+   */
+  get?: () => VestResultLike;
 }
 
 /**
@@ -376,6 +392,67 @@ function executeVestRun<TValue>(
 }
 
 /**
+ * Awaits a Vest run's settlement, recovering from a superseded resolver.
+ *
+ * Vest 6's `suite.run()` promise resolves via a single resolver tracked per
+ * suite root isolate: `ALL_RUNNING_TESTS_FINISHED` fires `root.data.resolver()`
+ * once, and any LATER `suite.run()` call on the SAME suite instance replaces
+ * that resolver before the earlier call's promise ever settles. Two
+ * registrations of the same suite with different field trees (e.g. two
+ * `focusCurrentField` validators on different fields) each call `run()`
+ * independently, so the earlier one's promise can be superseded and never
+ * settle — leaving that field `pending()` forever.
+ *
+ * When the suite exposes `subscribe`/`get` (true for suites created via
+ * Vest's `create()`), race the run's own promise against the suite-wide
+ * `ALL_RUNNING_TESTS_FINISHED` bus event, which only fires once ALL pending
+ * tests — including this run's — have finished, regardless of which `run()`
+ * call's resolver ends up firing it. On that event, `suite.get()` returns the
+ * suite's current accumulated result, which by then reflects this run's
+ * outcome. Suites without `subscribe`/`get` fall back to the original
+ * (potentially superseded) promise unchanged.
+ */
+function awaitVestRunSettlement<TValue>(
+  runResult: VestResultLike | PromiseLike<VestResultLike>,
+  suite: Pick<VestRunnableSuite<TValue>, 'subscribe' | 'get'>,
+): PromiseLike<unknown> {
+  if (
+    typeof suite.subscribe !== 'function' ||
+    typeof suite.get !== 'function'
+  ) {
+    return Promise.resolve(runResult);
+  }
+  const subscribe = suite.subscribe;
+  const get = suite.get;
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const settle = (fn: (value: unknown) => void, value: unknown): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      unsubscribe();
+      fn(value);
+    };
+
+    Promise.resolve(runResult).then(
+      (value) => {
+        settle(resolve, value);
+      },
+      (error: unknown) => {
+        settle(reject, error);
+      },
+    );
+
+    const unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+      settle(resolve, get());
+    });
+  });
+}
+
+/**
  * Normalizes Vest selector output into a flat list of field-targeted messages.
  */
 function toVestValidationEntries(
@@ -420,6 +497,35 @@ function createVestEntriesForField(
       occurrence,
     };
   });
+}
+
+/**
+ * Restricts mapped Vest entries to the validator's own bound field when it is
+ * NOT root-bound.
+ *
+ * Vest field paths are root-relative and Vest is stateful: fields excluded by
+ * `only()` retain their previous failures, so a focused run's result can
+ * still contain OTHER fields' retained messages. For a root-bound validator
+ * every field is a legitimate target, so no filtering is needed. For a
+ * subfield-bound validator (e.g. `focusCurrentField`), only entries for the
+ * bound field itself or one of its descendants belong to this registration —
+ * entries for unrelated fields are dropped rather than mis-attributed via
+ * {@link resolveVestWarningFieldTree}'s bound-field fallback.
+ */
+function filterEntriesForBoundField(
+  entries: readonly VestValidationEntry[],
+  boundFieldPath: string | undefined,
+): readonly VestValidationEntry[] {
+  if (boundFieldPath === undefined) {
+    return entries;
+  }
+
+  const descendantPrefix = `${boundFieldPath}.`;
+  return entries.filter(
+    (entry) =>
+      entry.fieldPath === boundFieldPath ||
+      entry.fieldPath.startsWith(descendantPrefix),
+  );
 }
 
 /**
@@ -498,17 +604,26 @@ function createVestValidationSnapshot(
 /**
  * Converts a Vest result into Angular validation errors, optionally subtracting
  * the sync snapshot that was already surfaced on the initial pass.
+ *
+ * `boundFieldPath` is the validator's own dotted field name from
+ * `ctx.pathKeys()` (`undefined` for a root-bound validator). When defined,
+ * entries for other fields are dropped — see
+ * {@link filterEntriesForBoundField}.
  */
 function mapVestValidationResult(
   result: VestResultLike,
   fieldTree: ReadonlyFieldTree<unknown>,
   options: VestValidationRegistrationOptions<unknown>,
+  boundFieldPath: string | undefined,
   baseline?: VestValidationSnapshot,
 ): readonly ValidationError.WithFieldTree[] {
   const errors = options.includeErrors
     ? toVestValidationErrors(
         filterExistingVestEntries(
-          toVestValidationEntries(result.getErrors()),
+          filterEntriesForBoundField(
+            toVestValidationEntries(result.getErrors()),
+            boundFieldPath,
+          ),
           baseline?.errors ?? [],
         ),
         fieldTree,
@@ -519,7 +634,10 @@ function mapVestValidationResult(
   const warnings = options.includeWarnings
     ? toVestValidationErrors(
         filterExistingVestEntries(
-          toVestValidationEntries(result.getWarnings()),
+          filterEntriesForBoundField(
+            toVestValidationEntries(result.getWarnings()),
+            boundFieldPath,
+          ),
           baseline?.warnings ?? [],
         ),
         fieldTree,
@@ -528,6 +646,27 @@ function mapVestValidationResult(
     : [];
 
   return [...errors, ...warnings];
+}
+
+/**
+ * Reports whether sync warning surfacing should be deferred for this
+ * validation pass.
+ *
+ * Angular's `validateAsync` only schedules its resource when the bound
+ * node's `syncValid()` is true, and `syncValid()` requires zero sync errors
+ * across the ENTIRE bound subtree. Toolkit warnings are ordinary
+ * `ValidationError`s (`warn:vest:*`), so a sync warning surfaced while the
+ * suite still has pending async tests would make `syncValid()` false and
+ * permanently prevent the async phase — including blocking async Vest
+ * errors — from ever running. Defer warnings only while pending; once the
+ * suite settles, {@link mapVestValidationResult}'s async `onSuccess` mapping
+ * surfaces them together with the final result.
+ */
+function shouldDeferVestWarnings(
+  options: VestValidationRegistrationOptions<unknown>,
+  initialResult: VestResultLike,
+): boolean {
+  return options.includeWarnings && initialResult.isPending();
 }
 
 /**
@@ -857,10 +996,21 @@ export function createVestAdapter(
         return [];
       }
 
+      const syncOptions = shouldDeferVestWarnings(
+        validationOptions as VestValidationRegistrationOptions<unknown>,
+        entry.initialResult,
+      )
+        ? {
+            ...validationOptions,
+            includeWarnings: false,
+          }
+        : validationOptions;
+
       return mapVestValidationResult(
         entry.initialResult,
         fieldTree,
-        validationOptions as VestValidationRegistrationOptions<unknown>,
+        syncOptions as VestValidationRegistrationOptions<unknown>,
+        deriveVestFieldNameFromContext(ctx),
       );
     });
 
@@ -892,11 +1042,26 @@ export function createVestAdapter(
           return undefined;
         }
 
+        // Match the sync `validateTree` pass above: while pending, warnings
+        // are deferred (not yet surfaced), so the baseline used to compute
+        // the async delta must NOT already count them as shown — otherwise
+        // `onSuccess`'s `filterExistingVestEntries` would treat them as
+        // already-emitted and drop them from the final, settled result.
+        const snapshotOptions = shouldDeferVestWarnings(
+          validationOptions as VestValidationRegistrationOptions<unknown>,
+          entry.initialResult,
+        )
+          ? {
+              ...validationOptions,
+              includeWarnings: false,
+            }
+          : validationOptions;
+
         return {
           runResult: entry.runResult,
           initialSnapshot: createVestValidationSnapshot(
             entry.initialResult,
-            validationOptions as VestValidationRegistrationOptions<unknown>,
+            snapshotOptions as VestValidationRegistrationOptions<unknown>,
           ),
         } satisfies PendingVestValidationPayload;
       },
@@ -904,7 +1069,10 @@ export function createVestAdapter(
         return resource({
           params: pendingValidation,
           loader: async ({ params }) => {
-            const result = await params.runResult;
+            const result = await awaitVestRunSettlement(
+              params.runResult,
+              suite,
+            );
             if (!isVestResultLike(result)) {
               // Throw so this lands in the validator's `onError` handler below,
               // which already encodes the right policy: blocking validators
@@ -926,11 +1094,12 @@ export function createVestAdapter(
           },
         });
       },
-      onSuccess: (pendingResult, { fieldTree }) => {
+      onSuccess: (pendingResult, ctx) => {
         return mapVestValidationResult(
           pendingResult.result,
-          fieldTree,
+          ctx.fieldTree,
           validationOptions as VestValidationRegistrationOptions<unknown>,
+          deriveVestFieldNameFromContext(ctx),
           pendingResult.initialSnapshot,
         );
       },

--- a/packages/toolkit/vitest.shared.mts
+++ b/packages/toolkit/vitest.shared.mts
@@ -9,7 +9,7 @@ import { type UserWorkspaceConfig } from 'vitest/config';
 process.env.NX_DAEMON ??= 'false';
 
 export const toolkitSpecRoots =
-  '{src,core,form-field,headless,assistive,testing,vest}';
+  '{src,core,form-field,headless,assistive,testing,vest,scripts}';
 export const toolkitSpecFiles = `${toolkitSpecRoots}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`;
 export const toolkitBrowserSpecFiles = `${toolkitSpecRoots}/**/*.browser.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}`;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,7 +598,7 @@ importers:
   packages/toolkit:
     dependencies:
       vest:
-        specifier: '>=6.0.0 <6.3.0 || >=6.3.1'
+        specifier: '>=6.0.0'
         version: 6.3.2
     devDependencies:
       '@angular/common':


### PR DESCRIPTION
## What

Consolidated fix for all six toolkit-area audit tickets from the v1.0.0 readiness map (#134). Each area's blockers were fixed TDD-style by an isolated agent, then integrated onto one branch (the six branches only conflicted on the append-only migration doc, resolved by keeping all sections).

Closes #159 (core) · Closes #160 (form-field) · Closes #161 (headless) · Closes #162 (vest) · Closes #163 (assistive) · Closes #164 (packaging)

## Blockers fixed (71 verified findings across 6 areas)

- **core (#159):** `canSubmitWithWarnings()` now aggregates descendant errors via `errorSummary()` (was root-only `errors()`, leaving a dead submit button); `injectFieldControl()` validates via `isFieldTree()` and its navigation guard accepts callable FieldTree nodes (real forms are callable) instead of an unsound cast.
- **form-field (#160):** spurious dev `console.error` race, `[hidden]` now hides fields, warnings-only fields render under `on-touch`, warnings suppressed beside a blocking error, bound-control probe scoping, custom-renderer `id` contract, host aria-label/describedby merging, bundle completeness.
- **headless (#161):** error-summary per-field dedupe, `warn:` prefix leak, Angular-internal id-prefix leak, required Date/File/Map leaves no longer dropped, `shouldShowWarnings` signal, tightened Signal types, doc/API corrections.
- **vest (#162):** superseded-run promise now settles (with a TDZ guard for synchronous suites), cross-field error attribution, lifecycle fixes.
- **assistive (#163):** `id="null"` attribute bindings, always-mounted `role="alert"`/`status` live regions (WCAG 4.1.3), error-summary autofocus no longer steals focus pre-submit, dropped non-standard `:host-context()` dark theming for a `prefers-color-scheme` + custom-property contract.
- **packaging (#164):** `@angular/common` peer range, LICENSE in tarball, entrypoint config, publish-pipeline assertions.

## Review comments

All 8 Copilot review comments from the original per-area PRs were addressed on their branches before integration (2 real bugs: the callable-FieldTree guard and the vest TDZ; 6 test/doc-quality items) — replies posted and threads resolved on #184–#188.

## Demo integration

The assistive dark-theme contract change required the demo (which themes via a `.dark` class) to set the public error-color custom properties per theme — done in `apps/demo/src/styles.scss`. The always-mounted alert shell changed a fieldset count assertion (now filters to contentful alerts). `@layout` screenshot baselines are regenerated (Linux, via the update-snapshots workflow) to ratify the new layout.

## Known post-1.0 polish

The empty always-mounted live-region shell reserves a ~16px flex-gap slot in grouped fieldsets (tracked in backlog #175). Cosmetic; not a blocker.

## Verification

`nx run-many -t test,lint,build --projects=toolkit` green: **1206 tests pass**, lint clean, build clean across all six entrypoints. Breaking changes documented in `docs/MIGRATING_BETA_TO_V1.md` (15 sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warning messages now have clearer display timing and can be controlled independently from blocking errors.
  * Custom form-field renderers keep author-supplied accessibility links intact and support improved error/warning rendering.

* **Bug Fixes**
  * Live regions now stay mounted and announce changes more reliably for screen readers.
  * Dark mode styling is more consistent across the toolkit.
  * Form controls and error summaries now handle nested validation and warning cases more accurately.

* **Compatibility**
  * Expanded support for newer Vest and Angular/Node runtime versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->