### PR TITLE
fix(demo-primeng): wire select label + checkbox ARIA, fix stale version pin

### DIFF
--- a/apps/demo-primeng-e2e/src/profile-form.spec.ts
+++ b/apps/demo-primeng-e2e/src/profile-form.spec.ts
@@ -10,7 +10,10 @@ import { expect, test, type Page } from '@playwright/test';
  */
 
 async function selectRole(page: Page, optionName: string): Promise<void> {
-  await page.getByRole('combobox', { name: /pick a role/i }).click();
+  // The combobox's accessible name is "Role" (from the visible <label> via
+  // aria-labelledby), not the transient "Pick a role" placeholder text —
+  // see the dedicated accessible-name regression test below.
+  await page.getByRole('combobox', { name: /^role$/i }).click();
   await page.getByRole('option', { name: optionName }).click();
 }
 
@@ -71,7 +74,7 @@ test.describe('demo-primeng — profile form', () => {
   test('select required error surfaces on blur and the combobox stays linked to its assistive text', async ({
     page,
   }) => {
-    const roleCombobox = page.getByRole('combobox', { name: /pick a role/i });
+    const roleCombobox = page.getByRole('combobox', { name: /^role$/i });
 
     await test.step('blur the untouched role control', async () => {
       await roleCombobox.focus();
@@ -102,11 +105,55 @@ test.describe('demo-primeng — profile form', () => {
     });
   });
 
+  test("the role combobox's accessible name comes from the visible label, not placeholder/selected-value content", async ({
+    page,
+  }) => {
+    // Regression test for the audit #147 blocker: PrimeSelectControlComponent
+    // put `inputId` on the non-labelable inner <span role="combobox">, so
+    // `<label for="profile-role">Role</label>` never established a
+    // programmatic label association and the accessible name fell back to
+    // the "Pick a role" placeholder (or the selected option's label once
+    // chosen). getByRole computing an accessible name of exactly "Role" in
+    // both states is the whole point of this assertion.
+    const roleCombobox = page.getByRole('combobox', { name: /^role$/i });
+    await expect(roleCombobox).toHaveAttribute(
+      'aria-labelledby',
+      'profile-role-label',
+    );
+
+    await selectRole(page, 'Designer');
+
+    // Even after a selection changes the visible content to "Designer", the
+    // accessible name (driven by aria-labelledby) must stay "Role".
+    await expect(
+      page.getByRole('combobox', { name: /^role$/i }),
+    ).toHaveAttribute('aria-labelledby', 'profile-role-label');
+  });
+
+  test('checkbox ARIA (describedby/invalid/required) is wired onto the real native input, not the <p-checkbox> host', async ({
+    page,
+  }) => {
+    // Regression test for the audit #147 blocker: NgxSignalFormAutoAria's
+    // selector catch-all wrote aria-describedby/aria-invalid/aria-required
+    // onto the <p-checkbox> host element instead of the real focusable
+    // native <input type="checkbox">, so the newsletter hint was never
+    // linked for assistive tech.
+    const newsletterCheckbox = page.getByRole('checkbox', {
+      name: /subscribe to the release notes/i,
+    });
+
+    await expect(newsletterCheckbox).toHaveJSProperty('tagName', 'INPUT');
+    await expect(newsletterCheckbox).toHaveAttribute(
+      'aria-describedby',
+      /profile-newsletter-hint/,
+    );
+  });
+
   test('submits a completed form and reset returns it to its initial state', async ({
     page,
   }) => {
     const emailInput = page.locator('#profile-email');
-    const roleCombobox = page.getByRole('combobox', { name: /pick a role/i });
+    const roleCombobox = page.getByRole('combobox', { name: /^role$/i });
     const newsletterCheckbox = page.getByRole('checkbox', {
       name: /subscribe to the release notes/i,
     });

--- a/apps/demo-primeng/README.md
+++ b/apps/demo-primeng/README.md
@@ -36,6 +36,10 @@ specific.
   `[formField]` on `<p-select>` collides with PrimeNG's inherited
   Angular-forms-style inputs, so Signal Forms needs a clean
   `FormValueControl` host.
+- A matching **`PrimeCheckboxControlComponent`** compatibility shim for
+  PrimeNG's `<p-checkbox>`, bridging the toolkit's ARIA primitives onto the
+  real native `<input type="checkbox">` PrimeNG renders internally (see
+  "ARIA writes target the host element" below).
 - A custom **`PrimeFieldHintComponent`** registered through
   `provideFormFieldHintRenderer({ component: ... })` so the hint slot is
   ready for the toolkit's future dynamic-outlet hint mode without any
@@ -98,7 +102,10 @@ form:
 - text input with `p-iconfield` + `pInputText`
 - select via `<prime-select-control>` (a minimal compatibility shim around
   PrimeNG's current `<p-select>` primitive — see version pin below)
-- checkbox via `<p-checkbox>`
+- checkbox via `<prime-checkbox-control>` (the same shim pattern applied to
+  `<p-checkbox>`, since its native `<input type="checkbox">` needs the same
+  host-vs-inner-element ARIA bridging as `<p-select>` — see "ARIA writes
+  target the host element" below)
 - a non-blocking warning on the email field, exercising the warnings
   branch of the renderer
 
@@ -113,7 +120,7 @@ tier-3 field-name resolution and the dev-mode missing-control assertion.
 
 | Package            | Version pinned by this demo |
 | ------------------ | --------------------------- |
-| `primeng`          | `21.1.6`                    |
+| `primeng`          | `21.1.9`                    |
 | `@primeuix/themes` | `2.0.3`                     |
 | `primeicons`       | `7.0.0`                     |
 
@@ -141,7 +148,7 @@ The other floating-label modes are intentionally **out of scope** — they
 introduce their own ARIA wiring and styling tokens that are orthogonal
 to the toolkit seam.
 
-### Why the demo keeps a tiny wrapper for `p-select`
+### Why the demo keeps tiny wrappers for `p-select` and `p-checkbox`
 
 Tim Deschryver's directive-first pattern is the right default when you only
 need to configure or extend a third-party component. This demo follows that
@@ -149,16 +156,20 @@ spirit for the actual integration seam: the Prime field wrapper, renderer
 tokens, hint registry, and control semantics are all toolkit primitives
 composed around PrimeNG.
 
-`<p-select>` is the exception. PrimeNG already supports Angular's CVA-based
-forms APIs, but Angular Signal Forms generates a broader host contract on a
-direct `[formField]` binding (including inputs like `pattern`). PrimeNG's
-inherited input surface does not line up with that contract, so a plain
-directive on `<p-select>` still fails type-checking.
+`<p-select>` and `<p-checkbox>` are the exceptions. PrimeNG already supports
+Angular's CVA-based forms APIs, but Angular Signal Forms generates a broader
+host contract on a direct `[formField]` binding (including inputs like
+`pattern`). PrimeNG's inherited input surface does not line up with that
+contract, so a plain directive on either host still fails type-checking —
+and, independently, both hosts render their real focusable element as an
+_internal_ child rather than on the host itself (see "ARIA writes target
+the host element" below), so a plain directive on the host couldn't reach
+the right element even if it did type-check.
 
-That is why this demo keeps a tiny wrapper component for select only: it
-creates a clean `FormValueControl<string>` host for Signal Forms while still
-rendering the real PrimeNG control inside. The wrapper is a compatibility
-shim, not the main integration story.
+That is why this demo keeps tiny wrapper components for select and
+checkbox: each creates a clean `FormValueControl` host for Signal Forms
+while still rendering the real PrimeNG control inside. The wrappers are
+compatibility shims, not the main integration story.
 
 ### ARIA writes target the host element, not PrimeNG's inner input
 
@@ -181,26 +192,43 @@ combobox/checkbox. Left alone, that write would clobber anything
 `{fieldName}-error` and `{fieldName}-hint` IDs would never reach the
 focusable inner element AT actually reads.
 
-The select demo solves this with a per-control bridge directive
-(`PrimeSelectControlComponent` in `apps/demo-primeng/src/app/controls/`)
-that mirrors the Material reference's `NgxMatSelectControl` pattern. The
-shim provides `NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` so auto-aria leaves
-the host alone, then binds the toolkit's `createAriaDescribedBySignal`
-output directly onto the inner `<p-select>`. The Playwright spec now
-asserts the result explicitly: the role combobox carries
-`aria-describedby` containing both `profile-role-hint` and
+The select and checkbox demos both solve this with a per-control bridge
+component (`PrimeSelectControlComponent` and `PrimeCheckboxControlComponent`
+in `apps/demo-primeng/src/app/controls/`) that mirrors the Material
+reference's `NgxMatSelectControl` pattern. Each shim provides
+`NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` so auto-aria leaves the host alone,
+then binds the toolkit's `createAriaDescribedBySignal` /
+`createAriaInvalidSignal` / `createAriaRequiredSignal` outputs onto the real
+inner element:
+
+- `PrimeSelectControlComponent` binds directly onto the inner `<p-select>`
+  via `[attr.*]`, and forwards a caller-supplied `ariaLabelledBy` id through
+  `<p-select>`'s own `ariaLabelledBy` input so the combobox's accessible
+  name comes from the visible `<label>`, not the transient
+  placeholder/selected-value content.
+- `PrimeCheckboxControlComponent` writes the three ARIA attributes
+  imperatively onto the real native `<input type="checkbox">`, reached via
+  `Checkbox.inputViewChild` — PrimeNG doesn't forward `aria-describedby` /
+  `aria-invalid` / `aria-required` from the host the way it does
+  `ariaLabelledBy` / `ariaLabel`, so `[formField]`'s `id`-based `for`
+  association on the checkbox's `<label>` already works out of the box, but
+  the toolkit's error/hint wiring needs the explicit bridge.
+
+The Playwright spec asserts the select result explicitly: the role combobox
+carries `aria-describedby` containing both `profile-role-hint` and
 `profile-role-error` tokens (plus `aria-invalid="true"` and
 `aria-required="true"`) — the host-component ARIA boundary is verified
-end-to-end via `NgxSignalFormAutoAria` + the shim, not just inferred
-from the rendered error element's id.
+end-to-end via `NgxSignalFormAutoAria` + the shim, not just inferred from
+the rendered error element's id.
 
 For text inputs (`<input pInputText [formField]>`) the bound element is
 the focusable element, so no shim is needed — the smoke + Playwright
 specs cover that path end-to-end.
 
 If you build a first-class `@ngx-signal-forms/primeng` package, ship a
-matching bridge for every host component (checkbox, multiselect,
-calendar, …). The select shim in this demo is the reference pattern.
+matching bridge for every remaining host component (multiselect, calendar,
+…) that renders its focusable surface as an internal child. The select and
+checkbox shims in this demo are the reference pattern.
 
 ### Theme-token interplay
 
@@ -254,8 +282,9 @@ that the same wrapper can render under any Prime theme.
 - PrimeNG's filled / outlined `pInputText` variants. Pick whichever your
   product uses; the wrapper is variant-agnostic.
 - `p-multiselect`, `p-autocomplete`, `p-calendar`, `p-radiobutton`, etc.
-  The seam is similar; this demo uses one representative select path
-  (`p-select` through `PrimeSelectControlComponent`) to prove the current
+  The seam is similar; this demo uses two representative host-component
+  paths (`p-select` through `PrimeSelectControlComponent`, `p-checkbox`
+  through `PrimeCheckboxControlComponent`) to prove the current
   compatibility contract.
 - A submission backend. The form's submit handler logs the JSON payload
   inline so the integration is self-contained.

--- a/apps/demo-primeng/src/app/controls/prime-checkbox-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-checkbox-control.ts
@@ -1,0 +1,192 @@
+import {
+  afterEveryRender,
+  Component,
+  computed,
+  inject,
+  Injector,
+  input,
+  model,
+  output,
+  signal,
+  viewChild,
+  type Signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  FORM_FIELD,
+  type FieldState,
+  type FormValueControl,
+} from '@angular/forms/signals';
+import {
+  createErrorVisibility,
+  NGX_SIGNAL_FORM_ARIA_MODE,
+  NGX_SIGNAL_FORM_FIELD_CONTEXT,
+  NGX_SIGNAL_FORM_HINT_REGISTRY,
+  type NgxSignalFormControlAriaMode,
+} from '@ngx-signal-forms/toolkit';
+import {
+  createAriaDescribedBySignal,
+  createAriaInvalidSignal,
+  createAriaRequiredSignal,
+  createHintIdsSignal,
+} from '@ngx-signal-forms/toolkit/headless';
+import { Checkbox, CheckboxModule } from 'primeng/checkbox';
+
+/**
+ * Frozen `manual` ARIA-mode signal. Mirrors the constant in Material's
+ * per-control directives (`apps/demo-material/src/app/wrapper/control-directives.ts`)
+ * and the sibling `PrimeSelectControlComponent` shim.
+ */
+const MANUAL_ARIA_MODE: Signal<NgxSignalFormControlAriaMode | null> =
+  signal('manual');
+
+/**
+ * Signal Forms adapter for PrimeNG's `<p-checkbox>`.
+ *
+ * **Why this shim exists:** `<p-checkbox inputId="…" [formField]="…">`
+ * binds Angular Signal Forms' `[formField]` directly on the `<p-checkbox>`
+ * host tag. `NgxSignalFormAutoAria`'s selector catch-all
+ * (`[formField]:not(input):not(textarea):not(select):not([ngxSignalFormAutoAriaDisabled])`)
+ * matches that host and writes `aria-describedby` / `aria-invalid` /
+ * `aria-required` onto the `<p-checkbox>` element itself. PrimeNG's compiled
+ * Checkbox template renders a separate native `<input type="checkbox">` as a
+ * child with no host-to-input ARIA passthrough for those three attributes
+ * (unlike `ariaLabelledBy` / `ariaLabel`, which PrimeNG forwards natively) —
+ * so hint/error text is visually shown but never linked to the real
+ * focusable checkbox input.
+ *
+ * **ARIA model — same pattern as `PrimeSelectControlComponent`:**
+ *
+ * The shim provides `NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` so `NgxSignalFormAutoAria`
+ * stands aside on the shim host, then composes the toolkit's ARIA primitive
+ * factories internally and writes the resolved attributes onto the real
+ * native `<input>` — reached via `Checkbox.inputViewChild`, a public
+ * `ElementRef` PrimeNG exposes for exactly this kind of host-component
+ * bridging (mirrors the `[role="combobox"]` DOM query the select shim uses
+ * where PrimeNG doesn't expose a component-level handle).
+ *
+ * TODO: Revisit when PrimeNG v22's Signal Forms support is available in this
+ * repo. At that point this shim may be removable in favour of direct binding.
+ */
+@Component({
+  selector: 'prime-checkbox-control',
+
+  imports: [FormsModule, CheckboxModule],
+  providers: [
+    { provide: NGX_SIGNAL_FORM_ARIA_MODE, useValue: MANUAL_ARIA_MODE },
+  ],
+  host: {
+    class: 'prime-checkbox-control',
+  },
+  template: `
+    <p-checkbox
+      [inputId]="inputId()"
+      [binary]="true"
+      [disabled]="disabled()"
+      [ngModel]="value()"
+      (ngModelChange)="value.set($event ?? false)"
+      (onBlur)="touch.emit()"
+    />
+  `,
+})
+export class PrimeCheckboxControlComponent implements FormValueControl<boolean> {
+  readonly #formField = inject(FORM_FIELD);
+  readonly #injector = inject(Injector);
+  readonly #fieldContext = inject(NGX_SIGNAL_FORM_FIELD_CONTEXT, {
+    optional: true,
+  });
+  readonly #hintRegistry = inject(NGX_SIGNAL_FORM_HINT_REGISTRY, {
+    optional: true,
+  });
+
+  protected readonly checkboxControl = viewChild.required(Checkbox);
+
+  readonly inputId = input.required<string>();
+  readonly disabled = input(false);
+  // Angular 22: emit `touch` (control → field) instead of the old `touched`
+  // model; the Field directive marks the field touched on blur.
+  readonly touch = output();
+  readonly value = model(false);
+
+  /**
+   * Reactive view of the bound `FieldState`. Resolved from `FORM_FIELD` the
+   * same way `PrimeSelectControlComponent` does.
+   */
+  readonly #fieldState = computed<FieldState<unknown> | null>(() => {
+    const field = this.#formField.field();
+    const state =
+      typeof field === 'function' ? field() : this.#formField.state();
+    return state ?? null;
+  });
+
+  readonly #visibility = createErrorVisibility(this.#fieldState);
+
+  readonly #hintIds = createHintIdsSignal({
+    registry: this.#hintRegistry,
+    fieldName: () => this.#fieldContext?.fieldName() ?? null,
+  });
+
+  protected readonly ariaInvalid = createAriaInvalidSignal(
+    this.#fieldState,
+    this.#visibility,
+  );
+
+  protected readonly ariaRequired = createAriaRequiredSignal(this.#fieldState);
+
+  protected readonly ariaDescribedBy = createAriaDescribedBySignal({
+    fieldState: this.#fieldState,
+    hintIds: this.#hintIds,
+    visibility: this.#visibility,
+    preservedIds: () => null,
+    fieldName: () => this.#fieldContext?.fieldName() ?? null,
+  });
+
+  constructor() {
+    afterEveryRender(
+      {
+        write: () => {
+          const nativeInput =
+            this.checkboxControl().inputViewChild?.nativeElement ?? null;
+
+          if (!nativeInput) {
+            return;
+          }
+
+          this.#setOrRemoveAttribute(
+            nativeInput,
+            'aria-describedby',
+            this.ariaDescribedBy(),
+          );
+          this.#setOrRemoveAttribute(
+            nativeInput,
+            'aria-invalid',
+            this.ariaInvalid(),
+          );
+          this.#setOrRemoveAttribute(
+            nativeInput,
+            'aria-required',
+            this.ariaRequired(),
+          );
+        },
+      },
+      { injector: this.#injector },
+    );
+  }
+
+  focus(): void {
+    this.checkboxControl().focus();
+  }
+
+  #setOrRemoveAttribute(
+    element: HTMLElement,
+    name: string,
+    value: string | null,
+  ): void {
+    if (value === null) {
+      element.removeAttribute(name);
+      return;
+    }
+
+    element.setAttribute(name, value);
+  }
+}

--- a/apps/demo-primeng/src/app/controls/prime-select-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-select-control.ts
@@ -61,6 +61,17 @@ const MANUAL_ARIA_MODE: Signal<NgxSignalFormControlAriaMode | null> =
  * the toolkit's signals reach the focusable element in one Angular binding
  * hop. No MutationObserver, no host-attribute mirroring.
  *
+ * **Accessible name:** `[inputId]` places its id on `<p-select>`'s inner
+ * `<span role="combobox">`, which is not a labelable element — a sibling
+ * `<label for="…">` therefore never establishes a programmatic association,
+ * and the combobox's accessible name falls back to its transient
+ * placeholder / selected-value content instead. The shim accepts an
+ * `ariaLabelledBy` input (the id of the projected `<label>`) and binds it to
+ * `<p-select>`'s own `ariaLabelledBy` input, which PrimeNG forwards straight
+ * onto the inner combobox span (`[attr.aria-labelledby]="ariaLabelledBy"` in
+ * PrimeNG's compiled template) — no DOM querying needed for this one, unlike
+ * the describedby/invalid/required attributes below.
+ *
  * TODO: Revisit when PrimeNG v22's Signal Forms support is available in this
  * repo. At that point this shim may be removable in favour of direct binding.
  */
@@ -84,6 +95,7 @@ const MANUAL_ARIA_MODE: Signal<NgxSignalFormControlAriaMode | null> =
       [disabled]="disabled()"
       [invalid]="ariaInvalid() === 'true'"
       [required]="ariaRequired() === 'true'"
+      [ariaLabelledBy]="ariaLabelledBy()"
       [ngModel]="value()"
       [attr.aria-describedby]="ariaDescribedBy()"
       [attr.aria-invalid]="ariaInvalid()"
@@ -107,6 +119,13 @@ export class PrimeSelectControlComponent implements FormValueControl<string> {
   protected readonly selectControl = viewChild.required(Select);
 
   readonly inputId = input.required<string>();
+  /**
+   * The id of the projected `<label>` this control belongs to. Bound
+   * straight through to `<p-select>`'s own `ariaLabelledBy` input so the
+   * inner `[role="combobox"]` element's accessible name is the label text —
+   * see the class doc's "Accessible name" note.
+   */
+  readonly ariaLabelledBy = input.required<string>();
   readonly options = input<readonly RoleOption[]>([]);
   readonly optionLabel = input('label');
   readonly optionValue = input('value');

--- a/apps/demo-primeng/src/app/profile-form/profile-form.behavior.spec.ts
+++ b/apps/demo-primeng/src/app/profile-form/profile-form.behavior.spec.ts
@@ -89,10 +89,34 @@ describe('ProfileFormComponent', () => {
     // focusable surface (PrimeNG's own [role="combobox"]) is what receives
     // aria-invalid, not just the outer shim host — that's the contract the
     // shim's whole reason-for-existing has to honour.
-    const roleCombobox = screen.getByRole('combobox', {
-      name: /pick a role/i,
-    });
+    //
+    // The combobox's accessible name comes from the visible "Role" <label>
+    // via aria-labelledby (not the transient "Pick a role" placeholder/
+    // selected-value content) — see the aria-labelledby regression test
+    // below for the dedicated assertion.
+    const roleCombobox = screen.getByRole('combobox', { name: /^role$/i });
     expect(roleCombobox.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it("wires the visible 'Role' label to the select's inner combobox via aria-labelledby so the accessible name never derives from transient placeholder/selected-value content", async () => {
+    await renderProfileForm();
+
+    // Regression test for the audit #147 blocker: PrimeSelectControlComponent
+    // put `inputId` on a non-labelable inner <span role="combobox">, so
+    // `<label for="profile-role">Role</label>` never established a
+    // programmatic label association — the accessible name was derived from
+    // the placeholder ("Pick a role") or, once selected, the chosen option's
+    // label instead. `getByRole` computing an accessible name of exactly
+    // "Role" (not "Pick a role") is the whole point of this assertion.
+    const roleCombobox = screen.getByRole('combobox', { name: /^role$/i });
+
+    const labelledBy = roleCombobox.getAttribute('aria-labelledby');
+    expect(labelledBy).not.toBeNull();
+
+    const label = document.getElementById(labelledBy ?? '');
+    expect(label).not.toBeNull();
+    expect(label?.tagName).toBe('LABEL');
+    expect(label?.textContent?.trim()).toBe('Role');
   });
 
   it('shows the personal-email warning and still submits once role is selected', async () => {
@@ -108,7 +132,7 @@ describe('ProfileFormComponent', () => {
       await screen.findByText(/personal email domains may complicate/i),
     ).toBeTruthy();
 
-    await user.click(screen.getByRole('combobox', { name: /pick a role/i }));
+    await user.click(screen.getByRole('combobox', { name: /^role$/i }));
     await user.click(await screen.findByText(/^Designer$/));
     await user.click(screen.getByTestId('submit-button'));
     await whenStable();
@@ -116,5 +140,33 @@ describe('ProfileFormComponent', () => {
     const submission = await screen.findByTestId('submission-summary');
     expect(submission.textContent).toContain('"email": "alex@gmail.com"');
     expect(submission.textContent).toContain('"role": "designer"');
+  });
+
+  it('wires aria-describedby/aria-invalid/aria-required onto the real native checkbox input, not the <p-checkbox> host', async () => {
+    const user = userEvent.setup();
+
+    const { whenStable } = await renderProfileForm();
+
+    // Regression test for the audit #147 blocker: NgxSignalFormAutoAria's
+    // selector catch-all wrote aria-describedby/aria-invalid/aria-required
+    // onto the <p-checkbox> host element, but PrimeNG's compiled Checkbox
+    // template renders a separate native <input type="checkbox"> as a child
+    // with no host-to-input ARIA passthrough — the hint text was visible but
+    // never linked to the real focusable checkbox input.
+    const newsletterCheckbox = screen.getByRole('checkbox', {
+      name: /subscribe to the release notes/i,
+    });
+    expect(newsletterCheckbox.tagName).toBe('INPUT');
+
+    // Touch + blur so on-touch strategy lights up (newsletter has no
+    // validators so aria-invalid should stay unset, but aria-describedby
+    // must always carry the hint id regardless of validity).
+    await user.click(newsletterCheckbox);
+    await user.tab();
+    await whenStable();
+
+    const describedBy = newsletterCheckbox.getAttribute('aria-describedby');
+    expect(describedBy).not.toBeNull();
+    expect(describedBy?.split(/\s+/)).toContain('profile-newsletter-hint');
   });
 });

--- a/apps/demo-primeng/src/app/profile-form/profile-form.ts
+++ b/apps/demo-primeng/src/app/profile-form/profile-form.ts
@@ -7,10 +7,10 @@ import {
 } from '@ngx-signal-forms/toolkit';
 import { NgxFormFieldHint } from '@ngx-signal-forms/toolkit/assistive';
 import { ButtonModule } from 'primeng/button';
-import { CheckboxModule } from 'primeng/checkbox';
 import { IconFieldModule } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
+import { PrimeCheckboxControlComponent } from '../controls/prime-checkbox-control';
 import { PrimeSelectControlComponent } from '../controls/prime-select-control';
 import { NgxPrimeFormBundle } from '../form-field';
 import {
@@ -32,7 +32,7 @@ import { profileFormSchema } from './profile-form.schema';
  *    errors render as PrimeNG's `<small class="p-error">` idiom.
  * 3. **`NgxSignalFormControlSemanticsDirective`** is declared on each control
  *    (text input via `pInputText`, the `prime-select-control` compatibility
- *    host, and `<p-checkbox>`)
+ *    host, and the `prime-checkbox-control` compatibility host)
  *    so the toolkit knows the control kind without DOM heuristics.
  * 4. **`NgxSignalFormAutoAria`** is in scope via `NgxSignalForm` / direct
  *    import so it can wire `aria-invalid` / `aria-describedby` on each
@@ -53,10 +53,10 @@ import { profileFormSchema } from './profile-form.schema';
   imports: [
     FormField,
     ButtonModule,
-    CheckboxModule,
     IconFieldModule,
     InputIconModule,
     InputTextModule,
+    PrimeCheckboxControlComponent,
     PrimeSelectControlComponent,
     NgxSignalFormToolkit,
     NgxFormFieldHint,
@@ -111,9 +111,10 @@ import { profileFormSchema } from './profile-form.schema';
           fieldName="profile-role"
           showRequiredMarker
         >
-          <label for="profile-role">Role</label>
+          <label id="profile-role-label" for="profile-role">Role</label>
           <prime-select-control
             inputId="profile-role"
+            ariaLabelledBy="profile-role-label"
             [options]="roleOptions"
             placeholder="Pick a role"
             ngxSignalFormControl="standalone-field-like"
@@ -131,9 +132,8 @@ import { profileFormSchema } from './profile-form.schema';
         fieldName="profile-newsletter"
       >
         <label for="profile-newsletter">Subscribe to the release notes</label>
-        <p-checkbox
+        <prime-checkbox-control
           inputId="profile-newsletter"
-          [binary]="true"
           ngxSignalFormControl="checkbox"
           [formField]="newsletterField"
         />


### PR DESCRIPTION
Closes #168

## Summary

Fixes the 3 verified blocker findings from audit #147 in the PrimeNG reference demo (`apps/demo-primeng`):

1. **`<p-select>` accessible name never came from the visible `Role` label** — `PrimeSelectControlComponent` put `[inputId]` on `<p-select>`'s inner `<span role="combobox">` (not labelable via `<label for>`), so the accessible name fell back to the transient "Pick a role" placeholder or, once selected, the chosen option's label. Fixed by adding an `ariaLabelledBy` input to the shim that forwards straight through to `<p-select>`'s own `ariaLabelledBy` input (which PrimeNG already wires onto the inner combobox span natively — no DOM querying needed for this one).
2. **`<p-checkbox>` ARIA (`aria-describedby`/`aria-invalid`/`aria-required`) landed on the outer host, not the real native checkbox input** — `NgxSignalFormAutoAria`'s selector catch-all wrote those attributes onto `<p-checkbox>` itself, but PrimeNG renders a separate native `<input type="checkbox">` as a child with no host-to-input ARIA passthrough for those three attributes, so the newsletter hint was never linked for assistive tech. Fixed by adding a new `PrimeCheckboxControlComponent` shim (mirrors the existing select shim: `NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` + imperative writes onto the native input reached via `Checkbox.inputViewChild`) and swapping the profile form's raw `<p-checkbox>` for it.
3. **README version-pin table was stale** — said `primeng` pinned at `21.1.6`; the `pnpm-workspace.yaml` catalog (and installed `node_modules`) actually pin `21.1.9`. Updated the table.

Also updated `apps/demo-primeng/README.md` narrative sections (What this shows / Demo coverage / gotchas / What's not shown) to document the new checkbox shim alongside the existing select shim.

**Skipped (documented, not a bug):** the ticket also asked to apply the error-color override contract (`--ngx-signal-form-error-color` / `--ngx-signal-form-warning-color` per `.dark` class) to `apps/demo-primeng`'s global styles *if it themes via a `.dark` class*. It does not — `main.ts` configures `darkModeSelector: 'system'`, meaning PrimeNG (and the toolkit's own `prefers-color-scheme`-only defaults) already stay in sync automatically via the OS media query, with no independently-toggled `.dark` class in this app. No change needed here.

No toolkit public API changes — this is demo-app-only, so no `docs/MIGRATING_BETA_TO_V1.md` entry.

## Test plan

- [x] TDD: added failing regression tests first (`profile-form.behavior.spec.ts`, `profile-form.spec.ts`), confirmed they failed against the pre-fix code, then implemented the fix and confirmed they pass
- [x] `pnpm nx test demo-primeng` — 7/7 passing
- [x] `pnpm nx lint demo-primeng` / `pnpm nx lint demo-primeng-e2e` — clean
- [x] `pnpm nx build demo-primeng` — succeeds
- [x] `pnpm nx run demo-primeng-e2e:e2e` (chromium, full suite) — 6/6 passing
- [x] `pnpm nx run demo-primeng-e2e:a11y` (chromium only — firefox is broken on this machine, CI covers it) — 0 violations

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>