### PR TITLE
fix(demo-spartan): fix Tailwind source glob, gated select/checkbox ARIA wiring

### DIFF
--- a/apps/demo-spartan-e2e/src/account-preferences.spec.ts
+++ b/apps/demo-spartan-e2e/src/account-preferences.spec.ts
@@ -8,11 +8,15 @@ import { expect, test } from '@playwright/test';
  * provider wiring (renderer-token registration, hint-registry projection,
  * auto-ARIA selector matching against `[hlmInput]`) surfaces here.
  *
- * Pre-interaction `aria-invalid` is not asserted. Helm's host directive stack
- * (`[hlmInput]` brings `BrnInput` + `BrnFieldControl` +
- * `BrnFieldControlDescribedBy`) interacts with focus on mount in real
- * browsers, which can mark the field touched before the test runs. The
- * post-interaction state is what the seam actually owns.
+ * Pre-interaction `aria-invalid` IS asserted for both the text input and the
+ * plan combobox (audit #148 finding 2). `BrnSelectTrigger` host-binds
+ * `aria-invalid` off the raw, ungated `FieldState.invalid` — with `plan`
+ * required and empty, that would fire `aria-invalid="true"` on first paint
+ * regardless of the demo's `on-touch` default, on a form nobody has touched
+ * yet. `HlmSelectTrigger` (`libs/spartan/ui/select`) now gates its own
+ * `aria-invalid` write off `BrnFieldControl.spartanInvalid()` — the same
+ * touched-aware signal driving the destructive-ring styling — so both
+ * controls agree on "no errors before touch".
  *
  * `aria-describedby` is the contract that the wrapper-scoped
  * `BrnFieldA11yService` factory in
@@ -51,6 +55,29 @@ test.describe('Spartan account preferences form', () => {
         page.getByRole('option', { name: 'Enterprise' }),
       ).toBeVisible();
     });
+  });
+
+  test('does not mark either required-and-empty control aria-invalid before it is touched', async ({
+    page,
+  }) => {
+    const displayName = page.getByLabel('Display name');
+    const plan = page.getByRole('combobox', { name: 'Plan' });
+
+    await expect(displayName).not.toHaveAttribute('aria-invalid', 'true');
+    await expect(plan).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
+  test('threads the newsletter hint into the checkbox button, not its display:contents host', async ({
+    page,
+  }) => {
+    const checkbox = page.getByRole('checkbox', {
+      name: 'Send me product updates',
+    });
+
+    await expect(checkbox).toHaveAttribute(
+      'aria-describedby',
+      /\bnewsletter-hint\b/,
+    );
   });
 
   test('shows blocking errors and wires aria-describedby after touch', async ({

--- a/apps/demo-spartan/README.md
+++ b/apps/demo-spartan/README.md
@@ -105,7 +105,7 @@ src/app/
 - A custom wrapper component (`spartan-form-field`) that **composes**
   Spartan's `BrnField` host directive instead of re-skinning Spartan's
   internals.
-- Real `@spartan-ng/helm` components scaffolded into `libs/ui` via
+- Real `@spartan-ng/helm` components scaffolded into `libs/spartan/ui` via
   `@spartan-ng/cli` (`hlmInput`, `<hlm-select>`, `<hlm-checkbox>`,
   `[hlmLabel]`) — the demo exercises the actual Spartan toolchain rather
   than a CSS impersonation.
@@ -179,13 +179,25 @@ not the wrapper itself. Mixing the two scopes (e.g. attaching
 `[formField]` to the wrapper) double-binds Angular's submission tracker
 and breaks both surfaces.
 
-The wrapper deliberately does **not** compose `BrnFieldControl`. That
-host directive is `NgControl`-based (Reactive Forms / Template-driven),
-and Angular Signal Forms expose state through `[formField]` / `FieldState`
-instead. Layering both would attempt to register the same control twice
-and double-write `aria-describedby` (Spartan's `BrnFieldA11yService` chain
-plus the toolkit's auto-ARIA chain). The toolkit's auto-ARIA owns the
-ARIA writes — Spartan's a11y service stays out of the picture.
+The wrapper itself doesn't add a second `BrnFieldControl` — but that's
+not because `BrnFieldControl` is reactive-forms-only. **It isn't.**
+Angular signal forms' `FormField` directive provides an interop
+`NgControl` on every bound control, and Brain 1.0.4 detects it
+(`createStateTracker()` picks its `SignalStateTracker` branch over the
+reactive-forms `ReactiveStateTracker`) and tracks it live — this is
+exactly why `data-touched` / `data-dirty` / `data-matches-spartan-invalid`
+reflect real field state on every helm control in this demo, with no
+`FormControl` anywhere. The helm directives (`[hlmInput]`, `[brnSelect]`,
+`brn-checkbox`) each bring their own `BrnFieldControl` host directive
+already, so the wrapper doesn't need to add one.
+
+What the wrapper — and the toolkit's auto-ARIA in general — does _not_
+uniformly own is the ARIA writes. See "`aria-invalid` ownership varies
+per control" below: `BrnInput`, `BrnSelectTrigger`, and `BrnCheckbox`
+each host-bind their own `aria-invalid` straight off `BrnFieldControl`'s
+raw (ungated) `invalid` signal, independently of any strategy. Whether
+auto-ARIA's strategy-gated value wins depends on whether `[formField]`
+happens to sit on the exact DOM node Brain writes to.
 
 ### `aria-describedby` interop — wrapper-scoped `BrnFieldA11yService`
 
@@ -214,9 +226,78 @@ stays compatible. This is a reusable pattern for any Brain + toolkit
 interop — the bridge primitive is exposed from
 `@ngx-signal-forms/toolkit/headless`.
 
-`aria-invalid` and `aria-required` stay owned by the toolkit's
-auto-aria — Brain does not write either of those, so no bridge is
-needed there.
+This bridge works for the text input because `BrnFieldControlDescribedBy`
+writes onto `[hlmInput]`'s own host element — the same element that's in
+the accessibility tree. It does **not** by itself fix the checkbox: see
+"Checkbox: `aria-describedby` needs an explicit hookup" below.
+
+### Checkbox: `aria-describedby` needs an explicit hookup
+
+`<hlm-checkbox>`'s host is `class: 'contents peer'` — `display: contents`,
+invisible to the accessibility tree. `HlmCheckbox` also brings
+`BrnFieldControlDescribedBy` as a `hostDirective`, so both Brain's own
+write and auto-ARIA's write land on that invisible host; neither reaches
+the real `role="checkbox"` button rendered inside `<brn-checkbox>`.
+
+`HlmCheckbox` does expose `aria-describedby` as a genuine `@Input()`
+(separate from the host-directive one) that it forwards straight to
+`<brn-checkbox [aria-describedby]="ariaDescribedby()">` — and that
+binding _does_ land on the real button. The consumer template feeds this
+wrapper's composed `toolkitAriaDescribedBy` signal into it explicitly,
+via an exported template reference:
+
+```html
+<spartan-form-field
+  [ngxSpartanFormField]="form.newsletter"
+  #newsletterField="ngxSpartanFormField"
+>
+  <hlm-checkbox
+    ngxSignalFormControl="checkbox"
+    [formField]="form.newsletter"
+    [aria-describedby]="newsletterField.toolkitAriaDescribedBy()"
+  />
+  ...
+</spartan-form-field>
+```
+
+`NgxSpartanFormField` exports itself as `ngxSpartanFormField` for exactly
+this purpose. Brain's own describedby write onto the `display: contents`
+host still happens — it's harmless, just invisible to AT — so no opt-out
+is needed.
+
+### `aria-invalid` ownership varies per control
+
+Auto-ARIA does not uniformly own `aria-invalid` across every helm
+control — whether its strategy-gated write "wins" over Brain's own raw
+(ungated) host binding depends entirely on _where_ Brain's write lands
+relative to `[formField]`:
+
+- **Text input** — `[formField]` sits on the same `<input>` element
+  `BrnInput` host-binds `aria-invalid` to. Auto-ARIA's `afterEveryRender`
+  write runs after Brain's per-change-detection write and overwrites it
+  with the strategy-gated value every render. Effectively shared
+  ownership, with auto-ARIA writing last.
+- **Select** — `[formField]` sits on `<hlm-select>`, one level above the
+  real `role="combobox"` button rendered inside `<hlm-select-trigger>`'s
+  own template. Auto-ARIA can only reach the `hlm-select` host, never the
+  button an AT actually reads, so Brain's raw `aria-invalid` (from
+  `BrnSelectTrigger`) would otherwise show `"true"` on a pristine,
+  required-and-empty select before it's touched.
+  `libs/spartan/ui/select/src/lib/hlm-select-trigger.ts` fixes this at
+  the source instead: it reads `BrnFieldControl.spartanInvalid()` —
+  Brain's own touched-gated invalid signal, the same one driving the
+  `data-matches-spartan-invalid` destructive-ring styling — and writes
+  the gated `aria-invalid` onto the button in `afterEveryRender`,
+  deterministically after Brain's raw write. No toolkit coupling needed.
+- **Checkbox** — `newsletter` has no validators in this demo, so its
+  `aria-invalid` is always `false` regardless of gating; not fixed here
+  because there's nothing to observe. A required checkbox would hit the
+  same displaced-write problem as the select (`[formField]` on
+  `<hlm-checkbox>`, whose host is `display: contents`), and would need
+  the same kind of fix.
+
+`aria-required` stays owned by the toolkit's auto-aria — Brain does not
+write it.
 
 ### `hlm-select`: pin `fieldName` explicitly
 
@@ -233,9 +314,16 @@ split, so they can rely on label-`for=` resolution (tier-2).
 
 ## What's not shown
 
-- `BrnFieldControl` and Spartan's `ErrorStateMatcher`. See "Host-directive
-  ordering" above — the toolkit owns control state via `[formField]`,
-  and Brain's a11y service is replaced by the bridge.
+- Overriding Spartan's `ErrorStateMatcher` (`provideErrorStateMatcher`).
+  `HlmSelectTrigger`'s `aria-invalid` gating reads
+  `BrnFieldControl.spartanInvalid()`, which is driven by whichever
+  `ErrorStateMatcher` is registered (default: `invalid && touched` — the
+  same semantics as this demo's `on-touch` default). A demo configuring a
+  different `errorStrategy` and wanting the select's `aria-invalid` to
+  track it exactly (rather than Brain's own touched gate) would need to
+  provide a custom `ErrorStateMatcher`, or feed the wrapper's own
+  strategy-aware `ariaInvalidValue` into the trigger instead — out of
+  scope here since Brain's default already matches this demo's strategy.
 - Submission patterns (`submitWithWarnings`, async submission, server
   errors). Out of scope per the PRD; the existing `apps/demo`
   "Submission patterns" page covers those independently of the wrapper
@@ -284,7 +372,7 @@ build.
 
 Spartan's `helm` styled components are not distributed as a runtime npm
 package — they ship as a `@spartan-ng/cli` generator that copies source
-into the consumer's tree. This demo did exactly that: `libs/ui` was
+into the consumer's tree. This demo did exactly that: `libs/spartan/ui` was
 scaffolded via the workspace-root `components.json` config and exposes
 `@spartan-ng/helm/*` secondary entry points. The Spartan version is
 pinned via the `spartan:` pnpm catalog in `pnpm-workspace.yaml`.
@@ -295,9 +383,51 @@ tokens helm uses (`--background`, `--foreground`, `--destructive`,
 `--ring`, `--radius`, etc.) in `oklch`. Both light and dark palettes
 ship; theme flipping uses the `.dark` variant.
 
+`@source '../../../libs/spartan/ui'` is what makes Tailwind's JIT scan
+the vendored helm components for the utility classes embedded in their
+templates — Nx runs Vite with `cwd: apps/demo-spartan` (see
+`project.json`'s `build`/`serve` options), so Tailwind's own auto-detection
+never reaches `libs/`. If this glob ever points at the wrong path (it's
+resolved relative to the stylesheet, not the repo root), helm components
+render structurally correct but completely unstyled — no build error, no
+failing test, just a silently unstyled `dist/` bundle. Verify after
+touching this line by building and grepping the output CSS for a
+helm-only class that isn't used anywhere in this demo's own templates
+(e.g. `data-highlighted`, from `hlm-select-item`):
+
+```bash
+pnpm nx build demo-spartan
+grep -c 'data-highlighted' dist/apps/demo-spartan/assets/*.css   # must be > 0
+```
+
 The wrapper's `data-spartan-form-field` attribute is the join point
 between Spartan's `helm` selectors and the toolkit's chrome — bespoke
 styling can target it without forking the wrapper.
+
+### Error/warning color overrides for `.dark`
+
+The toolkit's own error/warning colors (`--ngx-signal-form-error-color` /
+`--ngx-signal-form-warning-color`, consumed by
+`packages/toolkit/assistive`) default to tracking `prefers-color-scheme`
+directly — they do **not** detect a `.dark` ancestor class. Since this
+demo themes via a `.dark` class toggled independently of the OS
+preference (see `:root` / `.dark` above), `styles.css` sets both custom
+properties explicitly per theme:
+
+```css
+:root {
+  --ngx-signal-form-error-color: #db1818;
+  --ngx-signal-form-warning-color: #a16207;
+}
+.dark {
+  --ngx-signal-form-error-color: #fca5a5;
+  --ngx-signal-form-warning-color: #fcd34d;
+}
+```
+
+Without this, an explicit-light UI on an OS-prefers-dark machine (or vice
+versa) would show the wrong theme's error colors. `apps/demo` follows the
+same convention for the same reason.
 
 ## Pinned versions
 

--- a/apps/demo-spartan/src/app/form/account-preferences-form.spec.ts
+++ b/apps/demo-spartan/src/app/form/account-preferences-form.spec.ts
@@ -118,6 +118,50 @@ describe('Spartan reference wrapper — smoke', () => {
     expect(describedBy.split(/\s+/)).toContain(hintElement.id);
   });
 
+  it('does not mark the pristine plan combobox aria-invalid before it is touched', async () => {
+    // Regression for audit #148 finding 2: Brain's `BrnSelectTrigger` host-binds
+    // `aria-invalid` off the raw, ungated `FieldState.invalid` — with `plan`
+    // required and empty, that fires from first paint regardless of the
+    // configured `on-touch` strategy. `HlmSelectTrigger` gates its own
+    // `aria-invalid` write off `BrnFieldControl.spartanInvalid()` (Brain's own
+    // touched-aware invalid signal, the same one driving the destructive-ring
+    // styling) to match the text input's on-touch behavior.
+    await render(AccountPreferencesForm);
+
+    const plan = screen.getByRole('combobox', { name: /plan/i });
+    expect(plan.getAttribute('aria-invalid')).not.toBe('true');
+  });
+
+  it('marks the plan combobox aria-invalid once it has been touched and left empty', async () => {
+    const user = userEvent.setup();
+
+    await render(AccountPreferencesForm);
+
+    const plan = screen.getByRole('combobox', { name: /plan/i });
+    await user.click(plan);
+    await user.keyboard('{Escape}');
+    await user.tab();
+
+    expect(plan.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it("threads the wrapper's aria-describedby onto the checkbox's role=checkbox button, not its display:contents host", async () => {
+    // Regression for audit #148 finding 3: the toolkit-managed describedby
+    // chain (hint id) is only visible to AT when it lands on the actual
+    // `role="checkbox"` button rendered inside `<brn-checkbox>` — `hlm-checkbox`
+    // itself is `display: contents` and invisible to the accessibility tree.
+    await render(AccountPreferencesForm);
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /send me product updates/i,
+    });
+    const hint = screen.getByText(/you can unsubscribe at any time/i);
+    expect(hint.id).toBeTruthy();
+
+    const describedBy = checkbox.getAttribute('aria-describedby') ?? '';
+    expect(describedBy.split(/\s+/)).toContain(hint.id);
+  });
+
   it('submits when only warnings remain', async () => {
     const user = userEvent.setup();
 

--- a/apps/demo-spartan/src/app/form/account-preferences-form.ts
+++ b/apps/demo-spartan/src/app/form/account-preferences-form.ts
@@ -142,13 +142,28 @@ const accountSchema = schema<AccountPreferences>((path) => {
         </hlm-select>
       </spartan-form-field>
 
-      <!-- Checkbox -->
-      <spartan-form-field [ngxSpartanFormField]="form.newsletter">
+      <!--
+        Checkbox. hlm-checkbox's host is display:contents (invisible to
+        the accessibility tree) — the real role="checkbox" button lives
+        inside <brn-checkbox>. The toolkit-managed describedby chain (hint
+        + error/warning ids) only reaches that button through hlm-checkbox's
+        own [aria-describedby] *input*, so it's fed explicitly here from
+        the wrapper's toolkitAriaDescribedBy signal via the template
+        reference (#newsletterField="ngxSpartanFormField"). Brain's
+        BrnFieldControlDescribedBy host directive on <hlm-checkbox> writes
+        the same chain onto the display:contents host too, which is
+        harmless (AT never sees it) but not sufficient on its own.
+      -->
+      <spartan-form-field
+        [ngxSpartanFormField]="form.newsletter"
+        #newsletterField="ngxSpartanFormField"
+      >
         <div class="flex items-start gap-3">
           <hlm-checkbox
             ngxSignalFormControl="checkbox"
             inputId="newsletter"
             [formField]="form.newsletter"
+            [aria-describedby]="newsletterField.toolkitAriaDescribedBy()"
           />
           <div class="flex flex-col gap-1">
             <label hlmLabel for="newsletter">Send me product updates</label>

--- a/apps/demo-spartan/src/app/wrapper/spartan-form-field.ts
+++ b/apps/demo-spartan/src/app/wrapper/spartan-form-field.ts
@@ -73,12 +73,62 @@ type BrnFieldA11yPublicSurface = Pick<
  *
  * Spartan-specific composition: the `[brnField]` host directive keeps the
  * wrapper's `data-invalid` / `data-touched` state-attributes in lockstep
- * with Spartan's `helm` styling tokens. Because `BrnFieldControl` is
- * `NgControl`-based (Reactive forms), we compose only `BrnField` here —
- * the toolkit's `[formField]` directive owns control state, and auto-ARIA
- * owns the ARIA writes. Layering both would double-write `aria-describedby`
- * (Spartan's `BrnFieldA11yService` chain plus the toolkit's chain), which
- * is the exact failure mode the renderer-seam is designed to avoid.
+ * with Spartan's `helm` styling tokens.
+ *
+ * **Corrected ownership model (brain 1.0.4 + Angular 22 signal forms):**
+ *
+ * `BrnFieldControl` is *not* Reactive-forms-only. Angular signal forms'
+ * `FormField` directive provides an interop `NgControl` on every bound
+ * control (`@angular/forms/signals`'s `interop_ng_control.ts`), and brain
+ * 1.0.4 detects it via `createStateTracker()` and uses its `SignalStateTracker`
+ * branch instead of the reactive-forms `ReactiveStateTracker`. So
+ * `BrnFieldControl` is fully live on every helm control in this demo — it is
+ * precisely why `data-touched` / `data-dirty` / `data-matches-spartan-invalid`
+ * (and the wrapper's own `data-spartan-invalid` / `data-spartan-required`
+ * mirrors) reflect real field state at all, with no reactive-forms
+ * `FormControl` anywhere in this component.
+ *
+ * Nor does auto-ARIA own every ARIA write. `BrnInput`, `BrnSelectTrigger`,
+ * and `BrnCheckbox` each host-bind their own `aria-invalid` straight off
+ * `BrnFieldControl`'s raw (ungated) `invalid` signal, and
+ * `BrnFieldControlDescribedBy` (a `hostDirectives` entry on `HlmCheckbox`
+ * and mounted directly in `HlmInput`/`HlmSelectTrigger`'s templates)
+ * host-binds `aria-describedby` off this wrapper's `BrnFieldA11yService`
+ * bridge. Whether the toolkit's `NgxSignalFormAutoAria` "wins" depends
+ * entirely on *where* Brain's write lands relative to where `[formField]`
+ * sits:
+ *
+ * - Text input: `[formField]` is on the same `<input>` element `BrnInput`
+ *   host-binds to, so auto-ARIA's `afterEveryRender` write runs after
+ *   Brain's per-change-detection write and simply overwrites it with the
+ *   strategy-gated value. Ownership is effectively shared, with auto-ARIA
+ *   writing last.
+ * - Select: `[formField]` is on `<hlm-select>`, one level above the actual
+ *   `role="combobox"` button rendered inside `<hlm-select-trigger>`'s own
+ *   template — auto-ARIA can only reach the `hlm-select` host, never the
+ *   button an AT reads. `HlmSelectTrigger` (`libs/spartan/ui/select`) now
+ *   corrects this itself: it reads `BrnFieldControl.spartanInvalid()`
+ *   (Brain's own touched-gated invalid signal, the same one driving the
+ *   `data-matches-spartan-invalid` destructive-ring styling) and writes the
+ *   gated `aria-invalid` onto the button in `afterEveryRender`, deterministically
+ *   after Brain's raw write.
+ * - Checkbox: `HlmCheckbox`'s host is `display: contents`, so neither
+ *   Brain's `BrnFieldControlDescribedBy` write nor auto-ARIA's write (both
+ *   land on that host) reach the accessibility tree. `HlmCheckbox` exposes
+ *   `aria-describedby` as a real `@Input` that threads into `<brn-checkbox>`'s
+ *   own binding, which *does* land on the real `role="checkbox"` button —
+ *   so the consumer template feeds this wrapper's `toolkitAriaDescribedBy`
+ *   into that input explicitly (see `#newsletterField="ngxSpartanFormField"`
+ *   in `account-preferences-form.ts`) instead of relying on either
+ *   automatic chain.
+ *
+ * Layering the toolkit's `[formField]` alongside `[brnField]` does not
+ * double-write anything by itself; the failure mode this wrapper actually
+ * guards against is the `aria-describedby` chain being composed twice
+ * (Spartan's `BrnFieldA11yService` default plus the toolkit's own
+ * composition) — which is why the wrapper replaces Brain's
+ * `BrnFieldA11yService` with `createAriaDescribedByBridge` below, rather
+ * than letting the two coexist.
  *
  * **Bound-control discovery:**
  *
@@ -99,6 +149,7 @@ type BrnFieldA11yPublicSurface = Pick<
   // field via the aliased input (`[ngxSpartanFormField]`) instead, so only
   // the inner `<input [formField]>` gets the toolkit's `FormField` directive.
   selector: 'spartan-form-field[ngxSpartanFormField]',
+  exportAs: 'ngxSpartanFormField',
 
   imports: [NgComponentOutlet],
   hostDirectives: [

--- a/apps/demo-spartan/src/styles.css
+++ b/apps/demo-spartan/src/styles.css
@@ -12,8 +12,7 @@
 
 /* Tailwind needs to scan helm-generated sources so its JIT picks up the
    utility classes embedded in the @spartan-ng/helm components. */
-@source '../../../libs/ui';
-@source not '../../../.github';
+@source '../../../libs/spartan/ui';
 
 @variant dark (.dark &);
 
@@ -64,6 +63,19 @@
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.705 0.015 286.067);
+
+  /* Signal-forms error/warning colors.
+   *
+   * The toolkit drives its dark-mode error colors from `prefers-color-scheme`
+   * only; it does not detect a `.dark` ancestor class (that relied on the
+   * non-standard `:host-context()`, unsupported in Firefox/Safari — see the
+   * v1.0.0 accessibility audit). Because this demo themes via a `.dark` class
+   * toggled independently of the OS preference, it must set the public
+   * `--ngx-signal-form-error-color` / `--ngx-signal-form-warning-color`
+   * custom properties per theme, otherwise an explicit-light UI on an
+   * OS-prefers-dark machine would show dark-mode error colors. */
+  --ngx-signal-form-error-color: #db1818;
+  --ngx-signal-form-warning-color: #a16207;
 }
 
 .dark {
@@ -86,6 +98,8 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.552 0.016 285.938);
+  --ngx-signal-form-error-color: #fca5a5;
+  --ngx-signal-form-warning-color: #fcd34d;
 }
 
 @layer base {

--- a/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
@@ -70,8 +70,10 @@ export class HlmSelectTrigger {
     () => this._fieldControl?.spartanInvalid() ?? false,
   );
 
-  private readonly _triggerButton = viewChild.required('trigger', {
-    read: ElementRef<HTMLButtonElement>,
+  private readonly _triggerButton = viewChild.required<
+    ElementRef<HTMLButtonElement>
+  >('trigger', {
+    read: ElementRef,
   });
 
   constructor() {

--- a/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
@@ -70,11 +70,8 @@ export class HlmSelectTrigger {
     () => this._fieldControl?.spartanInvalid() ?? false,
   );
 
-  private readonly _triggerButton = viewChild.required<
-    ElementRef<HTMLButtonElement>
-  >('trigger', {
-    read: ElementRef,
-  });
+  private readonly _triggerButton =
+    viewChild.required<ElementRef<HTMLButtonElement>>('trigger');
 
   constructor() {
     afterEveryRender(() => {

--- a/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
@@ -1,7 +1,18 @@
-import { Component, computed, input } from '@angular/core';
+import {
+  afterEveryRender,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronDown } from '@ng-icons/lucide';
-import { BrnFieldControlDescribedBy } from '@spartan-ng/brain/field';
+import {
+  BrnFieldControl,
+  BrnFieldControlDescribedBy,
+} from '@spartan-ng/brain/field';
 import { BrnSelectTrigger } from '@spartan-ng/brain/select';
 import { hlm } from '@spartan-ng/helm/utils';
 import type { ClassValue } from 'clsx';
@@ -13,6 +24,7 @@ import type { ClassValue } from 'clsx';
 
   template: `
     <button
+      #trigger
       brnSelectTrigger
       brnFieldControlDescribedBy
       [id]="buttonId()"
@@ -29,6 +41,50 @@ import type { ClassValue } from 'clsx';
   `,
 })
 export class HlmSelectTrigger {
+  /**
+   * `BrnSelectTrigger` host-binds `[attr.aria-invalid]` off the raw,
+   * ungated `controlState().invalid` — it has no concept of "touched" or
+   * any error-display strategy, so a required-and-empty select reports
+   * `aria-invalid="true"` on first paint, before the user has interacted
+   * with it. This is inconsistent with the same field's `data-matches-spartan-invalid`
+   * attribute (used for the destructive-ring styling below), which is
+   * correctly gated by Brain's `ErrorStateMatcher` (`invalid && touched`)
+   * via `BrnFieldControl.spartanInvalid()`.
+   *
+   * Rather than relying on directive-matching/host-binding-write-order
+   * (fragile and undocumented) to make a second `[attr.aria-invalid]`
+   * binding "win" against `BrnSelectTrigger`'s own, this writes the gated
+   * value imperatively in `afterEveryRender`, which is guaranteed to run
+   * after Angular's regular change-detection (and therefore after Brain's
+   * host binding) on every render — the same technique
+   * `NgxSignalFormAutoAria` uses to correct `BrnInput`'s identical ungated
+   * binding when `[formField]` sits on the same DOM node it writes to.
+   * Here `[formField]` sits on the ancestor `<hlm-select>`, one level above
+   * this trigger's real `role="combobox"` button, so that toolkit-side
+   * correction can't reach it — this fixes it at the source instead,
+   * using Brain's own touched-aware signal (no toolkit coupling needed).
+   */
+  private readonly _fieldControl = inject(BrnFieldControl, { optional: true });
+
+  private readonly _gatedInvalid = computed(
+    () => this._fieldControl?.spartanInvalid() ?? false,
+  );
+
+  private readonly _triggerButton = viewChild.required('trigger', {
+    read: ElementRef<HTMLButtonElement>,
+  });
+
+  constructor() {
+    afterEveryRender(() => {
+      const button = this._triggerButton().nativeElement;
+      if (this._gatedInvalid()) {
+        button.setAttribute('aria-invalid', 'true');
+      } else {
+        button.removeAttribute('aria-invalid');
+      }
+    });
+  }
+
   private static _id = 0;
 
   public readonly userClass = input<ClassValue>('', { alias: 'class' });


### PR DESCRIPTION
Closes #169

## Summary

Fixes the 4 verified blocker findings from audit #148 (demo-spartan), plus applies the demo error-color override contract.

1. **Tailwind `@source` glob (bug)** — `apps/demo-spartan/src/styles.css` pointed at the nonexistent `libs/ui`; the vendored helm lib actually lives at `libs/spartan/ui`. Fixed the glob (and dropped the equally stale `@source not '../../../.github'`). Verified the built CSS now contains helm-only utility classes (`data-highlighted`, `matches-spartan-invalid`, `border-destructive`, `bg-popover`, `size-4`) that were previously missing.
2. **Pristine plan combobox `aria-invalid="true"` (a11y)** — `BrnSelectTrigger` host-binds `aria-invalid` off Brain's raw, ungated `invalid` signal, and the toolkit's `[formField]` sits on the ancestor `<hlm-select>`, one level above the real `role="combobox"` button, so auto-ARIA can't correct it. Fixed at the source: `HlmSelectTrigger` (`libs/spartan/ui/select`) now reads `BrnFieldControl.spartanInvalid()` (Brain's own touched-gated invalid signal — the same one driving the destructive-ring styling) and writes the gated `aria-invalid` onto the button in `afterEveryRender`, deterministically overriding Brain's raw write on every render.
3. **Checkbox hint `aria-describedby` never reaches the `role="checkbox"` button (a11y)** — `hlm-checkbox`'s host is `display: contents` (invisible to the accessibility tree); both Brain's own write and auto-ARIA's write land there instead of on the real button rendered inside `<brn-checkbox>`. Fixed by threading the wrapper's composed `toolkitAriaDescribedBy` signal into `HlmCheckbox`'s own `aria-describedby` `@Input()` (which *does* forward into `<brn-checkbox>`), via a new `#newsletterField="ngxSpartanFormField"` template reference on `NgxSpartanFormField` (now `exportAs`-exported).
4. **Wrapper docs' ownership-model premise is wrong for brain 1.0.4 (docs)** — rewrote the wrapper's JSDoc, the e2e spec header, and `README.md` to correct the claims: `BrnFieldControl` is live via the signal-forms `NgControl` interop (not reactive-forms-only), and auto-ARIA does not uniformly own every ARIA write — documented per-control (input/select/checkbox) where Brain vs. the toolkit vs. this demo's fixes actually land.

Also applied the demo error-color override contract to `apps/demo-spartan/src/styles.css` (it themes via a `.dark` class): set `--ngx-signal-form-error-color` / `--ngx-signal-form-warning-color` per theme, matching `apps/demo`'s convention.

No toolkit public API changes — all fixes are scoped to `apps/demo-spartan` and the vendored `libs/spartan/ui` helm components.

## Test plan

- [x] TDD: added failing regression tests first (smoke spec + e2e) for findings 2 and 3, confirmed red, then green after the fix
- [x] `pnpm nx test demo-spartan` — 9/9 passing
- [x] `pnpm nx build demo-spartan` — passes; verified helm utility classes present in built CSS
- [x] `pnpm nx build ui-helm` — passes (ng-packagr's full type-check caught and required fixing a `viewChild.required` overload issue not visible under the demo's esbuild/vite dev pipeline)
- [x] `pnpm nx lint demo-spartan`, `pnpm nx lint demo-spartan-e2e`, and `oxlint` on the vendored `libs/spartan/ui` file — clean (pre-existing warning-only patterns unchanged)
- [x] `pnpm nx e2e demo-spartan-e2e --project=chromium` — full suite, 5/5 passing (Firefox not run per environment note; CI covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)