### PR TITLE
fix(api): resolve v1.0.0 api-review promoted findings (#178)

### DIFF
--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -1236,3 +1236,7 @@ point:
   (`runInAngular`) had zero importers and a `@example` calling functions that
   don't exist anywhere in this repo. Deleted rather than published, since
   promoting it would have required writing a truthful example from scratch.
+
+## Form-level `errorStrategy` no longer accepts `'inherit'` (#178)
+
+`NgxSignalForm`'s `[errorStrategy]` input is now typed `ResolvedErrorDisplayStrategy` (`'immediate' | 'on-touch' | 'on-submit'`) instead of `ErrorDisplayStrategy`. `'inherit'` is a field-level-only value — there is nothing above the form root to inherit from — and was already silently treated as "use the default", so binding `[errorStrategy]="'inherit'"` on a `<form ngxSignalForm>` is now a compile-time error. **Fix:** remove the binding (the default already applies) or pass a concrete strategy. Field-level `[strategy]` still accepts `'inherit'`.

--- a/packages/toolkit/core/directives/ngx-signal-form.ts
+++ b/packages/toolkit/core/directives/ngx-signal-form.ts
@@ -8,11 +8,7 @@ import {
 } from '@angular/core';
 import { FormRoot, type FieldTree } from '@angular/forms/signals';
 import { NGX_SIGNAL_FORM_CONTEXT, NGX_SIGNAL_FORMS_CONFIG } from '../tokens';
-import type {
-  ErrorDisplayStrategy,
-  ResolvedErrorDisplayStrategy,
-  SubmittedStatus,
-} from '../types';
+import type { ResolvedErrorDisplayStrategy, SubmittedStatus } from '../types';
 import { createSubmittedStatusTracker } from '../utilities/submission-helpers';
 
 /**
@@ -143,8 +139,14 @@ export class NgxSignalForm {
   /**
    * Error display strategy for this form.
    * Overrides the global default for all fields in this form.
+   *
+   * Typed as {@link ResolvedErrorDisplayStrategy} (not `ErrorDisplayStrategy`)
+   * because `'inherit'` is a field-level-only value — there is nothing above
+   * the form root to inherit from — so binding it here is a compile-time error.
    */
-  readonly errorStrategy = input<ErrorDisplayStrategy | null | undefined>();
+  readonly errorStrategy = input<
+    ResolvedErrorDisplayStrategy | null | undefined
+  >();
 
   /**
    * Resolved error display strategy (form-level or global default).
@@ -152,11 +154,7 @@ export class NgxSignalForm {
   protected readonly resolvedErrorStrategy =
     computed<ResolvedErrorDisplayStrategy>(() => {
       const formStrategy = this.errorStrategy();
-      if (
-        formStrategy !== undefined &&
-        formStrategy !== null &&
-        formStrategy !== 'inherit'
-      ) {
+      if (formStrategy !== undefined && formStrategy !== null) {
         return formStrategy;
       }
 


### PR DESCRIPTION
## What

Wave-3 api-review area (ticket #178). Three of the four promoted findings were already resolved by merged wave-3 PRs (verified against main):
- **#2** NgxFieldIdentity doc references to non-existent `_setFieldName` — fixed by core PR (#171/#202).
- **#3** character-count i18n hook — fixed by assistive PR (#175/#203).
- **#4** `NgxHeadlessFieldset.fields` readonly/null-handling — fixed by headless PR (#173/#207).

This PR resolves the remaining **#1 (type-safety):** `NgxSignalForm.errorStrategy` was typed `ErrorDisplayStrategy`, which includes the field-level-only `'inherit'`. The directive already treated `'inherit'` as "use the default" at form level (there's nothing to inherit from above the form root). Narrowed the input to `ResolvedErrorDisplayStrategy | null | undefined` so the documented contract is compiler-enforced, and removed the now-dead `'inherit'` guard in `resolvedErrorStrategy`.

**Breaking (compile-time only):** `[errorStrategy]="'inherit'"` on a `<form ngxSignalForm>` is now a type error (documented in MIGRATING_BETA_TO_V1.md). It was a silent no-op before. Field-level `[strategy]` is unchanged.

## Verification

`nx run-many -t build,test,lint --projects=toolkit` green; `nx run-many -t build --all` green (no demo bound `'inherit'` at form level).

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form-level error display settings now require a valid explicit strategy.
  * Using `inherit` at the form root is now a compile-time error, while it remains valid for individual fields.

* **Documentation**
  * Added migration guidance explaining the updated error strategy behavior and what to change in existing forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->