### PR TITLE
fix(form-field): surface on-submit miswiring warning without form context

### DIFF
--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -2391,6 +2391,85 @@ describe('NgxSignalFormWrapperComponent', () => {
         formField?.classList.contains('ngx-signal-form-field-wrapper--warning'),
       ).toBe(false);
     });
+
+    describe('strategy="on-submit" without a form context', () => {
+      // Regression: `createShowErrorsComputed` (core/utilities/show-errors.ts)
+      // emits a one-shot dev warning when 'on-submit' is used without an
+      // explicit submittedStatus, since errors will otherwise never surface.
+      // The wrapper used to always supply a status signal that fell back to
+      // 'unsubmitted' when there was no [formRoot]/ngxSignalForm context, so
+      // `resolvedStatus === undefined` was never true through the wrapper
+      // and the diagnostic never fired — silently defeating the strategy
+      // with no signal why. The wrapper must let the primitive's warning
+      // fire (by passing `undefined` through, not a manufactured default)
+      // when it has no form context to source a real status from.
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('emits the dev-mode miswiring warning', async () => {
+        const invalidField = signal({
+          invalid: () => true,
+          touched: () => true,
+          errors: () => [{ kind: 'required', message: 'Required' }],
+        });
+
+        await render(
+          `<ngx-form-field-wrapper
+            [formField]="field"
+            fieldName="test-field"
+            strategy="on-submit"
+          >
+            <label for="test">Test</label>
+            <input id="test" type="text" />
+          </ngx-form-field-wrapper>`,
+          {
+            imports: [NgxSignalFormWrapperComponent],
+            componentProperties: { field: invalidField },
+          },
+        );
+
+        expect(warnSpy).toHaveBeenCalled();
+        const message = warnSpy.mock.calls
+          .map((call) => String(call[0]))
+          .find((text) => text.includes('on-submit'));
+        expect(message).toBeDefined();
+        expect(message).toContain('submittedStatus');
+      });
+
+      it('still never shows errors, matching the always-unsubmitted fallback behavior', async () => {
+        const invalidField = signal({
+          invalid: () => true,
+          touched: () => true,
+          errors: () => [{ kind: 'required', message: 'Required' }],
+        });
+
+        const { container } = await render(
+          `<ngx-form-field-wrapper
+            [formField]="field"
+            fieldName="test-field"
+            strategy="on-submit"
+          >
+            <label for="test">Test</label>
+            <input id="test" type="text" />
+          </ngx-form-field-wrapper>`,
+          {
+            imports: [NgxSignalFormWrapperComponent],
+            componentProperties: { field: invalidField },
+          },
+        );
+
+        // The strategy still resolves to 'unsubmitted' internally, so
+        // behavior is unchanged — only the dev diagnostic is new.
+        expect(container.querySelector('ngx-form-field-error')).toBeNull();
+      });
+    });
   });
 
   describe('Warning-only fields render independently of the blocking-error strategy', () => {

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -879,13 +879,22 @@ export class NgxFormFieldWrapper<TValue = unknown> {
 
   /**
    * Computed signal for submission status.
-   * Gets Angular's SubmittedStatus from the form provider context if available,
-   * otherwise defaults to 'unsubmitted'.
+   * Gets Angular's SubmittedStatus from the form provider context if available.
+   *
+   * Returns `undefined` (rather than manufacturing an `'unsubmitted'`
+   * default) when there is no form context. `createShowErrorsComputed`
+   * already falls back to `'unsubmitted'` internally when it sees
+   * `undefined`, so behavior is unchanged — but passing `undefined` through
+   * lets its one-shot dev-mode warning fire for `strategy="on-submit"`
+   * without a form context. A manufactured `'unsubmitted'` default here
+   * would mask that miswiring: the primitive would see a defined status and
+   * never suspect the field can't possibly know when the form was
+   * submitted, silently defeating the strategy with no diagnostic.
    */
   protected readonly submittedStatus = computed(() => {
     const formContext = this.#formContext;
 
-    return formContext ? formContext.submittedStatus() : 'unsubmitted';
+    return formContext ? formContext.submittedStatus() : undefined;
   });
 
   /**


### PR DESCRIPTION
Closes #172

## Summary

Fixes the 1 promoted pre-1.0 finding for the form-field area (audit #138):

- **strategy="on-submit" without a form context silently never showed errors, with no dev diagnostic.**
  `NgxFormFieldWrapper`'s `submittedStatus` computed always manufactured an `'unsubmitted'` fallback when there was no `[formRoot]`/`ngxSignalForm` context. `createShowErrorsComputed`'s one-shot dev-mode warning (core/utilities/show-errors.ts) only fires when it sees `resolvedStatus === undefined`, so the manufactured default meant a consumer using `<ngx-form-field-wrapper strategy="on-submit">` outside a form context got permanently-hidden errors with no signal why.

  Fix: `submittedStatus` now returns `undefined` (not a manufactured `'unsubmitted'`) when there is no form context. `createShowErrorsComputed` already falls back to `'unsubmitted'` internally on `undefined`, so runtime behavior (errors stay hidden) is unchanged — only the dev-mode diagnostic now fires as intended, in both the wrapper's own `shouldShowErrors` and the `submittedStatus` input forwarded to the projected `NgxFormFieldError` renderer.

This is an internal behavior fix only — no public API surface changed (no new/removed inputs, outputs, or types), so no entry was added to `docs/MIGRATING_BETA_TO_V1.md`.

## Test plan

- [x] Added a failing-first regression test asserting the dev-mode `console.warn` fires for `strategy="on-submit"` without a form context (`packages/toolkit/form-field/form-field-wrapper.spec.ts`)
- [x] Added a companion test confirming errors still stay hidden (behavior-preserving fix)
- [x] `pnpm nx run-many -t build,test,lint --projects=toolkit` — all green (74 test files / 1205 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form-field behavior when used outside a form context, while keeping validation messages hidden until a real submitted state is available.
  * Added a development warning for misconfigured setups, helping surface issues without changing the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->