### PR TITLE
fix(demo-material): fix 4 audit blockers (a11y, warning-blocks-submit, ErrorStateMatcher, README)

### DIFF
--- a/apps/demo-material/README.md
+++ b/apps/demo-material/README.md
@@ -47,6 +47,7 @@ src/app/
     slot-directives.ts                *ngxMatErrorSlot / *ngxMatHintSlot
     feedback-directive.ts             *ngxMatFeedback for non-form-field controls
     material-error-renderer.ts        renderer with { message, severity } contract
+    warning-aware-error-state-matcher.ts  ErrorStateMatcher that ignores warn:* kinds
     index.ts                          provideNgxMatForms + bundle exports
 ```
 
@@ -164,15 +165,19 @@ bootstrapApplication(AppComponent, {
     provideZonelessChangeDetection(),
     provideAnimationsAsync('noop'),
     provideNgxSignalFormsConfig({ defaultErrorStrategy: 'on-touch' }),
-    provideNgxMatForms(), // registers MaterialFeedbackRenderer for both error + hint slots
+    provideNgxMatForms(), // MaterialFeedbackRenderer/MaterialHintRenderer + NgxMatWarningAwareErrorStateMatcher
   ],
 });
 ```
 
 The renderer contract is the lean `{ message, severity }` shape
 (ADR-0002 §7) — the slot directives resolve `formField` → message text
-and the renderer is purely presentational. Override per app or per
-component:
+and the renderer is purely presentational. `provideNgxMatForms()` also
+registers `NgxMatWarningAwareErrorStateMatcher` in place of Material's
+default `ErrorStateMatcher` (see "Warnings and Material's
+`ErrorStateMatcher`" below) — every app wiring the wrapper should call
+it, not just apps that need renderer overrides. Override the renderers
+per app or per component:
 
 ```ts
 provideNgxMatForms({
@@ -215,31 +220,126 @@ Material's ARIA ownership.
 
 ### Warnings under `submission.action`
 
-Angular Signal Forms' `submission.action` rejects fields with **any**
-validation result, including non-blocking `warn:*` results. If a form
-relies on warnings (e.g. `warn:short-name` on the contact form's `name`
-field), submitting via `<form (submit)>` will be blocked by the warning
-unless the consumer routes the submit through `submitWithWarnings()`
-from `@ngx-signal-forms/toolkit`. The demo defaults to `on-touch` and
-documents the choice — adopt `submitWithWarnings()` for any form that
-needs warnings to remain non-blocking after a submit attempt.
+Angular Signal Forms' native `submit()` only runs `submission.action`
+when the field tree is not `invalid()` — and `invalid()` is `true` for
+**any** validation result on the tree, including the toolkit's
+non-blocking `warn:*` results. Left unpatched, a warning (e.g.
+`warn:short-name` on the contact form's `name` field) would silently
+prevent submission and route straight to `onInvalid`, contradicting the
+"gentle warning, not a blocker" contract warnings are supposed to have.
+
+The contact form's declarative `{ submission }` therefore sets
+`ignoreValidators: 'all'` and gates the actual submit logic on
+`hasOnlyWarnings(contactForm().errorSummary())` inside `action` itself
+(falling through to the toolkit's `onInvalid` handler when a real
+blocking error remains):
+
+```ts
+readonly contactForm = form(this.model, contactFormSchema, {
+  submission: {
+    ignoreValidators: 'all',
+    action: async () => {
+      if (!hasOnlyWarnings(this.contactForm().errorSummary())) {
+        this.#onInvalid(this.contactForm);
+        return;
+      }
+      await submitToApi(this.contactForm().value());
+    },
+  },
+});
+```
+
+This mirrors `apps/demo-primeng`'s profile form and is the pattern
+[`apps/demo`'s advanced section](../demo/src/app/05-advanced/README.md)
+documents as preferred for warning-tolerant submission when you're
+using declarative `{ submission }` rather than calling `submit()` /
+`submitWithWarnings()` by hand — see the
+[toolkit README](../../packages/toolkit/README.md)'s submission
+helpers table for `hasOnlyWarnings()` / `submitWithWarnings()`.
+
+### Warnings and Material's `ErrorStateMatcher`
+
+Material's `matInput` / `mat-select` compute `errorState` (and
+`aria-invalid`) from the injected `ErrorStateMatcher`. Signal Forms'
+`InteropNgControl` (the `NgControl` bridge Angular's `FormField`
+directive provides) reports `invalid` as `true` for **any**
+`ValidationError` on the field, warnings included — so Material's
+default matcher (`invalid && (touched || form.submitted)`) would give a
+warning-only field `aria-invalid="true"` and the full
+`mat-form-field-invalid` red-outline treatment, contradicting the
+`<mat-hint>` copy sitting right next to it that calls the same state a
+"gentle warning."
+
+`provideNgxMatForms()` (and `provideNgxMatFormsForComponent()`)
+therefore also registers `NgxMatWarningAwareErrorStateMatcher`
+(`src/app/wrapper/warning-aware-error-state-matcher.ts`) in place of
+Material's default. It reads the `warn:*` / non-`warn:*` split off
+`control.errors`' keys via the toolkit's canonical `isBlockingError()`
+predicate, and only falls through to the normal touched/submitted
+timing check when at least one **blocking** error is present — a
+warning-only field always reports `errorState: false`.
 
 ### `<mat-checkbox>` aria wiring
 
-`<mat-checkbox>` doesn't expose its inner `<input>` via a public API,
-so `aria-describedby` cannot be wired to the feedback block
-automatically. The demo leaves the wiring out because the
-`role="alert"` / `role="status"` live regions inside `*ngxMatFeedback`
-already announce changes to a screen reader. Consumers who need
-belt-and-braces wiring can set the attribute by hand using the IDs the
-directive emits (`{fieldName}-error` / `{fieldName}-warning`).
+`<mat-checkbox>` **does** expose a public `aria-describedby` input
+(`ariaDescribedby`, forwarded straight to the native `<input>`) even
+though it doesn't implement `MatFormFieldControl` — so the checkbox
+control-directives section above still applies, and `*ngxMatFeedback`
+exposes exactly what's needed to wire it by hand: a
+`describedByIds()` signal (via `exportAs: 'ngxMatFeedback'`) that
+resolves to the currently-rendered block's id, or `null` when neither
+an error nor a warning is showing (no dangling IDREFs). The contact
+form grabs the directive with a `viewChild(NgxMatFeedback)` query and
+binds it on the checkbox:
 
-### `floatLabel` is out of scope
+```html
+<div class="demo-form__row demo-form__row--agree">
+  <!-- *ngxMatFeedback is declared BEFORE <mat-checkbox> — Angular
+       evaluates a template's property bindings in source order, so the
+       checkbox's binding below cannot forward-reference an input this
+       directive hasn't been assigned yet. CSS `order` restores the
+       checkbox-first visual layout. -->
+  <ng-container
+    *ngxMatFeedback="
+      form.agree;
+      fieldName: 'contact-agree';
+      let messages;
+      severity as severity;
+      id as id
+    "
+  >
+    <p [id]="id" [attr.role]="severity === 'error' ? 'alert' : 'status'">…</p>
+  </ng-container>
+
+  <mat-checkbox
+    [formField]="form.agree"
+    ngxMatCheckboxControl
+    [aria-describedby]="agreeFeedback()?.describedByIds() ?? null"
+  >
+    I agree to be contacted
+  </mat-checkbox>
+</div>
+```
+
+```ts
+protected readonly agreeFeedback = viewChild(NgxMatFeedback);
+```
+
+The `role="alert"` / `role="status"` live region inside `*ngxMatFeedback`
+still announces changes transiently; the `aria-describedby` wiring adds
+the missing piece — a screen reader that focuses the checkbox **after**
+the error already rendered now hears the description too, not just
+whatever happened to be announced live.
+
+### `floatLabel="always"`
 
 Material's `floatLabel` (`'auto' | 'always'`) interacts with Material's
-internal `empty` / `focused` state and is not wired through the toolkit.
-The demo uses Material's default (`'auto'`); set a different mode on
-`<mat-form-field>` directly when needed.
+internal `empty` / `focused` state and is not wired through the
+toolkit. The contact form sets `floatLabel="always"` on every
+`<mat-form-field>` — purely a visual preference for this demo, not a
+toolkit requirement — so labels stay put instead of floating back down
+into the input on blur-with-empty-value. Omit the input (or set
+`floatLabel="auto"`) for Material's default float-on-focus behavior.
 
 ## Extending the error slot
 
@@ -276,7 +376,7 @@ Two automated layers verify the wrapper's ARIA wiring stays correct:
 ### Smoke spec (jsdom)
 
 `src/app/contact-form/contact-form.spec.ts` runs under
-`pnpm nx run demo-material:test`. Three assertions:
+`pnpm nx run demo-material:test`:
 
 1. After typing into the name field and tabbing away, `<mat-error>`
    renders the toolkit-driven validation message and has a non-empty
@@ -286,7 +386,22 @@ Two automated layers verify the wrapper's ARIA wiring stays correct:
    to existing DOM IDs, and at least one of those IDs belongs to a
    `<mat-error>` element.
 3. The `warn:short-name` warning renders inside `<mat-hint>` (not
-   `<mat-error>`), and no `<mat-error>` is visible on that field.
+   `<mat-error>`), no `<mat-error>` is visible on that field, **and**
+   `aria-invalid` is `"false"` / `mat-form-field-invalid` is absent —
+   pinning `NgxMatWarningAwareErrorStateMatcher`.
+4. Leaving the consent checkbox unchecked and blurring renders the
+   `agree-required` error via `*ngxMatFeedback`, and the checkbox's
+   `aria-describedby` resolves to that block's id (dropping back to
+   `null` once checked) — pinning the checkbox aria wiring.
+5. Filling out the whole form with a short-but-valid name (`'Bob'`,
+   trips `warn:short-name`) and submitting reaches the success banner —
+   pinning that a non-blocking warning never blocks `submission.action`.
+
+`src/app/wrapper/warning-aware-error-state-matcher.spec.ts` unit-tests
+`NgxMatWarningAwareErrorStateMatcher.isErrorState()` directly (null
+control, no errors, warning-only, blocking-but-untouched,
+blocking-and-touched, blocking-via-form-submitted, warning+blocking
+mixed).
 
 A wrapper-level spec
 (`src/app/wrapper/mat-form-field-wrapper.spec.ts`) additionally asserts

--- a/apps/demo-material/src/app/contact-form/contact-form.html
+++ b/apps/demo-material/src/app/contact-form/contact-form.html
@@ -87,38 +87,44 @@
     </mat-error>
   </mat-form-field>
 
-  <div class="demo-form__row">
+  <!-- `*ngxMatFeedback` is declared BEFORE `<mat-checkbox>` on purpose: the
+       checkbox's `[aria-describedby]` binding (below) reads this directive's
+       exported `describedByIds()` signal, and Angular evaluates a template's
+       property bindings in source order — a binding cannot forward-reference
+       an input that a later-declared directive hasn't been assigned yet.
+       `order: 1` / `order: 2` in styles.css restores the checkbox-then-error
+       visual arrangement despite the required DOM/source order. -->
+  <div class="demo-form__row demo-form__row--agree">
+    <ng-container
+      *ngxMatFeedback="
+        contactForm.agree;
+        fieldName: 'contact-agree';
+        let messages;
+        severity as severity;
+        id as id
+      "
+    >
+      <p
+        class="demo-form__feedback"
+        [class.demo-form__feedback--warning]="severity === 'warning'"
+        [attr.role]="severity === 'error' ? 'alert' : 'status'"
+        [id]="id"
+      >
+        @for (message of messages; track message) {
+        <ngx-mat-feedback-outlet [message]="message" [severity]="severity" />
+        }
+      </p>
+    </ng-container>
+
     <mat-checkbox
       id="contact-agree"
       [formField]="contactForm.agree"
       ngxMatCheckboxControl
+      [aria-describedby]="agreeFeedback()?.describedByIds() ?? null"
     >
       I agree to be contacted
     </mat-checkbox>
   </div>
-  <!-- Material's mat-checkbox does not project into mat-form-field, so
-       its errors render via the control-agnostic feedback slot. The
-       toolkit still owns visibility timing through the same DI seam. -->
-  <ng-container
-    *ngxMatFeedback="
-      contactForm.agree;
-      fieldName: 'contact-agree';
-      let messages;
-      severity as severity;
-      id as id
-    "
-  >
-    <p
-      class="demo-form__feedback"
-      [class.demo-form__feedback--warning]="severity === 'warning'"
-      [attr.role]="severity === 'error' ? 'alert' : 'status'"
-      [id]="id"
-    >
-      @for (message of messages; track message) {
-      <ngx-mat-feedback-outlet [message]="message" [severity]="severity" />
-      }
-    </p>
-  </ng-container>
 
   <div class="demo-form__actions">
     <button mat-stroked-button type="button" (click)="resetForm()">

--- a/apps/demo-material/src/app/contact-form/contact-form.spec.ts
+++ b/apps/demo-material/src/app/contact-form/contact-form.spec.ts
@@ -4,6 +4,7 @@ import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
 import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
+import { provideNgxMatForms } from '../wrapper';
 import { ContactFormComponent } from './contact-form';
 
 /**
@@ -30,6 +31,9 @@ describe('ContactFormComponent (Material reference, smoke)', () => {
           defaultErrorStrategy: 'on-touch',
           autoAria: true,
         }),
+        // Matches main.ts — registers MaterialFeedbackRenderer/
+        // MaterialHintRenderer AND NgxMatWarningAwareErrorStateMatcher.
+        provideNgxMatForms(),
       ],
     });
     return result;
@@ -116,7 +120,7 @@ describe('ContactFormComponent (Material reference, smoke)', () => {
     expect(hasMatError).toBe(true);
   });
 
-  it('renders warning content inside mat-hint without surfacing as an error', async () => {
+  it('renders warning content inside mat-hint without surfacing as an error or invalid state', async () => {
     const user = userEvent.setup();
     await setup();
 
@@ -137,12 +141,19 @@ describe('ContactFormComponent (Material reference, smoke)', () => {
     expect(errorHost).toBeNull();
 
     // No `<mat-error>` should be visible on the field — there are no
-    // *blocking* errors at this point, only a warning. (Note that Material's
-    // matInput will still report aria-invalid="true" because Angular Signal
-    // Forms treats warnings as ValidationErrors that flip `invalid()` — see
-    // README "Warnings rendering" for the framework limitation.)
+    // *blocking* errors at this point, only a warning.
     const nameField = nameInput.closest('mat-form-field');
     expect(nameField?.querySelector('mat-error:not([hidden])')).toBeFalsy();
+
+    // Regression for the "warning-only state reports invalid" a11y bug:
+    // `NgxMatWarningAwareErrorStateMatcher` (registered via provideNgxMatForms)
+    // only counts non-warn:* kinds as an error state, so a warning-only field
+    // must NOT get aria-invalid="true" or Material's invalid styling — see
+    // README "Warnings and Material's ErrorStateMatcher".
+    await waitFor(() => {
+      expect(nameInput.getAttribute('aria-invalid')).toBe('false');
+    });
+    expect(nameField?.classList.contains('mat-form-field-invalid')).toBe(false);
   });
 
   it('wires aria-describedby from the consent checkbox to the rendered feedback block', async () => {

--- a/apps/demo-material/src/app/contact-form/contact-form.spec.ts
+++ b/apps/demo-material/src/app/contact-form/contact-form.spec.ts
@@ -144,4 +144,82 @@ describe('ContactFormComponent (Material reference, smoke)', () => {
     const nameField = nameInput.closest('mat-form-field');
     expect(nameField?.querySelector('mat-error:not([hidden])')).toBeFalsy();
   });
+
+  it('wires aria-describedby from the consent checkbox to the rendered feedback block', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /i agree to be contacted/i,
+    });
+
+    // Focus and blur without checking — trips the agree-required validator
+    // and marks the field touched under the on-touch strategy, so the
+    // *ngxMatFeedback error block renders.
+    checkbox.focus();
+    await user.tab();
+
+    const feedback = await screen.findByText(/you need to agree/i);
+    const feedbackHost = feedback.closest('.demo-form__feedback');
+    expect(feedbackHost).not.toBeNull();
+    const feedbackId = feedbackHost?.getAttribute('id');
+    expect(feedbackId).toBeTruthy();
+
+    // Regression for the "no programmatic association" a11y blocker: the
+    // checkbox's aria-describedby must resolve to the rendered feedback
+    // block's id, not just rely on the transient role="alert" announcement.
+    await waitFor(() => {
+      expect(checkbox.getAttribute('aria-describedby')).toBe(feedbackId);
+    });
+
+    // Checking the box clears the error — aria-describedby must drop back
+    // to null rather than leaving a dangling IDREF.
+    await user.click(checkbox);
+    await waitFor(() => {
+      expect(checkbox.getAttribute('aria-describedby')).toBeNull();
+    });
+  });
+
+  it('does not block submission on a non-blocking warning (warn:short-name)', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    // 'Bob' passes minLength(2) but trips warn:short-name — a non-blocking
+    // warning per the schema and the form's own intro copy ("short-but-valid
+    // names surface as a gentle warning instead of a blocker").
+    const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+    await user.click(nameInput);
+    await user.type(nameInput, 'Bob');
+
+    const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+    await user.click(emailInput);
+    await user.type(emailInput, 'bob@example.com');
+
+    const topicSelect = screen.getByRole('combobox', { name: /topic/i });
+    await user.click(topicSelect);
+    const option = await screen.findByRole('option', {
+      name: /product support/i,
+    });
+    await user.click(option);
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /i agree to be contacted/i,
+    });
+    await user.click(checkbox);
+
+    // Regression for the submission-blocking bug: previously the declarative
+    // `submission.action` never ran because Angular's native submit() treats
+    // any ValidationError — including `warn:*` — as blocking.
+    const submit = screen.getByRole('button', { name: /send message/i });
+    await user.click(submit);
+
+    const banner = await screen.findByText(/thanks! we received your message/i);
+    expect(banner).toBeInTheDocument();
+
+    // The warning is still present — the fix must not "succeed" by silently
+    // dropping warn:short-name; it must let a warned-but-valid form through.
+    expect(
+      screen.getByText(/short names are easy to mis-type/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/demo-material/src/app/contact-form/contact-form.ts
+++ b/apps/demo-material/src/app/contact-form/contact-form.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -7,9 +7,10 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import {
   createOnInvalidHandler,
+  hasOnlyWarnings,
   NgxSignalFormToolkit,
 } from '@ngx-signal-forms/toolkit';
-import { NgxMatFormBundle } from '../wrapper';
+import { NgxMatFeedback, NgxMatFormBundle } from '../wrapper';
 import {
   INITIAL_CONTACT_MODEL,
   type ContactFormModel,
@@ -60,19 +61,42 @@ export class ContactFormComponent {
   /** Reactive model — Angular Signal Forms drives the form from this signal. */
   protected readonly model = signal<ContactFormModel>(INITIAL_CONTACT_MODEL);
 
-  /** Toolkit-aware Signal Forms instance with the validation schema applied. */
+  readonly #onInvalid = createOnInvalidHandler();
+
+  /**
+   * Toolkit-aware Signal Forms instance with the validation schema applied.
+   *
+   * `ignoreValidators: 'all'` + the `hasOnlyWarnings()` guard inside `action`
+   * is the toolkit's documented warning-tolerant pattern for forms that use
+   * declarative `{ submission }` (see `apps/demo-primeng`'s profile form and
+   * README "Warnings under submission.action"). Without it, Angular Signal
+   * Forms' native `submit()` treats `warn:short-name` as blocking — even
+   * though it's a non-blocking warning by the toolkit's own convention —
+   * and the action never runs.
+   */
   readonly contactForm = form(this.model, contactFormSchema, {
     submission: {
+      ignoreValidators: 'all',
       action: async () => {
+        if (!hasOnlyWarnings(this.contactForm().errorSummary())) {
+          this.#onInvalid(this.contactForm);
+          return;
+        }
         // Stand-in for a real API call; the demo is intentionally lean.
         await new Promise((resolve) => setTimeout(resolve, 250));
         this.submitted.set(true);
       },
-      onInvalid: createOnInvalidHandler(),
     },
   });
 
   protected readonly submitted = signal(false);
+
+  /**
+   * Drives the consent checkbox's `[aria-describedby]` in the template —
+   * `<mat-checkbox>` doesn't project into `<mat-form-field>`, so nothing
+   * else associates its rendered `*ngxMatFeedback` block with the control.
+   */
+  protected readonly agreeFeedback = viewChild(NgxMatFeedback);
 
   protected resetForm(): void {
     this.model.set({ ...INITIAL_CONTACT_MODEL });

--- a/apps/demo-material/src/app/wrapper/feedback-directive.ts
+++ b/apps/demo-material/src/app/wrapper/feedback-directive.ts
@@ -62,6 +62,7 @@ export interface NgxMatFeedbackContext {
  */
 @Directive({
   selector: '[ngxMatFeedback]',
+  exportAs: 'ngxMatFeedback',
 })
 export class NgxMatFeedback<TValue = unknown> {
   /** Field whose errors / warnings populate the feedback blocks. */
@@ -130,6 +131,23 @@ export class NgxMatFeedback<TValue = unknown> {
       ];
     }
     return [];
+  });
+
+  /**
+   * Space-joined id(s) of the block(s) currently rendered by this directive
+   * — `'{fieldName}-error'`, `'{fieldName}-warning'`, or `null` when neither
+   * is showing. Consumers grab the directive instance via a template
+   * reference (`#ref="ngxMatFeedback"`) and bind it to the bound control's
+   * `aria-describedby`-shaped input (e.g. `[aria-describedby]="ref.describedByIds()"`
+   * on `<mat-checkbox>`, which exposes a public `ariaDescribedby` input) so
+   * screen readers get a programmatic association even though the control
+   * lives outside `<mat-form-field>`. Because `#blocks` never renders more
+   * than one entry, `null` is returned whenever nothing is visible — no
+   * dangling IDREFs.
+   */
+  readonly describedByIds = computed<string | null>(() => {
+    const ids = this.#blocks().map((block) => block.id);
+    return ids.length > 0 ? ids.join(' ') : null;
   });
 
   /** @internal — type guard for template language services. */

--- a/apps/demo-material/src/app/wrapper/index.ts
+++ b/apps/demo-material/src/app/wrapper/index.ts
@@ -3,6 +3,7 @@ import {
   type Provider,
   type Type,
 } from '@angular/core';
+import { ErrorStateMatcher } from '@angular/material/core';
 import {
   provideFormFieldErrorRendererForComponent,
   provideFormFieldHintRendererForComponent,
@@ -11,6 +12,7 @@ import {
 } from '@ngx-signal-forms/toolkit';
 import { MaterialFeedbackRenderer } from './material-error-renderer';
 import { MaterialHintRenderer } from './material-hint-renderer';
+import { NgxMatWarningAwareErrorStateMatcher } from './warning-aware-error-state-matcher';
 
 export {
   NgxMatBoundControl,
@@ -39,6 +41,7 @@ export {
   type NgxMatErrorSlotContext,
   type NgxMatHintSlotContext,
 } from './slot-directives';
+export { NgxMatWarningAwareErrorStateMatcher } from './warning-aware-error-state-matcher';
 
 /**
  * Optional override shape for `provideNgxMatForms*`. When omitted, the
@@ -89,7 +92,7 @@ export interface NgxMatFormsProviderOptions {
  */
 export function provideNgxMatForms(
   options?: NgxMatFormsProviderOptions,
-): EnvironmentProviders[] {
+): (EnvironmentProviders | Provider)[] {
   const errorComponent =
     options?.feedbackRenderer?.component ?? MaterialFeedbackRenderer;
   const hintComponent =
@@ -97,6 +100,12 @@ export function provideNgxMatForms(
   return [
     provideFormFieldErrorRenderer({ component: errorComponent }),
     provideFormFieldHintRenderer({ component: hintComponent }),
+    // Warning-only fields must not read as Material "invalid" — see the
+    // class doc on NgxMatWarningAwareErrorStateMatcher.
+    {
+      provide: ErrorStateMatcher,
+      useClass: NgxMatWarningAwareErrorStateMatcher,
+    },
   ];
 }
 
@@ -131,5 +140,11 @@ export function provideNgxMatFormsForComponent(
   return [
     ...provideFormFieldErrorRendererForComponent({ component: errorComponent }),
     ...provideFormFieldHintRendererForComponent({ component: hintComponent }),
+    // Warning-only fields must not read as Material "invalid" — see the
+    // class doc on NgxMatWarningAwareErrorStateMatcher.
+    {
+      provide: ErrorStateMatcher,
+      useClass: NgxMatWarningAwareErrorStateMatcher,
+    },
   ];
 }

--- a/apps/demo-material/src/app/wrapper/warning-aware-error-state-matcher.spec.ts
+++ b/apps/demo-material/src/app/wrapper/warning-aware-error-state-matcher.spec.ts
@@ -1,0 +1,77 @@
+import type {
+  AbstractControl,
+  FormGroupDirective,
+  NgForm,
+} from '@angular/forms';
+import { describe, expect, it } from 'vitest';
+import { NgxMatWarningAwareErrorStateMatcher } from './warning-aware-error-state-matcher';
+
+/**
+ * Minimal shape the matcher actually reads off `control` / `form` — mirrors
+ * what `InteropNgControl` (Angular Signal Forms' `NgControl` bridge) and
+ * Material's `_ErrorStateTracker` pass at runtime, without depending on the
+ * full `AbstractControl` class.
+ */
+function fakeControl(
+  overrides: Partial<Pick<AbstractControl, 'errors' | 'touched'>>,
+): AbstractControl {
+  return {
+    errors: null,
+    touched: false,
+    ...overrides,
+  } as AbstractControl;
+}
+
+describe('NgxMatWarningAwareErrorStateMatcher', () => {
+  const matcher = new NgxMatWarningAwareErrorStateMatcher();
+
+  it('returns false for a null control', () => {
+    expect(matcher.isErrorState(null, null)).toBe(false);
+  });
+
+  it('returns false when there are no errors at all', () => {
+    const control = fakeControl({ errors: null, touched: true });
+    expect(matcher.isErrorState(control, null)).toBe(false);
+  });
+
+  it('returns false for a warning-only control, even when touched', () => {
+    const control = fakeControl({
+      errors: { 'warn:short-name': true },
+      touched: true,
+    });
+    expect(matcher.isErrorState(control, null)).toBe(false);
+  });
+
+  it('returns false for a blocking-error control that is not yet touched/submitted', () => {
+    const control = fakeControl({
+      errors: { required: true },
+      touched: false,
+    });
+    expect(matcher.isErrorState(control, null)).toBe(false);
+  });
+
+  it('returns true for a blocking-error control that is touched', () => {
+    const control = fakeControl({
+      errors: { required: true },
+      touched: true,
+    });
+    expect(matcher.isErrorState(control, null)).toBe(true);
+  });
+
+  it('returns true for a blocking-error control when the parent form was submitted', () => {
+    const control = fakeControl({
+      errors: { required: true },
+      touched: false,
+    });
+    const form = { submitted: true } as FormGroupDirective | NgForm;
+    expect(matcher.isErrorState(control, form)).toBe(true);
+  });
+
+  it('ignores warnings alongside a blocking error and still reports true once touched', () => {
+    const control = fakeControl({
+      errors: { required: true, 'warn:short-name': true },
+      touched: true,
+    });
+    expect(matcher.isErrorState(control, null)).toBe(true);
+  });
+});

--- a/apps/demo-material/src/app/wrapper/warning-aware-error-state-matcher.ts
+++ b/apps/demo-material/src/app/wrapper/warning-aware-error-state-matcher.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import type {
+  AbstractControl,
+  FormGroupDirective,
+  NgForm,
+} from '@angular/forms';
+import type { ValidationError } from '@angular/forms/signals';
+import { ErrorStateMatcher } from '@angular/material/core';
+import { isBlockingError } from '@ngx-signal-forms/toolkit';
+
+/**
+ * Warning-aware replacement for Material's default `ErrorStateMatcher`.
+ *
+ * The default matcher (`invalid && (touched || form.submitted)`) treats
+ * *any* validation result as an error, including the toolkit's non-blocking
+ * `warn:*` results — Angular Signal Forms' `InteropNgControl` flips
+ * `invalid` to `true` for warnings too (they're ordinary `ValidationError`s
+ * under the hood). Left unpatched, a warning-only field gets
+ * `aria-invalid="true"` and full `mat-form-field-invalid` styling on
+ * `matInput` / `mat-select`, contradicting the toolkit's own
+ * `shouldShowErrors()` / `shouldShowWarnings()` distinction and the "gentle
+ * warning, not a blocker" UX the reference form advertises.
+ *
+ * `control.errors` (as surfaced by `InteropNgControl`) is a
+ * `{ [kind]: value }` map — the same shape reactive forms uses — so this
+ * matcher inspects the *keys* for any kind that {@link isBlockingError}
+ * (the toolkit's canonical `warn:*` predicate) says is NOT a warning, and
+ * only then falls through to the default touched/submitted timing check.
+ *
+ * Registered app-wide by `provideNgxMatForms()` / at component scope by
+ * `provideNgxMatFormsForComponent()` — see `index.ts`.
+ */
+@Injectable()
+export class NgxMatWarningAwareErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(
+    control: AbstractControl | null,
+    form: FormGroupDirective | NgForm | null,
+  ): boolean {
+    if (!control) {
+      return false;
+    }
+
+    const errors = control.errors as Record<string, unknown> | null;
+    const hasBlockingError =
+      !!errors &&
+      Object.keys(errors).some((kind) =>
+        isBlockingError({ kind } as ValidationError),
+      );
+    if (!hasBlockingError) {
+      return false;
+    }
+
+    return !!(control.touched || form?.submitted);
+  }
+}

--- a/apps/demo-material/src/styles.css
+++ b/apps/demo-material/src/styles.css
@@ -253,6 +253,22 @@ body {
   color: var(--app-ink);
 }
 
+/* The consent checkbox's `*ngxMatFeedback` block is declared before
+ * `<mat-checkbox>` in the markup (see contact-form.html for why) — `order`
+ * restores the checkbox-first, feedback-second visual arrangement. */
+.demo-form__row--agree {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.demo-form__row--agree > mat-checkbox {
+  order: 1;
+}
+
+.demo-form__row--agree > .demo-form__feedback {
+  order: 2;
+}
+
 .demo-form__hint {
   color: var(--app-muted);
   font-size: 0.8rem;
@@ -260,7 +276,7 @@ body {
 }
 
 .demo-form__feedback {
-  margin: -0.45rem 0 0 3rem;
+  margin: 0.35rem 0 0 3rem;
   color: var(--app-muted);
   font-size: 0.93rem;
   line-height: 1.45;


### PR DESCRIPTION
Closes #167

Fixes all 4 verified blocker findings from audit #146 for `apps/demo-material`:

1. **Consent checkbox had no programmatic aria-describedby association** — `<mat-checkbox>` does expose a public `aria-describedby` input (`ariaDescribedby`, forwarded to the native input) despite the README's prior claim otherwise. `NgxMatFeedback` now exposes a `describedByIds()` signal (`exportAs: 'ngxMatFeedback'`), and the contact form wires it onto the checkbox via a `viewChild(NgxMatFeedback)` query. The `*ngxMatFeedback` block moves before `<mat-checkbox>` in template source order (CSS `order` restores the original visual layout) because Angular evaluates a template's property bindings in source order — a binding cannot forward-reference an input a later directive hasn't been assigned yet.

2. **`warn:short-name` blocked form submission**, contradicting the demo's own "warning instead of a blocker" copy. Angular Signal Forms' native `submit()` only runs `submission.action` when the tree is not `invalid()`, and warnings flip `invalid()` too. Switched to the toolkit's documented `ignoreValidators: 'all'` + `hasOnlyWarnings()` pattern (mirrors `apps/demo-primeng`'s profile form) so `action` always runs and only treats real blocking errors as invalid.

3. **Warning-only state got `aria-invalid="true"` and full Material invalid styling.** Material's default `ErrorStateMatcher` treats any `InteropNgControl.invalid` as an error, and Signal Forms flips `invalid()` for `warn:*` results too. Added `NgxMatWarningAwareErrorStateMatcher`, which only counts non-`warn:*` kinds (via the toolkit's `isBlockingError()`) as a real error state, registered via `provideNgxMatForms()` / `provideNgxMatFormsForComponent()`.

4. **README inaccuracies**: the `<mat-checkbox>` aria-wiring section was factually wrong (see #1), the `floatLabel` section claimed the demo uses Material's default when every field sets `floatLabel="always"`, the "Warnings under submission.action" section described advice the demo never followed, and the smoke spec referenced a non-existent "Warnings rendering" README section. All rewritten to match the actual code; added a new "Warnings and Material's ErrorStateMatcher" section.

**Skipped (not applicable):** the ticket also asked to apply the error-color CSS variable override contract (`--ngx-signal-form-error-color` / `--ngx-signal-form-warning-color`) to demo-material's global styles "if it themes via a `.dark` class" — `apps/demo-material` has no dark-mode toggle or `.dark` class anywhere in its styles/components, so it already gets the toolkit's correct `prefers-color-scheme`-driven colors with no override needed.

No toolkit (`packages/toolkit`) files were touched — all fixes are contained to `apps/demo-material`, so no `docs/MIGRATING_BETA_TO_V1.md` entry is needed.

## Test plan

- [x] TDD: regression tests added first for each behavioral fix (`contact-form.spec.ts` — checkbox aria-describedby wiring, non-blocking warning submission, warning-only aria-invalid/invalid-class; new `warning-aware-error-state-matcher.spec.ts` unit spec)
- [x] `pnpm nx run-many -t build test lint --projects=demo-material` — all green (16/16 tests)
- [x] `pnpm nx run demo-material-e2e:e2e` (chromium) — 2/2 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)