### PR TITLE
fix(assistive): NG0955 track-key bug, host margin, i18n hook, docs (wave 3, #175)

### DIFF
--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -149,7 +149,10 @@ When a matching max-length validator is present, `maxLength` can be omitted and 
 The built-in announcement strings ("Approaching limit: N characters remaining.", etc.) are English-only. Bind `[announcementFormatter]` to a `(state, { current, max, remaining, over }) => string` function to localize them:
 
 ```typescript
-formatter = (state: 'warning' | 'danger' | 'exceeded', info: { remaining: number; over: number }) => {
+formatter = (
+  state: 'warning' | 'danger' | 'exceeded',
+  info: { remaining: number; over: number },
+) => {
   switch (state) {
     case 'warning':
     case 'danger':
@@ -162,7 +165,7 @@ formatter = (state: 'warning' | 'danger' | 'exceeded', info: { remaining: number
 
 ### NgxFormMarkingLegend
 
-Form-level legend that explains the field marker (e.g. "* indicates a required field"). Place it once wherever it reads well — there is no automatic injection.
+Form-level legend that explains the field marker (e.g. "\* indicates a required field"). Place it once wherever it reads well — there is no automatic injection.
 
 ```html
 <form [formRoot]="userForm" ngxSignalForm>
@@ -173,13 +176,13 @@ Form-level legend that explains the field marker (e.g. "* indicates a required f
 
 Outside a form host, pass the tree explicitly: `<ngx-form-marking-legend [formTree]="userForm" />`.
 
-| Input             | Type                | Description                                                                          |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------- |
-| `formTree`        | `FieldTree`         | The form tree to reflect. Falls back to the ambient `ngxSignalForm` context.           |
-| `showMarkerWhen`  | `FieldMarkingMode`  | Override the marking mode (`'required' \| 'optional' \| 'none'`). Falls back to config. |
-| `text`            | `string`            | Override the legend text. `{marker}` is substituted with the resolved marker.         |
-| `requiredMarker`  | `string`            | Override the required marker used for `{marker}`. Falls back to config.               |
-| `optionalMarker`  | `string`            | Override the optional marker used for `{marker}`. Falls back to config.               |
+| Input            | Type               | Description                                                                             |
+| ---------------- | ------------------ | --------------------------------------------------------------------------------------- |
+| `formTree`       | `FieldTree`        | The form tree to reflect. Falls back to the ambient `ngxSignalForm` context.            |
+| `showMarkerWhen` | `FieldMarkingMode` | Override the marking mode (`'required' \| 'optional' \| 'none'`). Falls back to config. |
+| `text`           | `string`           | Override the legend text. `{marker}` is substituted with the resolved marker.           |
+| `requiredMarker` | `string`           | Override the required marker used for `{marker}`. Falls back to config.                 |
+| `optionalMarker` | `string`           | Override the optional marker used for `{marker}`. Falls back to config.                 |
 
 - In `'required'` mode, shows the required legend and hides when the form has no required fields.
 - In `'optional'` mode, shows the optional legend and hides when the form has no optional fields.

--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -17,6 +17,7 @@ import {
   NgxFormFieldErrorSummary,
   NgxFormFieldHint,
   NgxFormFieldCharacterCount,
+  NgxFormMarkingLegend,
   warningError,
   isWarningError,
   isBlockingError,
@@ -144,6 +145,46 @@ Character counter with progressive color states (ok → warning → danger → e
 ```
 
 When a matching max-length validator is present, `maxLength` can be omitted and detected automatically. Add `liveAnnounce` for polite screen reader announcements.
+
+The built-in announcement strings ("Approaching limit: N characters remaining.", etc.) are English-only. Bind `[announcementFormatter]` to a `(state, { current, max, remaining, over }) => string` function to localize them:
+
+```typescript
+formatter = (state: 'warning' | 'danger' | 'exceeded', info: { remaining: number; over: number }) => {
+  switch (state) {
+    case 'warning':
+    case 'danger':
+      return `Plus que ${info.remaining} caractères.`;
+    case 'exceeded':
+      return `Limite dépassée de ${info.over} caractères.`;
+  }
+};
+```
+
+### NgxFormMarkingLegend
+
+Form-level legend that explains the field marker (e.g. "* indicates a required field"). Place it once wherever it reads well — there is no automatic injection.
+
+```html
+<form [formRoot]="userForm" ngxSignalForm>
+  <ngx-form-marking-legend />
+  <!-- fields… -->
+</form>
+```
+
+Outside a form host, pass the tree explicitly: `<ngx-form-marking-legend [formTree]="userForm" />`.
+
+| Input             | Type                | Description                                                                          |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------- |
+| `formTree`        | `FieldTree`         | The form tree to reflect. Falls back to the ambient `ngxSignalForm` context.           |
+| `showMarkerWhen`  | `FieldMarkingMode`  | Override the marking mode (`'required' \| 'optional' \| 'none'`). Falls back to config. |
+| `text`            | `string`            | Override the legend text. `{marker}` is substituted with the resolved marker.         |
+| `requiredMarker`  | `string`            | Override the required marker used for `{marker}`. Falls back to config.               |
+| `optionalMarker`  | `string`            | Override the optional marker used for `{marker}`. Falls back to config.               |
+
+- In `'required'` mode, shows the required legend and hides when the form has no required fields.
+- In `'optional'` mode, shows the optional legend and hides when the form has no optional fields.
+- In `'none'` mode, renders nothing.
+- Renders visible, non-`aria-hidden` text — it is supplementary explanation, not a live-region status update; each control's `aria-required` already carries the required state to assistive tech.
 
 ## Warning utilities
 

--- a/packages/toolkit/assistive/character-count.spec.ts
+++ b/packages/toolkit/assistive/character-count.spec.ts
@@ -452,6 +452,45 @@ describe('NgxFormFieldCharacterCount', () => {
         'Character limit exceeded by 5 characters.',
       );
     });
+
+    it('should route announcements through a custom announcementFormatter for i18n', async () => {
+      // Regression test: the built-in announcement strings ("Approaching
+      // limit: N characters remaining.", etc.) were previously hardcoded
+      // English with no override hook, making them untranslatable without
+      // forking the component. `announcementFormatter` lets consumers
+      // supply localized strings.
+      @Component({
+        selector: 'ngx-test-i18n-announcement',
+        standalone: true,
+        imports: [NgxFormFieldCharacterCount],
+        template: `
+          <ngx-form-field-character-count
+            [formField]="testForm.text"
+            [maxLength]="100"
+            [liveAnnounce]="true"
+            [announcementFormatter]="formatter"
+          />
+        `,
+      })
+      class I18nWrapperComponent {
+        readonly #model = signal({ text: 'a'.repeat(80) });
+        protected readonly testForm = form(this.#model);
+        readonly formatter = (
+          state: 'warning' | 'danger' | 'exceeded',
+          info: { remaining: number; over: number },
+        ): string =>
+          `[${state}] restants: ${info.remaining}, dépassement: ${info.over}`;
+      }
+
+      const { container } = await render(I18nWrapperComponent);
+
+      const liveRegion = container.querySelector(
+        '.ngx-signal-form-field-char-count__sr',
+      );
+      expect(liveRegion).toHaveTextContent(
+        '[warning] restants: 20, dépassement: 0',
+      );
+    });
   });
 
   describe('Default token contrast (WCAG 1.4.3)', () => {

--- a/packages/toolkit/assistive/character-count.ts
+++ b/packages/toolkit/assistive/character-count.ts
@@ -32,6 +32,53 @@ import {
 export type NgxCharacterCountValue = CharacterCountValue;
 
 /**
+ * Non-`'ok'` limit states that ever produce a live-announcement string.
+ * `'ok'` is intentionally excluded — no announcement is emitted for it, so
+ * an {@link NgxCharacterCountAnnouncementFormatter} is never invoked with it.
+ */
+export type NgxCharacterCountAnnouncementState = Exclude<
+  CharacterCountLimitState,
+  'ok'
+>;
+
+/**
+ * Details passed to a custom {@link NgxCharacterCountAnnouncementFormatter}.
+ */
+export interface NgxCharacterCountAnnouncementInfo {
+  /** Current character/token count. */
+  readonly current: number;
+  /** The resolved maximum length. */
+  readonly max: number;
+  /** Characters remaining before the limit (`0` once at or past it). */
+  readonly remaining: number;
+  /** Characters over the limit (`0` unless `state === 'exceeded'`). */
+  readonly over: number;
+}
+
+/**
+ * Formats the polite live-announcement text for a given limit-state
+ * transition. Bind `[announcementFormatter]` to localize the built-in
+ * English strings ("Approaching limit: N characters remaining.", etc.) —
+ * the component has no other i18n hook, so non-English apps otherwise
+ * cannot translate what screen readers announce without forking it.
+ *
+ * @example
+ * ```typescript
+ * announcementFormatter = (state, { remaining, over }) => {
+ *   switch (state) {
+ *     case 'warning': return `Plus que ${remaining} caractères.`;
+ *     case 'danger': return `Attention, plus que ${remaining} caractères.`;
+ *     case 'exceeded': return `Limite dépassée de ${over} caractères.`;
+ *   }
+ * };
+ * ```
+ */
+export type NgxCharacterCountAnnouncementFormatter = (
+  state: NgxCharacterCountAnnouncementState,
+  info: NgxCharacterCountAnnouncementInfo,
+) => string;
+
+/**
  * Form field character count component with progressive color states.
  *
  * This styled wrapper uses the headless `createCharacterCount()` utility internally,
@@ -282,6 +329,16 @@ export class NgxFormFieldCharacterCount {
   });
 
   /**
+   * Optional formatter for the polite live-announcement text, for
+   * localizing the built-in English strings. See
+   * {@link NgxCharacterCountAnnouncementFormatter}.
+   *
+   * @default undefined — falls back to the built-in English strings.
+   */
+  readonly announcementFormatter =
+    input<NgxCharacterCountAnnouncementFormatter>();
+
+  /**
    * Percentage thresholds for color state changes.
    *
    * - `warning`: Percentage at which color changes to warning (default: 80%)
@@ -446,6 +503,11 @@ export class NgxFormFieldCharacterCount {
     const current = untracked(() => this.currentLength());
     const remaining = Math.max(0, max - current);
     const over = Math.max(0, current - max);
+
+    const formatter = this.announcementFormatter();
+    if (formatter) {
+      return formatter(state, { current, max, remaining, over });
+    }
 
     switch (state) {
       case 'warning':

--- a/packages/toolkit/assistive/form-field-error-summary.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.spec.ts
@@ -5,6 +5,7 @@ import {
   FormField,
   required,
   schema,
+  validate,
 } from '@angular/forms/signals';
 import type { SubmittedStatus } from '@ngx-signal-forms/toolkit';
 import { render, screen } from '@testing-library/angular';
@@ -162,6 +163,69 @@ describe('NgxFormFieldErrorSummary', () => {
     expect(buttons.length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText(/Email is required/iu)).toBeTruthy();
     expect(screen.getByText(/Name is required/iu)).toBeTruthy();
+  });
+
+  it('renders both entries without an NG0955 duplicate-track-key warning when the same field has two errors sharing a kind', async () => {
+    // Regression test: `dedupeValidationErrors` (headless/src/lib/utilities.ts)
+    // dedupes by `kind + '::' + message`, so two errors on the same field
+    // with the *same* kind but *different* messages both survive dedup. The
+    // summary's `@for` used to `track entry.kind + entry.fieldName`, which
+    // collapses to an identical string for both entries (same kind, same
+    // field) — Angular's dev-mode duplicate-key check logs a `console.warn`
+    // (NG0955) and degrades `@for`'s diffing during change detection.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    @Component({
+      selector: 'ngx-test-error-summary-duplicate-kind',
+      imports: [FormField, NgxFormFieldErrorSummary],
+
+      template: `
+        <input id="server" [formField]="contactForm.server" />
+        <ngx-form-field-error-summary
+          [formTree]="contactForm"
+          strategy="immediate"
+        />
+      `,
+    })
+    class TestComponent {
+      readonly model = signal({ server: 'x' });
+      readonly contactForm = form(
+        this.model,
+        schema((path) => {
+          validate(path.server, () => ({
+            kind: 'server',
+            message: 'Server error A',
+          }));
+          validate(path.server, () => ({
+            kind: 'server',
+            message: 'Server error B',
+          }));
+        }),
+      );
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    // Angular's `@for` duplicate-key detection only fires while
+    // reconciling against a *previously rendered* live collection (a
+    // brand-new list — nothing rendered yet — never hits that code path).
+    // Trigger a second render pass with a freshly computed (but
+    // content-equivalent) `entries()` array so the repeater actually
+    // reconciles two lists that both key by `kind + fieldName`.
+    fixture.componentInstance.model.set({ server: 'y' });
+    fixture.detectChanges();
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBe(2);
+    expect(screen.getByText(/Server error A/iu)).toBeTruthy();
+    expect(screen.getByText(/Server error B/iu)).toBeTruthy();
+
+    const duplicateKeyWarning = warnSpy.mock.calls.find((call) =>
+      String(call[0]).includes('duplicated keys'),
+    );
+    expect(duplicateKeyWarning).toBeUndefined();
+
+    warnSpy.mockRestore();
   });
 
   it('renders nothing when the form is valid', async () => {

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -99,7 +99,7 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
         <ul class="ngx-form-field-error-summary__list" role="list">
           @for (
             entry of summary.entries();
-            track entry.kind + entry.fieldName
+            track entry.fieldName + '::' + entry.kind + '::' + entry.message
           ) {
             <li class="ngx-form-field-error-summary__item">
               <button

--- a/packages/toolkit/assistive/form-field-error.css
+++ b/packages/toolkit/assistive/form-field-error.css
@@ -97,6 +97,19 @@
   margin-top: var(--_error-margin-top);
 }
 
+/* Zeroes the host's own top margin while both the alert and status
+ * containers are empty. The `--empty` class on each inner container
+ * already collapses *its own* box model to nothing, but `:host`'s
+ * `margin-top` above is unconditional — without this rule a field with no
+ * visible errors or warnings still contributed stray vertical whitespace.
+ * `ngx-form-field-error-host--empty` is set via a host class binding (see
+ * form-field-error.ts) rather than `[hidden]`/`aria-hidden`, which stay off
+ * the live-region containers for the WCAG 4.1.3 first-insertion reasons
+ * documented on the template. */
+:host(.ngx-form-field-error-host--empty) {
+  margin-top: 0;
+}
+
 /* Dark-mode defaults are driven by `prefers-color-scheme` only. An earlier
  * revision also tried to special-case a `.dark` class ancestor via
  * `:host-context()`, but that selector is non-standard and unsupported in

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -769,9 +769,9 @@ describe('NgxFormFieldError', () => {
       input.blur();
       fixture.detectChanges();
 
-      expect(
-        host.classList.contains('ngx-form-field-error-host--empty'),
-      ).toBe(false);
+      expect(host.classList.contains('ngx-form-field-error-host--empty')).toBe(
+        false,
+      );
     });
 
     it('should rely on role="alert" implicit semantics (no redundant aria-live/aria-atomic)', async () => {

--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -725,6 +725,55 @@ describe('NgxFormFieldError', () => {
       expect(statusContainer?.hasAttribute('hidden')).toBe(false);
     });
 
+    it('should zero its own :host margin-top when both the alert and status containers are empty', async () => {
+      // Regression test: `:host` unconditionally sets `margin-top:
+      // var(--_error-margin-top)` (form-field-error.css), so even while both
+      // inner containers are content-empty (and visually collapsed via the
+      // `--empty` class) the host element itself still contributed stray
+      // vertical whitespace above every field with no visible errors or
+      // warnings. The host now carries a marker class while both containers
+      // are empty so the CSS can zero its own margin-top too.
+      @Component({
+        selector: 'ngx-test-host-empty-margin',
+        imports: [FormField, NgxFormFieldError],
+
+        template: `
+          <input id="email" [formField]="contactForm.email" />
+          <ngx-form-field-error
+            [formField]="contactForm.email"
+            fieldName="email"
+            strategy="on-touch"
+          />
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ email: '' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.email, { message: 'Email is required' });
+          }),
+        );
+      }
+
+      const { container, fixture } = await render(TestComponent);
+
+      const host = container.querySelector('ngx-form-field-error')!;
+      expect(host.classList.contains('ngx-form-field-error-host--empty')).toBe(
+        true,
+      );
+
+      // Touch + blur to surface the error under the 'on-touch' strategy.
+      const input = container.querySelector<HTMLInputElement>('input#email')!;
+      input.focus();
+      input.blur();
+      fixture.detectChanges();
+
+      expect(
+        host.classList.contains('ngx-form-field-error-host--empty'),
+      ).toBe(false);
+    });
+
     it('should rely on role="alert" implicit semantics (no redundant aria-live/aria-atomic)', async () => {
       /**
        * `role="alert"` already implies `aria-live="assertive"` and

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -98,6 +98,17 @@ export type NgxFormFieldErrorListStyle = NgxFormFieldListStyle;
 @Component({
   selector: 'ngx-form-field-error',
 
+  host: {
+    // The role="alert"/role="status" containers stay mounted (see the
+    // template docs), and each collapses visually while empty via its own
+    // `--empty` class — but that leaves `:host`'s own `margin-top`
+    // (form-field-error.css) contributing stray vertical whitespace above
+    // every field with no visible errors *or* warnings. This class lets the
+    // CSS zero that margin too, without touching `[hidden]`/`aria-hidden`
+    // (which stay off the inner containers for the WCAG 4.1.3 reasons
+    // documented on the template).
+    '[class.ngx-form-field-error-host--empty]': 'hostEmpty()',
+  },
   hostDirectives: [
     {
       directive: NgxHeadlessErrorState,
@@ -424,6 +435,17 @@ export class NgxFormFieldError {
       this.showWarnings() &&
       this.headless.hasWarnings() &&
       !this.errorContainerVisible(),
+  );
+
+  /**
+   * True when neither the alert nor the status container has visible
+   * content. Drives the `ngx-form-field-error-host--empty` host class so
+   * the CSS can zero `:host`'s own `margin-top` — see the `host` binding
+   * above for why that margin needs a separate collapse from the inner
+   * containers' `--empty` class.
+   */
+  protected readonly hostEmpty = computed(
+    () => !this.errorContainerVisible() && !this.warningContainerVisible(),
   );
 
   // ── Resolved messages (delegate to the public createErrorMessageSignal) ──

--- a/packages/toolkit/assistive/index.ts
+++ b/packages/toolkit/assistive/index.ts
@@ -18,7 +18,13 @@
  * ```
  */
 
-export { NgxFormFieldCharacterCount } from './character-count';
+export {
+  NgxFormFieldCharacterCount,
+  type NgxCharacterCountAnnouncementFormatter,
+  type NgxCharacterCountAnnouncementInfo,
+  type NgxCharacterCountAnnouncementState,
+  type NgxCharacterCountValue,
+} from './character-count';
 export {
   NgxFormFieldError,
   type NgxFormFieldListStyle,


### PR DESCRIPTION
Closes #175

Resolves the 5 promoted pre-1.0 findings from audit #141 (assistive area, wave 3).

## Per-finding summary

1. **`[hidden]` inert on live-region containers (bug)** — The `[hidden]`/`aria-hidden` toggling described in the finding was already removed in an earlier pass; neither `NgxFormFieldError` nor `NgxFormFieldNotification` toggles those attributes today, and the CSS comments already describe the current `--empty`-class-only collapse accurately. The finding's still-live remainder was real, though: `:host` in `form-field-error.css` unconditionally sets `margin-top`, so a field with no visible errors *or* warnings still contributed stray vertical whitespace above it. Fixed with a `ngx-form-field-error-host--empty` host class (driven by a new `hostEmpty` computed) and a `:host(.ngx-form-field-error-host--empty) { margin-top: 0; }` rule. `[hidden]`/`aria-hidden` remain untouched on the inner containers for the documented WCAG 4.1.3 first-insertion reasons.

2. **Error summary `@for` track key can produce duplicate keys (NG0955) (bug)** — `track entry.kind + entry.fieldName` collapses to an identical string for two errors on the same field sharing a `kind` but differing `message` (e.g. two `customError({kind: 'server', ...})` entries), which `dedupeValidationErrorsByField` legitimately keeps as separate entries. Fixed by tracking `entry.fieldName + '::' + entry.kind + '::' + entry.message`. Regression test forces a second render pass (Angular's duplicate-key check only fires while reconciling against a *live* collection, not on first mount) and asserts no `NG0955` `console.warn`. Note: the same anti-pattern also appears in the headless entrypoint's usage-docs example (`packages/toolkit/headless/src/lib/error-summary.ts:97`) — left untouched as out-of-scope for this agent's area (headless, not assistive).

3. **`NgxCharacterCountValue` not exported from entrypoint index (api-design)** — Added to `index.ts`.

4. **Hardcoded English live-announcement strings, no i18n hook (a11y)** — Added an optional `[announcementFormatter]` input (`(state, info) => string`) to `NgxFormFieldCharacterCount`. Omitting it keeps the existing English strings (backward compatible, not a breaking change). Documented in the assistive README.

5. **`NgxFormMarkingLegend` undocumented in assistive README (docs)** — Added an import-example entry and a full Components section mirroring the component JSDoc.

## Skipped / out of scope
- The headless-entrypoint docs-comment instance of the same track-key anti-pattern (finding 2) — belongs to a different toolkit entrypoint (`headless`), out of this agent's assigned area.

## Verification
`pnpm nx run-many -t build,test,lint --projects=toolkit` — all green (1206 jsdom tests passed, build succeeded, lint had only pre-existing warnings, no errors).

No breaking public-API changes — no migration doc entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>