### PR TITLE
fix(toolkit): surface aria-required for Standard Schema (Zod) fields

### DIFF
--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/traveler-step.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/traveler-step.ts
@@ -53,9 +53,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
           [appearance]="appearance()"
           [orientation]="orientation()"
         >
-          <label for="firstName">
-            First Name <span class="text-red-500">*</span>
-          </label>
+          <label for="firstName">First Name</label>
           <input
             id="firstName"
             type="text"
@@ -72,9 +70,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
           [appearance]="appearance()"
           [orientation]="orientation()"
         >
-          <label for="lastName">
-            Last Name <span class="text-red-500">*</span>
-          </label>
+          <label for="lastName">Last Name</label>
           <input
             id="lastName"
             type="text"
@@ -88,7 +84,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
           [appearance]="appearance()"
           [orientation]="orientation()"
         >
-          <label for="email"> Email <span class="text-red-500">*</span> </label>
+          <label for="email">Email</label>
           <input id="email" type="email" [formField]="travelerForm.email" />
           <ngx-form-field-hint>
             We'll send booking confirmation to this address
@@ -101,9 +97,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
           [appearance]="appearance()"
           [orientation]="orientation()"
         >
-          <label for="nationality">
-            Nationality <span class="text-red-500">*</span>
-          </label>
+          <label for="nationality">Nationality</label>
           <input
             id="nationality"
             type="text"
@@ -121,9 +115,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
               [appearance]="appearance()"
               [orientation]="orientation()"
             >
-              <label for="passportNumber">
-                Passport Number <span class="text-red-500">*</span>
-              </label>
+              <label for="passportNumber">Passport Number</label>
               <input
                 id="passportNumber"
                 type="text"
@@ -137,9 +129,7 @@ type ReadonlyDestination = Readonly<Omit<Destination, 'activities'>> & {
               [appearance]="appearance()"
               [orientation]="orientation()"
             >
-              <label for="passportExpiry">
-                Expiry Date <span class="text-red-500">*</span>
-              </label>
+              <label for="passportExpiry">Expiry Date</label>
               <input
                 id="passportExpiry"
                 type="date"

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/trip-step.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/trip-step.ts
@@ -75,9 +75,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
               [appearance]="appearance()"
               [orientation]="orientation()"
             >
-              <label [for]="'dest-country-' + destIdx">
-                Country <span class="text-red-500">*</span>
-              </label>
+              <label [for]="'dest-country-' + destIdx">Country</label>
               <input
                 [id]="'dest-country-' + destIdx"
                 type="text"
@@ -91,9 +89,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
               [appearance]="appearance()"
               [orientation]="orientation()"
             >
-              <label [for]="'dest-city-' + destIdx">
-                City <span class="text-red-500">*</span>
-              </label>
+              <label [for]="'dest-city-' + destIdx">City</label>
               <input
                 [id]="'dest-city-' + destIdx"
                 type="text"
@@ -109,9 +105,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
               [appearance]="appearance()"
               [orientation]="orientation()"
             >
-              <label [for]="'dest-arrival-' + destIdx">
-                Arrival Date <span class="text-red-500">*</span>
-              </label>
+              <label [for]="'dest-arrival-' + destIdx">Arrival Date</label>
               <input
                 [id]="'dest-arrival-' + destIdx"
                 type="date"
@@ -126,7 +120,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
               [orientation]="orientation()"
             >
               <label [for]="'dest-departure-' + destIdx">
-                Departure Date <span class="text-red-500">*</span>
+                Departure Date
               </label>
               <input
                 [id]="'dest-departure-' + destIdx"

--- a/apps/demo/src/app/05-advanced/advanced-wizard/forms/traveler-step.form.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/forms/traveler-step.form.ts
@@ -5,6 +5,7 @@ import {
   validate,
   validateStandardSchema,
 } from '@angular/forms/signals';
+import { requiredFromStandardSchema } from '@ngx-signal-forms/toolkit';
 
 import { type Traveler, TravelerSchema } from '../schemas/wizard.schemas';
 import type { WizardStore } from '../stores/wizard.store';
@@ -49,6 +50,17 @@ export function createTravelerStepForm(
   // Form with Zod + cross-step passport validation
   const travelerForm = form(model, (path) => {
     validateStandardSchema(path, TravelerSchema);
+
+    // `validateStandardSchema` only registers tree-level validation errors —
+    // Zod's schema shape isn't statically introspectable, so `aria-required`
+    // (and the wrapper's auto marker) need required-ness wired explicitly per
+    // field. See `requiredFromStandardSchema`'s docs and issue #118.
+    requiredFromStandardSchema(path.firstName, TravelerSchema);
+    requiredFromStandardSchema(path.lastName, TravelerSchema);
+    requiredFromStandardSchema(path.email, TravelerSchema);
+    requiredFromStandardSchema(path.nationality, TravelerSchema);
+    requiredFromStandardSchema(path.passportNumber, TravelerSchema);
+    requiredFromStandardSchema(path.passportExpiry, TravelerSchema);
 
     // Cross-step: Passport must be valid 6 months after last departure
     validate(path.passportExpiry, (ctx) => {

--- a/apps/demo/src/app/05-advanced/advanced-wizard/forms/trip-step.form.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/forms/trip-step.form.ts
@@ -6,6 +6,7 @@ import {
   validate,
   validateStandardSchema,
 } from '@angular/forms/signals';
+import { requiredFromStandardSchema } from '@ngx-signal-forms/toolkit';
 
 import {
   ActivitySchema,
@@ -62,6 +63,14 @@ export function createTripStepForm(store: InstanceType<typeof WizardStore>): {
   const tripForm = form(model, (path) => {
     applyEach(path.destinations, (destPath) => {
       validateStandardSchema(destPath, DestinationSchema);
+
+      // See traveler-step.form.ts / issue #118: `validateStandardSchema`
+      // never surfaces required-ness on its own, so wire it explicitly for
+      // the fields that carry a required marker in the destination card.
+      requiredFromStandardSchema(destPath.country, DestinationSchema);
+      requiredFromStandardSchema(destPath.city, DestinationSchema);
+      requiredFromStandardSchema(destPath.arrivalDate, DestinationSchema);
+      requiredFromStandardSchema(destPath.departureDate, DestinationSchema);
 
       applyEach(destPath.activities, (actPath) => {
         validateStandardSchema(actPath, ActivitySchema);

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -1287,3 +1287,63 @@ point:
 ## Form-level `errorStrategy` no longer accepts `'inherit'` (#178)
 
 `NgxSignalForm`'s `[errorStrategy]` input is now typed `ResolvedErrorDisplayStrategy` (`'immediate' | 'on-touch' | 'on-submit'`) instead of `ErrorDisplayStrategy`. `'inherit'` is a field-level-only value — there is nothing above the form root to inherit from — and was already silently treated as "use the default", so binding `[errorStrategy]="'inherit'"` on a `<form ngxSignalForm>` is now a compile-time error. **Fix:** remove the binding (the default already applies) or pass a concrete strategy. Field-level `[strategy]` still accepts `'inherit'`.
+
+## New API: `requiredFromStandardSchema()` — `aria-required` for Standard Schema (Zod, etc.) fields (#118)
+
+**Root cause:** `validateStandardSchema()` (from `@angular/forms/signals`) only
+registers tree-level validation errors — it never touches Angular's
+`REQUIRED` metadata, because the Standard Schema spec has no runtime way to
+ask "is this key required?" (no shape/keys introspection, only
+`~standard.validate(value)`). Without `REQUIRED` metadata,
+`FieldState.required()` stayed `false` for every Zod/Valibot/ArkType-validated
+field, so `NgxSignalFormAutoAria` never wrote `aria-required`, and
+`ngx-form-field-wrapper`'s `showMarkerWhen: 'required'` auto-marker never
+fired for them — only hand-written `required()` fields got the marker. The
+`advanced-wizard` demo had worked around this with a hardcoded `*` span in
+the label (kept intentionally pending this fix, see #117).
+
+**New public API:** `requiredFromStandardSchema(path, schema)`, exported from
+`@ngx-signal-forms/toolkit` (and `/core`). It closes the gap with the only
+library-agnostic technique available: probing the schema with the field's own
+key set to `undefined` (via `~standard.validate({ [key]: undefined })`) and
+registering the result as `REQUIRED` metadata via Angular's own `metadata()` +
+`REQUIRED` key. `REQUIRED` is an OR-reducing metadata key, so this composes
+safely alongside `required()`/other `metadata(path, REQUIRED, …)`
+registrations on the same field.
+
+Call it once per field, bound directly to that field's own path, next to the
+`validateStandardSchema()` call that validates the object owning it —
+Standard Schema doesn't expose an object's keys at runtime, so there is no
+way to derive every required field from a single root-level call:
+
+```typescript
+import { form, validateStandardSchema } from '@angular/forms/signals';
+import { requiredFromStandardSchema } from '@ngx-signal-forms/toolkit';
+
+const travelerForm = form(model, (path) => {
+  validateStandardSchema(path, TravelerSchema);
+  requiredFromStandardSchema(path.firstName, TravelerSchema);
+  requiredFromStandardSchema(path.lastName, TravelerSchema);
+});
+```
+
+**Known limitations** (documented on the function's JSDoc, not silently
+papered over):
+
+- Async validators (`~standard.validate` returning a `Promise`) can't be
+  resolved synchronously, so the probe reports "not required" rather than
+  block the reactive metadata graph on an async result.
+- A schema that throws while being probed (e.g. a `.refine()` that assumes
+  other fields are present) is treated as "not required" rather than
+  propagating the exception into form compilation.
+- Required-ness that only exists via cross-field refinement (e.g. "email is
+  required only when phone is empty") isn't captured — only the field's
+  unconditional base-schema requiredness is.
+
+**Demo fix:** `apps/demo/src/app/05-advanced/advanced-wizard`'s
+`traveler-step.form.ts` / `trip-step.form.ts` now call
+`requiredFromStandardSchema()` for their Zod-required fields, and the
+hardcoded `<span class="text-red-500">*</span>` markers have been removed
+from `traveler-step.ts` / `trip-step.ts` — the wrapper's auto-marker now
+covers them, consistent with every other demo. Purely additive; no existing
+API changed.

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -88,6 +88,12 @@ export * from './utilities/on-invalid-handler';
 export * from './utilities/read-direct-errors';
 export * from './utilities/resolve-error-message';
 export {
+  requiredFromStandardSchema,
+  type StandardSchemaLike,
+  type StandardSchemaLikeIssue,
+  type StandardSchemaLikeResult,
+} from './utilities/schema/required-from-standard-schema';
+export {
   resolveErrorDisplayStrategy,
   resolveStrategyFromContext,
   resolveSubmittedStatusFromContext,

--- a/packages/toolkit/core/utilities/schema/required-from-standard-schema.spec.ts
+++ b/packages/toolkit/core/utilities/schema/required-from-standard-schema.spec.ts
@@ -1,0 +1,216 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { form, FormField } from '@angular/forms/signals';
+import { TestBed } from '@angular/core/testing';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxSignalFormAutoAria } from '../../directives/auto-aria';
+import {
+  requiredFromStandardSchema,
+  type StandardSchemaLike,
+} from './required-from-standard-schema';
+
+/**
+ * Builds a minimal Standard Schema (v1) compatible validator for tests.
+ * Mirrors the subset of behavior that matters for required-ness probing:
+ * a top-level key is "required" when it is missing/`undefined` in the
+ * validated object.
+ */
+function createFakeStandardSchema<T extends Record<string, unknown>>(
+  requiredKeys: readonly string[],
+): StandardSchemaLike<T> {
+  return {
+    '~standard': {
+      validate: (value: unknown) => {
+        const record = (value ?? {}) as Record<string, unknown>;
+        const issues = requiredKeys
+          .filter((key) => record[key] === undefined)
+          .map((key) => ({ message: `${key} is required`, path: [key] }));
+
+        return issues.length > 0 ? { issues } : { value: record as T };
+      },
+    },
+  };
+}
+
+describe('requiredFromStandardSchema', () => {
+  it("sets FieldState.required() to true for a key the schema rejects when it's undefined", async () => {
+    const schema = createFakeStandardSchema<{
+      firstName: string;
+      nickname: string;
+    }>(['firstName']);
+
+    @Component({
+      selector: 'ngx-test-standard-schema-required',
+      imports: [FormField],
+      template: `
+        <input [formField]="testForm.firstName" />
+        <input [formField]="testForm.nickname" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ firstName: '', nickname: '' });
+      readonly testForm = form(this.#model, (path) => {
+        requiredFromStandardSchema(path.firstName, schema);
+        requiredFromStandardSchema(path.nickname, schema);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.testForm.firstName().required()).toBe(
+      true,
+    );
+    expect(fixture.componentInstance.testForm.nickname().required()).toBe(
+      false,
+    );
+  });
+
+  it('resolves an issue path using the `{ key }` path-segment object form', async () => {
+    const schema: StandardSchemaLike<{ email: string }> = {
+      '~standard': {
+        validate: (value: unknown) => {
+          const record = (value ?? {}) as { email?: unknown };
+          return record.email === undefined
+            ? { issues: [{ message: 'Required', path: [{ key: 'email' }] }] }
+            : { value: record as { email: string } };
+        },
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-standard-schema-required-object-path',
+      imports: [FormField],
+      template: `<input [formField]="testForm.email" />`,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly testForm = form(this.#model, (path) => {
+        requiredFromStandardSchema(path.email, schema);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.testForm.email().required()).toBe(true);
+  });
+
+  it('resolves a schema supplied as a LogicFn', async () => {
+    const schema = createFakeStandardSchema<{ firstName: string }>([
+      'firstName',
+    ]);
+
+    @Component({
+      selector: 'ngx-test-standard-schema-required-logic-fn',
+      imports: [FormField],
+      template: `<input [formField]="testForm.firstName" />`,
+    })
+    class TestComponent {
+      readonly #model = signal({ firstName: '' });
+      readonly testForm = form(this.#model, (path) => {
+        requiredFromStandardSchema(path.firstName, () => schema);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.testForm.firstName().required()).toBe(
+      true,
+    );
+  });
+
+  it('reports not-required when the schema returns a Promise (async validators are not probed synchronously)', async () => {
+    const schema: StandardSchemaLike<{ firstName: string }> = {
+      '~standard': {
+        validate: () =>
+          Promise.resolve({
+            issues: [{ message: 'Required', path: ['firstName'] }],
+          }),
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-standard-schema-required-async',
+      imports: [FormField],
+      template: `<input [formField]="testForm.firstName" />`,
+    })
+    class TestComponent {
+      readonly #model = signal({ firstName: '' });
+      readonly testForm = form(this.#model, (path) => {
+        requiredFromStandardSchema(path.firstName, schema);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.testForm.firstName().required()).toBe(
+      false,
+    );
+  });
+
+  it('reports not-required when the schema throws while being probed', async () => {
+    const schema: StandardSchemaLike<{ firstName: string }> = {
+      '~standard': {
+        validate: () => {
+          throw new Error('boom');
+        },
+      },
+    };
+
+    @Component({
+      selector: 'ngx-test-standard-schema-required-throws',
+      imports: [FormField],
+      template: `<input [formField]="testForm.firstName" />`,
+    })
+    class TestComponent {
+      readonly #model = signal({ firstName: '' });
+      readonly testForm = form(this.#model, (path) => {
+        requiredFromStandardSchema(path.firstName, schema);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.testForm.firstName().required()).toBe(
+      false,
+    );
+  });
+
+  it('writes aria-required="true" via NgxSignalFormAutoAria for a schema-required field (regression #118)', async () => {
+    const schema = createFakeStandardSchema<{
+      firstName: string;
+      nickname: string;
+    }>(['firstName']);
+
+    @Component({
+      selector: 'ngx-test-standard-schema-required-aria',
+      imports: [FormField, NgxSignalFormAutoAria],
+      template: `
+        <label for="firstName">First name</label>
+        <input id="firstName" [formField]="testForm.firstName" />
+        <label for="nickname">Nickname</label>
+        <input id="nickname" [formField]="testForm.nickname" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ firstName: '', nickname: '' });
+      readonly testForm = form(this.#model, (path) => {
+        requiredFromStandardSchema(path.firstName, schema);
+        requiredFromStandardSchema(path.nickname, schema);
+      });
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const firstNameInput = container.querySelector('#firstName');
+    const nicknameInput = container.querySelector('#nickname');
+
+    expect(firstNameInput).toHaveAttribute('aria-required', 'true');
+    expect(nicknameInput).not.toHaveAttribute('aria-required');
+  });
+});

--- a/packages/toolkit/core/utilities/schema/required-from-standard-schema.ts
+++ b/packages/toolkit/core/utilities/schema/required-from-standard-schema.ts
@@ -1,0 +1,194 @@
+import {
+  metadata,
+  REQUIRED,
+  type FieldContext,
+  type LogicFn,
+  type PathKind,
+  type SchemaPath,
+  type SchemaPathRules,
+} from '@angular/forms/signals';
+
+/**
+ * Minimal structural contract for a Standard Schema (v1) compatible
+ * validator — e.g. a Zod, Valibot, or ArkType schema.
+ *
+ * Deliberately narrower than `@standard-schema/spec`'s `StandardSchemaV1`
+ * (which also requires `vendor`/`version`/`types`): this toolkit only ever
+ * *calls* `~standard.validate`, so keeping the contract to that single method
+ * avoids importing an extra runtime type-only dependency while remaining
+ * structurally assignable from any real Standard Schema implementation.
+ *
+ * @public
+ */
+export interface StandardSchemaLike<TInput = unknown> {
+  readonly '~standard': {
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | StandardSchemaLikeResult<TInput>
+      | PromiseLike<StandardSchemaLikeResult<TInput>>;
+  };
+}
+
+/**
+ * A single Standard Schema validation issue, narrowed to the fields this
+ * toolkit reads (`path`, to target the failing key).
+ *
+ * @public
+ */
+export interface StandardSchemaLikeIssue {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>;
+}
+
+/**
+ * Result shape returned by `~standard.validate`. A successful validation
+ * omits `issues` (or returns an empty array); a failed one returns a
+ * non-empty `issues` array.
+ *
+ * @public
+ */
+export interface StandardSchemaLikeResult<TInput> {
+  readonly issues?: ReadonlyArray<StandardSchemaLikeIssue>;
+  readonly value?: TInput;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function issueTargetsKey(issue: StandardSchemaLikeIssue, key: string): boolean {
+  const [firstSegment] = issue.path ?? [];
+
+  if (firstSegment === undefined) {
+    return false;
+  }
+
+  const firstKey =
+    typeof firstSegment === 'object' ? firstSegment.key : firstSegment;
+
+  return firstKey === key;
+}
+
+/**
+ * Probes a Standard Schema to determine whether a given top-level object key
+ * is required, using only the public `~standard.validate` contract (Standard
+ * Schema has no runtime shape/keys introspection, so this is the only
+ * library-agnostic signal available).
+ *
+ * The probe validates `{ [key]: undefined }` — an otherwise-empty object with
+ * only `key` present-but-undefined — and reports the key as required when the
+ * result contains an issue whose path targets it. Other keys are left absent
+ * from the probe object; any issues they produce are irrelevant and ignored.
+ *
+ * Known limitations (documented, not silently papered over):
+ * - Async validators (`~standard.validate` returning a `Promise`) can't be
+ *   resolved synchronously, so the probe reports `false` rather than block
+ *   the reactive metadata graph on an async result.
+ * - A schema that throws synchronously when probed (e.g. a `.refine()` that
+ *   assumes other fields are present) is treated as `false` rather than
+ *   propagating the exception into form compilation.
+ * - Required-ness that only exists via cross-field refinement (e.g. "email is
+ *   required only when phone is empty") cannot be captured by a single-key
+ *   probe; this reports the key's *unconditional* base-schema requiredness.
+ */
+function isStandardSchemaKeyRequired(
+  schema: StandardSchemaLike,
+  key: string,
+): boolean {
+  let result:
+    | StandardSchemaLikeResult<unknown>
+    | PromiseLike<StandardSchemaLikeResult<unknown>>;
+
+  try {
+    result = schema['~standard'].validate({ [key]: undefined });
+  } catch {
+    return false;
+  }
+
+  if (isPromiseLike(result)) {
+    return false;
+  }
+
+  return (result.issues ?? []).some((issue) => issueTargetsKey(issue, key));
+}
+
+/**
+ * Derives `aria-required` for a Standard Schema (Zod, Valibot, ArkType, …)
+ * validated field by wiring Angular Signal Forms' `REQUIRED` metadata key
+ * from the schema, mirroring what the native `required()` validator does for
+ * hand-written Signal Forms validation.
+ *
+ * **Why this exists**: `validateStandardSchema()` (from
+ * `@angular/forms/signals`) only registers tree-level validation errors — it
+ * never touches `REQUIRED` metadata, because the Standard Schema spec has no
+ * runtime way to ask "is this key required?" directly. Without `REQUIRED`
+ * metadata, `FieldState.required()` stays `false`, so `NgxSignalFormAutoAria`
+ * never writes `aria-required`, and `ngx-form-field-wrapper`'s
+ * `showMarkerWhen: 'required'` auto-marker never fires — see
+ * [#118](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/118).
+ *
+ * This function closes that gap with the only library-agnostic technique
+ * available: probing the schema with the field's own key set to `undefined`
+ * (see {@link isStandardSchemaKeyRequired}) and registering the result as
+ * `REQUIRED` metadata. `REQUIRED` is an OR-reducing metadata key, so this
+ * composes safely alongside other `required()`/`metadata(path, REQUIRED, …)`
+ * registrations on the same field.
+ *
+ * **Call this once per field**, bound directly to that field's own path, next
+ * to the `validateStandardSchema()` call that validates the object owning it.
+ * Standard Schema doesn't expose an object's keys at runtime, so there's no
+ * way to derive every required field from a single root-level call — this
+ * mirrors calling `required()` per field in hand-written schemas.
+ *
+ * @param path The field's own `SchemaPath` (e.g. `path.firstName`) — required-ness
+ *   is registered on this exact field.
+ * @param schema The same Standard Schema (or `LogicFn` resolving to one) passed to
+ *   `validateStandardSchema()` for the object that owns `path`.
+ *
+ * @example
+ * ```typescript
+ * import { form, validateStandardSchema } from '@angular/forms/signals';
+ * import { requiredFromStandardSchema } from '@ngx-signal-forms/toolkit/core';
+ *
+ * const travelerForm = form(model, (path) => {
+ *   validateStandardSchema(path, TravelerSchema);
+ *   requiredFromStandardSchema(path.firstName, TravelerSchema);
+ *   requiredFromStandardSchema(path.lastName, TravelerSchema);
+ * });
+ * ```
+ *
+ * @public
+ */
+export function requiredFromStandardSchema<
+  TValue,
+  TModel = unknown,
+  TPathKind extends PathKind = PathKind.Root,
+>(
+  // oxlint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types -- SchemaPath is an Angular Signal Forms framework type, not modeled as readonly.
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  schema:
+    | StandardSchemaLike<TModel>
+    | LogicFn<TValue, StandardSchemaLike<TModel> | undefined, TPathKind>,
+): void {
+  metadata(path, REQUIRED, (ctx: FieldContext<TValue, TPathKind>) => {
+    const resolvedSchema = typeof schema === 'function' ? schema(ctx) : schema;
+
+    if (!resolvedSchema) {
+      return false;
+    }
+
+    const pathKeys = ctx.pathKeys();
+    const key = pathKeys.at(-1);
+
+    if (key === undefined) {
+      return false;
+    }
+
+    return isStandardSchemaKeyRequired(resolvedSchema, key);
+  });
+}

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -1,7 +1,13 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { Component, inputBinding, signal } from '@angular/core';
-import { FormField, form, required, schema } from '@angular/forms/signals';
+import {
+  FormField,
+  form,
+  required,
+  schema,
+  validateStandardSchema,
+} from '@angular/forms/signals';
 import { TestBed } from '@angular/core/testing';
 import {
   NGX_SIGNAL_FORMS_CONFIG,
@@ -9,6 +15,7 @@ import {
   NgxSignalFormToolkit,
   provideNgxSignalFormControlPresets,
   provideNgxSignalFormControlPresetsForComponent,
+  requiredFromStandardSchema,
 } from '@ngx-signal-forms/toolkit';
 import { DEFAULT_NGX_SIGNAL_FORMS_CONFIG } from '@ngx-signal-forms/toolkit/core';
 import {
@@ -1068,6 +1075,76 @@ describe('NgxSignalFormWrapperComponent', () => {
       ).toBeNull();
       // …but required state is still exposed programmatically.
       expect(input).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('marks a Standard Schema (Zod-style) required field via requiredFromStandardSchema (regression #118)', async () => {
+      // `validateStandardSchema` alone never surfaces required-ness (Standard
+      // Schema has no runtime shape introspection), so the wrapper's
+      // auto-marker never fired for Zod-validated fields and demos resorted
+      // to a hardcoded `*` in the label. `requiredFromStandardSchema` closes
+      // that gap by probing the schema; this reproduces the wrapper's
+      // acceptance criteria straight from the GitHub issue: aria-required on
+      // the control, a single auto-marker, and a clean accessible name.
+      const fakeZodLikeSchema = {
+        '~standard': {
+          validate: (value: unknown) => {
+            const record = (value ?? {}) as { firstName?: unknown };
+            return record.firstName === undefined
+              ? {
+                  issues: [
+                    { message: 'First name required', path: ['firstName'] },
+                  ],
+                }
+              : { value: record };
+          },
+        },
+      };
+
+      @Component({
+        selector: 'ngx-test-standard-schema-marker',
+        imports: [
+          NgxSignalFormWrapperComponent,
+          NgxSignalFormToolkit,
+          FormField,
+        ],
+        template: `
+          <ngx-form-field-wrapper [formField]="testForm.firstName">
+            <label for="firstName">First Name</label>
+            <input
+              id="firstName"
+              type="text"
+              [formField]="testForm.firstName"
+            />
+          </ngx-form-field-wrapper>
+        `,
+      })
+      class Host {
+        protected readonly testForm = form(
+          signal({ firstName: '' }),
+          schema<{ firstName: string }>((p) => {
+            validateStandardSchema(p, fakeZodLikeSchema);
+            requiredFromStandardSchema(p.firstName, fakeZodLikeSchema);
+          }),
+        );
+      }
+
+      const { container } = await render(Host);
+
+      const input = container.querySelector('#firstName');
+      const formField = container.querySelector('ngx-form-field-wrapper');
+      const markers = formField?.querySelectorAll(
+        '.ngx-signal-form-field-wrapper__marker',
+      );
+
+      expect(input).toHaveAttribute('aria-required', 'true');
+      expect(formField).toHaveAttribute('data-marker', 'required');
+      expect(markers).toHaveLength(1);
+      // The marker text lives outside the label's accessible name (it's
+      // `aria-hidden`), so the control's accessible name stays "First Name",
+      // never "First Name *".
+      expect(container.querySelector('label')?.textContent?.trim()).toBe(
+        'First Name',
+      );
     });
 
     it('honours a global showMarkerWhen config (provider fallback, no input)', async () => {

--- a/packages/toolkit/index.ts
+++ b/packages/toolkit/index.ts
@@ -70,6 +70,7 @@ export {
   provideNgxSignalFormsConfigForComponent,
   readDirectErrors,
   readNgxSignalFormControlSemantics,
+  requiredFromStandardSchema,
   resolveErrorDisplayStrategy,
   resolveFieldName,
   resolveFieldNameFromCandidates,
@@ -128,5 +129,8 @@ export type {
   ResolvedNgxSignalFormControlSemantics,
   SignalLike,
   SplitErrors,
+  StandardSchemaLike,
+  StandardSchemaLikeIssue,
+  StandardSchemaLikeResult,
   SubmittedStatus,
 } from '@ngx-signal-forms/toolkit/core';


### PR DESCRIPTION
Closes #118

## Root cause

`validateStandardSchema()` (from `@angular/forms/signals`) only registers tree-level validation errors via `validateTree`/`validateAsync` — it never touches Angular's `REQUIRED` metadata key. That's not an oversight in this toolkit or in Angular: the Standard Schema spec has no runtime way to ask "is this key required?" — the only contract is `~standard.validate(value)`, an opaque function that returns issues or a value. Without `REQUIRED` metadata, `FieldState.required()` stays `false` for every Zod/Valibot/ArkType-validated field, so `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`, via `createAriaRequiredSignal`) never writes `aria-required`, and `ngx-form-field-wrapper`'s `showMarkerWhen: 'required'` auto-marker never fires for them. Only hand-written `required()` fields (which explicitly set that metadata) got the marker — confirmed live: `#firstName` in the wizard had `required=false`, `aria-required=null`, and no marker element.

## Fix

Added `requiredFromStandardSchema(path, schema)`, a new toolkit export (`packages/toolkit/core/utilities/schema/required-from-standard-schema.ts`, re-exported from `@ngx-signal-forms/toolkit` and `/core`). It closes the gap with the only library-agnostic technique available: probing the schema with the field's own key set to `undefined` (`~standard.validate({ [key]: undefined })`) and registering the result as Angular's `REQUIRED` metadata via `metadata(path, REQUIRED, …)`. `REQUIRED` is an OR-reducing metadata key, so this composes safely alongside `required()` or other metadata registrations on the same field. No changes were needed in `auto-aria.ts` itself — once `REQUIRED` metadata is set, the existing `createAriaRequiredSignal` pipeline picks it up automatically.

**Usage** — call once per field, next to the existing `validateStandardSchema()` call for the object owning it (Standard Schema has no runtime key enumeration, so there's no way to derive every required field from a single root-level call — this mirrors calling `required()` per field):

```ts
const travelerForm = form(model, (path) => {
  validateStandardSchema(path, TravelerSchema);
  requiredFromStandardSchema(path.firstName, TravelerSchema);
  requiredFromStandardSchema(path.lastName, TravelerSchema);
});
```

Documented limitations (in the function's JSDoc): async validators can't be probed synchronously (reports not-required), a schema that throws while probed is treated as not-required rather than propagating, and cross-field conditional requiredness (e.g. "required only if X") isn't captured — only the field's unconditional base-schema requiredness is.

## Demo

Wired `requiredFromStandardSchema()` into the `advanced-wizard` demo's `traveler-step.form.ts` (6 fields) and `trip-step.form.ts` (4 destination fields), and **removed the hardcoded `<span class="text-red-500">*</span>` markers** from `traveler-step.ts` / `trip-step.ts` — the wrapper's auto-marker now covers them, consistent with every other demo (`complex-forms`, etc.).

## Tests

- New unit suite: `packages/toolkit/core/utilities/schema/required-from-standard-schema.spec.ts` — sync/async/throwing schemas, `LogicFn` schema resolution, object-path (`{ key }`) issue segments, and a full `aria-required` DOM assertion via `NgxSignalFormAutoAria`.
- New regression test in `packages/toolkit/form-field/form-field-wrapper.spec.ts` ("regression #118") reproducing the issue's acceptance criteria end-to-end: `aria-required="true"` on the control, exactly one auto-marker, and a clean accessible name ("First Name", not "First Name *").
- Documented in `docs/MIGRATING_BETA_TO_V1.md` (new API + limitations, appended at the end).

## Verification

- `pnpm nx run-many -t test,lint,build --projects=toolkit` — all green (1239 tests passed).
- `pnpm nx run-many -t build --all` — all 7 projects build successfully.
- `demo-e2e` `advanced-wizard.spec.ts` on chromium — all 10 tests pass, no *new* console errors (a pre-existing `NG0992` warning in the wizard's cross-step passport validation was confirmed present on `main` too, unrelated to this change).
- Live DOM check against the running demo (`/advanced-scenarios/advanced-wizard`):
  - `#firstName`: `aria-required="true"`, wrapper `data-marker="required"`, exactly 1 marker, label text stays `"First Name"` (clean accessible name).
  - Traveler step: exactly 6 required markers (firstName, lastName, email, nationality, passportNumber, passportExpiry) — no more, no less.
  - Trip step: destination `country` gets `aria-required="true"` + marker; optional `accommodation` correctly has no `aria-required`.
  - No literal `*` spans remain in the demo source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)