### PR TITLE
docs: fix v1.0.0 API drift across guides and READMEs (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Default recommendation: **skip `ngxSignalForm` until you need it**.
 
 The examples above use the default `'on-touch'` strategy: errors appear after the
 user blurs a field or submits the form. This works because Angular's `submit()` calls
-`markAllAsTouched()` internally, so `touched()` becomes true for all fields.
+`markAsTouched()` internally, so `touched()` becomes true for all fields.
 
 When you need more control, add `ngxSignalForm` alongside `[formRoot]`:
 

--- a/docs/ANGULAR_VS_TOOLKIT.md
+++ b/docs/ANGULAR_VS_TOOLKIT.md
@@ -96,7 +96,7 @@ add the `ngxSignalForm` attribute. It adds:
 
 `NgxSignalFormToolkit` is a convenience bundle that combines `FormRoot` +
 `NgxSignalForm` + `NgxSignalFormAutoAria` +
-`NgxSignalFormControlSemantics`. Import it instead of `FormRoot` separately.
+`NgxSignalFormControlSemanticsDirective`. Import it instead of `FormRoot` separately.
 
 ```typescript
 imports: [FormField, NgxSignalFormToolkit];

--- a/docs/CSS_FRAMEWORK_INTEGRATION.md
+++ b/docs/CSS_FRAMEWORK_INTEGRATION.md
@@ -76,12 +76,14 @@ import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    // Configure CSS status classes via Angular's native API
+    // Configure CSS status classes via Angular's native API.
+    // `classes` is a flat map of class name -> predicate over the
+    // FormFieldBinding; it is NOT keyed by state name.
     provideSignalFormsConfig({
       classes: {
-        valid: { 'is-valid': () => true },
-        invalid: { 'is-invalid': () => true },
-        touched: { 'is-touched': () => true },
+        'is-valid': (f) => f.state().valid(),
+        'is-invalid': (f) => f.state().invalid() && f.state().touched(),
+        'is-touched': (f) => f.state().touched(),
       },
     }),
 
@@ -107,8 +109,9 @@ export const appConfig: ApplicationConfig = {
     />
     <!-- Bootstrap's invalid-feedback auto-shows when sibling has .is-invalid -->
     <div class="invalid-feedback">
-      @for (error of userForm.email().errors() | keyvalue; track error.key) { {{
-      error.value }} }
+      <!-- errors() is an array of ValidationError, not a kind-keyed object -->
+      @for (error of userForm.email().errors(); track error.kind) { {{
+      error.message }} }
     </div>
   </div>
 
@@ -230,12 +233,14 @@ If you prefer explicit classes for more control, use Angular's `provideSignalFor
 
 ```typescript
 // app.config.ts
+// `classes` is a flat map of class name -> predicate over the
+// FormFieldBinding; it is NOT keyed by state name.
 provideSignalFormsConfig({
   classes: {
-    invalid: { 'field-invalid': () => true },
-    valid: { 'field-valid': () => true },
-    touched: { 'field-touched': () => true },
-    dirty: { 'field-dirty': () => true },
+    'field-invalid': (f) => f.state().invalid(),
+    'field-valid': (f) => f.state().valid(),
+    'field-touched': (f) => f.state().touched(),
+    'field-dirty': (f) => f.state().dirty(),
   },
 }),
 ```
@@ -301,49 +306,40 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-### Custom ErrorStateMatcher
+### Why `ErrorStateMatcher` doesn't help here
 
-To align Material's error display with the toolkit's strategy:
+Material's `ErrorStateMatcher` reads `FormControl` / `NgForm` (Reactive Forms).
+A `matInput` bound via `[formField]` has no `NgControl` at all, so a custom
+`ErrorStateMatcher` is never consulted for it — the matcher silently has no
+effect on Signal Forms fields.
+
+To align Material's error timing with the toolkit's strategy, resolve
+visibility from the field itself instead. The toolkit's
+`createErrorMessageSignal` (from `@ngx-signal-forms/toolkit/headless`) is the
+same primitive the canonical form-field wrapper uses, so a structural
+directive built on it stays in sync with whatever `errorStrategy` the form
+declares:
 
 ```typescript
-// shared/error-state-matcher.ts
-import { Injectable } from '@angular/core';
-import { ErrorStateMatcher } from '@angular/material/core';
-import { FormControl, FormGroupDirective, NgForm } from '@angular/forms';
+import { Directive, computed, inject, input } from '@angular/core';
+import type { FieldTree } from '@angular/forms/signals';
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
 
-/**
- * ErrorStateMatcher that aligns with toolkit's 'on-touch' strategy.
- * Shows errors when field is invalid AND (touched OR form submitted).
- */
-@Injectable()
-export class OnTouchErrorStateMatcher implements ErrorStateMatcher {
-  isErrorState(
-    control: FormControl | null,
-    form: FormGroupDirective | NgForm | null,
-  ): boolean {
-    const isSubmitted = form?.submitted ?? false;
-    const isTouched = control?.touched ?? false;
-    const isInvalid = control?.invalid ?? false;
+@Directive({ selector: '[matError][ngxMatErrorFor]' })
+export class NgxMatErrorFor {
+  readonly field = input.required<FieldTree<unknown>>({
+    alias: 'ngxMatErrorFor',
+  });
 
-    return isInvalid && (isTouched || isSubmitted);
-  }
+  readonly #messages = createErrorMessageSignal(() => this.field()());
+  protected readonly message = computed(() => this.#messages()[0]?.message);
 }
 ```
 
-Provide globally:
-
-```typescript
-// app.config.ts
-import { ErrorStateMatcher } from '@angular/material/core';
-import { OnTouchErrorStateMatcher } from './shared/error-state-matcher';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    { provide: ErrorStateMatcher, useClass: OnTouchErrorStateMatcher },
-    // ... other providers
-  ],
-};
-```
+For a complete, tested reference implementation of this pattern — including
+warnings and grouped `mat-hint` output — see `apps/demo-material`'s
+`ngxMatErrorSlot` / `ngxMatHintSlot` directives
+(`apps/demo-material/src/app/wrapper/slot-directives.ts`).
 
 ### Template
 
@@ -353,8 +349,10 @@ export const appConfig: ApplicationConfig = {
     <mat-label>Email</mat-label>
     <input matInput type="email" [formField]="userForm.email" />
     <mat-error>
-      @if (userForm.email().errors()?.['required']) { Email is required } @else
-      if (userForm.email().errors()?.['email']) { Please enter a valid email }
+      <!-- errors() is an array of ValidationError — check `kind`, don't index it -->
+      @if (userForm.email().errors().some((e) => e.kind === 'required')) { Email
+      is required } @else if (userForm.email().errors().some((e) => e.kind ===
+      'email')) { Please enter a valid email }
     </mat-error>
   </mat-form-field>
 

--- a/docs/CUSTOM_CONTROLS.md
+++ b/docs/CUSTOM_CONTROLS.md
@@ -391,7 +391,7 @@ Or with headless primitives:
 >
   <app-custom-field [formField]="form.password" />
 
-  @if (errorState.showWarnings() && errorState.hasWarnings()) {
+  @if (errorState.shouldShowWarnings() && errorState.hasWarnings()) {
   <div role="status" aria-live="polite">
     @for (warning of errorState.resolvedWarnings(); track warning.kind) {
     <span>{{ warning.message }}</span>

--- a/docs/CUSTOM_CONTROLS.md
+++ b/docs/CUSTOM_CONTROLS.md
@@ -46,19 +46,21 @@ The primary interface for custom controls that read and write a value:
 @Directive({
   selector: '[appCustomInput]',
   host: {
-    '(input)': 'onChange($event.target.value)',
-    '(blur)': 'onTouched()',
+    '[value]': 'value()',
+    '(input)': 'value.set($event.target.value)',
+    '(blur)': 'touch.emit()',
   },
 })
 export class CustomInputDirective implements FormValueControl<string> {
   readonly #el = inject(ElementRef<HTMLInputElement>);
 
-  onChange: (value: string) => void = () => {};
-  onTouched: () => void = () => {};
+  // `value` is the only member the contract requires — Angular keeps it in
+  // sync with the bound field in both directions.
+  readonly value = model('');
 
-  writeValue(value: string): void {
-    this.#el.nativeElement.value = value ?? '';
-  }
+  // `touch` is optional: emit it whenever the control should report
+  // interaction (the `Field` directive marks the field touched in response).
+  readonly touch = output();
 
   focus(): void {
     this.#el.nativeElement.focus();
@@ -78,19 +80,20 @@ For toggle-like inputs with a checked state:
 @Directive({
   selector: '[appCustomToggle]',
   host: {
-    '(change)': 'onChange($event.target.checked)',
-    '(blur)': 'onTouched()',
+    '[checked]': 'checked()',
+    '(change)': 'checked.set($event.target.checked)',
+    '(blur)': 'touch.emit()',
   },
 })
 export class CustomToggleDirective implements FormCheckboxControl {
   readonly #el = inject(ElementRef<HTMLInputElement>);
 
-  onChange: (value: boolean) => void = () => {};
-  onTouched: () => void = () => {};
+  // `checked` is the only member the contract requires. A control that
+  // implements `FormCheckboxControl` must not also define `value`.
+  readonly checked = model(false);
 
-  writeValue(value: boolean): void {
-    this.#el.nativeElement.checked = value;
-  }
+  // Optional: report interaction so strategy-aware error visibility works.
+  readonly touch = output();
 
   focus(): void {
     this.#el.nativeElement.focus();
@@ -440,9 +443,12 @@ on the wrapper or an `id` on the bound control:
 When building custom controls that work with the toolkit:
 
 - [ ] Implement `FormValueControl<T>`, `FormCheckboxControl`, or `FormUiControl`
+- [ ] Expose the contract's required model — `readonly value = model<T>(...)` for
+      `FormValueControl<T>`, `readonly checked = model(false)` for
+      `FormCheckboxControl` (never define both on the same control)
 - [ ] Implement `focus()` method for `focusBoundControl()` support
-- [ ] Call `onTouched()` on blur for strategy-aware error visibility
-- [ ] Call `onChange()` on value change for reactive model updates
+- [ ] Emit an optional `touch = output()` on blur for strategy-aware error visibility
+- [ ] Update the `value`/`checked` model signal on user interaction so the bound field stays in sync
 - [ ] Accept `disabled` and `invalid` signal inputs for state reflection
 - [ ] Use `[formField]` directive binding (not manual wiring)
 - [ ] Test that `focusFirstInvalid()` reaches your control
@@ -456,6 +462,8 @@ import {
   Component,
   ElementRef,
   input,
+  model,
+  output,
   viewChild,
 } from '@angular/core';
 import type { FormValueControl } from '@angular/forms/signals';
@@ -467,8 +475,9 @@ import type { FormValueControl } from '@angular/forms/signals';
     <select
       #select
       [id]="selectId()"
-      (change)="onChange(select.value)"
-      (blur)="onTouched()"
+      [value]="value()"
+      (change)="value.set(select.value)"
+      (blur)="touch.emit()"
       [disabled]="disabled()"
       [attr.aria-invalid]="invalid() ? 'true' : null"
     >
@@ -488,12 +497,8 @@ export class CustomSelectComponent implements FormValueControl<string> {
   readonly disabled = input<boolean>(false);
   readonly invalid = input<boolean>(false);
 
-  onChange: (value: string) => void = () => {};
-  onTouched: () => void = () => {};
-
-  writeValue(value: string): void {
-    this.#select().nativeElement.value = value ?? '';
-  }
+  readonly value = model('');
+  readonly touch = output();
 
   focus(): void {
     this.#select().nativeElement.focus();

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -50,7 +50,7 @@ releases will not include any of the renames below.
 - **BREAKING: `@angular/common` is now a declared peer dependency** — it was always required at runtime (form-field wrapper/fieldset use `NgComponentOutlet`/`NgTemplateOutlet`) but was previously undeclared
 - **BREAKING: `canSubmitWithWarnings()` now reads `errorSummary()`** — child-path blocking errors now correctly disable submission (see [§5c](#5c-cansubmitwithwarnings-now-aggregates-descendant-errors))
 - **BREAKING: `injectFieldControl()` validates the resolved value against the runtime `FieldTree` contract** — an id resolving to a non-`FieldTree` property now throws instead of silently returning an unsound cast (see [§5d](#5d-injectfieldcontrol-validates-the-resolved-fieldtree))
-- **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§9](#9-headless-audit-fixes-v100))
+- **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§8](#8-headless-audit-fixes-v100))
 - **BREAKING: `CharacterCountResult` members are now typed `Signal<T>`** (was the looser `ReadSignal<T>` alias); a new `hasLimit` member was added — compile-time tightening only, no runtime change
 - **Bug fix** — error summary no longer drops a second field's error when two different fields share the same kind + message-less default; `NgxHeadlessNotification` no longer leaks the internal `warn:` prefix; `createErrorMessageSignal`'s ID fallback strips Angular's internal `{appId}.form{n}.` prefix; required `Date`/`File`/`Map`-valued leaves no longer vanish from field-optionality summaries
 
@@ -78,10 +78,18 @@ by adding the `ngxSignalForm` attribute alongside `[formRoot]`.
 
 Notes:
 
-- `[errorStrategy]`, `[submittedStatus]`, and friends still live on the
-  toolkit directive — you still need `ngxSignalForm` on any form that
-  consumes toolkit features (wrapper, auto-aria, error display, error
-  summary, headless directives).
+- `[errorStrategy]` is the toolkit directive's only input; `submittedStatus`
+  is a derived signal, not a bindable input.
+- **`ngxSignalForm` is not required** to use toolkit features. Every toolkit
+  component (wrapper, auto-ARIA, error display, error summary, headless
+  directives) injects the form context optionally and falls back to
+  `'on-touch'` / `'unsubmitted'` when it is absent — the right default for
+  most forms. Add `ngxSignalForm` when you want a configurable
+  `errorStrategy` (`'on-submit'` / `'immediate'`), submit-lifecycle tracking
+  via `submittedStatus`, or one shared strategy propagated to every
+  descendant via DI instead of passing inputs around. See the root
+  [`README.md`](../README.md#adding-form-level-context-with-ngxsignalform)
+  for the full with/without comparison.
 - The directive's `exportAs` is now `ngxSignalForm` (was `ngxFormRoot`).
 - The `NgxSignalFormToolkit` bundle now also re-exports Angular's
   `FormRoot`, so a single import keeps working:
@@ -126,7 +134,8 @@ Starting in v1, the published `package.json` no longer exposes the
   `@ngx-signal-forms/toolkit` (the root entry) and only use symbols
   that are re-exported from the root barrel.
 - `packages/toolkit/index.ts` is the authoritative list of the stable
-  public surface (54 values and 26 types, enumerated by hand).
+  public surface, enumerated by hand (the exact export count drifts as the
+  API grows — check that file directly rather than trusting a number here).
 - CSS custom properties — two prefix families remain stable and split by
   role: `--ngx-signal-form-*` covers cross-cutting feedback concerns
   (e.g. `--ngx-signal-form-feedback-font-size`,
@@ -441,10 +450,9 @@ miswiring loud during development without throwing.
 // before — relied on the accidental fallback
 const show = showErrors(field, 'on-submit');
 
-// after — pass the form's submittedStatus explicitly
-const show = showErrors(field, 'on-submit', {
-  submittedStatus: formDirective.submittedStatus,
-});
+// after — pass the form's submittedStatus value or signal directly
+// (the third parameter, not an options object)
+const show = showErrors(field, 'on-submit', formDirective.submittedStatus);
 ```
 
 ---
@@ -529,96 +537,6 @@ callable and resolve to an object exposing `value`, `touched`, `errors`,
 Resolution also remains a **one-shot, non-reactive** lookup — the form
 instance and the element's `id` are both read once, at call time. This was
 previously undocumented; see the updated `injectFieldControl()` JSDoc.
-
-### Control semantics contract — `ngxSignalFormControl`
-
-A small, directive-first API for telling the toolkit how a control
-should be laid out and wired for ARIA, without brittle DOM heuristics:
-
-```html
-<!-- Treat this checkbox as a switch for layout + auto-ARIA -->
-<input
-  id="emailUpdates"
-  type="checkbox"
-  role="switch"
-  ngxSignalFormControl="switch"
-  [formField]="form.emailUpdates"
-/>
-```
-
-Custom widgets can opt out of toolkit ARIA management entirely with
-`ngxSignalFormControlAria="manual"` or
-`ngxSignalFormAutoAriaDisabled` on the host element, and use
-`buildAriaDescribedBy()` to assemble their own described-by chain. See
-[`docs/CUSTOM_CONTROLS.md`](./CUSTOM_CONTROLS.md).
-
-### Error summary
-
-First-class error-summary feature split across headless and assistive
-entry points:
-
-- `NgxHeadlessErrorSummary` — strategy-aware visibility,
-  deduplicated entries, `focusBoundControl()` support.
-- `NgxFormFieldErrorSummary` — WCAG 2.2-compliant clickable
-  error list with `role="alert"` and themable CSS custom properties.
-
-See [`docs/COMPLEX_NESTED_FORMS.md`](./COMPLEX_NESTED_FORMS.md) for
-usage patterns.
-
-### Field labels and warning/error split utilities
-
-- `provideFieldLabels()` / `NGX_SIGNAL_FORM_FIELD_LABELS` for mapping
-  field paths to human-readable labels (used by error summary).
-- `isBlockingError` / `isWarningError` / `warningError` helpers and
-  the split between blocking errors and warnings, so
-  `canSubmitWithWarnings()` lets a form submit while soft warnings
-  remain visible. See [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md).
-
-### Headless error-message resolution — `createErrorMessageSignal()`
-
-`@ngx-signal-forms/toolkit/headless` now exports a `createErrorMessageSignal(field, options?)`
-primitive that returns a `Signal<readonly ResolvedFieldError[]>` combining the visibility
-cascade (`createErrorVisibility`), the 3-tier message cascade (validator `message` →
-`NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs
-(`{fieldName}-error-{kind}` via `generateErrorId`). Each entry is `{ kind, message, id, error }`
-— `kind`/`message`/`id` lifted to the top level for template ergonomics, with the raw
-`ValidationError` retained on `.error` for consumers that need validator params.
-
-Use it when you want the directive's resolution logic without the directive itself — for
-example inside a custom error renderer driven via `*ngComponentOutlet` or any component
-reading errors directly off a `FieldTree`. The in-tree `NgxFormFieldError` now consumes
-this primitive, so external renderers and the wrapper share one resolution path.
-
-```ts
-import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
-
-readonly resolvedErrors = createErrorMessageSignal(() => this.field()(), {
-  fieldName: 'email',
-  // includeWarnings: false (default) | true | 'only'
-});
-```
-
-See [`packages/toolkit/headless/README.md`](../packages/toolkit/headless/README.md#createerrormessagesignal)
-for full options and worked examples.
-
-### Internal debugger entry point
-
-The `@ngx-signal-forms/debugger` entry ships a development-only
-component that replaces the old `debug: true` config flag. Gate it with
-`isDevMode()` and drop it anywhere in the form template:
-
-```ts
-import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
-
-@Component({
-  imports: [NgxSignalFormDebugger /* … */],
-  template: `
-    @if (isDev()) {
-      <ngx-signal-form-debugger [formTree]="form" />
-    }
-  `,
-})
-```
 
 ---
 
@@ -720,6 +638,96 @@ driven by `prefers-color-scheme` only, consistently across all engines.
 The following additions are part of the current public surface. They are
 non-breaking (except where noted) but are worth calling out because they change
 what the defaults cover and what you may want to adopt before going stable.
+
+### Control semantics contract — `ngxSignalFormControl`
+
+A small, directive-first API for telling the toolkit how a control
+should be laid out and wired for ARIA, without brittle DOM heuristics:
+
+```html
+<!-- Treat this checkbox as a switch for layout + auto-ARIA -->
+<input
+  id="emailUpdates"
+  type="checkbox"
+  role="switch"
+  ngxSignalFormControl="switch"
+  [formField]="form.emailUpdates"
+/>
+```
+
+Custom widgets can opt out of toolkit ARIA management entirely with
+`ngxSignalFormControlAria="manual"` or
+`ngxSignalFormAutoAriaDisabled` on the host element, and use
+`buildAriaDescribedBy()` to assemble their own described-by chain. See
+[`docs/CUSTOM_CONTROLS.md`](./CUSTOM_CONTROLS.md).
+
+### Error summary
+
+First-class error-summary feature split across headless and assistive
+entry points:
+
+- `NgxHeadlessErrorSummary` — strategy-aware visibility,
+  deduplicated entries, `focusBoundControl()` support.
+- `NgxFormFieldErrorSummary` — WCAG 2.2-compliant clickable
+  error list with `role="alert"` and themable CSS custom properties.
+
+See [`docs/COMPLEX_NESTED_FORMS.md`](./COMPLEX_NESTED_FORMS.md) for
+usage patterns.
+
+### Field labels and warning/error split utilities
+
+- `provideFieldLabels()` for mapping field paths to human-readable labels
+  (used by error summary).
+- `isBlockingError` / `isWarningError` / `warningError` helpers and
+  the split between blocking errors and warnings, so
+  `canSubmitWithWarnings()` lets a form submit while soft warnings
+  remain visible. See [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md).
+
+### Headless error-message resolution — `createErrorMessageSignal()`
+
+`@ngx-signal-forms/toolkit/headless` now exports a `createErrorMessageSignal(field, options?)`
+primitive that returns a `Signal<readonly ResolvedFieldError[]>` combining the visibility
+cascade (`createErrorVisibility`), the 3-tier message cascade (validator `message` →
+`NGX_ERROR_MESSAGES` registry → default), and stable per-error DOM IDs
+(`{fieldName}-error-{kind}` via `generateErrorId`). Each entry is `{ kind, message, id, error }`
+— `kind`/`message`/`id` lifted to the top level for template ergonomics, with the raw
+`ValidationError` retained on `.error` for consumers that need validator params.
+
+Use it when you want the directive's resolution logic without the directive itself — for
+example inside a custom error renderer driven via `*ngComponentOutlet` or any component
+reading errors directly off a `FieldTree`. The in-tree `NgxFormFieldError` now consumes
+this primitive, so external renderers and the wrapper share one resolution path.
+
+```ts
+import { createErrorMessageSignal } from '@ngx-signal-forms/toolkit/headless';
+
+readonly resolvedErrors = createErrorMessageSignal(() => this.field()(), {
+  fieldName: 'email',
+  // includeWarnings: false (default) | true | 'only'
+});
+```
+
+See [`packages/toolkit/headless/README.md`](../packages/toolkit/headless/README.md#createerrormessagesignal)
+for full options and worked examples.
+
+### Internal debugger entry point
+
+The `@ngx-signal-forms/debugger` entry ships a development-only
+component that replaces the old `debug: true` config flag. Gate it with
+`isDevMode()` and drop it anywhere in the form template:
+
+```ts
+import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
+
+@Component({
+  imports: [NgxSignalFormDebugger /* … */],
+  template: `
+    @if (isDev()) {
+      <ngx-signal-form-debugger [formTree]="form" />
+    }
+  `,
+})
+```
 
 ### `warningStrategy` input — independent warning timing
 
@@ -906,7 +914,7 @@ surface it instead of silently allowing the gap.
 
 ---
 
-## 9. Headless audit fixes (v1.0.0)
+## 8. Headless audit fixes (v1.0.0)
 
 A pre-1.0 audit of `@ngx-signal-forms/toolkit/headless` found a handful of
 correctness and API-surface issues. Fixes shipped together; the API-affecting
@@ -992,7 +1000,7 @@ leaf is counted consistently whether it's `null` or populated.
 
 ---
 
-## 8. Migration checklist
+## 9. Migration checklist
 
 - **Add `ngxSignalForm`** next to every `[formRoot]` that uses toolkit
   features.
@@ -1057,7 +1065,7 @@ leaf is counted consistently whether it's `null` or populated.
 
 ---
 
-## 9. `form-field` v1.0.0 audit blockers
+## 10. `form-field` v1.0.0 audit blockers
 
 The `form-field` entry point (`NgxFormFieldWrapper`, `NgxFormFieldset`) and
 its `NgxFormFieldError` collaborator shipped several defects fixed as part
@@ -1176,7 +1184,7 @@ overriding what the author opted out of. `NgxFormField` now includes
 `NgxSignalFormControlSemanticsDirective`; it's selector-gated and inert for
 consumers who never add the attribute.
 
-## Public API consistency pass (v1.0.0 audit #165)
+## 11. Public API consistency pass (v1.0.0 audit #165)
 
 A pre-freeze sweep of the public surface. Breaking changes are listed first; the last two entries are deliberate design decisions recorded for clarity.
 

--- a/docs/MIGRATING_FROM_NGX_VEST_FORMS.md
+++ b/docs/MIGRATING_FROM_NGX_VEST_FORMS.md
@@ -32,7 +32,7 @@ If you are coming from `ngx-vest-forms` with **Vest 5.x**, the first migration s
 
 You cannot keep Vest 5.x and migrate directly to `@ngx-signal-forms/toolkit/vest`.
 
-- `@ngx-signal-forms/toolkit` declares `vest` as an optional peer dependency at `^6.0.0`
+- `@ngx-signal-forms/toolkit` declares `vest` as an optional peer dependency at `>=6.0.0` (see `packages/toolkit/package.json`)
 - current toolkit docs and demos assume **Vest 6**
 - `@ngx-signal-forms/toolkit/vest` will **not work on Vest 5.x**
 - your existing suite logic will often still look familiar, but you should verify any usage of `only()`, `skip()`, `omitWhen()`, async warnings, and focused updates against Vest 6 docs
@@ -300,7 +300,7 @@ Typical migration layering:
 See also:
 
 - [`apps/demo/src/app/05-advanced/zod-vest-validation/README.md`](../apps/demo/src/app/05-advanced/zod-vest-validation/README.md)
-- [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#using-vest-together-with-zod-or-openapi-generated-schemas)
+- [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#combining-with-zod--standard-schema)
 
 ### Remove framework-specific `field` plumbing first
 

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -51,11 +51,11 @@ Apply a headless directive, export it via `exportAs`, and bind to its signals:
     [formField]="form.email"
     [attr.aria-invalid]="errorState.hasErrors() ? 'true' : null"
     [attr.aria-describedby]="
-      errorState.showErrors() ? errorState.errorId() : null
+      errorState.shouldShowErrors() ? errorState.errorId() : null
     "
   />
 
-  @if (errorState.showErrors() && errorState.hasErrors()) {
+  @if (errorState.shouldShowErrors() && errorState.hasErrors()) {
   <div [id]="errorState.errorId()" role="alert" class="my-error">
     @for (error of errorState.resolvedErrors(); track error.kind) {
     <span>{{ error.message }}</span>
@@ -80,7 +80,7 @@ Headless directives work as Angular [host directives](https://angular.dev/guide/
   ],
   template: `
     <ng-content />
-    @if (errorState.showErrors()) {
+    @if (errorState.shouldShowErrors()) {
       <div class="error-container">
         @for (error of errorState.resolvedErrors(); track error.kind) {
           <span class="error">{{ error.message }}</span>
@@ -110,7 +110,7 @@ Exposes error state signals for custom error display.
 | `strategy`        | `ErrorDisplayStrategy`                          | Override (inherits from context)                                                                                                                              |
 | `submittedStatus` | `SubmittedStatus`                               | Override for `'on-submit'` strategy                                                                                                                           |
 
-Signals: `showErrors()`, `showWarnings()`, `hasErrors()`, `hasWarnings()`, `errors()`, `warnings()`, `resolvedErrors()`, `resolvedWarnings()`, `errorId` (nullable), `warningId` (nullable).
+Signals: `shouldShowErrors()`, `shouldShowWarnings()`, `hasErrors()`, `hasWarnings()`, `errors()`, `warnings()`, `resolvedErrors()`, `resolvedWarnings()`, `errorId` (nullable), `warningId` (nullable).
 
 ### NgxHeadlessErrorSummary
 


### PR DESCRIPTION
Closes #170

Fixes all 8 verified blocker findings from audit #149 that were still fixable in-scope (root README.md, packages/toolkit/README.md's non-demo entrypoint READMEs, and docs/*.md guides). One finding (apps/demo/README.md) is out of scope for this ticket — the demo tickets own that file — and is left untouched. One finding (headless README's NgxHeadlessErrorState input table) was already fixed on `main` by the prior toolkit blocker-fix PRs (#159-165); verified against source, no change needed.

## Changes

1. **`docs/CUSTOM_CONTROLS.md`** — rewrote the CVA-style (`writeValue`/`onChange`/`onTouched`) examples to the real Angular 22 `FormValueControl`/`FormCheckboxControl` contract (`model()` + optional `touch = output()`), mirroring `apps/demo`'s `RatingControl` reference implementation. Fixed the checklist to match.
2. **`docs/CSS_FRAMEWORK_INTEGRATION.md`** — fixed `provideSignalFormsConfig({ classes })` from the wrong nested state-keyed shape to the real flat `{ className: predicate }` map; fixed `errors()` usage from Reactive-Forms-style object/keyvalue indexing to array iteration (`ValidationError[]`); replaced the non-functional `ErrorStateMatcher` example (never consulted for `[formField]`-bound `matInput`, which has no `NgControl`) with guidance built on `createErrorMessageSignal`, pointing at `apps/demo-material`'s slot-directive pattern.
3. **`docs/MIGRATING_BETA_TO_V1.md`** — fixed the `showErrors(field, 'on-submit', …)` migration snippet's third argument (it's the `SubmittedStatus` value/signal directly, not an options object); removed the nonexistent `NGX_SIGNAL_FORM_FIELD_LABELS` token in favor of `provideFieldLabels()`; corrected the false "`ngxSignalForm` is required" claim (every toolkit component injects the form context optionally); dropped a fragile hand-counted export count that had already drifted; moved five orphaned "new API" subsections out from under `§5d` into their proper home (`§7`); renumbered the tail sections, which had `§9` appearing twice (once before `§8`).
4. **`README.md`** — `markAllAsTouched()` → `markAsTouched()` (the actual Signal Forms API name; the behavioral claim was already correct).
5. **`docs/ANGULAR_VS_TOOLKIT.md`** — `NgxSignalFormControlSemantics` (the interface) → `NgxSignalFormControlSemanticsDirective` (the actual bundle member).
6. **`docs/MIGRATING_FROM_NGX_VEST_FORMS.md`** — updated the vest peer-range wording (the 6.3.0 exclusion this finding flagged was already removed from `package.json` by a prior fix; aligned the doc with the current unbounded `>=6.0.0`) and fixed a broken anchor to the vest README's "Combining with Zod / Standard Schema" section.
7. **`packages/toolkit/headless/README.md`** + one more spot in `CUSTOM_CONTROLS.md` — found while verifying the headless README against source: `NgxHeadlessErrorState` examples still called the removed `showErrors()`/`showWarnings()` signal names; fixed to the frozen API's `shouldShowErrors()`/`shouldShowWarnings()`.

## core/ and testing/ entrypoints

No new READMEs were added for `packages/toolkit/core` or `packages/toolkit/testing`. Both are intentionally non-public: `core` is stripped from the published `exports` map (`ERR_PACKAGE_PATH_NOT_EXPORTED` for consumers) and `testing` has no `ng-package.json`/`package.json` at all — it's an internal axe-core test helper used only by `tools/a11y/scan.ts`. `docs/PACKAGE_ARCHITECTURE.md` already documents this boundary clearly, so adding entry-point-style READMEs for either would falsely imply they're importable.

## Verification

Every changed code example and API claim was checked against the real source (Angular 22's `signals.d.ts`/`_structure-chunk.d.ts` and the toolkit's own source) rather than trusting the audit's prose — see individual commits for the specific file:line evidence. This is a docs-only change; no build/test/e2e run was needed, and there is no markdown-code-compiling pipeline in this repo to type-check fenced samples against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>