### PR TITLE
fix(demo-spartan): restore vendored helm fidelity + correct a11y-guard comment (audit #148)

### DIFF
--- a/apps/demo-spartan/src/app/wrapper/spartan-form-field.ts
+++ b/apps/demo-spartan/src/app/wrapper/spartan-form-field.ts
@@ -37,13 +37,18 @@ import {
 import { NgxSpartanFormFieldError } from './spartan-form-field-error';
 
 /**
- * Compile-time guard that the inline `BrnFieldA11yService` factory below
- * stays a structural superset of Brain's public contract. If Brain adds a
- * new public member, the `useFactory` return-type annotation fails at
- * typecheck time. We `Pick` the documented members (rather than asserting
- * full structural equivalence) because Brain's class also has `private`
- * fields the bridge intentionally keeps separate — DI matches by token
- * identity at runtime, not by structural compatibility.
+ * The subset of `BrnFieldA11yService`'s public contract this bridge
+ * re-implements. `Pick` alone is NOT a completeness guard — a `Pick` with a
+ * fixed key list still compiles unchanged when the source class gains new
+ * members; it only fails on removal/rename of a *listed* key. So this alias
+ * by itself would stay silently green if Brain 1.1 added e.g.
+ * `registerLabel()` and some helm primitive started calling it on the
+ * injected (bridged) service — that would throw a runtime `TypeError` with
+ * zero compile-time signal.
+ *
+ * The real exhaustiveness guard is `assertBrnFieldA11yPublicSurfaceIsExhaustive`
+ * below, which fails to typecheck if Brain's public surface grows beyond
+ * what's listed here.
  */
 type BrnFieldA11yPublicSurface = Pick<
   BrnFieldA11yService,
@@ -53,6 +58,42 @@ type BrnFieldA11yPublicSurface = Pick<
   | 'registerError'
   | 'unregisterError'
 >;
+
+/**
+ * Private fields on `BrnFieldA11yService` (per Brain 1.0.4's `.d.ts`) that
+ * the bridge intentionally does NOT implement — DI matches by token
+ * identity at runtime, not by structural compatibility, so these never need
+ * a bridged counterpart. Listed explicitly (rather than inferred) so this
+ * assertion fails loudly — not silently passes — if Brain ever makes one of
+ * these public, since a newly-public member would then need a real bridge
+ * implementation and a `BrnFieldA11yPublicSurface` entry above.
+ */
+type BrnFieldA11yKnownPrivateMembers = '_descriptions' | '_errors';
+
+/**
+ * Compile-time exhaustiveness guard: fails to typecheck if
+ * `BrnFieldA11yService` has any member that is neither in
+ * {@link BrnFieldA11yPublicSurface} nor {@link BrnFieldA11yKnownPrivateMembers}.
+ * That is the guard the `useFactory` return-type annotation on its own
+ * cannot provide (see the comment on `BrnFieldA11yPublicSurface`): if Brain
+ * adds a new public member, `keyof BrnFieldA11yService` grows, the
+ * `Exclude` below stops resolving to `never`, and assigning `true` to the
+ * conditional's non-`true` branch fails typecheck — turning an
+ * otherwise-silent structural gap into a build failure.
+ */
+type BrnFieldA11yUncoveredMembers = Exclude<
+  keyof BrnFieldA11yService,
+  BrnFieldA11yKnownPrivateMembers | keyof BrnFieldA11yPublicSurface
+>;
+type AssertBrnFieldA11yPublicSurfaceIsExhaustive =
+  BrnFieldA11yUncoveredMembers extends never
+    ? true
+    : [
+        'BrnFieldA11yService gained new member(s) not covered by BrnFieldA11yPublicSurface or BrnFieldA11yKnownPrivateMembers:',
+        BrnFieldA11yUncoveredMembers,
+      ];
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- type-only assertion; see comment above
+const assertBrnFieldA11yPublicSurfaceIsExhaustive: AssertBrnFieldA11yPublicSurfaceIsExhaustive = true;
 
 /**
  * Spartan-flavoured form-field wrapper composing `BrnField` (the unstyled
@@ -182,9 +223,10 @@ type BrnFieldA11yPublicSurface = Pick<
     // The factory delegates to the toolkit's `createAriaDescribedByBridge`
     // primitive — it merges the toolkit composition with any IDs registered
     // through Brain's `register*` API, so other helm primitives that push
-    // descriptions through the service stay compatible. The return-type
-    // annotation (`BrnFieldA11yPublicSurface`) is the typecheck guard that
-    // fires if Brain ever adds a new public member to its contract.
+    // descriptions through the service stay compatible. The exhaustiveness
+    // check above `assertBrnFieldA11yPublicSurfaceIsExhaustive` (not just
+    // the return-type annotation) is what fires if Brain ever adds a new
+    // public member to its contract.
     {
       provide: BrnFieldA11yService,
       useFactory: (): BrnFieldA11yPublicSurface =>

--- a/apps/demo-spartan/src/app/wrapper/vendored-helm-force-invalid.spec.ts
+++ b/apps/demo-spartan/src/app/wrapper/vendored-helm-force-invalid.spec.ts
@@ -1,0 +1,97 @@
+import { Component } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { HlmInput } from '@spartan-ng/helm/input';
+import {
+  HlmSelect,
+  HlmSelectContent,
+  HlmSelectItem,
+  HlmSelectPortal,
+  HlmSelectTrigger,
+  HlmSelectValue,
+} from '@spartan-ng/helm/select';
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    value: vi.fn(),
+    configurable: true,
+    writable: true,
+  });
+});
+
+/**
+ * Regression for audit #148 finding 1: the vendored `hlm-input` and
+ * `hlm-select-trigger` had dropped upstream v1.0.4's `forceInvalid`
+ * forwarding (they forward only `['id']` to their Brain host directive),
+ * so consumers copying this reference lost the ability to force the
+ * destructive/invalid visual state independent of live field validity.
+ *
+ * `hlm-checkbox` already threads `forceInvalid` through correctly — these
+ * specs pin the same contract for input and select-trigger.
+ */
+describe('vendored helm forceInvalid forwarding (audit #148 finding 1)', () => {
+  it('hlm-input forwards [forceInvalid] to BrnInput (data-matches-spartan-invalid)', async () => {
+    @Component({
+      selector: 'test-hlm-input-force-invalid',
+      imports: [HlmInput],
+      template: `<input hlmInput [forceInvalid]="true" aria-label="name" />`,
+    })
+    class TestHost {}
+
+    await render(TestHost);
+
+    const input = screen.getByLabelText('name');
+    expect(input.getAttribute('data-matches-spartan-invalid')).toBe('true');
+  });
+
+  it('hlm-input does not mark data-matches-spartan-invalid when forceInvalid is false/unset', async () => {
+    @Component({
+      selector: 'test-hlm-input-not-force-invalid',
+      imports: [HlmInput],
+      template: `<input hlmInput aria-label="name" />`,
+    })
+    class TestHost {}
+
+    await render(TestHost);
+
+    const input = screen.getByLabelText('name');
+    expect(input.getAttribute('data-matches-spartan-invalid')).not.toBe('true');
+  });
+
+  it('hlm-select-trigger forwards [forceInvalid] to BrnSelectTrigger (aria-invalid + data-matches-spartan-invalid)', async () => {
+    @Component({
+      selector: 'test-hlm-select-trigger-force-invalid',
+      imports: [
+        HlmSelect,
+        HlmSelectTrigger,
+        HlmSelectValue,
+        HlmSelectContent,
+        HlmSelectItem,
+        HlmSelectPortal,
+      ],
+      template: `
+        <hlm-select>
+          <hlm-select-trigger [forceInvalid]="true" buttonId="plan-trigger">
+            <hlm-select-value placeholder="Select a plan" />
+          </hlm-select-trigger>
+          <hlm-select-content *hlmSelectPortal>
+            <hlm-select-item value="starter">Starter</hlm-select-item>
+          </hlm-select-content>
+        </hlm-select>
+      `,
+    })
+    class TestHost {}
+
+    await render(TestHost);
+
+    const trigger = screen.getByRole('combobox');
+    // BrnSelectTrigger's own `data-matches-spartan-invalid` host binding
+    // ORs `forceInvalid()` in — this is what drives the destructive-ring
+    // styling in `_computedClass`.
+    expect(trigger.getAttribute('data-matches-spartan-invalid')).toBe('true');
+    // `HlmSelectTrigger`'s own gated `aria-invalid` write (afterEveryRender)
+    // must also honor forceInvalid, or a forced-invalid trigger would show
+    // the destructive ring without announcing invalidity to assistive tech.
+    expect(trigger.getAttribute('aria-invalid')).toBe('true');
+  });
+});

--- a/libs/spartan/ui/README.md
+++ b/libs/spartan/ui/README.md
@@ -1,24 +1,56 @@
 # ui-helm
 
-Spartan's `@spartan-ng/helm` UI components, scaffolded into the workspace
-via the Spartan CLI (`nx g @spartan-ng/cli:ui …`). Spartan ships with a
-copy-the-source distribution model (à la shadcn/ui): the helm components
-are installed _into_ your repo so you own them and can theme them
-locally. The files under `libs/spartan/ui/{checkbox,icon,input,label,select,utils}`
-are the output of that CLI step — not custom reimplementations.
+Spartan's `@spartan-ng/helm` UI components, originally scaffolded into the
+workspace via the Spartan CLI (`nx g @spartan-ng/cli:ui …`). Spartan ships
+with a copy-the-source distribution model (à la shadcn/ui): the helm
+components are installed _into_ your repo so you own them and can theme
+them locally.
 
-## Upstream fidelity is the default
+## These files are NOT kept identical to CLI output
 
-We keep these files **identical to the Spartan CLI output**. Two reasons:
+Earlier revisions of this README claimed the files under
+`libs/spartan/ui/{checkbox,icon,input,label,select,utils}` were kept
+byte-identical to the Spartan CLI's output. That claim is false and has
+been for a while — diffing against `@spartan-ng/cli@1.0.4`'s generator
+templates shows real divergence, most of it intentional:
 
-- The CLI is the supported way to refresh helm. Local divergences turn
-  every regenerate into a manual merge.
-- `apps/demo-spartan` — the consumer of this lib — only needs the
-  CLI's stock surface to make its toolkit-integration point.
+- **Deep form-state integration.** `hlm-input`'s `error: 'auto' | true`
+  CVA variant, `hlm-checkbox`'s `_spartanInvalid`/`_errorStateClass`
+  wiring, and `hlm-select-trigger`'s `afterEveryRender`-gated
+  `aria-invalid` correction (see the doc comment in
+  `select/src/lib/hlm-select-trigger.ts`) all exist to make these
+  components track `ngx-signal-forms`' field state correctly — upstream's
+  stock output has no equivalent. Regenerating via the CLI would silently
+  drop this integration, not just cosmetic styling.
+- **Restored-but-previously-dropped upstream surface (audit #148 / #182).**
+  `forceInvalid` forwarding on `hlm-input` and `hlm-select-trigger`, the
+  `data-slot="input"` host attribute on `hlm-input`, and
+  `ChangeDetectionStrategy.OnPush` on `hlm-select-content`,
+  `hlm-select-trigger`, `hlm-select-item`, `hlm-checkbox`, and the
+  scroll-up/down affordances had drifted out of these files relative to
+  upstream v1.0.4 with no accompanying reason — those have been restored
+  to match upstream, since they don't conflict with the form-state
+  integration above.
+- **Older Tailwind utility styling.** The class strings in this lib
+  predate upstream's newer semantic `spartan-*` class-name convention
+  (visible by diffing e.g. `hlm-select-trigger.ts` against the CLI
+  template) and have not been migrated. Swapping to the new class names
+  requires vendoring upstream's companion CSS layer too, which this repo
+  does not currently do — left as-is rather than half-migrated.
 
-PR review suggestions that target `libs/spartan/ui/*` are typically declined for
-this reason, even when they identify real issues — fixes belong upstream
-in `@spartan-ng/ui`, then come back through `nx g @spartan-ng/cli:ui …`.
+## Regenerating from the CLI is a manual merge, not a drop-in
+
+Because of the above, **do not** run `nx g @spartan-ng/cli:ui …` and
+blindly accept its output for these files — it will regress the
+form-state integration this demo depends on. Treat a regenerate as a
+three-way diff: upstream's new baseline, this repo's current file, and
+the toolkit-integration bits that must survive the merge.
+
+PR review suggestions that target `libs/spartan/ui/*` should call out
+which category (integration / restorable drift / styling-convention drift)
+a proposed change falls into — restorable-drift fixes (like #182 above)
+are welcome; wholesale regeneration is not, without a plan for
+re-threading the integration pieces.
 
 ## Consumed in-tree only
 

--- a/libs/spartan/ui/checkbox/src/lib/hlm-checkbox.ts
+++ b/libs/spartan/ui/checkbox/src/lib/hlm-checkbox.ts
@@ -1,6 +1,7 @@
 import type { BooleanInput } from '@angular/cdk/coercion';
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   forwardRef,
@@ -30,7 +31,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
   imports: [BrnCheckbox, NgIcon, HlmIcon],
   providers: [HLM_CHECKBOX_VALUE_ACCESSOR],
   viewProviders: [provideIcons({ lucideCheck })],
-
+  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [BrnFieldControlDescribedBy],
   host: {
     class: 'contents peer',

--- a/libs/spartan/ui/input/src/lib/hlm-input.ts
+++ b/libs/spartan/ui/input/src/lib/hlm-input.ts
@@ -23,9 +23,10 @@ type InputVariants = VariantProps<typeof inputVariants>;
 @Directive({
   selector: '[hlmInput]',
   hostDirectives: [
-    { directive: BrnInput, inputs: ['id'] },
+    { directive: BrnInput, inputs: ['id', 'forceInvalid'] },
     BrnFieldControlDescribedBy,
   ],
+  host: { 'data-slot': 'input' },
 })
 export class HlmInput {
   /** Controls the error visual state of the input.

--- a/libs/spartan/ui/select/src/lib/hlm-select-content.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-content.ts
@@ -1,5 +1,11 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, computed, input } from '@angular/core';
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
 import { BrnSelectContent } from '@spartan-ng/brain/select';
 import { classes, hlm } from '@spartan-ng/helm/utils';
 import { HlmSelectScrollDown } from './hlm-select-scroll-down';
@@ -8,7 +14,7 @@ import { HlmSelectScrollUp } from './hlm-select-scroll-up';
 @Component({
   selector: 'hlm-select-content',
   imports: [HlmSelectScrollUp, HlmSelectScrollDown],
-
+  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [BrnSelectContent],
   template: `
     @if (showScroll()) {

--- a/libs/spartan/ui/select/src/lib/hlm-select-item.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-item.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideCheck } from '@ng-icons/lucide';
 import { BrnSelectItem } from '@spartan-ng/brain/select';
@@ -8,7 +8,7 @@ import { classes } from '@spartan-ng/helm/utils';
   selector: 'hlm-select-item',
   imports: [NgIcon],
   providers: [provideIcons({ lucideCheck })],
-
+  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     { directive: BrnSelectItem, inputs: ['id', 'disabled', 'value'] },
   ],

--- a/libs/spartan/ui/select/src/lib/hlm-select-scroll-down.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-scroll-down.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronDown } from '@ng-icons/lucide';
 import { BrnSelectScrollDown } from '@spartan-ng/brain/select';
@@ -8,7 +8,7 @@ import { classes } from '@spartan-ng/helm/utils';
   selector: 'hlm-select-scroll-down',
   imports: [NgIcon],
   providers: [provideIcons({ lucideChevronDown })],
-
+  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [BrnSelectScrollDown],
   template: ` <ng-icon name="lucideChevronDown" /> `,
 })

--- a/libs/spartan/ui/select/src/lib/hlm-select-scroll-up.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-scroll-up.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronUp } from '@ng-icons/lucide';
 import { BrnSelectScrollUp } from '@spartan-ng/brain/select';
@@ -8,7 +8,7 @@ import { classes } from '@spartan-ng/helm/utils';
   selector: 'hlm-select-scroll-up',
   imports: [NgIcon],
   providers: [provideIcons({ lucideChevronUp })],
-
+  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [BrnSelectScrollUp],
   template: ` <ng-icon name="lucideChevronUp" /> `,
 })

--- a/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
+++ b/libs/spartan/ui/select/src/lib/hlm-select-trigger.ts
@@ -1,5 +1,8 @@
+import type { BooleanInput } from '@angular/cdk/coercion';
 import {
   afterEveryRender,
+  booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -21,7 +24,7 @@ import type { ClassValue } from 'clsx';
   selector: 'hlm-select-trigger',
   imports: [NgIcon, BrnSelectTrigger, BrnFieldControlDescribedBy],
   providers: [provideIcons({ lucideChevronDown })],
-
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <button
       #trigger
@@ -30,6 +33,7 @@ import type { ClassValue } from 'clsx';
       [id]="buttonId()"
       [class]="_computedClass()"
       [attr.data-size]="size()"
+      [forceInvalid]="forceInvalid()"
       data-slot="select-trigger"
     >
       <ng-content />
@@ -63,11 +67,18 @@ export class HlmSelectTrigger {
    * this trigger's real `role="combobox"` button, so that toolkit-side
    * correction can't reach it — this fixes it at the source instead,
    * using Brain's own touched-aware signal (no toolkit coupling needed).
+   *
+   * `forceInvalid()` is OR'd in here too — it also feeds `[forceInvalid]`
+   * on the `brnSelectTrigger` binding above, which drives Brain's own
+   * `data-matches-spartan-invalid` (the destructive-ring styling below).
+   * Without the OR, a forced-invalid trigger would show the destructive
+   * ring without announcing invalidity to assistive tech.
    */
   private readonly _fieldControl = inject(BrnFieldControl, { optional: true });
 
   private readonly _gatedInvalid = computed(
-    () => this._fieldControl?.spartanInvalid() ?? false,
+    () =>
+      this.forceInvalid() || (this._fieldControl?.spartanInvalid() ?? false),
   );
 
   private readonly _triggerButton =
@@ -100,4 +111,9 @@ export class HlmSelectTrigger {
   );
 
   public readonly size = input<'default' | 'sm'>('default');
+
+  /** Whether to force the trigger into an invalid state. */
+  public readonly forceInvalid = input<boolean, BooleanInput>(false, {
+    transform: booleanAttribute,
+  });
 }


### PR DESCRIPTION
Closes #182

Fixes the 2 promoted pre-1.0 findings from audit #148 (demo-spartan).

## Finding 1 (api-design): vendored helm drifted from upstream v1.0.4; README overclaimed fidelity

- Restored `forceInvalid` forwarding on `hlm-input` (`libs/spartan/ui/input/src/lib/hlm-input.ts`) and `hlm-select-trigger` (`libs/spartan/ui/select/src/lib/hlm-select-trigger.ts`) to match upstream `@spartan-ng/cli@1.0.4` — verified against the actual installed CLI generator templates, not just the finding's description. `hlm-checkbox` already had this; input and select-trigger did not.
  - `hlm-select-trigger`'s own gated `aria-invalid` write (`afterEveryRender`) now also ORs in `forceInvalid()`, so a forced-invalid trigger shows the destructive ring *and* announces invalidity to AT consistently (previously those two would have disagreed).
- Restored `data-slot="input"` host attribute on `hlm-input` and `ChangeDetectionStrategy.OnPush` on `hlm-select-content`, `hlm-select-trigger`, `hlm-select-item`, `hlm-checkbox`, `hlm-select-scroll-up`, `hlm-select-scroll-down` — all match upstream and are safe with the existing signal-based reactivity in these components.
- Rewrote `libs/spartan/ui/README.md`: it claimed these files are kept byte-identical to Spartan CLI output. That's false — diffing against the real v1.0.4 templates shows deliberate, substantial customization (deep `ngx-signal-forms` field-state integration: the error-variant CVA on `hlm-input`, `_errorStateClass` wiring on `hlm-checkbox`, the `afterEveryRender`-gated `aria-invalid` correction on `hlm-select-trigger`) plus an older Tailwind utility-class convention that predates upstream's newer `spartan-*` semantic classes. The README now documents these categories and stops implying a blind CLI regenerate is safe (it would silently drop the form-state integration).

## Finding 2 (type-safety): `BrnFieldA11yPublicSurface` guard comment overclaimed

`apps/demo-spartan/src/app/wrapper/spartan-form-field.ts` claimed a `Pick<BrnFieldA11yService, ...>` return-type annotation is a compile-time guard against Brain adding new public members. It isn't — a `Pick` with a fixed key list still compiles unchanged when the source type gains members; it only fails on removal/rename of a listed key.

Added a real exhaustiveness assertion (`assertBrnFieldA11yPublicSurfaceIsExhaustive`) that `Exclude`s the known private members (`_descriptions`, `_errors`, per Brain 1.0.4's `.d.ts`) and the documented public surface from `keyof BrnFieldA11yService`, and fails to typecheck if anything is left over. Verified the mechanism against a standalone `tsc` repro (passes today, fails when a synthetic new public member is added) before wiring it into the real file. Corrected the comment to describe what the guard actually catches.

## Testing

- TDD: added `apps/demo-spartan/src/app/wrapper/vendored-helm-force-invalid.spec.ts` covering `forceInvalid` forwarding on `hlm-input` and `hlm-select-trigger` (confirmed select-trigger test failed before the fix, passed after). `libs/spartan/ui` (`ui-helm`) has no test target of its own, so this imports the vendored components directly through the `@spartan-ng/helm/*` path aliases, same as any in-tree consumer.
- No breaking changes — all additions are optional inputs / internal `ChangeDetectionStrategy` / doc + comment corrections. No `docs/MIGRATING_BETA_TO_V1.md` entry needed.

## Verification

- `pnpm nx run-many -t build,test,lint --projects=demo-spartan` — all pass (pre-existing warnings only, no new errors)
- `pnpm nx run demo-spartan-e2e:e2e -- --project=chromium` — 5/5 pass
- `pnpm nx run demo-spartan-e2e:a11y -- --project=chromium` — 1/1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>