### PR TITLE
fix(toolkit/vest): fix concurrent-mount reset and 'root' field collision

### DIFF
--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -343,6 +343,16 @@ persist across mounts:
 validateVest(path, signupSuite, { resetOnDestroy: false }); // opt out of teardown reset
 ```
 
+### Concurrent mounts of the same suite
+
+Registrations against the same suite are reference-counted, so mounting the
+same module-scope suite in two forms at once — e.g. a list/detail view, a
+wizard step rendered alongside a summary, or two tabs open simultaneously —
+is safe: the suite is only reset once the **last** surviving registration's
+injection context tears down, not the first one. Destroying one mount while
+a sibling mount is still using the same suite leaves that sibling's retained
+`only()`-run state and any in-flight async run untouched.
+
 ### Async caveats
 
 - `suite.run(data)` returns a synchronous `SuiteResult` that is _also_ a

--- a/packages/toolkit/vest/src/vest-adapter.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter.spec.ts
@@ -280,4 +280,87 @@ describe('createVestAdapter', () => {
     });
     expect(sixth.fromCache).toBe(true);
   });
+
+  it('attaches errors for a Vest field literally named "root" to that child field, not the validator-bound root', async () => {
+    const adapter = createVestAdapter();
+    const suite = create((data: { root: string }) => {
+      vestTest('root', 'Root is required', () => {
+        enforce(data.root).isNotBlank();
+      });
+    });
+
+    @Component({
+      selector: 'ngx-test-adapter-root-field',
+      imports: [FormField],
+
+      template: `<input [formField]="f.root" />`,
+    })
+    class TestComponent {
+      readonly model = signal({ root: '' });
+      // Register against the whole-form path, so the validator's own bound
+      // field IS the form root -- the same shape the reported bug relies on.
+      readonly f = form(this.model, (path) => {
+        adapter.register(path, suite);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const rootFieldErrors = fixture.componentInstance.f.root().errors();
+    const formRootErrors = fixture.componentInstance.f().errors();
+
+    // The model's `root` field failure must land on that child field...
+    expect(
+      rootFieldErrors.some((error) => error.message === 'Root is required'),
+    ).toBe(true);
+    // ...and must NOT be mis-attached to the validator-bound form root just
+    // because the Vest field name happens to be the literal string "root".
+    expect(
+      formRootErrors.some((error) => error.message === 'Root is required'),
+    ).toBe(false);
+  });
+
+  it('does not reset a shared suite while another registration is still mounted (concurrent mounts)', () => {
+    const adapter = createVestAdapter();
+    const baseSuite = create((data: { email: string }) => {
+      vestTest('email', 'Email is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+
+    let resetCount = 0;
+    const suite = {
+      ...baseSuite,
+      reset: () => {
+        resetCount += 1;
+        baseSuite.reset();
+      },
+    };
+
+    // No template/inputs needed: `form()` (and the adapter registration it
+    // triggers) runs during construction, before any change detection pass.
+    @Component({ template: '' })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly f = form(this.model, (path) => {
+        adapter.register(path, suite);
+      });
+    }
+
+    // Two independently mounted forms sharing the SAME module-scope suite --
+    // the README-recommended pattern.
+    const first = TestBed.createComponent(TestComponent);
+    const second = TestBed.createComponent(TestComponent);
+
+    first.destroy();
+    // The second mount is still alive and relying on this suite -- resetting
+    // now would wipe its retained only()-run state and any in-flight async
+    // run out from under it.
+    expect(resetCount).toBe(0);
+
+    second.destroy();
+    // Only the LAST surviving registration's teardown actually resets.
+    expect(resetCount).toBe(1);
+  });
 });

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -186,6 +186,19 @@ const VEST_KIND_SEGMENT_MAX_LEN = 48;
 const VEST_KEY_SEPARATOR = '\u0000';
 
 /**
+ * Internal sentinel `fieldPath` meaning "attach directly to the validator's
+ * own bound field tree" rather than resolving a child field by name.
+ *
+ * Composed from the same NUL-based separator as {@link VEST_KEY_SEPARATOR} so
+ * it can never collide with a REAL Vest field name -- including a field
+ * literally named `root`. Using the bare string `'root'` as this sentinel
+ * previously meant that a suite with a test registered against a field named
+ * `root` (e.g. model shape `{ root: ... }`) had its failures mis-attached to
+ * the validator-bound field instead of resolved to the `root` child field.
+ */
+const VEST_ROOT_FIELD_SENTINEL = `${VEST_KEY_SEPARATOR}root${VEST_KEY_SEPARATOR}`;
+
+/**
  * Runtime guard for the subset of Vest's public result object that the adapter
  * consumes.
  */
@@ -485,7 +498,7 @@ function toVestValidationEntries(
   }
 
   if (Array.isArray(messages)) {
-    return createVestEntriesForField('root', messages);
+    return createVestEntriesForField(VEST_ROOT_FIELD_SENTINEL, messages);
   }
 
   return Object.entries(messages).flatMap(([fieldPath, fieldMessages]) => {
@@ -587,7 +600,7 @@ function toVestValidationErrors(
 ): readonly ValidationError.WithFieldTree[] {
   return entries.map(({ fieldPath, message, occurrence }) => {
     const targetFieldTree =
-      fieldPath === 'root'
+      fieldPath === VEST_ROOT_FIELD_SENTINEL
         ? fieldTree
         : resolveVestWarningFieldTree(fieldTree, fieldPath);
 
@@ -843,6 +856,11 @@ export function createVestAdapter(
 ): VestSuiteAdapter {
   const defaultResetOnDestroy = options.resetOnDestroy ?? true;
   const runCache = new WeakMap<object, VestRunCache>();
+  // Tracks how many live `resetOnDestroy`-enabled registrations currently
+  // reference each suite, so a suite shared across concurrently mounted forms
+  // (the README-recommended module-scope pattern) is only reset once the
+  // LAST registration tears down -- see `maybeRegisterResetOnDestroy`.
+  const resetOnDestroyRefCounts = new WeakMap<object, number>();
 
   /**
    * Retrieves the per-suite validation cache, creating it on first access.
@@ -952,6 +970,14 @@ export function createVestAdapter(
    * the current injection context is torn down. No-op when `resetOnDestroy` is
    * false or when the suite does not expose a `reset` callable. The hook clears
    * the SAME shared run cache so a subsequent mount re-executes `run()`.
+   *
+   * Registrations are reference-counted per suite: a module-scope suite
+   * shared by multiple concurrently mounted forms (the README-recommended
+   * pattern) increments this count on each opted-in registration and only
+   * actually resets once the LAST one tears down. Without this, destroying
+   * any one mount would reset (and drop the run cache for) a suite that a
+   * SURVIVING mount is still relying on -- wiping its retained `only()`-run
+   * state and, for an in-flight async run, orphaning its promise.
    */
   function maybeRegisterResetOnDestroy<TValue>(
     suite: VestRunnableSuite<TValue>,
@@ -966,10 +992,25 @@ export function createVestAdapter(
       return;
     }
 
+    const suiteKey = suite as object;
+    resetOnDestroyRefCounts.set(
+      suiteKey,
+      (resetOnDestroyRefCounts.get(suiteKey) ?? 0) + 1,
+    );
+
     inject(DestroyRef).onDestroy(() => {
+      const remaining = (resetOnDestroyRefCounts.get(suiteKey) ?? 1) - 1;
+      if (remaining > 0) {
+        // Another registration is still relying on this suite -- leave its
+        // state (and run cache) alone.
+        resetOnDestroyRefCounts.set(suiteKey, remaining);
+        return;
+      }
+
+      resetOnDestroyRefCounts.delete(suiteKey);
       // Also clear the per-suite run cache so a subsequent mount re-executes
       // `run()` even when the field tree reference happens to be reused.
-      invalidate(suite as object);
+      invalidate(suiteKey);
       (suite as { reset: () => void }).reset();
     });
   }


### PR DESCRIPTION
Closes #174

Fixes the 2 promoted pre-1.0 findings from audit #140 (vest adapter).

## Findings

**1. Default `resetOnDestroy` broke concurrently mounted forms sharing one module-scope suite**
`packages/toolkit/vest/src/vest-adapter.ts`

The `DestroyRef` teardown hook unconditionally called `suite.reset()` (and dropped the shared run cache) whenever ANY registering injection context was destroyed — even while a sibling mount was still relying on the same suite. That wiped the surviving form's retained `only()`-run state and could orphan an in-flight async run's promise (the never-resolving-promise hang, reached via the reset path).

Fix: registrations are now reference-counted per suite. The suite is only actually reset (and its run cache dropped) once the **last** live `resetOnDestroy`-enabled registration tears down. Documented the now-safe concurrent-mount behavior in the vest README's "Suite lifecycle" section (new "Concurrent mounts of the same suite" subsection).

**2. `'root'` sentinel collided with a real Vest field named `root`**
`packages/toolkit/vest/src/vest-adapter.ts`

`toVestValidationErrors` special-cased `fieldPath === 'root'` to attach an entry directly to the validator-bound field tree instead of resolving it as a child field. Since Vest field names come straight from `Object.entries(result.getErrors())`, a suite with a real test registered against a field literally named `root` (model shape `{ root: ... }`) had its failures mis-attached to the bound field instead of the `root` child field.

Fix: replaced the bare string `'root'` sentinel with `VEST_ROOT_FIELD_SENTINEL`, a NUL-delimited token (reusing the existing `VEST_KEY_SEPARATOR` convention already used elsewhere in this file) that can never collide with a real Vest field/path name.

## Notes

- Both are internal bug fixes with no public API surface changes (no new exports, no signature changes) — no entry needed in `docs/MIGRATING_BETA_TO_V1.md`.
- TDD: added two regression tests in `vest-adapter.spec.ts`, verified both fail against the pre-fix adapter, then verified they pass after the fix.

## Test plan
- [x] `pnpm nx run-many -t build,test,lint --projects=toolkit` passes (1205 tests)
- [x] New regression tests reproduce each bug pre-fix and pass post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>