### PR TITLE
fix(demo-primeng): drop redundant manual aria-required write on select combobox

### DIFF
--- a/apps/demo-primeng/src/app/controls/prime-select-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-select-control.ts
@@ -61,6 +61,13 @@ const MANUAL_ARIA_MODE: Signal<NgxSignalFormControlAriaMode | null> =
  * the toolkit's signals reach the focusable element in one Angular binding
  * hop. No MutationObserver, no host-attribute mirroring.
  *
+ * `aria-required` is the one exception: PrimeNG's own compiled `<p-select>`
+ * template already writes `[attr.aria-required]="required()"` on the inner
+ * combobox span, fed by this shim's `[required]="ariaRequired() === 'true'"`
+ * input. The shim relies on that existing binding instead of also writing
+ * the attribute itself — duplicating it would just be two writers racing to
+ * set the same value.
+ *
  * **Accessible name:** `[inputId]` places its id on `<p-select>`'s inner
  * `<span role="combobox">`, which is not a labelable element — a sibling
  * `<label for="…">` therefore never establishes a programmatic association,
@@ -196,11 +203,6 @@ export class PrimeSelectControlComponent implements FormValueControl<string> {
             combobox,
             'aria-invalid',
             this.ariaInvalid(),
-          );
-          this.#setOrRemoveAttribute(
-            combobox,
-            'aria-required',
-            this.ariaRequired(),
           );
         },
       },

--- a/apps/demo-primeng/src/app/profile-form/profile-form.behavior.spec.ts
+++ b/apps/demo-primeng/src/app/profile-form/profile-form.behavior.spec.ts
@@ -98,6 +98,20 @@ describe('ProfileFormComponent', () => {
     expect(roleCombobox.getAttribute('aria-invalid')).toBe('true');
   });
 
+  it("reflects aria-required on the role combobox via PrimeNG's own [required] passthrough, with no duplicate manual write", async () => {
+    await renderProfileForm();
+
+    // Regression test for audit #147: PrimeSelectControlComponent used to
+    // also copy `aria-required` onto the inner [role="combobox"] span by
+    // hand in its afterEveryRender block, duplicating PrimeNG's own
+    // `[attr.aria-required]="required()"` binding on that same span (fed by
+    // the same `[required]="ariaRequired() === 'true'"` input this shim
+    // sets). The shim now relies solely on that PrimeNG-owned binding — this
+    // asserts the attribute still lands correctly with the manual write gone.
+    const roleCombobox = screen.getByRole('combobox', { name: /^role$/i });
+    expect(roleCombobox.getAttribute('aria-required')).toBe('true');
+  });
+
   it("wires the visible 'Role' label to the select's inner combobox via aria-labelledby so the accessible name never derives from transient placeholder/selected-value content", async () => {
     await renderProfileForm();
 


### PR DESCRIPTION
Closes #181

## Summary

Fixes the 1 promoted pre-1.0 finding from audit #147 for demo-primeng.

- **PrimeSelectControlComponent manually re-writes aria-required onto the combobox, duplicating PrimeNG's own binding** (`apps/demo-primeng/src/app/controls/prime-select-control.ts`) — the `afterEveryRender` write block was manually copying `aria-required` onto the inner `[role="combobox"]` span, duplicating PrimeNG's own compiled Select template, which already writes `[attr.aria-required]="required()"` on that same span, fed by the same `[required]="ariaRequired() === 'true'"` input this shim sets. The two writes always agreed in practice, but it was redundant complexity and a latent double-write race if PrimeNG's internal `required()` computation ever diverges from the raw input echo. Removed the manual write, kept the `aria-invalid`/`aria-describedby` manual writes (PrimeNG doesn't provide those itself), and added a regression test asserting the combobox still correctly reflects `aria-required` via PrimeNG's own passthrough.

No public toolkit API changes — this is an internal demo-app implementation detail, so no `docs/MIGRATING_BETA_TO_V1.md` entry was needed.

## Test plan
- [x] `pnpm nx run-many -t build,test,lint --projects=demo-primeng` — all pass
- [x] `pnpm nx e2e demo-primeng-e2e --project=chromium` — 6/6 pass
- [x] `pnpm nx run demo-primeng-e2e:a11y` (chromium project) — pass (firefox project in this target times out on browser launch in this sandboxed environment, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>