### PR TITLE
fix(demo): OnPush, dead headless utilities, computed idiom (wave 3, #179)

### DIFF
--- a/apps/demo-e2e/src/forms/03-headless/fieldset-utilities.spec.ts
+++ b/apps/demo-e2e/src/forms/03-headless/fieldset-utilities.spec.ts
@@ -281,7 +281,7 @@ test.describe('Headless - Fieldset + Utilities', () => {
     });
   });
 
-  test.describe('Delivery Notes - NgxHeadlessCharacterCount', () => {
+  test.describe('Delivery Notes - createCharacterCount()', () => {
     test('should update headless character count and reflect limit state', async ({
       page,
     }) => {
@@ -317,6 +317,39 @@ test.describe('Headless - Fieldset + Utilities', () => {
         await expect(assistiveCounter).toBeVisible();
         // The assistive component renders currentLength/maxLength
         await expect(assistiveCounter).toContainText('195/200');
+      });
+    });
+
+    test('should expose the counter as a real DOM node referenced by aria-describedby', async ({
+      page,
+    }) => {
+      const notesInput = page.getByLabel('Notes');
+      const counter = page.locator('#deliveryNotes-counter');
+
+      await test.step('Counter element exists with the id notesDescribedBy() references', async () => {
+        await expect(counter).toBeVisible();
+      });
+
+      await test.step('Notes textarea describedby includes the counter id', async () => {
+        const describedBy = await notesInput.getAttribute('aria-describedby');
+        expect(describedBy?.split(' ')).toContain('deliveryNotes-counter');
+      });
+    });
+
+    test('should show utility-derived field-state flags', async ({ page }) => {
+      const notesInput = page.getByLabel('Notes');
+      const flags = page.getByTestId('notes-utility-flags');
+
+      await test.step('Initial state: not touched, not dirty', async () => {
+        await expect(flags).toContainText('notes touched = false');
+        await expect(flags).toContainText('notes dirty = false');
+      });
+
+      await test.step('Touch and dirty the field', async () => {
+        await notesInput.fill('Some notes');
+        await notesInput.blur();
+        await expect(flags).toContainText('notes touched = true');
+        await expect(flags).toContainText('notes dirty = true');
       });
     });
   });

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.form.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.form.ts
@@ -1,4 +1,4 @@
-import {  Component, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy,  Component, input, signal } from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import type { ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import {
@@ -17,6 +17,7 @@ import { contactFormSchema } from './your-first-form.validations';
 @Component({
 
   selector: 'ngx-your-first-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, NgxSignalFormToolkit, NgxFormFieldError],
   template: `
     <form

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.page.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import type { ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 import {
@@ -17,6 +23,7 @@ import { YourFirstFormComponent } from './your-first-form.form';
 
 @Component({
   selector: 'ngx-your-first-form-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     YourFirstFormComponent,
     ExampleCardsComponent,

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.form.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.form.ts
@@ -1,4 +1,10 @@
-import { Component, computed, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from '@angular/core';
 import type { FieldState, FieldTree } from '@angular/forms/signals';
 import { form, FormField } from '@angular/forms/signals';
 import {
@@ -30,6 +36,7 @@ const INITIAL_MODEL: ProductFeedbackModel = {
 
 @Component({
   selector: 'ngx-error-display-helpers',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   template: `
     <div
@@ -129,6 +136,7 @@ export class ErrorDisplayHelpersComponent {
  */
 @Component({
   selector: 'ngx-error-display-modes-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     ErrorDisplayHelpersComponent,

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.page.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.page.ts
@@ -1,4 +1,9 @@
-import { Component, computed, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
 import { type ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 import {
@@ -17,6 +22,7 @@ import { ErrorDisplayModesFormComponent } from './error-display-modes.form';
 
 @Component({
   selector: 'ngx-error-display-modes-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ErrorDisplayModesFormComponent,
     ExampleCardsComponent,

--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.form.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 import {
   NgxSignalFormToolkit,
@@ -10,6 +15,7 @@ import { createPasswordForm } from './warning-support.validations';
 
 @Component({
   selector: 'ngx-warning-support-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   host: {

--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.page.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { type ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 import {
@@ -17,6 +23,7 @@ import { WarningsSupportFormComponent } from './warning-support.form';
 
 @Component({
   selector: 'ngx-warning-support-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     ExampleCardsComponent,

--- a/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.form.ts
+++ b/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.form.ts
@@ -1,4 +1,9 @@
-import { Component, computed, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
 import {
   form,
   FormField,
@@ -69,6 +74,7 @@ function ariaDescribedBy(errors: readonly ResolvedFieldError[]): string | null {
 
 @Component({
   selector: 'ngx-error-message-signal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, FormRoot],
   templateUrl: './error-message-signal.form.html',

--- a/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.page.ts
+++ b/apps/demo/src/app/03-headless/error-message-signal/error-message-signal.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 import {
   ExampleCardsComponent,
@@ -10,6 +10,7 @@ import { ErrorMessageSignalComponent } from './error-message-signal.form';
 
 @Component({
   selector: 'ngx-error-message-signal-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.form.html
+++ b/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.form.html
@@ -353,13 +353,16 @@
             #notesName="fieldName"
             class="space-y-2 sm:col-span-2"
           >
-            <div
-              ngxHeadlessErrorState
-              #notesState="errorState"
-              [field]="deliveryForm.deliveryNotes"
-              [fieldName]="notesName.resolvedFieldName()"
-              class="space-y-2"
-            >
+            <!--
+              Delivery notes intentionally skips ngxHeadlessErrorState /
+              ngxHeadlessCharacterCount and wires createErrorState(),
+              createCharacterCount(), createFieldStateFlags(), and the
+              notesDescribedBy() composition below directly — the "build
+              fully custom UI from plain functions" path this page's
+              utilities exist for, contrasted with the directive-driven
+              fields above (contact email, address).
+            -->
+            <div class="space-y-2">
               <div class="flex items-end justify-between gap-2">
                 <label
                   [for]="notesName.resolvedFieldName()"
@@ -369,59 +372,50 @@
                 </label>
 
                 <!--
-                  Headless character count — NgxHeadlessCharacterCount
-                  Provides all count signals (currentLength, remaining,
-                  limitState, percentUsed…) for fully custom markup.
+                  Headless character count — createCharacterCount()
+                  Same count signals as NgxHeadlessCharacterCount
+                  (currentLength, remaining, limitState, percentUsed…),
+                  composed as a plain class field instead of a directive.
+                  Carries `notesCounterId` so notesDescribedBy() below
+                  resolves to a real DOM node.
                   States: ok → warning (≥80 %) → danger (≥95 %) → exceeded.
-
-                  The directive is attached to an ng-container so the
-                  exported template reference (#notesCharCount) is read by
-                  child elements only — this avoids NG0950 (required input
-                  not available during the creation pass of the same element).
                 -->
-                <ng-container
-                  ngxHeadlessCharacterCount
-                  #notesCharCount="characterCount"
-                  [field]="deliveryForm.deliveryNotes"
-                  [maxLength]="200"
+                <span
+                  [id]="notesCounterId"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  [attr.data-limit-state]="notesCount.limitState()"
+                  [attr.data-testid]="'headless-char-count'"
+                  class="text-xs"
+                  [class.text-gray-500]="notesCount.limitState() === 'ok'"
+                  [class.dark:text-gray-400]="notesCount.limitState() === 'ok'"
+                  [class.text-amber-700]="
+                    notesCount.limitState() === 'warning'
+                  "
+                  [class.dark:text-amber-400]="
+                    notesCount.limitState() === 'warning'
+                  "
+                  [class.text-red-600]="notesCount.limitState() === 'danger'"
+                  [class.dark:text-red-400]="notesCount.limitState() === 'danger'"
+                  [class.font-semibold]="
+                    notesCount.limitState() === 'exceeded'
+                  "
+                  [class.text-red-800]="
+                    notesCount.limitState() === 'exceeded'
+                  "
+                  [class.dark:text-red-400]="
+                    notesCount.limitState() === 'exceeded'
+                  "
                 >
-                  <span
-                    aria-live="polite"
-                    aria-atomic="true"
-                    [attr.data-limit-state]="notesCharCount.limitState()"
-                    [attr.data-testid]="'headless-char-count'"
-                    class="text-xs"
-                    [class.text-gray-500]="notesCharCount.limitState() === 'ok'"
-                    [class.dark:text-gray-400]="notesCharCount.limitState() === 'ok'"
-                    [class.text-amber-700]="
-                      notesCharCount.limitState() === 'warning'
-                    "
-                    [class.dark:text-amber-400]="
-                      notesCharCount.limitState() === 'warning'
-                    "
-                    [class.text-red-600]="notesCharCount.limitState() === 'danger'"
-                    [class.dark:text-red-400]="notesCharCount.limitState() === 'danger'"
-                    [class.font-semibold]="
-                      notesCharCount.limitState() === 'exceeded'
-                    "
-                    [class.text-red-800]="
-                      notesCharCount.limitState() === 'exceeded'
-                    "
-                    [class.dark:text-red-400]="
-                      notesCharCount.limitState() === 'exceeded'
-                    "
+                  {{ notesCount.currentLength() }}/{{
+                  notesCount.resolvedMaxLength() }} @if (notesCount.limitState()
+                  !== 'ok') {
+                  <span class="ml-1"
+                    >({{ notesCount.remaining() >= 0 ? notesCount.remaining() +
+                    ' left' : notesCount.remaining() * -1 + ' over' }})</span
                   >
-                    {{ notesCharCount.currentLength() }}/{{
-                    notesCharCount.resolvedMaxLength() }} @if
-                    (notesCharCount.limitState() !== 'ok') {
-                    <span class="ml-1"
-                      >({{ notesCharCount.remaining() >= 0 ?
-                      notesCharCount.remaining() + ' left' :
-                      notesCharCount.remaining() * -1 + ' over' }})</span
-                    >
-                    }
-                  </span>
-                </ng-container>
+                  }
+                </span>
               </div>
 
               <textarea
@@ -430,41 +424,55 @@
                 rows="3"
                 [formField]="deliveryForm.deliveryNotes"
                 placeholder="Special instructions…"
-                [attr.aria-invalid]="notesState.hasErrors() ? 'true' : null"
-                [attr.aria-describedby]="
-                  notesState.shouldShowErrors() && notesState.hasErrors()
-                    ? notesState.errorId()
-                    : notesState.shouldShowWarnings() && notesState.hasWarnings()
-                      ? notesState.warningId()
-                      : null
-                "
+                [attr.aria-invalid]="notesError.hasErrors() ? 'true' : null"
+                [attr.aria-describedby]="notesDescribedBy()"
               ></textarea>
 
-              @if (notesState.shouldShowErrors() && notesState.hasErrors()) {
+              @if (notesError.shouldShowErrors() && notesError.hasErrors()) {
               <div
-                [id]="notesState.errorId()"
+                [id]="notesError.errorId()"
                 role="alert"
                 class="headless-alert-error text-xs"
               >
-                @for ( error of notesState.resolvedErrors(); track error.kind +
-                ':' + error.message + ':' + $index ) {
+                @for ( error of notesError.errors(); track error.kind + ':' +
+                error.message + ':' + $index ) {
                 <div>{{ error.message }}</div>
                 }
               </div>
-              } @else if ( notesState.shouldShowWarnings() &&
-              notesState.hasWarnings() ) {
+              } @else if ( notesError.shouldShowWarnings() &&
+              notesError.hasWarnings() ) {
               <div
-                [id]="notesState.warningId()"
+                [id]="notesError.warningId()"
                 role="status"
                 aria-live="polite"
                 class="headless-alert-warning text-xs"
               >
-                @for ( warning of notesState.resolvedWarnings(); track
-                warning.kind + ':' + warning.message + ':' + $index ) {
+                @for ( warning of notesError.warnings(); track warning.kind +
+                ':' + warning.message + ':' + $index ) {
                 <div>{{ warning.message }}</div>
                 }
               </div>
               }
+
+              <!--
+                Field-state flags — createFieldStateFlags()
+                Same touched/dirty/invalid/pending booleans as the
+                shipping-address fieldset's debug strip above, composed
+                here as plain computed signals instead of a directive.
+                Labeled "notes X = …" (not "X: …") so this strip's text
+                can't collide with the address fieldset's "touched:" /
+                "dirty:" / "invalid:" / "pending:" locators above — both
+                live inside the same visual <fieldset>.
+              -->
+              <div
+                class="flex flex-wrap gap-2 text-xs text-gray-600 dark:text-gray-400"
+                data-testid="notes-utility-flags"
+              >
+                <span>notes touched = {{ notesFlags.isTouched() }}</span>
+                <span>notes dirty = {{ notesFlags.isDirty() }}</span>
+                <span>notes invalid = {{ notesFlags.isInvalid() }}</span>
+                <span>notes pending = {{ notesFlags.isPending() }}</span>
+              </div>
 
               <!--
                 Assistive-tier alternative — NgxFormFieldCharacterCount

--- a/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.form.ts
+++ b/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.form.ts
@@ -132,6 +132,10 @@ export class HeadlessFieldsetUtilitiesComponent {
     },
   });
 
+  // Delivery notes is deliberately built from these four utilities instead
+  // of ngxHeadlessErrorState / ngxHeadlessCharacterCount — see the template
+  // for the "plain functions instead of directives" wiring they power.
+
   protected readonly notesCounterId = 'deliveryNotes-counter';
 
   protected readonly notesError = createErrorState({

--- a/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.form.ts
+++ b/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.form.ts
@@ -1,4 +1,10 @@
-import { Component, computed, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from '@angular/core';
 import {
   email,
   form,
@@ -81,6 +87,7 @@ const deliverySchema = schema<HeadlessDeliveryModel>((path) => {
 
 @Component({
   selector: 'ngx-headless-fieldset-utilities',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     FormField,

--- a/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.page.ts
+++ b/apps/demo/src/app/03-headless/fieldset-utilities/fieldset-utilities.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import type { ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 import {
@@ -18,6 +24,7 @@ import { HeadlessFieldsetUtilitiesComponent } from './fieldset-utilities.form';
 
 @Component({
   selector: 'ngx-headless-fieldset-utilities-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.form.ts
@@ -1,4 +1,10 @@
-import { Component, computed, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import type {
   ErrorDisplayStrategy,
@@ -55,6 +61,7 @@ function createInitialComplexFormModel(): ComplexFormModel {
  */
 @Component({
   selector: 'ngx-complex-forms',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     FormField,

--- a/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.page.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import type {
   ErrorDisplayStrategy,
   FormFieldAppearance,
@@ -42,6 +48,7 @@ const FIELDSET_ERROR_PLACEMENT_LABELS: Record<
 
 @Component({
   selector: 'ngx-complex-forms-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/04-form-field-wrapper/complex-forms/fieldset.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/complex-forms/fieldset.form.ts
@@ -1,4 +1,10 @@
-import { booleanAttribute, Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  booleanAttribute,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   email,
   FormField,
@@ -100,6 +106,7 @@ const placementDesignPreviewSchema = schema<PlacementDesignPreviewModel>(
  */
 @Component({
   selector: 'ngx-fieldset-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   templateUrl: './fieldset.form.html',

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.form.ts
@@ -1,5 +1,11 @@
 // Custom controls demo form - product review with rating, switch, checkbox controls
-import { Component, computed, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import {
   buildAriaDescribedBy,
@@ -41,6 +47,7 @@ import { customControlsSchema } from './custom-controls.validations';
  */
 @Component({
   selector: 'ngx-custom-controls',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   providers: [
     ...provideNgxSignalFormControlPresetsForComponent({

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.page.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import type {
   ErrorDisplayStrategy,
   FormFieldAppearance,
@@ -28,6 +34,7 @@ import { CustomControlsFormComponent } from './custom-controls.form';
 
 @Component({
   selector: 'ngx-custom-controls-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CustomControlsFormComponent,
     ErrorDisplayModeSelectorComponent,

--- a/apps/demo/src/app/04-form-field-wrapper/field-marking/field-marking.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/field-marking/field-marking.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   email,
   FormField,
@@ -27,6 +32,7 @@ import {
  */
 @Component({
   selector: 'ngx-field-marking-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     FormField,

--- a/apps/demo/src/app/04-form-field-wrapper/field-marking/field-marking.page.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/field-marking/field-marking.page.ts
@@ -1,4 +1,9 @@
-import { Component, computed, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type {
   FieldMarkingMode,
@@ -26,6 +31,7 @@ const MODE_OPTIONS: readonly { value: FieldMarkingMode; label: string }[] = [
 
 @Component({
   selector: 'ngx-field-marking-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     FormsModule,

--- a/apps/demo/src/app/04-form-field-wrapper/fieldset-appearance/fieldset-appearance.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/fieldset-appearance/fieldset-appearance.form.ts
@@ -1,4 +1,9 @@
-import { Component, computed, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
 import type { ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import {
   type NgxFormFieldsetAppearance,
@@ -98,6 +103,7 @@ const ERROR_PLACEMENT_LABELS: Record<NgxFormFieldErrorPlacement, string> = {
 
 @Component({
   selector: 'ngx-fieldset-appearance-form',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     DisplayControlsCardComponent,

--- a/apps/demo/src/app/04-form-field-wrapper/fieldset-appearance/fieldset-appearance.page.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/fieldset-appearance/fieldset-appearance.page.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ExampleCardsComponent, PageHeaderComponent } from '../../ui';
 import { FIELDSET_APPEARANCE_CONTENT } from './fieldset-appearance.content';
 import { FieldsetAppearanceFormComponent } from './fieldset-appearance.form';
 
 @Component({
   selector: 'ngx-fieldset-appearance-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     ExampleCardsComponent,

--- a/apps/demo/src/app/04-form-field-wrapper/labelless-fields/labelless-fields.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/labelless-fields/labelless-fields.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import { FormField, form } from '@angular/forms/signals';
 import {
   createOnInvalidHandler,
@@ -24,6 +29,7 @@ import { labellessFieldsSchema } from './labelless-fields.validations';
  */
 @Component({
   selector: 'ngx-labelless-fields',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   templateUrl: './labelless-fields.html',

--- a/apps/demo/src/app/04-form-field-wrapper/labelless-fields/labelless-fields.page.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/labelless-fields/labelless-fields.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import type {
   ErrorDisplayStrategy,
   FormFieldAppearance,
@@ -28,6 +34,7 @@ import { LabellessFieldsFormComponent } from './labelless-fields.form';
 
 @Component({
   selector: 'ngx-labelless-fields-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     LabellessFieldsFormComponent,
     ErrorDisplayModeSelectorComponent,

--- a/apps/demo/src/app/05-advanced/advanced-wizard/advanced-wizard.page.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/advanced-wizard.page.ts
@@ -1,4 +1,9 @@
-import { Component, computed, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
 import { type FormFieldAppearance } from '@ngx-signal-forms/toolkit';
 
 import {
@@ -20,6 +25,7 @@ import { WizardContainerComponent } from './components/wizard-container';
 
 @Component({
   selector: 'ngx-advanced-wizard-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     WizardContainerComponent,

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/review-step.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/review-step.ts
@@ -1,4 +1,10 @@
-import { Component, ElementRef, inject, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  viewChild,
+} from '@angular/core';
 
 import {
   createReviewStepForm,
@@ -9,6 +15,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
 
 @Component({
   selector: 'ngx-review-step',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   template: `
     <div class="review-step">

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/traveler-step.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/traveler-step.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -36,6 +37,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
 
 @Component({
   selector: 'ngx-traveler-step',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/trip-step.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/trip-step.ts
@@ -1,4 +1,11 @@
-import { Component, ElementRef, inject, input, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 
 import {
@@ -15,6 +22,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
 
 @Component({
   selector: 'ngx-trip-step',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/wizard-container.ts
@@ -1,5 +1,6 @@
 import { DatePipe } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   afterRenderEffect,
   Component,
   computed,
@@ -37,6 +38,7 @@ const MIN_DISPLAY_MS = 500;
 
 @Component({
   selector: 'ngx-wizard-container',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     DatePipe,

--- a/apps/demo/src/app/05-advanced/async-validation/async-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/async-validation/async-validation.form.ts
@@ -1,5 +1,11 @@
 import { JsonPipe } from '@angular/common';
-import { Component, computed, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from '@angular/core';
 import {
   debounce,
   form,
@@ -93,6 +99,7 @@ const registrationSchema = schema<Registration>((path) => {
 
 @Component({
   selector: 'ngx-async-validation',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField, JsonPipe],
   template: `

--- a/apps/demo/src/app/05-advanced/async-validation/async-validation.page.ts
+++ b/apps/demo/src/app/05-advanced/async-validation/async-validation.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { AsyncValidationComponent } from './async-validation.form';
 
 @Component({
   selector: 'ngx-async-validation-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/cross-field-validation/cross-field-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/cross-field-validation/cross-field-validation.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   form,
   FormField,
@@ -62,6 +67,7 @@ const bookingSchema = schema<Booking>((path) => {
 
 @Component({
   selector: 'ngx-cross-field-validation',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `

--- a/apps/demo/src/app/05-advanced/cross-field-validation/cross-field-validation.page.ts
+++ b/apps/demo/src/app/05-advanced/cross-field-validation/cross-field-validation.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { CrossFieldValidationComponent } from './cross-field-validation.form';
 
 @Component({
   selector: 'ngx-cross-field-validation-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/field-state-patterns/field-state-patterns.form.ts
+++ b/apps/demo/src/app/05-advanced/field-state-patterns/field-state-patterns.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   disabled,
   email,
@@ -66,6 +71,7 @@ const fieldStatePatternsSchema = schema<FieldStatePatternsModel>((path) => {
 
 @Component({
   selector: 'ngx-field-state-patterns',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `

--- a/apps/demo/src/app/05-advanced/field-state-patterns/field-state-patterns.page.ts
+++ b/apps/demo/src/app/05-advanced/field-state-patterns/field-state-patterns.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { FieldStatePatternsComponent } from './field-state-patterns.form';
 
 @Component({
   selector: 'ngx-field-state-patterns-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/global-configuration/global-configuration.form.ts
+++ b/apps/demo/src/app/05-advanced/global-configuration/global-configuration.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import { form, FormField } from '@angular/forms/signals';
 import {
   type ErrorDisplayStrategy,
@@ -31,6 +36,7 @@ import { globalConfigSchema } from './global-configuration.validations';
  */
 @Component({
   selector: 'ngx-global-configuration',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   /**
    * Component-scoped providers demonstrating the configuration cascade:

--- a/apps/demo/src/app/05-advanced/global-configuration/global-configuration.page.ts
+++ b/apps/demo/src/app/05-advanced/global-configuration/global-configuration.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { GlobalConfigurationComponent } from './global-configuration.form';
 
 @Component({
   selector: 'ngx-global-configuration-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.form.ts
+++ b/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.form.ts
@@ -1,4 +1,10 @@
-import { Component, computed, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  signal,
+} from '@angular/core';
 import { form, FormField } from '@angular/forms/signals';
 import {
   type ErrorDisplayStrategy,
@@ -36,6 +42,7 @@ import { submissionSchema } from './submission-patterns.validations';
  */
 @Component({
   selector: 'ngx-submission-state-indicator',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
       class="mb-6 flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900"
@@ -114,6 +121,7 @@ export class SubmissionStateIndicatorComponent {
  */
 @Component({
   selector: 'ngx-submission-patterns',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     FormField,

--- a/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.page.ts
+++ b/apps/demo/src/app/05-advanced/submission-patterns/submission-patterns.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { SubmissionPatternsComponent } from './submission-patterns.form';
 
 @Component({
   selector: 'ngx-submission-patterns-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/vest-validation/vest-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/vest-validation/vest-validation.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   form,
   FormField,
@@ -34,6 +39,7 @@ const vestValidationSchema: SchemaFn<Readonly<VestValidationModel>> = (
 
 @Component({
   selector: 'ngx-vest-validation',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   styles: `

--- a/apps/demo/src/app/05-advanced/vest-validation/vest-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/vest-validation/vest-validation.form.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   signal,
 } from '@angular/core';
@@ -284,11 +285,10 @@ export class VestValidationComponent {
     },
   });
 
-  protected useSingleColumnFieldRows(): boolean {
-    return (
-      this.appearance() === 'standard' && this.orientation() === 'horizontal'
-    );
-  }
+  protected readonly useSingleColumnFieldRows = computed(
+    () =>
+      this.appearance() === 'standard' && this.orientation() === 'horizontal',
+  );
 
   protected resetForm(): void {
     this.accountForm().reset();

--- a/apps/demo/src/app/05-advanced/vest-validation/vest-validation.page.ts
+++ b/apps/demo/src/app/05-advanced/vest-validation/vest-validation.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { VestValidationComponent } from './vest-validation.form';
 
 @Component({
   selector: 'ngx-vest-validation-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/zod-validation/zod-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/zod-validation/zod-validation.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   form,
   FormField,
@@ -30,6 +35,7 @@ const zodValidationSchema: SchemaFn<Readonly<ZodValidationModel>> = (
 
 @Component({
   selector: 'ngx-zod-validation',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   styles: `

--- a/apps/demo/src/app/05-advanced/zod-validation/zod-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/zod-validation/zod-validation.form.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   signal,
 } from '@angular/core';
@@ -220,11 +221,10 @@ export class ZodValidationComponent {
   validateStandardSchema(path, zodBaselineAccountSchema);
 });`;
 
-  protected useSingleColumnFieldRows(): boolean {
-    return (
-      this.appearance() === 'standard' && this.orientation() === 'horizontal'
-    );
-  }
+  protected readonly useSingleColumnFieldRows = computed(
+    () =>
+      this.appearance() === 'standard' && this.orientation() === 'horizontal',
+  );
 
   protected resetForm(): void {
     this.accountForm().reset();

--- a/apps/demo/src/app/05-advanced/zod-validation/zod-validation.page.ts
+++ b/apps/demo/src/app/05-advanced/zod-validation/zod-validation.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { ZodValidationComponent } from './zod-validation.form';
 
 @Component({
   selector: 'ngx-zod-validation-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/05-advanced/zod-vest-validation/zod-vest-validation.form.ts
+++ b/apps/demo/src/app/05-advanced/zod-vest-validation/zod-vest-validation.form.ts
@@ -1,4 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  signal,
+} from '@angular/core';
 import {
   form,
   FormField,
@@ -37,6 +42,7 @@ const zodVestValidationSchema: SchemaFn<Readonly<ZodVestValidationModel>> = (
 
 @Component({
   selector: 'ngx-zod-vest-validation',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `

--- a/apps/demo/src/app/05-advanced/zod-vest-validation/zod-vest-validation.page.ts
+++ b/apps/demo/src/app/05-advanced/zod-vest-validation/zod-vest-validation.page.ts
@@ -1,4 +1,10 @@
-import { Component, computed, signal, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {
   type ErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -28,6 +34,7 @@ import { ZodVestValidationComponent } from './zod-vest-validation.form';
 
 @Component({
   selector: 'ngx-zod-vest-validation-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/app.ts
+++ b/apps/demo/src/app/app.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   afterNextRender,
   Component,
   effect,
@@ -25,6 +26,7 @@ import { PageControlsService } from './ui/page-controls';
 
 @Component({
   selector: 'ngx-root',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [
     RouterOutlet,

--- a/apps/demo/src/app/shared/controls/rating-control.ts
+++ b/apps/demo/src/app/shared/controls/rating-control.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -44,6 +45,7 @@ import { NgxFieldIdentity } from '@ngx-signal-forms/toolkit';
  */
 @Component({
   selector: 'ngx-rating-control',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   host: {
     'data-ngx-signal-form-control': '',

--- a/apps/demo/src/app/shared/controls/switch-control.ts
+++ b/apps/demo/src/app/shared/controls/switch-control.ts
@@ -1,9 +1,10 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormField, type FieldTree } from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 
 @Component({
   selector: 'ngx-switch-control',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [FormField, NgxSignalFormToolkit],
   host: {

--- a/apps/demo/src/app/shared/wizard/wizard.ts
+++ b/apps/demo/src/app/shared/wizard/wizard.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   booleanAttribute,
   Component,
   computed,
@@ -89,6 +90,7 @@ export interface WizardSubmitEvent {
  */
 @Component({
   selector: 'ngx-wizard',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [NgTemplateOutlet],
   templateUrl: './wizard.html',

--- a/apps/demo/src/app/ui/appearance-toggle/appearance-toggle.ts
+++ b/apps/demo/src/app/ui/appearance-toggle/appearance-toggle.ts
@@ -1,9 +1,10 @@
-import { Component, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, model } from '@angular/core';
 import type { FormFieldAppearance } from '@ngx-signal-forms/toolkit';
 import { APPEARANCE_LABELS, APPEARANCE_OPTIONS } from './appearance.constants';
 
 @Component({
   selector: 'ngx-appearance-toggle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   template: `
     <div

--- a/apps/demo/src/app/ui/badge/badge.ts
+++ b/apps/demo/src/app/ui/badge/badge.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 export type BadgeVariant = 'solid' | 'outline' | 'ghost';
 export type BadgeAppearance =
@@ -10,6 +10,7 @@ export type BadgeAppearance =
 
 @Component({
   selector: 'ngx-badge',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   host: {
     '[class]': 'badgeClasses()',

--- a/apps/demo/src/app/ui/card/card.ts
+++ b/apps/demo/src/app/ui/card/card.ts
@@ -1,8 +1,14 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, input, type TemplateRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  type TemplateRef,
+} from '@angular/core';
 
 @Component({
   selector: 'ngx-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [NgTemplateOutlet],
   host: {

--- a/apps/demo/src/app/ui/display-controls-card/display-controls-card.ts
+++ b/apps/demo/src/app/ui/display-controls-card/display-controls-card.ts
@@ -1,4 +1,9 @@
-import { Component, inject, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+} from '@angular/core';
 import { PanelHelpService } from './panel-help.service';
 
 export type DisplayControlsLayout = 'single' | 'split';
@@ -16,6 +21,7 @@ export type DisplayControlChip = {
  */
 @Component({
   selector: 'ngx-display-controls-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   templateUrl: './display-controls-card.html',
   styleUrl: './display-controls-card.scss',

--- a/apps/demo/src/app/ui/display-controls-card/display-controls-section.ts
+++ b/apps/demo/src/app/ui/display-controls-card/display-controls-section.ts
@@ -1,8 +1,14 @@
-import { Component, inject, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+} from '@angular/core';
 import { PanelHelpService } from './panel-help.service';
 
 @Component({
   selector: 'ngx-display-controls-section',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/ui/error-display-mode-selector/error-display-mode-selector.ts
+++ b/apps/demo/src/app/ui/error-display-mode-selector/error-display-mode-selector.ts
@@ -1,4 +1,11 @@
-import { Component, computed, inject, input, model } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  model,
+} from '@angular/core';
 import { type ErrorDisplayStrategy } from '@ngx-signal-forms/toolkit';
 import { PanelHelpService } from '../display-controls-card/panel-help.service';
 
@@ -70,6 +77,7 @@ export const ERROR_DISPLAY_MODES: ErrorDisplayModeConfig[] = [
  */
 @Component({
   selector: 'ngx-error-display-mode-selector',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     .error-mode-wrapper--embedded {

--- a/apps/demo/src/app/ui/example-cards/example-cards.ts
+++ b/apps/demo/src/app/ui/example-cards/example-cards.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CardComponent } from '../card/card';
 
 type DemonstratedCardConfig = {
@@ -31,6 +31,7 @@ type LearningCardConfig = {
  */
 @Component({
   selector: 'ngx-example-cards',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [CardComponent],
   templateUrl: './example-cards.html',

--- a/apps/demo/src/app/ui/nav-tree/nav-tree.ts
+++ b/apps/demo/src/app/ui/nav-tree/nav-tree.ts
@@ -1,4 +1,9 @@
-import { Component, inject, linkedSignal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  linkedSignal,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   NavigationEnd,
@@ -13,6 +18,7 @@ type CategoryId = (typeof DEMO_CATEGORIES)[number]['id'];
 
 @Component({
   selector: 'ngx-nav-tree',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [RouterLink, RouterLinkActive],
   host: {

--- a/apps/demo/src/app/ui/orientation-toggle/orientation-toggle.ts
+++ b/apps/demo/src/app/ui/orientation-toggle/orientation-toggle.ts
@@ -1,4 +1,9 @@
-import { Component, input, model } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  model,
+} from '@angular/core';
 import type {
   FormFieldAppearance,
   FormFieldOrientation,
@@ -11,6 +16,7 @@ import {
 
 @Component({
   selector: 'ngx-orientation-toggle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   template: `
     <div

--- a/apps/demo/src/app/ui/page-header/page-header.ts
+++ b/apps/demo/src/app/ui/page-header/page-header.ts
@@ -1,7 +1,8 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
   selector: 'ngx-page-header',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   template: `
     <header class="mb-8 text-center">

--- a/apps/demo/src/app/ui/right-rail/right-rail.ts
+++ b/apps/demo/src/app/ui/right-rail/right-rail.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   afterNextRender,
   Component,
   effect,
@@ -24,6 +25,7 @@ import { PanelHelpService } from '../display-controls-card/panel-help.service';
  */
 @Component({
   selector: 'ngx-right-rail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   imports: [NgTemplateOutlet],
   host: {

--- a/apps/demo/src/app/ui/split-layout/split-layout.ts
+++ b/apps/demo/src/app/ui/split-layout/split-layout.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'ngx-split-layout',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   styles: `
     :host {

--- a/apps/demo/src/app/ui/theme-switcher/theme-switcher.ts
+++ b/apps/demo/src/app/ui/theme-switcher/theme-switcher.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   afterRenderEffect,
   Component,
   computed,
@@ -9,6 +10,7 @@ import {
 
 @Component({
   selector: 'ngx-theme-switcher',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 
   host: { class: 'theme-toggle-wrapper' },
   imports: [],


### PR DESCRIPTION
Closes #179

Fixes the 3 promoted pre-1.0 findings from audit #145 (area: demo).

## Summary

1. **Zero demo components used `ChangeDetectionStrategy.OnPush`** (0 of 60+ `@Component`s). The flagship reference app should be OnPush/zoneless-safe by default since every component is already signal-first — users copy this code verbatim into apps that may still run zone-based change detection. Mechanically added `changeDetection: ChangeDetectionStrategy.OnPush` to every `@Component` decorator (61 decorators across 59 files; 2 files already had it).

2. **`fieldset-utilities` instantiated headless utilities the template never used.** `createErrorState()`/`createCharacterCount()`/`createFieldStateFlags()` plus a `notesDescribedBy()`/`notesCounterId` composition were declared on the component but the template used the `ngxHeadlessErrorState`/`ngxHeadlessCharacterCount` *directives* for every field instead — dead code that misleads readers of a page whose entire purpose is teaching "headless utilities for fully custom UI," and `notesDescribedBy` referenced a `deliveryNotes-counter` id that never existed in the DOM. Delivery notes now runs entirely off the four utilities (contrasted against the directive-driven contact-email/address fields above it), and a new touched/dirty/invalid/pending debug strip (mirroring the address fieldset's existing convention) uses `notesFlags`. Added e2e coverage for the previously-dead id reference and the new flags strip.

3. **`useSingleColumnFieldRows()` was a plain method, not a `computed()`.** Both `vest-validation.form.ts` and `zod-validation.form.ts` had the identical anti-pattern (a template class-binding calling a plain method that only reads signals, instead of the `computed()` idiom used everywhere else in the demo). Converted both.

No public toolkit API changes — all three fixes are internal to `apps/demo`, so no `docs/MIGRATING_BETA_TO_V1.md` entry is needed.

## Test plan

- [x] `pnpm nx run-many -t build,test,lint --projects=demo` — all green (pre-existing warnings only, no new ones)
- [x] `pnpm nx run demo-e2e:e2e -- --project=chromium` (full suite, not affected-subset) — 269 passed, 8 failed. All 8 failures are `@layout` visual-regression screenshot baselines (labelless-fields, complex-forms, custom-controls, vest-validation) that fail identically on the pre-wave parent commit `d3b4f9d3` (verified by checking it out and re-running the same specs) — stale local macOS baselines, unrelated to this PR's changes.
- [x] New/updated e2e assertions in `fieldset-utilities.spec.ts` for the utility-wiring fix, all passing.

## Skipped

None — all 3 findings were fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>