### PR TITLE
docs: fix stale anchor link and version/port drift

### DIFF
--- a/apps/demo-material/README.md
+++ b/apps/demo-material/README.md
@@ -2,8 +2,8 @@
 
 A runnable end-to-end example showing how to integrate
 [`@ngx-signal-forms/toolkit`](../../packages/toolkit/README.md) on top of
-**Angular Material 22+**. Pinned to the workspace's Angular 22 catalog,
-currently `@angular/material@22.0.0` and `@angular/cdk@22.0.0`.
+**Angular Material 22+**. Pinned via the workspace's `angular-material`
+pnpm catalog — see `pnpm-workspace.yaml` for the exact versions in use.
 
 ## Why use this on Material?
 
@@ -433,8 +433,12 @@ which Nx schedules automatically via the `dependsOn` in
 
 ## Pinned versions
 
+Versions are pinned via the workspace's pnpm catalogs (`pnpm-workspace.yaml`),
+not hard-coded here, so they stay in sync automatically. At the time of
+writing:
+
 | Package               | Version  |
 | --------------------- | -------- |
-| `@angular/material`   | `22.0.0` |
-| `@angular/cdk`        | `22.0.0` |
-| `@angular/animations` | `22.0.0` |
+| `@angular/material`   | `22.0.3` |
+| `@angular/cdk`        | `22.0.3` |
+| `@angular/animations` | `22.0.5` |

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -415,7 +415,7 @@ Building blocks for custom wrappers and headless UIs that want to join the
 > `warningStrategy` input on `NgxFormFieldError` (default:
 > `'immediate'`). See
 > [`WARNINGS_SUPPORT.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/WARNINGS_SUPPORT.md#when-warnings-appear--warningstrategy)
-> and the [assistive README](./assistive/README.md#ngxformfielderrorcomponent)
+> and the [assistive README](./assistive/README.md#ngxformfielderror)
 > for usage.
 
 ### Field interactivity


### PR DESCRIPTION
Closes #183

## Summary

Fixes the 3 promoted pre-1.0 docs findings from audit #149:

1. **`packages/toolkit/README.md`** — the link to the assistive README used
   the stale pre-rename anchor `#ngxformfielderrorcomponent`. The heading
   is now `### NgxFormFieldError` (anchor `#ngxformfielderror`). Fixed the
   fragment.
2. **`apps/demo-material/README.md`** — the intro line and "Pinned
   versions" table hard-coded `@angular/material@22.0.0`,
   `@angular/cdk@22.0.0`, `@angular/animations@22.0.0`, which had drifted
   from the `angular-material` pnpm catalog (22.0.3 / 22.0.3 / 22.0.5).
   Reworded to point at the catalog as the source of truth and refreshed
   the table with the current pinned values.
3. **`apps/demo-primeng/README.md`** — finding claimed a stale `21.1.6`
   version pin and a wrong dev-server port (4220). On this branch the
   file already reads `21.1.9` (matching the catalog) and port `4620`
   (matching `project.json`) — this was already fixed by prior PRs #195
   and #196 before this branch was cut off main, so no change was needed
   here. Verified against `pnpm-workspace.yaml` and
   `apps/demo-primeng/project.json`.

No public API or breaking changes — docs-only. No
`docs/MIGRATING_BETA_TO_V1.md` entry needed.

## Test plan

- [x] `pnpm nx run-many -t build,test,lint --projects=toolkit` — all pass
      (74 test files / 1211 tests, build + lint clean)
- [x] Verified anchor against actual heading in
      `packages/toolkit/assistive/README.md`
- [x] Verified version numbers against `pnpm-workspace.yaml` catalogs
- [x] Verified dev-server/preview ports against
      `apps/demo-material/project.json` and `apps/demo-primeng/project.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)