### PR TITLE
fix(toolkit/core): 6 promoted pre-1.0 findings from audit #137 (core)

### DIFF
--- a/packages/toolkit/core/directives/auto-aria.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.spec.ts
@@ -336,6 +336,48 @@ describe('NgxSignalFormAutoAria', () => {
       expect(input?.getAttribute('aria-required')).toBe('false');
     });
 
+    it('should clear toolkit-written aria-invalid/aria-required when switching from auto to manual mode', async () => {
+      @Component({
+        template:
+          '<input type="checkbox" role="switch" id="emailUpdates" ngxSignalFormControl="switch" [ngxSignalFormControlAria]="ariaMode()" [formField]="switchControl()" />',
+        imports: [
+          MockFormFieldDirective,
+          NgxSignalFormAutoAria,
+          NgxSignalFormControlSemanticsDirective,
+        ],
+      })
+      class TestComponent {
+        readonly ariaMode = signal<'auto' | 'manual' | null>(null);
+        switchControl = signal(() => ({
+          invalid: signal(true),
+          touched: signal(true),
+          errors: signal([{ kind: 'required', message: 'Switch is required' }]),
+          valid: signal(false),
+          dirty: signal(true),
+          value: signal(''),
+          required: signal(true),
+          focusBoundControl: vi.fn(),
+        }));
+      }
+
+      const { container, fixture } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const input = container.querySelector('input');
+      // Auto mode: toolkit writes aria-invalid/aria-required unconditionally.
+      expect(input?.getAttribute('aria-invalid')).toBe('true');
+      expect(input?.getAttribute('aria-required')).toBe('true');
+
+      fixture.componentInstance.ariaMode.set('manual');
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      // Ownership transferred to the consumer, who hasn't written anything
+      // yet — the stale toolkit-written values must not linger.
+      expect(input?.hasAttribute('aria-invalid')).toBe(false);
+      expect(input?.hasAttribute('aria-required')).toBe(false);
+    });
+
     it('should apply switch ARIA when both role="switch" and ngxSignalFormControl="switch" are present', async () => {
       @Component({
         template:

--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -145,6 +145,23 @@ export class NgxSignalFormAutoAria {
   });
 
   /**
+   * Whether the previous `afterEveryRender` write tick ran in manual mode —
+   * `null` before the first tick has run. Plain instance state (not a
+   * signal): it is only read/written imperatively inside the write callback
+   * and never needs to trigger reactivity on its own.
+   *
+   * Used solely to detect the auto → manual transition tick (previous tick
+   * was `false`, this tick is manual), so the toolkit-written
+   * `aria-invalid`/`aria-required` values — written unconditionally every
+   * tick in auto mode — can be cleared exactly once when ownership passes to
+   * the consumer, instead of being silently adopted as the new "manual"
+   * snapshot value forever. Starting from `null` (rather than `false`)
+   * avoids misfiring that clear on the very first tick when the control
+   * starts life already in manual mode with consumer-authored attributes.
+   */
+  #previousTickWasManualAriaMode: boolean | null = null;
+
+  /**
    * Shared visibility-timing computed. Centralizes the `shouldShowErrors`
    * decision so `#shouldShowBy` only contributes the per-error-type filter.
    * Keeps auto-aria in lockstep with the wrapper component and the form
@@ -427,8 +444,27 @@ export class NgxSignalFormAutoAria {
               this.#managedDescribedByIds.set([]);
             }
 
+            // Auto → manual transition: aria-invalid/aria-required were
+            // toolkit-owned (written unconditionally every tick in auto
+            // mode) up through the previous tick, so the value just read
+            // off the DOM in `earlyRead` is a stale toolkit write, not a
+            // consumer-authored value. Clear both so the consumer starts
+            // from a clean slate instead of inheriting the last
+            // auto-computed values as the new "manual" snapshot. Only fires
+            // on the transition tick itself (`previousTickWasManualAriaMode
+            // === false`) — a control that starts life in manual mode, or
+            // stays in manual mode across ticks, never hits this branch.
+            if (this.#previousTickWasManualAriaMode === false) {
+              this.#writeManagedAttribute('aria-invalid', null);
+              this.#writeManagedAttribute('aria-required', null);
+            }
+
+            this.#previousTickWasManualAriaMode = true;
+
             return;
           }
+
+          this.#previousTickWasManualAriaMode = false;
 
           this.#writeManagedAttribute('aria-invalid', this.ariaInvalid());
           this.#writeManagedAttribute(

--- a/packages/toolkit/core/providers/field-labels.provider.spec.ts
+++ b/packages/toolkit/core/providers/field-labels.provider.spec.ts
@@ -50,6 +50,27 @@ describe('Field Label Provider', () => {
       const resolver = TestBed.inject(NGX_FIELD_LABEL_RESOLVER);
       expect(resolver('address.postalCode')).toBe('Postcode');
     });
+
+    it('should not resolve inherited Object.prototype members as map entries', () => {
+      // 'constructor'/'toString'/etc. are not own properties of the map
+      // object, but plain-object property access resolves them anyway via
+      // the prototype chain. Object.hasOwn must gate the lookup so these
+      // paths fall through to humanizeFieldPath instead of returning a
+      // non-string inherited function/value.
+      TestBed.configureTestingModule({
+        providers: [
+          provideFieldLabels({
+            contactEmail: 'E-mailadres',
+          }),
+        ],
+      });
+
+      const resolver = TestBed.inject(NGX_FIELD_LABEL_RESOLVER);
+      expect(resolver('constructor')).toBe('Constructor');
+      expect(resolver('constructor')).not.toBe(Object);
+      expect(resolver('toString')).toBe('To string');
+      expect(resolver('hasOwnProperty')).toBe('Has own property');
+    });
   });
 
   describe('provideFieldLabels with factory function', () => {

--- a/packages/toolkit/core/providers/field-labels.provider.ts
+++ b/packages/toolkit/core/providers/field-labels.provider.ts
@@ -105,7 +105,10 @@ export function provideFieldLabels(
 function createMapResolver(map: FieldLabelMap): FieldLabelResolver {
   return (fieldPath) =>
     createCascadingResolver({
-      input: map[fieldPath],
+      // `Object.hasOwn` guards against inherited `Object.prototype` members
+      // (e.g. a field path of 'constructor' or 'toString' resolving the
+      // inherited function instead of falling back to `humanizeFieldPath`).
+      input: Object.hasOwn(map, fieldPath) ? map[fieldPath] : undefined,
       fallback: humanizeFieldPath(fieldPath),
     });
 }

--- a/packages/toolkit/core/providers/index.ts
+++ b/packages/toolkit/core/providers/index.ts
@@ -1,4 +1,0 @@
-export * from './config.provider';
-export * from './control-semantics.provider';
-export * from './error-messages.provider';
-export * from './field-labels.provider';

--- a/packages/toolkit/core/services/field-identity.ts
+++ b/packages/toolkit/core/services/field-identity.ts
@@ -101,7 +101,7 @@ export class NgxFieldIdentity {
 
   /**
    * Resolved field name. Null when no field name can be determined.
-   * Updated by `NgxFormFieldWrapper` via `_setFieldName`.
+   * Updated by `NgxFormFieldWrapper` via `setFieldName`.
    */
   readonly fieldName = this.#fieldName.asReadonly();
 
@@ -206,7 +206,7 @@ export class NgxFieldIdentity {
     return this.#controlElement();
   }
 
-  // -- Package-internal setters. Prefixed with `_` to signal non-public intent --
+  // -- Package-internal setters. `@internal`-tagged to signal non-public intent --
 
   /**
    * Updates the resolved field name.
@@ -224,7 +224,7 @@ export class NgxFieldIdentity {
    * Updates the bound control element reference.
    *
    * Called by `NgxFormFieldWrapper` in its `afterEveryRender` write phase.
-   * Callers should set `_setFieldName` first so dev-only diagnostics evaluate
+   * Callers should call `setFieldName` first so dev-only diagnostics evaluate
    * the latest explicit name state before checking id-less controls.
    * Emits a dev-mode warning when the element has no `id` attribute and no
    * explicit `fieldName` override is present — the a11y gap is surfaced once

--- a/packages/toolkit/core/utilities/resolve-error-message.spec.ts
+++ b/packages/toolkit/core/utilities/resolve-error-message.spec.ts
@@ -88,6 +88,23 @@ describe('resolveValidationErrorMessage — 3-tier priority', () => {
       'Please enter a valid email address',
     );
   });
+
+  it('should not resolve inherited Object.prototype members as registry entries', () => {
+    // 'constructor'/'toString'/etc. are not own properties of the registry
+    // object, but plain-object property access resolves them anyway via the
+    // prototype chain. Object.hasOwn must gate the lookup so these kinds
+    // fall through to the default (humanized) message instead of returning
+    // a non-string inherited function/value.
+    const error: ValidationError = { kind: 'constructor' };
+
+    expect(resolveValidationErrorMessage(error, registry)).toBe('constructor');
+    expect(resolveValidationErrorMessage(error, registry)).not.toBe(Object);
+
+    const toStringError: ValidationError = { kind: 'toString' };
+    expect(resolveValidationErrorMessage(toStringError, registry)).toBe(
+      'toString',
+    );
+  });
 });
 
 describe('getDefaultValidationMessage', () => {

--- a/packages/toolkit/core/utilities/resolve-error-message.ts
+++ b/packages/toolkit/core/utilities/resolve-error-message.ts
@@ -111,7 +111,13 @@ export function resolveValidationErrorMessage(
     return error.message;
   }
 
-  if (registry) {
+  // `Object.hasOwn` guards against inherited `Object.prototype` members
+  // (e.g. an error kind of 'constructor' or 'toString' resolving the
+  // inherited function instead of being treated as "no registry entry").
+  // `provideErrorMessages` spreads consumer input into a plain `{}`, so
+  // without this guard a developer-authored (but attacker-shaped) kind
+  // string could silently violate the string-return contract.
+  if (registry && Object.hasOwn(registry, error.kind)) {
     const registryMessage = registry[error.kind];
     if (registryMessage !== undefined) {
       return typeof registryMessage === 'function'

--- a/packages/toolkit/core/utilities/submission-helpers.spec.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.spec.ts
@@ -137,6 +137,20 @@ describe('Submission Helpers', () => {
         expect(result()).toBe(false);
       });
     });
+
+    describe('Injection Context', () => {
+      it('should throw NG0203 attributed to hasSubmitted when called outside an injection context', () => {
+        const submittingState = signal(false);
+        const mockForm = createMockFormWithSubmitting(() => submittingState());
+
+        // Calling directly (no TestBed.runInInjectionContext /
+        // constructor / field initializer) must throw, and the thrown
+        // error must name `hasSubmitted` — not the internal
+        // `createSubmittedStatusTracker` delegate — so a caller sees the
+        // public API surface they actually called in the error message.
+        expect(() => hasSubmitted(mockForm)).toThrowError(/hasSubmitted/u);
+      });
+    });
   });
 
   describe('Integration - Combined Usage', () => {

--- a/packages/toolkit/core/utilities/submission-helpers.ts
+++ b/packages/toolkit/core/utilities/submission-helpers.ts
@@ -132,9 +132,22 @@ export function createSubmittedStatusTracker(
  * @param formTree The form tree to check submission history for
  * @returns Signal that emits `true` when form has been submitted
  *
+ * @remarks
+ * Must be called in an injection context — delegates to
+ * {@link createSubmittedStatusTracker}, which uses `effect()` internally.
+ * Calling this from a plain method (outside a constructor, field
+ * initializer, or `runInInjectionContext()`) throws Angular's NG0203, and
+ * the error will report `createSubmittedStatusTracker` (not `hasSubmitted`)
+ * as the offending call.
+ *
  * @public
  */
 export function hasSubmitted(formTree: FieldTree<unknown>): Signal<boolean> {
+  // Assert here (in addition to the check createSubmittedStatusTracker
+  // already performs) so a caller outside an injection context sees
+  // `hasSubmitted` named as the offending call in Angular's NG0203 error,
+  // not the internal delegate.
+  assertInInjectionContext(hasSubmitted);
   const submittedStatus = createSubmittedStatusTracker(formTree);
   return computed(() => submittedStatus() === 'submitted');
 }
@@ -201,6 +214,27 @@ export function canSubmitWithWarnings(
  * double-click, Enter spam, or an overlapping native submit — are silently
  * dropped. The in-flight guard is cleared in the `finally` block so the form
  * is always re-submittable after the current call settles (even on rejection).
+ *
+ * **`errorStrategy: 'on-submit'` interplay**: this helper runs `action`
+ * outside Angular's native `submit()` flow, so it never flips the native
+ * `submitting()` signal and has no integration with `NgxSignalForm`'s
+ * internal submitted-attempt tracking. When called from a `type="button"`
+ * click handler (i.e. there is no native `submit` event on
+ * `form[ngxSignalForm]`), `createSubmittedStatusTracker`'s derived status —
+ * and therefore any form configured with `errorStrategy: 'on-submit'` — never
+ * observes a completed submit attempt, so blocking errors never become
+ * visible after a failed `submitWithWarnings()` call. (`markAsTouched()`,
+ * called unconditionally above, only satisfies the `'on-touch'` strategy.)
+ * To surface errors after a blocked `submitWithWarnings()` call:
+ * - Trigger it from inside a real `<form (ngSubmit)>` / `[ngxSignalForm]`
+ *   submit handler so the native submit event still fires, or
+ * - Use `errorStrategy: 'on-touch'` (or `'always'`) instead of `'on-submit'`
+ *   for forms that call this from a plain button, or
+ * - Pass a `WritableSignal<boolean>` into your own
+ *   {@link createSubmittedStatusTracker} call (its `submitAttempted`
+ *   parameter) and set it to `true` when this function returns without
+ *   invoking `action`, mirroring how a native failed submit would be
+ *   recorded.
  *
  * @param formTree - The root `FieldTree` of the form to submit
  * @param action - Async callback invoked only when no blocking errors remain


### PR DESCRIPTION
Closes #171

Resolves the 6 promoted pre-1.0 findings from audit #137 (core), reclassified from post-1.0 to pre-1.0. No public API changes — all fixes are internal-behavior corrections or doc-accuracy fixes, so `docs/MIGRATING_BETA_TO_V1.md` is untouched.

## Findings

1. **Auto-ARIA stale attributes on auto→manual transition** (bug) — `NgxSignalFormAutoAria` wrote `aria-invalid`/`aria-required` unconditionally every tick in auto mode, but the manual-mode write branch only restored `aria-describedby` symmetrically, silently leaving stale toolkit-written values in the DOM when `ngxSignalFormControlAria` flips from `auto` to `manual`. Added tri-state previous-tick-mode tracking (`null` before first tick, so controls starting life in manual mode are untouched) and clear both attributes exactly once on the transition tick. TDD: new test in `auto-aria.spec.ts`.

2. **Registry/map lookups hit inherited `Object.prototype` members** (bug) — `resolveValidationErrorMessage` (`registry[error.kind]`) and `createMapResolver` (`map[fieldPath]`) did plain bracket lookups on plain objects, so a kind/path of `'constructor'`/`'toString'`/etc. resolved the inherited function instead of falling through, violating the string-return contract. Guarded both with `Object.hasOwn`, matching the existing `isBuiltInError` pattern. TDD: new tests in both spec files.

3. **`submitWithWarnings` never marks the form 'submitted'** (docs) — documented the `errorStrategy: 'on-submit'` interplay and three concrete workarounds (real submit event, `'on-touch'`/`'always'` strategy, or threading a `WritableSignal` into a custom `createSubmittedStatusTracker` call).

4. **Stale, unused `providers/index.ts` barrel** (packaging) — deleted; nothing imported it, and it was missing `form-field-renderer.provider`, making it a drift trap for a future refactor. Verified with `grep` that no source or test references it, and `nx build toolkit` still succeeds.

5. **`NgxFieldIdentity` docs reference nonexistent `_setFieldName`** (docs) — fixed all three doc references to the real method names (`setFieldName`, etc.) and dropped the fictional underscore-prefix convention claim in favor of the `@internal` tag the methods already carry.

6. **`hasSubmitted()` doesn't document its injection-context requirement** (docs) — added the same `@remarks` note `createSubmittedStatusTracker` already has, and call `assertInInjectionContext(hasSubmitted)` directly so NG0203 names the right function. TDD: new test asserting the thrown error mentions `hasSubmitted`.

## Skipped
None — all 6 findings addressed.

## Test plan
- [x] `pnpm nx run-many -t build,test,lint --projects=toolkit` — all green (74 test files / 1207 tests passing)
- [x] New/updated unit tests cover findings 1, 2, and 6 (behavior-affecting); findings 3, 4, 5 are docs/packaging-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>