### PR TITLE
test(demo e2e): close deferred demo e2e coverage gaps (#194)

### DIFF
--- a/apps/demo-e2e/src/forms/05-advanced/advanced-wizard.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/advanced-wizard.spec.ts
@@ -546,4 +546,82 @@ test.describe('Advanced Wizard Demo', () => {
       );
     });
   });
+
+  // Regression coverage for #194: the only existing header-click spec proves
+  // navigation is *blocked* from an invalid current step. Nothing asserted
+  // the "happy path" contract in wizard.ts's `canNavigateToStep` — that
+  // unvisited future steps are disabled, and that a click on an already
+  // visited step (forward OR backward) actually jumps there directly,
+  // without going through Next/Previous.
+  test('disables header buttons for unvisited future steps', async ({
+    page,
+  }) => {
+    const tripStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Trip Details' });
+    const reviewStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Review' });
+
+    await expect(tripStep).toBeDisabled();
+    await expect(reviewStep).toBeDisabled();
+
+    await test.step('Advancing to Trip marks it visited and enables its header button', async () => {
+      await fillTravelerStep(page);
+      await page.getByRole('button', { name: 'Next' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Trip Details', exact: true }),
+      ).toBeVisible();
+
+      await expect(tripStep).toBeEnabled();
+      // Review has still never been visited.
+      await expect(reviewStep).toBeDisabled();
+    });
+  });
+
+  test('header-click navigates directly between already-visited steps, forward and backward', async ({
+    page,
+  }) => {
+    await test.step('Walk forward to Review via Next so every step is visited', async () => {
+      await fillTravelerStep(page);
+      await page.getByRole('button', { name: 'Next' }).click();
+      await fillTripStepMinimal(page);
+      await page.getByRole('button', { name: 'Next' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Review Your Booking' }),
+      ).toBeVisible();
+    });
+
+    const travelerStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Traveler Info' });
+    const tripStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Trip Details' });
+    const reviewStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Review' });
+
+    await test.step('Header-click jumps backward two steps, straight to Traveler', async () => {
+      await travelerStep.click();
+      await expect(
+        page.getByRole('heading', { name: 'Traveler Information' }),
+      ).toBeVisible();
+      await expect(travelerStep).toHaveAttribute('aria-current', 'step');
+    });
+
+    await test.step('Header-click jumps forward two steps, straight to Review, skipping Trip', async () => {
+      await reviewStep.click();
+      await expect(
+        page.getByRole('heading', { name: 'Review Your Booking' }),
+      ).toBeVisible();
+      await expect(reviewStep).toHaveAttribute('aria-current', 'step');
+      await expect(tripStep).not.toHaveAttribute('aria-current', 'step');
+    });
+
+    await test.step('Trip stays enabled and marked completed after being skipped over', async () => {
+      await expect(tripStep).toBeEnabled();
+      await expect(tripStep).toHaveClass(/completed/);
+    });
+  });
 });

--- a/apps/demo-e2e/src/forms/05-advanced/submission-patterns.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/submission-patterns.spec.ts
@@ -151,6 +151,31 @@ test.describe('Advanced - Submission Patterns', () => {
       await expect(page.errorSummary).toBeVisible({ timeout: 5000 });
       await expect(page.errorSummary).toContainText('already taken');
     });
+
+    // Regression coverage for #194: the submission action's server-error
+    // branch (submission-patterns.form.ts) returns a field-level error
+    // WITHOUT calling `formData().reset()` — unlike the success branch,
+    // which resets immediately and drives `submittedStatus` straight back to
+    // 'unsubmitted'. That means the green "Submitted" badge (the
+    // @case('submitted') branch of the state indicator's @switch) should
+    // stay visible at the same time as the error summary. No existing test
+    // ever asserted the badge for this branch — only `errorSummary` was
+    // checked.
+    test('badge shows the "Submitted" state alongside a simulated server error, not "Ready to Submit"', async () => {
+      await page.fillField('username', 'taken_user');
+      await page.fillField('password', 'password123');
+      await page.fillField('confirmPassword', 'password123');
+      await page.page.getByLabel('Simulate server error').check();
+
+      await page.submit();
+
+      await expect(page.errorSummary).toBeVisible({ timeout: 5000 });
+      await expect(page.stateBadge).toContainText('Submitted');
+      await expect(page.stateBadge).not.toContainText('Ready to Submit');
+      await expect(page.stateBadge).not.toContainText(
+        'Unhandled submittedStatus',
+      );
+    });
   });
 
   test.describe('Error Summary (GOV.UK Pattern)', () => {

--- a/apps/demo-e2e/src/ui/responsive.spec.ts
+++ b/apps/demo-e2e/src/ui/responsive.spec.ts
@@ -1,5 +1,6 @@
 import { DEMO_CATEGORIES, DEMO_PATHS } from '@ngx-signal-forms/demo-shared';
 import { expect, test } from '@playwright/test';
+import { collectConsoleErrors } from '../fixtures/form-validation.fixture';
 /**
  * Demo Application UI Tests - Responsive Behavior
  *
@@ -50,6 +51,37 @@ test.describe('Demo Application UI - Page Loading', () => {
         await routePage.close();
       }
     });
+  });
+
+  // Regression coverage for #194: nothing anywhere in this suite attaches a
+  // console listener across the full route set — `collectConsoleErrors` is
+  // otherwise only used on a single page (custom-controls.spec.ts) to filter
+  // for one specific regression string. This sweeps every routed page and
+  // asserts general console cleanliness, catching an accidental
+  // `console.error` regression on any page, not just the one previously
+  // known to be risky.
+  test('should not log console errors while loading any routed page', async ({
+    page,
+  }) => {
+    const routes = [
+      '/',
+      ...DEMO_CATEGORIES.flatMap((c) => c.links.map((l) => l.path)),
+    ];
+
+    for (const route of routes) {
+      const routePage = await page.context().newPage();
+      const consoleErrors = collectConsoleErrors(routePage);
+
+      await routePage.goto(route, { waitUntil: 'domcontentloaded' });
+      await routePage.locator('main, [role="main"]').first().waitFor({
+        state: 'visible',
+        timeout: 5000,
+      });
+
+      expect(consoleErrors, `Route ${route} logged console errors`).toEqual([]);
+
+      await routePage.close();
+    }
   });
 });
 
@@ -142,5 +174,52 @@ test.describe('Demo Application UI - Narrow viewport (< 900px)', () => {
     // RightRailComponent.onDialogBackdropClick, not a click "on" the panel.
     await page.mouse.click(2, 2);
     await expect(dialog).not.toHaveAttribute('open', '');
+  });
+});
+
+/**
+ * The narrow-viewport suite above only ever visits `yourFirstForm`, the
+ * simplest routed page (one flat field stack, no nested groups). The
+ * multi-step wizard is the app's most layout-dense page — a progress header
+ * of step buttons plus grid-based destination/activity cards — and had never
+ * been exercised below the 900px shell-reflow breakpoint.
+ */
+test.describe('Demo Application UI - Narrow viewport (advanced wizard)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(DEMO_PATHS.advancedWizard);
+  });
+
+  test('wizard reflows without introducing horizontal scroll at 390px', async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole('heading', { name: 'Traveler Information' }),
+    ).toBeVisible();
+
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+  });
+
+  test('progress-header step buttons stay visible and operable at 390px', async ({
+    page,
+  }) => {
+    const travelerStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Traveler Info' });
+    await expect(travelerStep).toBeVisible();
+    await expect(travelerStep).toHaveAttribute('aria-current', 'step');
+
+    // Future steps are unvisited from a fresh load, so their header buttons
+    // are disabled — but still rendered and visible, not clipped off-screen
+    // by the narrower layout.
+    const tripStep = page
+      .locator('.wizard-step-button')
+      .filter({ hasText: 'Trip Details' });
+    await expect(tripStep).toBeVisible();
+    await expect(tripStep).toBeDisabled();
   });
 });

--- a/apps/demo-material-e2e/src/contact-form.spec.ts
+++ b/apps/demo-material-e2e/src/contact-form.spec.ts
@@ -1,4 +1,6 @@
+import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
+import { WCAG_22_AA_TAGS } from '@ngx-signal-forms/toolkit/testing';
 
 /**
  * Single Playwright spec for the Material reference demo.
@@ -100,5 +102,152 @@ test.describe('Material reference contact form (E2E)', () => {
     const matError = emailField.locator('mat-error');
     await expect(matError).toBeVisible();
     await expect(matError).not.toHaveText('');
+  });
+
+  // Regression coverage for #194: the smoke spec (contact-form.spec.ts,
+  // jsdom) already exercises the warning/checkbox/select/reset paths, but
+  // nothing ran them through a real Chromium render — exactly the class of
+  // timing/layout bug jsdom can't surface (per this file's own top comment).
+
+  test('renders the warning in mat-hint (not mat-error) for a short-but-valid name', async ({
+    page,
+  }) => {
+    const name = page.getByRole('textbox', { name: /name/i });
+
+    await test.step('type a short name and blur', async () => {
+      await name.click();
+      await name.fill('Bob');
+      await name.blur();
+    });
+
+    await test.step('mat-hint renders the warning, mat-error stays empty', async () => {
+      const nameField = page.locator('mat-form-field', { has: name });
+      const hint = nameField.locator('mat-hint');
+      await expect(hint).toContainText(/short names are easy to mis-type/i);
+
+      const matError = nameField.locator('mat-error');
+      await expect(matError).toBeHidden();
+    });
+
+    await test.step('a warning alone does not mark the field invalid', async () => {
+      await expect(name).toHaveAttribute('aria-invalid', 'false');
+    });
+  });
+
+  test('shows the *ngxMatFeedback error for the consent checkbox and wires its describedby', async ({
+    page,
+  }) => {
+    const checkbox = page.getByRole('checkbox', {
+      name: /i agree to be contacted/i,
+    });
+
+    await test.step('blur the untouched checkbox', async () => {
+      await checkbox.focus();
+      await checkbox.press('Tab');
+    });
+
+    await test.step('the feedback block renders and is wired to the checkbox', async () => {
+      // `.demo-form__feedback` is the `role="alert"`/`[id]` host `<p>`; the
+      // matched text lives one level deeper, inside
+      // `<ngx-mat-feedback-outlet>`'s rendered `<span>`.
+      const feedback = page
+        .locator('.demo-form__feedback')
+        .filter({ hasText: /you need to agree/i });
+      await expect(feedback).toBeVisible();
+      await expect(feedback).toHaveAttribute('role', 'alert');
+
+      const feedbackId = await feedback.getAttribute('id');
+      expect(feedbackId).toBeTruthy();
+      await expect(checkbox).toHaveAttribute(
+        'aria-describedby',
+        feedbackId ?? '',
+      );
+    });
+
+    await test.step('checking the box clears the feedback and the describedby link', async () => {
+      await checkbox.click();
+      await expect(
+        page
+          .locator('.demo-form__feedback')
+          .filter({ hasText: /you need to agree/i }),
+      ).toHaveCount(0);
+      await expect(checkbox).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
+  test('shows mat-error for the topic select when it is left unset', async ({
+    page,
+  }) => {
+    const topic = page.getByRole('combobox', { name: /topic/i });
+
+    await test.step('open and close the select without picking an option', async () => {
+      await topic.click();
+      await page.keyboard.press('Escape');
+      await topic.press('Tab');
+    });
+
+    await test.step('mat-error renders the required-topic message', async () => {
+      const topicField = page.locator('mat-form-field', { has: topic });
+      const matError = topicField.locator('mat-error');
+      await expect(matError).toBeVisible();
+      await expect(matError).toContainText(/pick a topic/i);
+      await expect(topic).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  test('Reset clears field values, the success banner, and any pending errors', async ({
+    page,
+  }) => {
+    const name = page.getByRole('textbox', { name: /name/i });
+    const email = page.getByRole('textbox', { name: /email/i });
+    const topic = page.getByRole('combobox', { name: /topic/i });
+    const checkbox = page.getByRole('checkbox', {
+      name: /i agree to be contacted/i,
+    });
+
+    await test.step('complete and submit the form successfully', async () => {
+      await name.fill('Alex Doe');
+      await email.fill('alex@example.com');
+      await topic.click();
+      await page.getByRole('option', { name: /sales question/i }).click();
+      await checkbox.click();
+
+      await page.getByRole('button', { name: /send message/i }).click();
+      await expect(
+        page.getByText(/thanks! we received your message/i),
+      ).toBeVisible();
+    });
+
+    await test.step('click Reset', async () => {
+      await page.getByRole('button', { name: /^reset$/i }).click();
+    });
+
+    await test.step('the form returns to a pristine, untouched state', async () => {
+      await expect(name).toHaveValue('');
+      await expect(email).toHaveValue('');
+      await expect(checkbox).not.toBeChecked();
+      await expect(
+        page.getByText(/thanks! we received your message/i),
+      ).toBeHidden();
+      await expect(page.locator('mat-error')).toHaveCount(0);
+    });
+  });
+
+  test('has no WCAG 2.2 AA axe violations while every blocking error is on screen', async ({
+    page,
+  }) => {
+    // Submit the empty form so every blocking error (name, email, topic,
+    // agree) renders simultaneously — the demo's densest error state, and
+    // the one accessibility.spec.ts's pristine-route sweep never reaches.
+    // Unlike that sweep (which only diffs against a baseline), this is a
+    // hard assertion: zero violations, no baseline escape hatch.
+    await page.getByRole('button', { name: /send message/i }).click();
+    await expect(page.locator('mat-error').first()).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_22_AA_TAGS])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
   });
 });

--- a/apps/demo-primeng-e2e/src/profile-form.spec.ts
+++ b/apps/demo-primeng-e2e/src/profile-form.spec.ts
@@ -185,4 +185,100 @@ test.describe('demo-primeng — profile form', () => {
       await expect(page.locator('#profile-role-error')).toBeHidden();
     });
   });
+
+  // Regression coverage for #194: ProfileFormComponent's own docblock lists
+  // createOnInvalidHandler's submit-time focus behaviour as one of five
+  // contracts this reference exercises, but nothing asserted it end-to-end —
+  // schema declaration order is email, then role (profile-form.schema.ts),
+  // so an empty submit should focus email first, and a submit with only
+  // email fixed should move focus on to the role combobox.
+  test('createOnInvalidHandler focuses the first invalid control on submit, then the next', async ({
+    page,
+  }) => {
+    const emailInput = page.locator('#profile-email');
+    const roleCombobox = page.getByRole('combobox', { name: /^role$/i });
+    const submitButton = page.getByTestId('submit-button');
+
+    await test.step('submitting the empty form focuses email (first in schema order)', async () => {
+      await submitButton.click();
+      await expect(emailInput).toBeFocused({ timeout: 3000 });
+    });
+
+    await test.step('fixing email and resubmitting focuses role next', async () => {
+      await emailInput.fill('team@company.com');
+      await submitButton.click();
+      await expect(roleCombobox).toBeFocused({ timeout: 3000 });
+    });
+
+    await test.step('a fully valid form does not steal focus on submit', async () => {
+      await selectRole(page, 'Designer');
+      const newsletterCheckbox = page.getByRole('checkbox', {
+        name: /subscribe to the release notes/i,
+      });
+
+      await submitButton.click();
+      await expect(page.getByTestId('submission-summary')).toBeVisible();
+      await expect(emailInput).not.toBeFocused();
+      await expect(roleCombobox).not.toBeFocused();
+      await expect(newsletterCheckbox).not.toBeFocused();
+    });
+  });
+
+  // Regression coverage for #194: PrimeSelectControlComponent exists
+  // specifically to bridge a bespoke ARIA combobox onto Signal Forms, but the
+  // suite never drove it with anything but mouse clicks (selectRole() above).
+  // p-select supports the standard listbox keyboard contract — this exercises
+  // that surface without ever calling .click() on the trigger or an option.
+  test('the role combobox is fully operable from the keyboard', async ({
+    page,
+  }) => {
+    const roleCombobox = page.getByRole('combobox', { name: /^role$/i });
+
+    await test.step('Tab onto the combobox and open it with the keyboard', async () => {
+      await page.locator('#profile-email').focus();
+      await page.keyboard.press('Tab');
+      await expect(roleCombobox).toBeFocused();
+
+      await roleCombobox.press('Enter');
+      await expect(
+        page.getByRole('option', { name: 'Frontend developer' }),
+      ).toBeVisible();
+    });
+
+    await test.step('arrow down to a later option and select it with Enter', async () => {
+      // Opening highlights nothing yet — the first ArrowDown highlights
+      // "Frontend developer" (index 0), so three presses land on
+      // "Designer" (index 2).
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Enter');
+
+      await expect(roleCombobox).toHaveText('Designer');
+      await expect(page.getByRole('option')).toHaveCount(0);
+    });
+
+    await test.step('reopen and select the first option with Home + Enter', async () => {
+      await roleCombobox.press('Enter');
+      await expect(
+        page.getByRole('option', { name: 'Frontend developer' }),
+      ).toBeVisible();
+
+      await page.keyboard.press('Home');
+      await page.keyboard.press('Enter');
+
+      await expect(roleCombobox).toHaveText('Frontend developer');
+    });
+
+    await test.step('Escape closes the overlay without changing the selection', async () => {
+      await roleCombobox.press('Enter');
+      await expect(
+        page.getByRole('option', { name: 'Designer' }),
+      ).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('option')).toHaveCount(0);
+      await expect(roleCombobox).toHaveText('Frontend developer');
+    });
+  });
 });

--- a/apps/demo-spartan-e2e/src/account-preferences.spec.ts
+++ b/apps/demo-spartan-e2e/src/account-preferences.spec.ts
@@ -137,4 +137,121 @@ test.describe('Spartan account preferences form', () => {
       );
     });
   });
+
+  // Regression coverage for #194 (a): no test previously submitted/touched
+  // the plan select empty and asserted the required error, or that its id
+  // chains into the trigger button's aria-describedby the same way the text
+  // input's error does.
+  test('shows the plan required error on blur and chains it into the trigger button aria-describedby', async ({
+    page,
+  }) => {
+    const plan = page.getByRole('combobox', { name: 'Plan' });
+
+    await test.step('Open and close the select without choosing an option, then blur', async () => {
+      await plan.focus();
+      await plan.press('ArrowDown');
+      await expect(page.getByRole('option', { name: 'Starter' })).toBeVisible();
+      await plan.press('Escape');
+      await plan.press('Tab');
+    });
+
+    await test.step('The required error renders at #plan-error and is wired to the trigger', async () => {
+      const error = page.locator('#plan-error');
+      await expect(error).toContainText(/choose a plan/i);
+
+      await expect(plan).toHaveAttribute('aria-describedby', /\bplan-error\b/);
+      await expect(plan).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    await test.step('Choosing a plan clears the error', async () => {
+      await plan.press('ArrowDown');
+      await page.getByRole('option', { name: 'Starter' }).click();
+
+      await expect(page.locator('#plan-error')).toBeHidden();
+      await expect(plan).not.toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  // Regression coverage for #194 (b): the existing describedby test only
+  // asserts the static attribute after page load. This exercises the
+  // checkbox from the keyboard (a real <button role="checkbox">, so Space
+  // toggles it natively) and confirms the hint stays wired across state
+  // changes rather than only on first render.
+  test('the newsletter checkbox is keyboard-toggleable and keeps its describedby link while doing so', async ({
+    page,
+  }) => {
+    const checkbox = page.getByRole('checkbox', {
+      name: 'Send me product updates',
+    });
+
+    await checkbox.focus();
+    await expect(checkbox).not.toBeChecked();
+    await expect(checkbox).toHaveAttribute(
+      'aria-describedby',
+      /\bnewsletter-hint\b/,
+    );
+
+    await test.step('Space checks it', async () => {
+      await page.keyboard.press('Space');
+      await expect(checkbox).toBeChecked();
+      await expect(checkbox).toHaveAttribute(
+        'aria-describedby',
+        /\bnewsletter-hint\b/,
+      );
+    });
+
+    await test.step('Space again unchecks it', async () => {
+      await page.keyboard.press('Space');
+      await expect(checkbox).not.toBeChecked();
+      await expect(checkbox).toHaveAttribute(
+        'aria-describedby',
+        /\bnewsletter-hint\b/,
+      );
+    });
+  });
+
+  // Regression coverage for #194 (c): every existing interaction with the
+  // plan select ends in a mouse `.click()` on the option. `BrnSelectTrigger`
+  // hosts a real listbox `ActiveDescendantKeyManager` (arrow keys +
+  // Enter-to-select) — this drives the whole flow without ever clicking.
+  //
+  // Kept to a single open/close cycle: reopening the select re-highlights
+  // whichever item currently matches `value()` via an internal effect, which
+  // races any manually-pressed arrow key right before a second `Enter` — so
+  // this asserts one full open → navigate → commit pass instead of chaining
+  // a reopen. Each ArrowDown press also waits for `[data-highlighted]` (the
+  // keyManager's active-descendant marker, `BrnSelectItem`) to land on the
+  // expected option before sending the next key — the highlight update is
+  // driven by an effect, not synchronous with the keydown itself.
+  test('the plan select is fully operable from the keyboard, never clicking an option', async ({
+    page,
+  }) => {
+    const plan = page.getByRole('combobox', { name: 'Plan' });
+    const starter = page.getByRole('option', { name: 'Starter' });
+    const pro = page.getByRole('option', { name: 'Pro' });
+    const enterprise = page.getByRole('option', { name: 'Enterprise' });
+
+    await test.step('Open with ArrowDown — opening auto-highlights the first item (Starter)', async () => {
+      await plan.focus();
+      await plan.press('ArrowDown');
+      await expect(starter).toHaveAttribute('data-highlighted', '');
+    });
+
+    await test.step('Arrow down twice more to Enterprise and commit with Enter', async () => {
+      await plan.press('ArrowDown'); // Starter -> Pro
+      await expect(pro).toHaveAttribute('data-highlighted', '');
+
+      await plan.press('ArrowDown'); // Pro -> Enterprise
+      await expect(enterprise).toHaveAttribute('data-highlighted', '');
+
+      await plan.press('Enter');
+
+      // BrnSelectValue's default itemToString renders the raw option value
+      // (not the item's projected "Enterprise" label content) when no
+      // custom itemToString is configured — the same value shown in the
+      // submitted JSON payload elsewhere in this spec.
+      await expect(plan).toHaveText('enterprise');
+      await expect(page.getByRole('option')).toHaveCount(0);
+    });
+  });
 });


### PR DESCRIPTION
Refs #194 (demo e2e coverage)

Test-only change (no production code touched). Adds Playwright e2e coverage locking in the CURRENT correct behavior of each demo, closing the demo/demo-material/demo-primeng/demo-spartan sections of #194's deferred test-coverage gaps.

## demo (`demo-e2e`)
- Console-error monitoring: a new route-sweep test asserts zero `console.error` output across every routed page (`ui/responsive.spec.ts`).
- Narrow-viewport (390px) coverage for the advanced wizard — previously only the simplest routed page was exercised below the 900px shell-reflow breakpoint.
- Wizard progress-header click navigation: disabled state for unvisited future steps, and successful forward/backward jumps between already-visited steps (`advanced-wizard.spec.ts`) — the only prior header-click test proved navigation was *blocked*, never that it succeeds.
- Submission-state badge assertion for the server-error branch, which never calls `reset()` and so should keep showing "Submitted" rather than reverting to "Ready to Submit" (`submission-patterns.spec.ts`).

## demo-material (`demo-material-e2e`)
Broadened `contact-form.spec.ts` from 2 specs / 3 tests covering only the email field to also cover:
- the warning-in-hint flow for a short-but-valid name (`mat-hint`, not `mat-error`)
- the `*ngxMatFeedback` checkbox error and its `aria-describedby` wiring
- the topic `<mat-select>` required error
- Reset clearing values, the success banner, and pending errors
- a hard-fail WCAG 2.2 AA axe scan while every blocking error is visible (the existing `accessibility.spec.ts` only scans the pristine home route and never hard-fails)

## demo-primeng (`demo-primeng-e2e`)
- `createOnInvalidHandler`'s submit-time focus behavior is now asserted end-to-end (email focused first per schema order, then role once email is fixed, no focus theft on a valid submit).
- The `<p-select>` role combobox is driven entirely from the keyboard (Tab, Enter to open, ArrowDown to navigate, Home, Enter to select, Escape to cancel) — the prior suite only used `.click()`.

## demo-spartan (`demo-spartan-e2e`)
- Plan select required-error path: touching it empty renders `Choose a plan` at `#plan-error`, chained into the trigger button's `aria-describedby`, clearing once a plan is chosen.
- Newsletter checkbox toggled purely via Space on the focused `role="checkbox"` button, with the `describedby` link asserted across both the check and uncheck transitions.
- The plan `<hlm-select>` combobox driven end-to-end via keyboard (ArrowDown to open/navigate, Enter to commit) — the prior suite only used `.click()` on rendered options.

## Test plan
- [x] `demo-e2e` full suite, chromium — 275 passed (8 pre-existing `@layout` screenshot failures unrelated to this change; macOS-only baseline mismatches, regenerated on CI/Linux)
- [x] `demo-material-e2e` full suite, chromium — 7 passed
- [x] `demo-primeng-e2e` full suite, chromium — 8 passed
- [x] `demo-spartan-e2e` full suite, chromium — 8 passed (new keyboard-select test verified stable across repeated runs)
- [x] `pnpm nx run-many -t lint --projects=demo-e2e,demo-material-e2e,demo-primeng-e2e,demo-spartan-e2e` — passes (pre-existing `require-unicode-regexp` warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>