### PR TITLE
fix(demo): resolve all 7 v1.0.0 audit blockers (#166)

### DIFF
--- a/apps/demo-e2e/a11y-baseline.json
+++ b/apps/demo-e2e/a11y-baseline.json
@@ -1,15 +1,5 @@
 {
   "$comment": "Known WCAG 2.2 AA axe violations for this app, keyed by route::ruleId::target. Maintained by tools/scripts/a11y-report-violations.mjs: new violations open issues and are appended; resolved ones are dropped. Empty means zero known violations.",
   "app": "demo-e2e",
-  "violations": [
-    {
-      "route": "/headless/error-message-signal",
-      "ruleId": "color-contrast",
-      "target": ".gap-3 > .text-gray-400.dark\\:text-gray-500.text-xs",
-      "impact": "serious",
-      "help": "Elements must meet minimum color contrast ratio thresholds",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=playwright",
-      "browsers": ["chromium"]
-    }
-  ]
+  "violations": []
 }

--- a/apps/demo-e2e/src/fixtures/form-validation.fixture.ts
+++ b/apps/demo-e2e/src/fixtures/form-validation.fixture.ts
@@ -7,6 +7,25 @@ import { ROLE_ALERT_SELECTOR } from './aria-selectors';
  */
 
 /**
+ * Starts collecting `console.error` messages on `page`. Must be called
+ * BEFORE navigating — attaching the listener after `page.goto()` misses
+ * everything logged during the initial render, which is exactly when a
+ * one-shot dev-mode diagnostic (like the toolkit's field-name-resolution
+ * warning) would fire.
+ *
+ * @returns the live array of collected messages (grows as the page runs)
+ */
+export function collectConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text());
+    }
+  });
+  return errors;
+}
+
+/**
  * Verifies that NO error messages are visible on initial page load.
  * This is critical for 'on-touch' error display strategy.
  *

--- a/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
+++ b/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from '@playwright/test';
 
 import { ROLE_ALERT_SELECTOR } from '../../fixtures/aria-selectors';
-import { verifyNoErrorsOnInitialLoad } from '../../fixtures/form-validation.fixture';
+import {
+  collectConsoleErrors,
+  verifyNoErrorsOnInitialLoad,
+} from '../../fixtures/form-validation.fixture';
 import { stabilizeLayoutSnapshotViewport } from '../../fixtures/layout-screenshot.fixture';
 import { CustomControlsPage } from '../../page-objects/custom-controls.page';
 
@@ -29,6 +32,35 @@ test.describe('Custom Signal Forms Controls', () => {
   }) => {
     await verifyNoErrorsOnInitialLoad(playwrightPage);
     await expect(page.form).toBeVisible();
+  });
+
+  // Regression test for #166 finding #1: this page follows the documented,
+  // recommended id-derivation path for every wrapper (explicit fieldName is
+  // never set) and projects ngx-form-field-hint under several of them —
+  // exactly the trigger condition audit #145 identified for a false-positive
+  // "Could not resolve a deterministic field name for ngx-form-field-wrapper"
+  // dev console.error firing on first render, one render before the id
+  // resolves. The toolkit's form-field-wrapper.ts (afterEveryRender write
+  // phase, see #warnedUnresolvedFieldName there) already gates this
+  // diagnostic on the post-render snapshot rather than the pre-render
+  // computed, so this should never fire — this test pins that down.
+  test('should not log the "could not resolve a deterministic field name" dev warning', async ({
+    page: playwrightPage,
+  }) => {
+    const consoleErrors = collectConsoleErrors(playwrightPage);
+    const freshPage = new CustomControlsPage(playwrightPage);
+    await freshPage.goto();
+    await expect(freshPage.form).toBeVisible();
+
+    // Interact with a couple of hint-bearing custom controls to exercise
+    // more than just the very first render pass.
+    await freshPage.ratingControl.focus();
+    await freshPage.ratingControl.blur();
+
+    const fieldNameWarnings = consoleErrors.filter((message) =>
+      message.includes('Could not resolve a deterministic field name'),
+    );
+    expect(fieldNameWarnings).toEqual([]);
   });
 
   test.describe('Rating Control Rendering', () => {

--- a/apps/demo-e2e/src/forms/05-advanced/advanced-wizard.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/advanced-wizard.spec.ts
@@ -469,4 +469,81 @@ test.describe('Advanced Wizard Demo', () => {
     ).toBeVisible();
     await expect(page.locator('.error-message')).toHaveCount(0);
   });
+
+  test('progress-header step click cannot skip validation on an invalid current step (#166 finding #3)', async ({
+    page,
+  }) => {
+    await test.step('Complete Traveler and Trip steps so both are committed and valid', async () => {
+      await fillTravelerStep(page);
+      await page.getByRole('button', { name: 'Next' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Trip Details', exact: true }),
+      ).toBeVisible();
+
+      await fillTripStepMinimal(page);
+      // Advancing to Review commits the Trip step's local form data into the
+      // store (WizardContainerComponent#commitCurrentStep), which is what
+      // actually marks `trip` as valid/navigable from the header — merely
+      // being the active step makes the header button non-disabled too, so
+      // this commit is required for a faithful repro of forward navigation
+      // *away* from an invalid current step.
+      await page.getByRole('button', { name: 'Next' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Review Your Booking' }),
+      ).toBeVisible();
+    });
+
+    await test.step('Navigate back to Traveler via the progress header', async () => {
+      await page
+        .locator('.wizard-step-button')
+        .filter({ hasText: 'Traveler Info' })
+        .click();
+      await expect(
+        page.getByRole('heading', { name: 'Traveler Information' }),
+      ).toBeVisible();
+    });
+
+    await test.step('Invalidate the current (Traveler) step', async () => {
+      await page.getByLabel('First Name').fill('');
+      await page.getByLabel('First Name').blur();
+    });
+
+    await test.step('Click "Trip Details" in the progress header', async () => {
+      await page
+        .locator('.wizard-step-button')
+        .filter({ hasText: 'Trip Details' })
+        .click();
+
+      // The buggy implementation set `currentStep` synchronously (before the
+      // container's `await`-based validation resolved), so the DOM briefly
+      // *still* shows Traveler right after the click and only flips to Trip
+      // Details once the async validation's (too-late) `preventDefault()`
+      // has already been ignored. Give that microtask/render race a moment
+      // to fully settle before asserting the final state below — asserting
+      // immediately after the click can catch the transient pre-flip frame
+      // and produce a false pass.
+      await page.waitForTimeout(300);
+    });
+
+    await test.step('Wizard stays on the invalid Traveler step instead of navigating away', async () => {
+      await expect(
+        page.getByRole('heading', { name: 'Traveler Information' }),
+      ).toBeVisible();
+      await expect(
+        page
+          .locator('.wizard-step-button')
+          .filter({ hasText: 'Traveler Info' }),
+      ).toHaveAttribute('aria-current', 'step');
+      await expect(
+        page.locator('.wizard-step-button').filter({ hasText: 'Trip Details' }),
+      ).not.toHaveAttribute('aria-current', 'step');
+    });
+
+    await test.step('Validation error is visible on the empty required field', async () => {
+      await expect(page.getByLabel('First Name')).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      );
+    });
+  });
 });

--- a/apps/demo-e2e/src/forms/05-advanced/submission-patterns.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/submission-patterns.spec.ts
@@ -23,6 +23,46 @@ test.describe('Advanced - Submission Patterns', () => {
     });
   });
 
+  test.describe('Submission State Indicator', () => {
+    // Regression test for #166 finding #2: the indicator's badge used to be
+    // permanently stuck on the red "Unhandled submittedStatus: undefined"
+    // fallback because the page injected NGX_SIGNAL_FORM_CONTEXT at the
+    // wrong DI level (host component instead of a child rendered inside the
+    // ngxSignalForm-provided <form>). This asserts the badge actually
+    // reflects the live submission lifecycle instead.
+    test('should cycle through Ready to Submit -> Submitting -> back to Ready without ever showing the unhandled fallback', async () => {
+      await test.step('Initial state reads Ready to Submit', async () => {
+        await expect(page.stateBadge).toContainText('Ready to Submit');
+        await expect(page.stateBadge).not.toContainText(
+          'Unhandled submittedStatus',
+        );
+      });
+
+      await test.step('Fill valid data and submit', async () => {
+        await page.fillField('username', 'valid_user');
+        await page.fillField('password', 'password123');
+        await page.fillField('confirmPassword', 'password123');
+        await page.submitButton.click();
+      });
+
+      await test.step('Badge flips to Submitting while the action is pending', async () => {
+        await expect(page.stateBadge).toContainText('Submitting...');
+        await expect(page.stateBadge).not.toContainText(
+          'Unhandled submittedStatus',
+        );
+      });
+
+      await test.step('Badge settles back to a valid state once the action resolves', async () => {
+        await expect(page.stateBadge).not.toContainText('Submitting...', {
+          timeout: 5000,
+        });
+        await expect(page.stateBadge).not.toContainText(
+          'Unhandled submittedStatus',
+        );
+      });
+    });
+  });
+
   test.describe('Submission Failures', () => {
     test('should show validation errors on submit of empty form', async () => {
       // Trigger validation by trying to submit the empty form

--- a/apps/demo-e2e/src/page-objects/submission-patterns.page.ts
+++ b/apps/demo-e2e/src/page-objects/submission-patterns.page.ts
@@ -11,11 +11,13 @@ import { ErrorStrategyFormPage } from './base-form.page';
 export class SubmissionPatternsPage extends ErrorStrategyFormPage {
   readonly submitButton: Locator;
   readonly stateIndicator: Locator;
+  readonly stateBadge: Locator;
 
   constructor(page: Page) {
     super(page);
     this.submitButton = this.getSubmitButton(/Create Account/i);
     this.stateIndicator = this.page.locator('text=Submission State').first();
+    this.stateBadge = this.page.getByTestId('submission-state-badge');
   }
 
   async goto(): Promise<void> {

--- a/apps/demo-e2e/src/ui/responsive.spec.ts
+++ b/apps/demo-e2e/src/ui/responsive.spec.ts
@@ -52,3 +52,95 @@ test.describe('Demo Application UI - Page Loading', () => {
     });
   });
 });
+
+/**
+ * Regression coverage for #166 findings #5 and #7 — until now this suite
+ * never changed viewport size, so neither the shell's hard-coded
+ * `min-width: 900px` (which forced horizontal scrolling at narrow widths,
+ * WCAG 2.2 AA 1.4.10 Reflow) nor the slide-over's missing focus management
+ * were ever exercised.
+ */
+test.describe('Demo Application UI - Narrow viewport (< 900px)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(DEMO_PATHS.yourFirstForm);
+  });
+
+  test('shell reflows without introducing horizontal scroll at 390px', async ({
+    page,
+  }) => {
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+  });
+
+  test('left nav becomes a drawer, toggled by a hamburger button', async ({
+    page,
+  }) => {
+    await expect(page.locator('.shell__nav')).toBeHidden();
+
+    const toggle = page.getByRole('button', { name: 'Open navigation' });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await test.step('Opening the drawer moves focus into it', async () => {
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      const closeButton = page.getByRole('button', {
+        name: 'Close navigation',
+      });
+      await expect(closeButton).toBeFocused();
+      await expect(page.locator('.shell__nav')).toBeVisible();
+    });
+
+    await test.step('Escape closes the drawer and returns focus to the toggle', async () => {
+      await page.keyboard.press('Escape');
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(toggle).toBeFocused();
+    });
+  });
+
+  test('display-controls slide-over manages focus and closes on Escape', async ({
+    page,
+  }) => {
+    const pin = page.getByRole('button', { name: 'Open display controls' });
+    await expect(pin).toBeVisible();
+
+    const dialog = page.locator('dialog.panel--slideover');
+
+    await test.step('Opening the slide-over moves focus into it', async () => {
+      await pin.click();
+      await expect(dialog).toHaveAttribute('open', '');
+
+      const closeButton = page.getByRole('button', {
+        name: 'Close configuration panel',
+      });
+      await expect(closeButton).toBeFocused();
+    });
+
+    await test.step('Escape closes the slide-over and returns focus to the pin', async () => {
+      await page.keyboard.press('Escape');
+      await expect(dialog).not.toHaveAttribute('open', '');
+      await expect(pin).toBeFocused();
+    });
+  });
+
+  test('clicking the slide-over backdrop closes it', async ({ page }) => {
+    const pin = page.getByRole('button', { name: 'Open display controls' });
+    await pin.click();
+
+    const dialog = page.locator('dialog.panel--slideover');
+    await expect(dialog).toHaveAttribute('open', '');
+
+    // The slide-over is anchored to the right edge (`width: min(26rem,
+    // 94vw)`), so the viewport's top-left corner is genuine backdrop at
+    // this 390px width. Native <dialog> attributes backdrop clicks to the
+    // dialog element itself — this exercises the bounding-rect check in
+    // RightRailComponent.onDialogBackdropClick, not a click "on" the panel.
+    await page.mouse.click(2, 2);
+    await expect(dialog).not.toHaveAttribute('open', '');
+  });
+});

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.form.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.form.ts
@@ -143,7 +143,7 @@ export class ErrorDisplayHelpersComponent {
       ngxSignalForm
       [errorStrategy]="errorDisplayMode()"
       class="form-container"
-      aria-labelledby="productFeedbackHeading"
+      aria-label="Product feedback"
     >
       <ngx-error-display-helpers
         [nameField]="productForm.name"

--- a/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.form.html
+++ b/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.form.html
@@ -28,7 +28,7 @@
       >
         Swap registry
       </button>
-      <span class="text-xs text-gray-400 dark:text-gray-500">
+      <span class="text-xs text-gray-600 dark:text-gray-400">
         Messages re-resolve reactively
       </span>
     </div>
@@ -72,7 +72,7 @@
       </ul>
 
       @if (blockingErrors().length === 0) {
-      <p class="text-xs text-gray-400 dark:text-gray-500">
+      <p class="text-xs text-gray-600 dark:text-gray-400">
         No blocking errors to display
       </p>
       }
@@ -104,7 +104,7 @@
       </ul>
 
       @if (allErrors().length === 0) {
-      <p class="text-xs text-gray-400 dark:text-gray-500">
+      <p class="text-xs text-gray-600 dark:text-gray-400">
         No errors or warnings to display
       </p>
       }
@@ -137,7 +137,7 @@
         </ul>
 
         @if (warningsOnly().length === 0) {
-        <p class="text-xs text-gray-400 dark:text-gray-500">
+        <p class="text-xs text-gray-600 dark:text-gray-400">
           No warnings to display
         </p>
         }

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.html
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.html
@@ -14,7 +14,7 @@
     [(currentStep)]="currentStep"
     [completedSteps]="completedSteps()"
     [showNavigation]="false"
-    (stepChange)="onStepChange($event)"
+    [canNavigate]="guardStepNavigation"
   >
     <!-- Traveler Step -->
     <ng-template ngxWizardStep="traveler" label="Traveler Info">

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.ts
@@ -17,8 +17,8 @@ import {
 import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 
 import {
+  WizardCanNavigate,
   WizardComponent,
-  WizardNavigationEvent,
   WizardStepDirective,
 } from '../../../shared/wizard';
 import type { WizardStep } from '../stores/wizard.store';
@@ -133,13 +133,23 @@ export class WizardContainerComponent {
   });
 
   /**
-   * Handle step navigation events from the wizard progress indicator.
-   * Validates before allowing forward navigation.
+   * Async-aware guard for step navigation events from the wizard progress
+   * header. Bound via `[canNavigate]` rather than `(stepChange)` — the
+   * wizard `await`s this before ever writing its `currentStep`, so the
+   * `await this.#validateCurrentStep()` below is guaranteed to run (and be
+   * honored) BEFORE the UI moves, unlike the old `(stepChange)` +
+   * synchronous `event.preventDefault()` combination, which raced: the
+   * wizard checked `defaultPrevented` synchronously, right after emitting,
+   * while this handler was still suspended on its first `await` — so the
+   * step change always went through regardless of validation, and the
+   * store's `currentStep` (only updated below, once truly allowed) could
+   * desync from the wizard's own UI-level `currentStep`. Declared as an
+   * arrow-function field (not a method) so it stays bound to `this` when
+   * the wizard invokes it as a plain function reference.
    */
-  protected async onStepChange(event: WizardNavigationEvent): Promise<void> {
+  protected readonly guardStepNavigation: WizardCanNavigate = async (event) => {
     if (this.store.hasConfirmedBooking()) {
-      event.preventDefault();
-      return;
+      return false;
     }
 
     const isForwardNavigation = event.toIndex > event.fromIndex;
@@ -147,14 +157,14 @@ export class WizardContainerComponent {
     if (isForwardNavigation) {
       const isValid = await this.#validateCurrentStep();
       if (!isValid) {
-        event.preventDefault();
-        return;
+        return false;
       }
       this.#commitCurrentStep();
     }
 
     this.store.goToStep(event.toStep as WizardStep, isForwardNavigation);
-  }
+    return true;
+  };
 
   protected previousStep(): void {
     if (this.store.hasConfirmedBooking()) {

--- a/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.form.ts
+++ b/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.form.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, signal } from '@angular/core';
+import { Component, computed, input, signal } from '@angular/core';
 import { form, FormField } from '@angular/forms/signals';
 import {
   type ErrorDisplayStrategy,
@@ -8,13 +8,99 @@ import {
 } from '@ngx-signal-forms/toolkit';
 import {
   createOnInvalidHandler,
-  NGX_SIGNAL_FORM_CONTEXT,
+  injectFormContext,
   NgxSignalFormToolkit,
 } from '@ngx-signal-forms/toolkit';
 import { NgxFormFieldErrorSummary } from '@ngx-signal-forms/toolkit/assistive';
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 import type { SubmissionModel } from './submission-patterns.model';
 import { submissionSchema } from './submission-patterns.validations';
+
+/**
+ * Submission state indicator.
+ *
+ * Rendered as a *child* of `<form ngxSignalForm>` (see the template below) so
+ * that `injectFormContext()` actually resolves the `NgxSignalFormContext`
+ * provided by the `ngxSignalForm` directive. Directive providers are only
+ * visible within that element's own subtree — a class-level `inject()` on
+ * the component that HOSTS the `<form>` in its own template never sees them,
+ * because that host component is instantiated by ITS OWN parent, outside the
+ * `<form>` element's injector chain. This mirrors the pattern demonstrated on
+ * the error-display-modes page (`ErrorDisplayHelpersComponent`).
+ *
+ * `submittedStatus` is exposed publicly so the host page can also showcase
+ * passing an explicit value into `ngx-form-field-error-summary`'s
+ * `[submittedStatus]` input — this component is the only place in the page
+ * actually rendered inside the `<form ngxSignalForm>` subtree, so it's the
+ * only place `injectFormContext()` resolves a non-null context.
+ */
+@Component({
+  selector: 'ngx-submission-state-indicator',
+  template: `
+    <div
+      class="mb-6 flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900"
+    >
+      <span class="text-2xl">📊</span>
+      <div class="flex-1">
+        <div class="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">
+          Submission State
+        </div>
+        <div
+          class="flex items-center gap-2"
+          data-testid="submission-state-badge"
+        >
+          @switch (submittedStatus()) {
+            @case ('unsubmitted') {
+              <span
+                class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+              >
+                <span class="h-2 w-2 rounded-full bg-gray-400"></span>
+                Ready to Submit
+              </span>
+            }
+            @case ('submitting') {
+              <span
+                class="inline-flex items-center gap-1.5 rounded-full bg-purple-100 px-3 py-1 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+              >
+                <span
+                  class="h-2 w-2 animate-pulse rounded-full bg-purple-600"
+                ></span>
+                Submitting...
+              </span>
+            }
+            @case ('submitted') {
+              <span
+                class="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200"
+              >
+                <span class="h-2 w-2 rounded-full bg-green-600"></span>
+                Submitted
+              </span>
+            }
+            @default {
+              <span class="text-xs text-red-700 dark:text-red-300">
+                {{ unreachableSubmittedStatus(submittedStatus()) }}
+              </span>
+            }
+          }
+          <span class="text-xs text-gray-500 dark:text-gray-400">
+            (Automatically tracked by toolkit)
+          </span>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class SubmissionStateIndicatorComponent {
+  readonly #formContext = injectFormContext();
+
+  readonly submittedStatus = computed<SubmittedStatus>(
+    () => this.#formContext?.submittedStatus() ?? 'unsubmitted',
+  );
+
+  protected unreachableSubmittedStatus(status: SubmittedStatus): string {
+    return `Unhandled submittedStatus: ${status}`;
+  }
+}
 
 /**
  * Submission Patterns Component
@@ -34,6 +120,7 @@ import { submissionSchema } from './submission-patterns.validations';
     NgxSignalFormToolkit,
     NgxFormField,
     NgxFormFieldErrorSummary,
+    SubmissionStateIndicatorComponent,
   ],
   template: `
     <form
@@ -42,59 +129,9 @@ import { submissionSchema } from './submission-patterns.validations';
       [errorStrategy]="errorDisplayMode()"
       class="form-container"
     >
-      <!-- Submission state indicator -->
-      <div
-        class="mb-6 flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900"
-      >
-        <span class="text-2xl">📊</span>
-        <div class="flex-1">
-          <div
-            class="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Submission State
-          </div>
-          <div class="flex items-center gap-2">
-            @switch (formContext?.submittedStatus()) {
-              @case ('unsubmitted') {
-                <span
-                  class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-                >
-                  <span class="h-2 w-2 rounded-full bg-gray-400"></span>
-                  Ready to Submit
-                </span>
-              }
-              @case ('submitting') {
-                <span
-                  class="inline-flex items-center gap-1.5 rounded-full bg-purple-100 px-3 py-1 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-200"
-                >
-                  <span
-                    class="h-2 w-2 animate-pulse rounded-full bg-purple-600"
-                  ></span>
-                  Submitting...
-                </span>
-              }
-              @case ('submitted') {
-                <span
-                  class="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200"
-                >
-                  <span class="h-2 w-2 rounded-full bg-green-600"></span>
-                  Submitted
-                </span>
-              }
-              @default {
-                <span class="text-xs text-red-700 dark:text-red-300">
-                  {{
-                    unreachableSubmittedStatus(formContext?.submittedStatus())
-                  }}
-                </span>
-              }
-            }
-            <span class="text-xs text-gray-500 dark:text-gray-400">
-              (Automatically tracked by toolkit)
-            </span>
-          </div>
-        </div>
-      </div>
+      <!-- Submission state indicator: rendered inside the form so
+           injectFormContext() resolves the real NgxSignalFormContext. -->
+      <ngx-submission-state-indicator #stateIndicator />
 
       <!-- Success message (if submission succeeded) -->
       @if (submissionSuccess()) {
@@ -130,7 +167,7 @@ import { submissionSchema } from './submission-patterns.validations';
       -->
       <ngx-form-field-error-summary
         [formTree]="registrationForm"
-        [submittedStatus]="explicitSubmittedStatus()"
+        [submittedStatus]="stateIndicator.submittedStatus()"
         summaryLabel="Please fix the following errors before submitting:"
         [autoFocus]="false"
       />
@@ -274,11 +311,6 @@ export class SubmissionPatternsComponent {
   readonly appearance = input<FormFieldAppearance>('outline');
   readonly orientation = input<FormFieldOrientation>('vertical');
 
-  /// Form context - provides automatic submission tracking
-  protected readonly formContext = inject(NGX_SIGNAL_FORM_CONTEXT, {
-    optional: true,
-  });
-
   readonly #model = signal<SubmissionModel>({
     username: '',
     password: '',
@@ -287,14 +319,6 @@ export class SubmissionPatternsComponent {
   });
 
   protected readonly model = this.#model.asReadonly();
-
-  /// Demonstrates passing submittedStatus explicitly via the public API.
-  /// The value is read from the same form context that the component would
-  /// inherit automatically — the round-trip is intentional to showcase that
-  /// the input works for consumers who don't use ngxSignalForm at all.
-  protected readonly explicitSubmittedStatus = computed<
-    SubmittedStatus | undefined
-  >(() => this.formContext?.submittedStatus());
 
   readonly registrationForm = form(this.#model, submissionSchema, {
     submission: {
@@ -359,11 +383,5 @@ export class SubmissionPatternsComponent {
 
     /// Note: the derived submittedStatus returns to 'unsubmitted' after
     /// submitting() is false and the form has been reset (touched cleared)
-  }
-
-  protected unreachableSubmittedStatus(
-    status: SubmittedStatus | undefined,
-  ): string {
-    return `Unhandled submittedStatus: ${String(status)}`;
   }
 }

--- a/apps/demo/src/app/app.ts
+++ b/apps/demo/src/app/app.ts
@@ -1,4 +1,13 @@
-import { Component, effect, inject } from '@angular/core';
+import {
+  afterNextRender,
+  Component,
+  effect,
+  ElementRef,
+  inject,
+  Injector,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   NavigationEnd,
   Router,
@@ -29,11 +38,15 @@ import { PageControlsService } from './ui/page-controls';
       display: block;
     }
 
-    /* ── Shell layout ── */
+    /* ── Shell layout ──
+       Below 900px the left nav becomes an off-canvas drawer (see the
+       ".shell__nav" media query below) instead of forcing the shell to
+       stay wide — there is no hard minimum width, so the shell reflows
+       down to 320px CSS px without a horizontal scrollbar (WCAG 2.2 AA
+       1.4.10 Reflow). ≥900px is visually unchanged from before. */
     .shell {
       display: flex;
       height: 100dvh;
-      min-width: 900px;
       overflow: hidden;
       background: rgb(248 250 252);
     }
@@ -60,9 +73,161 @@ import { PageControlsService } from './ui/page-controls';
       border-right-color: rgb(15 23 42);
     }
 
+    /* Below 900px: the nav leaves the flex flow and becomes a fixed
+       off-canvas drawer, closed by default. The is-nav-open class (toggled
+       by the hamburger button in .shell__mobile-bar) slides it in. */
+    @media (width < 900px) {
+      .shell__nav {
+        position: fixed;
+        inset-block: 0;
+        left: 0;
+        z-index: 70;
+        width: min(80vw, 18rem);
+        transform: translateX(-100%);
+        transition: transform 220ms cubic-bezier(0.16, 1, 0.3, 1);
+        box-shadow: 12px 0 32px -16px rgba(15, 23, 42, 0.35);
+      }
+
+      .shell__nav.is-nav-open {
+        transform: translateX(0);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .shell__nav {
+          transition: none;
+        }
+      }
+    }
+
+    /* Backdrop behind the open drawer — click closes it, same pattern as
+       the display-controls slide-over. */
+    .shell__nav-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 65;
+      background: rgb(15 23 42 / 0.4);
+      animation: navBackdropIn 160ms ease;
+    }
+
+    @keyframes navBackdropIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    /* Mobile top bar with the hamburger toggle — only exists below 900px. */
+    .shell__mobile-bar {
+      display: none;
+    }
+
+    @media (width < 900px) {
+      .shell__mobile-bar {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-shrink: 0;
+        height: 3.25rem;
+        padding-inline: 1rem;
+        background: rgb(255 255 255);
+        border-bottom: 1px solid rgb(226 232 240);
+      }
+
+      :host-context(.dark) .shell__mobile-bar {
+        background: rgb(2 6 23);
+        border-bottom-color: rgb(15 23 42);
+      }
+    }
+
+    .shell__nav-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.25rem;
+      height: 2.25rem;
+      flex-shrink: 0;
+      border: 1px solid rgb(226 232 240);
+      border-radius: 0.5rem;
+      background: none;
+      color: rgb(51 65 85);
+      cursor: pointer;
+    }
+
+    :host-context(.dark) .shell__nav-toggle {
+      border-color: rgb(30 41 59);
+      color: rgb(226 232 240);
+    }
+
+    .shell__nav-toggle:focus-visible {
+      outline: 2px solid rgb(99 102 241);
+      outline-offset: 2px;
+    }
+
+    .shell__nav-toggle svg {
+      width: 1.15rem;
+      height: 1.15rem;
+    }
+
+    .shell__mobile-bar-brand {
+      font-size: 1.1rem;
+      font-weight: 800;
+      letter-spacing: -0.045em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .shell__nav-header {
       padding: 1.4rem 1rem 0.45rem 1.25rem;
       flex-shrink: 0;
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    /* Only meaningful once the nav is a drawer (<900px) — hidden at wide
+       widths where the nav is always visible and there's nothing to close. */
+    .shell__nav-close {
+      display: none;
+    }
+
+    @media (width < 900px) {
+      .shell__nav-close {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        flex-shrink: 0;
+        border: none;
+        border-radius: 0.5rem;
+        background: none;
+        color: rgb(100 116 139);
+        cursor: pointer;
+      }
+
+      .shell__nav-close:hover {
+        background: rgb(241 245 249);
+        color: rgb(15 23 42);
+      }
+
+      .shell__nav-close:focus-visible {
+        outline: 2px solid rgb(99 102 241);
+        outline-offset: 2px;
+      }
+
+      .shell__nav-close svg {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+
+    :host-context(.dark) .shell__nav-close:hover {
+      background: rgb(30 41 59);
+      color: rgb(226 232 240);
     }
 
     .shell__brand {
@@ -292,9 +457,28 @@ import { PageControlsService } from './ui/page-controls';
       Skip to main content
     </a>
 
+    <!-- Below 900px, clicking the backdrop or pressing Escape closes the
+         nav drawer — the .shell__nav-backdrop only renders while it's open,
+         mirroring the display-controls slide-over's backdrop pattern. -->
+    @if (navOpen()) {
+      <div
+        class="shell__nav-backdrop"
+        aria-hidden="true"
+        (click)="closeNav()"
+      ></div>
+    }
+
     <div class="shell text-gray-900 dark:text-gray-100">
       <!-- ── Left nav ── -->
-      <nav class="shell__nav" aria-label="Site navigation">
+      <nav
+        #siteNav
+        id="site-nav"
+        class="shell__nav"
+        aria-label="Site navigation"
+        [class.is-nav-open]="navOpen()"
+        (keydown.escape)="closeNav()"
+        (click)="onNavAreaClick($event)"
+      >
         <div class="shell__nav-header">
           <a
             [routerLink]="'/getting-started/your-first-form'"
@@ -303,6 +487,24 @@ import { PageControlsService } from './ui/page-controls';
           >
             ngx-signal-forms
           </a>
+          <button
+            #navCloseButton
+            type="button"
+            class="shell__nav-close"
+            aria-label="Close navigation"
+            (click)="closeNav()"
+          >
+            <svg
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              aria-hidden="true"
+            >
+              <path d="M1 1l12 12M13 1L1 13" />
+            </svg>
+          </button>
         </div>
 
         <div class="shell__nav-tree">
@@ -365,6 +567,34 @@ import { PageControlsService } from './ui/page-controls';
 
       <!-- ── Main content ── -->
       <main id="maincontent" tabindex="-1" class="shell__main">
+        <!-- Only visible below 900px — opens the nav drawer above. -->
+        <div class="shell__mobile-bar">
+          <button
+            #navToggleButton
+            type="button"
+            class="shell__nav-toggle"
+            aria-label="Open navigation"
+            aria-controls="site-nav"
+            [attr.aria-expanded]="navOpen()"
+            (click)="toggleNav()"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              aria-hidden="true"
+            >
+              <line x1="2" y1="4.5" x2="14" y2="4.5" />
+              <line x1="2" y1="8" x2="14" y2="8" />
+              <line x1="2" y1="11.5" x2="14" y2="11.5" />
+            </svg>
+          </button>
+          <span class="shell__mobile-bar-brand brand-gradient">
+            ngx-signal-forms
+          </span>
+        </div>
         <div class="shell__scroll">
           <div class="shell__container">
             <router-outlet />
@@ -386,6 +616,7 @@ import { PageControlsService } from './ui/page-controls';
     <!-- Floating pin — reopens the controls panel (wide: expands the rail,
          narrow: opens the slide-over). Hidden while the panel is visible. -->
     <button
+      #pinButton
       type="button"
       class="shell__pin"
       [class.is-rail-collapsed]="railCollapsed()"
@@ -420,9 +651,17 @@ export class AppComponent {
   readonly #router = inject(Router);
   readonly #title = inject(Title);
   readonly #pageControls = inject(PageControlsService);
+  readonly #injector = inject(Injector);
 
   protected readonly panelOpen = this.#pageControls.panelOpen;
   protected readonly railCollapsed = this.#pageControls.railCollapsed;
+
+  // TS `private` (compile-time only), not a native JS `#` field — see the
+  // matching note on RightRailComponent.slideoverDialog for why: `#` fields
+  // on `viewChild()` queries miscompile under this workspace's dev
+  // toolchain and throw a nonsensical runtime error.
+  private readonly pinButton =
+    viewChild<ElementRef<HTMLButtonElement>>('pinButton');
 
   readonly #currentPath = toSignal(
     this.#router.events.pipe(
@@ -442,6 +681,35 @@ export class AppComponent {
   });
 
   /**
+   * The mobile slide-over's native `<dialog>` already restores focus to
+   * whatever was focused before `showModal()` ran (see
+   * `RightRailComponent`'s dialog-sync effect) — normally the pin button
+   * itself, since clicking it is what opened the panel. That restore step
+   * only succeeds if the pin is actually focusable (rendered, not
+   * `display: none`) at the exact moment the dialog closes, which races
+   * against this same component's own `[class.is-slideover-open]` binding
+   * removal on the same `panelOpen` signal. Explicitly re-focusing the pin
+   * here — once, after the next render following a close — makes the
+   * outcome deterministic instead of depending on CD ordering.
+   */
+  #wasPanelOpen = false;
+  // oxlint-disable-next-line no-unused-private-class-members -- EffectRef is intentionally kept as a named field to document the side effect.
+  readonly #restoreFocusToPinEffect = effect(() => {
+    const isOpen = this.panelOpen();
+    const wasOpen = this.#wasPanelOpen;
+    this.#wasPanelOpen = isOpen;
+
+    if (wasOpen && !isOpen) {
+      afterNextRender(
+        () => {
+          this.pinButton()?.nativeElement.focus();
+        },
+        { injector: this.#injector },
+      );
+    }
+  });
+
+  /**
    * Reopen the controls panel using the affordance that fits the current
    * breakpoint: expand the persistent rail on wide screens, open the
    * slide-over below.
@@ -452,6 +720,61 @@ export class AppComponent {
       this.#pageControls.expandRail();
     } else {
       this.#pageControls.openPanel();
+    }
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // Mobile nav drawer (<900px) — see the ".shell__nav" media query above.
+  // Unlike the display-controls slide-over this isn't a native <dialog>
+  // (it shares markup with the always-visible ≥900px nav, so swapping in a
+  // <dialog> would mean two templates), so focus-in/focus-out and Escape
+  // are wired up by hand below instead of coming for free.
+  // ══════════════════════════════════════════════════════════════════════
+
+  protected readonly navOpen = signal(false);
+
+  private readonly navCloseButton =
+    viewChild<ElementRef<HTMLButtonElement>>('navCloseButton');
+  private readonly navToggleButton =
+    viewChild<ElementRef<HTMLButtonElement>>('navToggleButton');
+
+  #wasNavOpen = false;
+  // oxlint-disable-next-line no-unused-private-class-members -- EffectRef is intentionally kept as a named field to document the side effect.
+  readonly #navFocusEffect = effect(() => {
+    const isOpen = this.navOpen();
+    const wasOpen = this.#wasNavOpen;
+    this.#wasNavOpen = isOpen;
+
+    if (isOpen === wasOpen) return;
+
+    afterNextRender(
+      () => {
+        if (isOpen) {
+          this.navCloseButton()?.nativeElement.focus();
+        } else {
+          this.navToggleButton()?.nativeElement.focus();
+        }
+      },
+      { injector: this.#injector },
+    );
+  });
+
+  protected toggleNav(): void {
+    this.navOpen.update((open) => !open);
+  }
+
+  protected closeNav(): void {
+    this.navOpen.set(false);
+  }
+
+  /** Closing the drawer when a nav link is activated is standard mobile
+   * drawer UX — otherwise the drawer stays open, covering the page the
+   * user just navigated to, until they explicitly dismiss it. */
+  protected onNavAreaClick(event: MouseEvent): void {
+    if (!this.navOpen()) return;
+    const target = event.target;
+    if (target instanceof Element && target.closest('a')) {
+      this.closeNav();
     }
   }
 }

--- a/apps/demo/src/app/shared/wizard/index.ts
+++ b/apps/demo/src/app/shared/wizard/index.ts
@@ -1,4 +1,8 @@
 export { WizardStepDirective } from './wizard-step';
 export type { WizardStepContext } from './wizard-step';
 export { WizardComponent } from './wizard';
-export type { WizardNavigationEvent, WizardSubmitEvent } from './wizard';
+export type {
+  WizardCanNavigate,
+  WizardNavigationEvent,
+  WizardSubmitEvent,
+} from './wizard';

--- a/apps/demo/src/app/shared/wizard/wizard.ts
+++ b/apps/demo/src/app/shared/wizard/wizard.ts
@@ -31,6 +31,22 @@ export interface WizardNavigationEvent {
 }
 
 /**
+ * Async-aware guard invoked before the wizard commits navigation to a new
+ * step. Return `false` (or resolve to `false`) to block the navigation.
+ *
+ * Prefer this over {@link WizardNavigationEvent.preventDefault} for guards
+ * that need to `await` something (e.g. step validation) — `preventDefault`
+ * is only checked *synchronously*, immediately after `stepChange` is
+ * emitted, so a decision made after an `await` is already too late: the
+ * wizard has moved on by the time it runs. `canNavigate` is awaited by
+ * `goToStep` before `currentStep` is ever written, so it's safe to perform
+ * async validation here.
+ */
+export type WizardCanNavigate = (
+  event: WizardNavigationEvent,
+) => boolean | Promise<boolean>;
+
+/**
  * Event emitted when the wizard is submitted.
  */
 export interface WizardSubmitEvent {
@@ -111,11 +127,23 @@ export class WizardComponent {
   /** Whether users can navigate to any visited step by clicking. */
   readonly allowStepClick = input(true, { transform: booleanAttribute });
 
+  /**
+   * Optional async-aware navigation guard, checked by `goToStep` (and, in
+   * turn, `next()`/`previous()`) for every attempted transition — including
+   * progress-header step clicks. See {@link WizardCanNavigate}.
+   */
+  readonly canNavigate = input<WizardCanNavigate | null>(null);
+
   // ══════════════════════════════════════════════════════════════════════════
   // Outputs
   // ══════════════════════════════════════════════════════════════════════════
 
-  /** Emitted before navigating to a different step. Can be prevented. */
+  /**
+   * Emitted before navigating to a different step. Can be prevented via
+   * `event.preventDefault()`, but only for *synchronous* guards — the check
+   * happens immediately after this emits, before any `canNavigate` promise
+   * has settled. Async guards must use the `canNavigate` input instead.
+   */
   readonly stepChange = output<WizardNavigationEvent>();
 
   /** Emitted when the submit button is clicked on the last step. */
@@ -178,8 +206,17 @@ export class WizardComponent {
   // Public Methods
   // ══════════════════════════════════════════════════════════════════════════
 
-  /** Navigate to a specific step by ID. */
-  goToStep(stepId: string): void {
+  /**
+   * Navigate to a specific step by ID.
+   *
+   * Async by design: after the synchronous `stepChange`/`preventDefault`
+   * check, this awaits the `canNavigate` guard (if one is bound) BEFORE
+   * writing `currentStep` — so a consumer performing async validation there
+   * can reliably block the transition. Callers that only need the
+   * synchronous guard (e.g. a simple "booking already confirmed" check) can
+   * ignore the returned promise, same as before.
+   */
+  async goToStep(stepId: string): Promise<void> {
     if (!this.canNavigateToStep(stepId)) {
       return;
     }
@@ -200,27 +237,34 @@ export class WizardComponent {
     );
     this.stepChange.emit(event);
 
-    if (!event.defaultPrevented) {
-      this.#visitedSteps.update((visited) => new Set([...visited, stepId]));
-      this.currentStep.set(stepId);
+    if (event.defaultPrevented) {
+      return;
     }
+
+    const guard = this.canNavigate();
+    if (guard && !(await guard(event))) {
+      return;
+    }
+
+    this.#visitedSteps.update((visited) => new Set([...visited, stepId]));
+    this.currentStep.set(stepId);
   }
 
   /** Navigate to the next step. */
-  next(): void {
+  async next(): Promise<void> {
     const allSteps = this.steps();
     const nextIndex = this.currentStepIndex() + 1;
     if (nextIndex < allSteps.length) {
-      this.goToStep(allSteps[nextIndex].stepId());
+      await this.goToStep(allSteps[nextIndex].stepId());
     }
   }
 
   /** Navigate to the previous step. */
-  previous(): void {
+  async previous(): Promise<void> {
     const allSteps = this.steps();
     const prevIndex = this.currentStepIndex() - 1;
     if (prevIndex >= 0) {
-      this.goToStep(allSteps[prevIndex].stepId());
+      await this.goToStep(allSteps[prevIndex].stepId());
     }
   }
 

--- a/apps/demo/src/app/ui/right-rail/right-rail.html
+++ b/apps/demo/src/app/ui/right-rail/right-rail.html
@@ -5,14 +5,43 @@
     <ng-container [ngTemplateOutlet]="panelBody" />
   </div>
 </div>
-} @else if (panelOpen()) {
-<div class="panel-backdrop" (click)="closePanel()" aria-hidden="true"></div>
-<div
+} @else {
+<!--
+  Native <dialog>, shown modally via showModal()/close() (see the
+  #syncDialogEffect in the component). This buys us, for free, what a
+  hand-rolled role="dialog" overlay had to hand-wire and previously didn't:
+  - Focus moves into the dialog on open (the close button below carries
+    autofocus, so showModal()'s focusing steps land there).
+  - Focus is restored to the triggering element (the app shell's floating
+    pin button) when the dialog closes.
+  - Escape closes the dialog (fires cancel then close; onDialogClosed
+    below syncs that back into PageControlsService so panelOpen doesn't
+    drift out of sync with the DOM).
+  - The rest of the page becomes inert and unreachable by Tab while the
+    dialog is open (native modal-dialog behavior) — a real focus trap
+    instead of none at all.
+  Click-outside-to-close is still hand-wired below since native <dialog>
+  does not auto-close on ::backdrop clicks.
+-->
+<dialog
+  #slideoverDialog
   class="panel panel--slideover"
-  role="dialog"
   aria-label="Display controls"
-  aria-modal="true"
+  (close)="onDialogClosed()"
+  (click)="onDialogBackdropClick($event)"
 >
+  <!--
+    Content is gated on panelOpen() (not just the dialog's own open/closed
+    CSS state) so it exists in the component tree ONLY while the slide-over
+    is actually in use. The page's registered controls (via
+    [ngTemplateOutlet]="template()!"` in panelBody) are model()-bound to
+    page-level state shared with the persistent "rail" variant; leaving
+    this content permanently mounted — as a naive "always render the
+    dialog" conversion would — stands up a SECOND live instance of every
+    control, wired to the same signals, racing the visible one on every
+    interaction.
+  -->
+  @if (panelOpen()) {
   <ng-container
     [ngTemplateOutlet]="panelHeader"
     [ngTemplateOutletContext]="{ closable: true }"
@@ -20,7 +49,8 @@
   <div class="panel__body">
     <ng-container [ngTemplateOutlet]="panelBody" />
   </div>
-</div>
+  }
+</dialog>
 }
 
 <!-- Pinned header — "Display Controls" -->
@@ -70,6 +100,7 @@
         class="panel__close"
         type="button"
         aria-label="Close configuration panel"
+        autofocus
         (click)="closePanel()"
       >
         <svg

--- a/apps/demo/src/app/ui/right-rail/right-rail.scss
+++ b/apps/demo/src/app/ui/right-rail/right-rail.scss
@@ -60,17 +60,40 @@
   box-shadow: none;
 }
 
+/* `.panel--slideover` is now a native <dialog> shown via showModal() — reset
+   the UA defaults (centered via `margin: auto`, `padding: 1em`, a
+   viewport-relative `max-width`/`max-height`) that would otherwise fight
+   the fixed, edge-anchored layout below. */
 .panel--slideover {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0 0 0 auto;
+  margin: 0;
+  padding: 0;
+  max-width: none;
+  max-height: none;
   z-index: 50;
   width: min(26rem, 94vw);
   border-right: 0;
   border-radius: 1.25rem 0 0 1.25rem;
   box-shadow: -10px 0 44px -18px rgba(15, 23, 42, 0.32);
   animation: slideIn 220ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* The shared `.panel` rule above sets `display: flex` unconditionally,
+     which (being an author style) beats the UA stylesheet's
+     `dialog:not([open]) { display: none }` — without this override the
+     closed dialog would still render (and intercept clicks) at its fixed
+     position. Only actually apply the flex layout once shown. */
+  &:not([open]) {
+    display: none;
+  }
+
+  /* Replaces the old hand-rolled `.panel-backdrop` div — shown
+     automatically while the dialog is open modally. */
+  &::backdrop {
+    background: rgb(15 23 42 / 0.4);
+    backdrop-filter: blur(2px);
+    animation: fadeIn 180ms ease;
+  }
 }
 
 :host-context(.dark) .panel {
@@ -283,16 +306,6 @@
   line-height: 1.5;
   color: rgb(148 163 184);
   max-width: 22ch;
-}
-
-/* ── Slide-over backdrop ───────────────────────────────── */
-.panel-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 40;
-  background: rgb(15 23 42 / 0.4);
-  backdrop-filter: blur(2px);
-  animation: fadeIn 180ms ease;
 }
 
 @keyframes fadeIn {

--- a/apps/demo/src/app/ui/right-rail/right-rail.ts
+++ b/apps/demo/src/app/ui/right-rail/right-rail.ts
@@ -1,5 +1,14 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, inject, input } from '@angular/core';
+import {
+  afterNextRender,
+  Component,
+  effect,
+  ElementRef,
+  inject,
+  Injector,
+  input,
+  viewChild,
+} from '@angular/core';
 import { PageControlsService } from '../page-controls/page-controls.service';
 import { PanelHelpService } from '../display-controls-card/panel-help.service';
 
@@ -26,11 +35,55 @@ import { PanelHelpService } from '../display-controls-card/panel-help.service';
 export class RightRailComponent {
   readonly #pageControls = inject(PageControlsService);
   readonly #help = inject(PanelHelpService);
+  readonly #injector = inject(Injector);
 
   readonly variant = input<'rail' | 'slideover'>('rail');
   readonly panelOpen = this.#pageControls.panelOpen;
   readonly showDetails = this.#help.showDetails;
   readonly template = this.#pageControls.template;
+
+  // Native `#private` fields on a `viewChild()` query miscompile under this
+  // workspace's dev toolchain (Vite + @analogjs/vite-plugin-angular JIT
+  // compilation of an external `templateUrl`): the query silently corrupts
+  // the component's view and Angular's runtime throws a nonsensical
+  // NG0304 "'ngx-root' is not a known element" from deep inside
+  // RightRailComponent on first render. A TypeScript `private` (compile-time
+  // only, not a real JS private field) query behaves identically at
+  // runtime and reproduces the bug in neither dev nor prod builds — use it
+  // for query fields in this file instead of `#`.
+  private readonly slideoverDialog =
+    viewChild<ElementRef<HTMLDialogElement>>('slideoverDialog');
+
+  constructor() {
+    // Keep the native <dialog>'s open/closed state in lockstep with
+    // `panelOpen`. showModal() (not show()) is what makes the dialog
+    // "modal": it renders the ::backdrop, makes the rest of the document
+    // inert, traps Tab focus, and moves focus in — see right-rail.html for
+    // the full rationale.
+    effect(() => {
+      const dialog = this.slideoverDialog()?.nativeElement;
+      if (!dialog) return;
+
+      const shouldBeOpen = this.panelOpen();
+      if (shouldBeOpen && !dialog.open) {
+        // The dialog's content (including the `autofocus` close button) is
+        // gated on this same `panelOpen` signal in the template — deferring
+        // to afterNextRender guarantees that content has actually been
+        // committed to the DOM before showModal() runs its focusing steps.
+        // showModal() looks for an `[autofocus]` descendant synchronously,
+        // once, at call time; calling it before the content renders would
+        // silently fall back to focusing the dialog itself instead.
+        afterNextRender(
+          () => {
+            dialog.showModal();
+          },
+          { injector: this.#injector },
+        );
+      } else if (!shouldBeOpen && dialog.open) {
+        dialog.close();
+      }
+    });
+  }
 
   protected toggleHelp(): void {
     this.#help.toggle();
@@ -42,5 +95,40 @@ export class RightRailComponent {
 
   protected collapseRail(): void {
     this.#pageControls.collapseRail();
+  }
+
+  /**
+   * Fires for every way the native dialog closes — our own `close()` call
+   * above, the Escape key (browser-default `cancel` -> `close`), or
+   * `HTMLDialogElement.close()` called from anywhere else. Syncing back
+   * into the service here (rather than only handling Escape specially)
+   * means `panelOpen` can never drift out of sync with the DOM's actual
+   * open/closed state.
+   */
+  protected onDialogClosed(): void {
+    this.#pageControls.closePanel();
+  }
+
+  /**
+   * Native <dialog> does not close on ::backdrop clicks by itself. A click
+   * whose coordinates land outside the dialog's own content box (i.e. on
+   * the backdrop) reports `event.target` as the dialog element — the
+   * bounding-rect check below is the standard light-dismiss pattern and is
+   * robust even when the dialog has padding.
+   */
+  protected onDialogBackdropClick(event: MouseEvent): void {
+    const dialog = event.currentTarget;
+    if (!(dialog instanceof HTMLDialogElement)) return;
+
+    const rect = dialog.getBoundingClientRect();
+    const clickedOutsideContent =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom;
+
+    if (clickedOutsideContent) {
+      this.closePanel();
+    }
   }
 }


### PR DESCRIPTION
Closes #166

## Summary

Reviews and fixes `apps/demo` (the plain-CSS flagship reference app) against the frozen v1.0.0 toolkit API, resolving all 7 verified blocker findings from audit #145:

1. **False-positive "could not resolve a deterministic field name" console.error** — already fixed upstream in `packages/toolkit/form-field/form-field-wrapper.ts` by a prior audit pass; verified across the full demo-e2e forms suite (zero occurrences). Added a regression test on `custom-controls` (one of the originally affected pages) plus a reusable `collectConsoleErrors()` e2e fixture.
2. **Submission-patterns "Submission State" indicator permanently broken** — `NGX_SIGNAL_FORM_CONTEXT` was injected at the wrong DI level (the host component instead of a child rendered inside the `ngxSignalForm`-provided `<form>`), so the badge always showed the red "Unhandled submittedStatus: undefined" fallback. Extracted a `SubmissionStateIndicatorComponent` using `injectFormContext()`, mirroring the pattern already demonstrated on `error-display-modes`.
3. **Wizard progress-header navigation bypassed step validation** — `WizardComponent.goToStep()` checked `event.defaultPrevented` synchronously while the container's validation handler was async, so the synchronous check always won and the wizard's UI-level `currentStep` could desync from the store's. Replaced the sync-only `preventDefault` contract with a new `canNavigate: (event) => boolean | Promise<boolean>` input that `goToStep()` awaits before writing `currentStep`.
4. **Dangling `aria-labelledby="productFeedbackHeading"`** on `error-display-modes` (no matching id anywhere) — replaced with `aria-label="Product feedback"`.
5. **Slide-over "Display Controls" dialog had no focus management, focus trap, or Escape handling** — converted to a native `<dialog>` shown via `showModal()`/`close()`, giving focus-in, focus-trap/inert background, and Escape-to-close for free; click-outside-to-close is still hand-wired. (Uncovered and fixed two follow-on issues along the way — see commit `db0c4bae` for details, including a genuine dev-toolchain bug where a native `#private` `viewChild()` field on this component miscompiles under this repo's Vite + Analog JIT pipeline.)
6. **Baselined color-contrast violation on `/headless/error-message-signal`** — bumped `text-gray-400`/`dark:text-gray-500` helper text to `text-gray-600`/`dark:text-gray-400` (WCAG 2.2 AA) and cleared the now-resolved entry from `a11y-baseline.json`.
7. **App shell hard-coded `min-width: 900px`** — fails WCAG 2.2 AA 1.4.10 Reflow at 320px. Dropped the floor and made the left nav a focus-managed, Escape/backdrop-dismissible off-canvas drawer below 900px; the ≥900px desktop layout is visually unchanged.

## Test plan

- [x] `pnpm nx run-many -t build,test,lint --projects=demo` — all green
- [x] Full `demo-e2e` forms suite on chromium, `@layout` excluded — 244/244 passed (one `fieldset-appearance` test flaked once under parallel load on an unrelated `oklab` color-tint assertion; confirmed unrelated to this change and passes reliably in isolation/repeat runs)
- [x] Manual verification at 390px viewport: `document.documentElement.scrollWidth === innerWidth` (no overflow), nav drawer opens/closes with correct focus management, desktop (≥900px / ≥1280px) layout unchanged
- [x] New e2e regression coverage added for findings #1, #2, #3, #5, #7 (see commits for specifics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
