### PR TITLE
fix(toolkit/vest): isolate concurrently-pending field trees sharing one suite (#214)

### DIFF
--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -860,6 +860,27 @@ behavior:
   synchronously (without waiting for `whenStable()`/the async result), a
   warning may now appear one tick later than before while async tests are
   in flight.
+- **Fixed (#214): a suite instance shared across two concurrently-mounted,
+  independent field trees could cross-contaminate their results.** Vest
+  suites created via `create()` hold exactly ONE canonical accumulated result
+  per suite _object_. When the SAME suite instance backed two unrelated,
+  simultaneously-live `form()` trees (e.g. a module-scope suite reused by
+  repeated form rows) with overlapping in-flight async validation, one tree
+  could observe the OTHER tree's outcome instead of its own once both runs
+  settled. The adapter now detects this exact overlap — two different field
+  trees with a concurrently pending, unfocused run against the same suite —
+  and defers the later-arriving tree's actual `suite.run()` call until the
+  suite is idle, so the two runs never overlap. This is scoped to unfocused
+  (whole-suite) runs only: the wave-3 pattern of several `focusCurrentField`/
+  `only` registrations for different fields of the SAME form intentionally
+  keeps sharing the suite's retained state and is unaffected. The only
+  observable change is a small added latency for the rare case of two
+  independent, concurrently-validating trees sharing one suite instance — the
+  later one's validation now genuinely waits for the earlier one's async work
+  to finish before its own starts, rather than racing it (and getting
+  intermittently-wrong results). Consumers who give each field tree its own
+  suite instance (or who don't share a suite across concurrently-mounted
+  forms at all) see no behavior change.
 
 ### Vest peer dependency range widened
 

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -1395,7 +1395,7 @@ describe('validateVest', () => {
     expect(fixture.componentInstance.f.username().errors()).toHaveLength(0);
   });
 
-  it('registers the same suite instance on two concurrently-pending field trees without either one hanging forever', async () => {
+  it('isolates two concurrently-pending field trees sharing the same suite instance (#214)', async () => {
     // Multi-registration coverage for a different angle than the
     // focusCurrentField superseded-run tests above: here ONE suite constant
     // (the documented module-scope pattern) backs TWO completely separate
@@ -1403,26 +1403,24 @@ describe('validateVest', () => {
     // the same shared suite constant — with both runs in flight at the same
     // time.
     //
-    // KNOWN LIMITATION (discovered by this test, not fixed here — this is a
-    // test-hardening pass, not a behavior change): Vest suites created via
-    // `create()` hold exactly ONE canonical accumulated result per suite
-    // *object*, not one per caller/data payload (see `awaitVestRunSettlement`
-    // above — `suite.get()` returns "the suite's current accumulated
-    // result", singular). When the same suite instance validates two
-    // unrelated field trees concurrently, both trees' `validateAsync` settle
-    // off that single shared result, so one tree can observe the OTHER
-    // tree's outcome instead of its own. Concretely: formA's email
-    // ('first@example.com', valid) ends up reporting formB's "Email is
-    // required" failure once both runs settle. The only guarantee the
-    // adapter actually makes here (and the one this test asserts) is that
-    // neither registration is left permanently `pending()` — the specific
-    // regression `awaitVestRunSettlement`'s doc comment describes. Result
-    // *content* isolation across concurrent unrelated field trees sharing
-    // one suite instance is NOT currently guaranteed; consumers should give
-    // each independently-validated field tree its own suite instance (or
-    // rely on the per-field `only`/`focusCurrentField` pattern used
-    // elsewhere in this file, which scopes concurrent runs to fields of the
-    // SAME tree, not unrelated trees).
+    // Fixed in #214: Vest suites created via `create()` hold exactly ONE
+    // canonical accumulated result per suite *object*, not one per
+    // caller/data payload (see `awaitVestRunSettlement` above — `suite.get()`
+    // returns "the suite's current accumulated result", singular). When the
+    // same suite instance validates two unrelated field trees concurrently,
+    // letting both trees' `validateAsync` settle off that single shared
+    // result let one tree observe the OTHER tree's outcome instead of its
+    // own — concretely, formA's email ('first@example.com', valid) used to
+    // end up reporting formB's "Email is required" failure once both runs
+    // settled. The adapter now detects this exact overlap (two DIFFERENT
+    // field trees with a concurrently PENDING, UNFOCUSED run against the
+    // same suite instance) and defers the later-arriving registration's
+    // ACTUAL `suite.run()` call until the suite is idle (see
+    // `deferVestRunUntilIdle`), so the two runs never overlap and neither can
+    // observe or corrupt the other's in-flight state. This test asserts BOTH
+    // the "never permanently pending" guarantee (unchanged from the original
+    // wave-3 fix) AND full result isolation: formA must report ITS OWN
+    // (valid) outcome, not formB's failure.
     let releaseFirst: (() => void) | undefined;
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
@@ -1476,16 +1474,107 @@ describe('validateVest', () => {
     releaseFirst?.();
     await TestBed.inject(ApplicationRef).whenStable();
 
-    // The guaranteed contract: neither registration is left pending forever
-    // (the exact failure mode `awaitVestRunSettlement`'s settlement race
-    // exists to prevent).
+    // Guarantee #1 (wave-3, unchanged): neither registration is left pending
+    // forever (the exact failure mode `awaitVestRunSettlement`'s settlement
+    // race exists to prevent).
     expect(fixture.componentInstance.formA.email().pending()).toBe(false);
     expect(fixture.componentInstance.formB.email().pending()).toBe(false);
 
-    // formB's blank email always reports its own failure correctly.
+    // Guarantee #2 (#214, new): each tree reports ONLY its own outcome.
+    // formB's blank email fails...
     const formBErrors = fixture.componentInstance.formB.email().errors();
     expect(formBErrors).toHaveLength(1);
     expect(formBErrors[0]?.message).toBe('Email is required');
+
+    // ...and formA's valid, non-blank email must NOT pick up formB's
+    // failure -- the exact cross-contamination #214 reported.
+    const formAErrors = fixture.componentInstance.formA.email().errors();
+    expect(formAErrors).toHaveLength(0);
+  });
+
+  it('isolates warnings (not just blocking errors) across two concurrently-pending field trees sharing a suite (#214)', async () => {
+    // Same shared-suite-two-trees shape as the isolation test above, but
+    // exercising the `includeWarnings` path together with an async blocking
+    // test — the combination the adapter's warning-deferral logic
+    // (`shouldDeferVestWarnings`) is most likely to get tangled up in if the
+    // deferred (contested) run's snapshot/baseline bookkeeping leaked
+    // between trees. formA's bio is long enough to pass the sync warning
+    // check; formB's is short and must fail it. Both share a blocking async
+    // `email` check gated independently per tree.
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let releaseSecond: (() => void) | undefined;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    const sharedSuite = create((data: { email: string; bio: string }) => {
+      test('email', 'Email is required', async () => {
+        await (data.email === 'first@example.com' ? firstGate : secondGate);
+        enforce(data.email).isNotBlank();
+      });
+      test('bio', 'Consider adding more detail', () => {
+        warn();
+        enforce(data.bio.length >= 20).isTruthy();
+      });
+    });
+
+    @Component({
+      selector: 'ngx-test-vest-shared-suite-two-trees-warnings',
+      imports: [FormField],
+
+      template: `
+        <input id="email-a" [formField]="formA.email" />
+        <input id="bio-a" [formField]="formA.bio" />
+        <input id="email-b" [formField]="formB.email" />
+        <input id="bio-b" [formField]="formB.bio" />
+      `,
+    })
+    class TestComponent {
+      readonly modelA = signal({
+        email: 'first@example.com',
+        bio: 'a sufficiently long biography',
+      });
+      readonly formA = form(this.modelA, (path) => {
+        validateVest(path, sharedSuite, { includeWarnings: true });
+      });
+
+      readonly modelB = signal({ email: '', bio: 'short' });
+      readonly formB = form(this.modelB, (path) => {
+        validateVest(path, sharedSuite, { includeWarnings: true });
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.formA.email().pending()).toBe(true);
+      expect(fixture.componentInstance.formB.email().pending()).toBe(true);
+    });
+
+    releaseSecond?.();
+    releaseFirst?.();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.formA.email().pending()).toBe(false);
+    expect(fixture.componentInstance.formB.email().pending()).toBe(false);
+
+    // formA: valid email, long bio -- no errors, no warnings.
+    expect(fixture.componentInstance.formA.email().errors()).toHaveLength(0);
+    expect(fixture.componentInstance.formA.bio().errors()).toHaveLength(0);
+
+    // formB: blank email fails, short bio warns -- and neither leaks onto
+    // formA's fields (asserted above) nor is missing/duplicated on formB's.
+    const formBEmailErrors = fixture.componentInstance.formB.email().errors();
+    expect(formBEmailErrors).toHaveLength(1);
+    expect(formBEmailErrors[0]?.message).toBe('Email is required');
+
+    const formBBioErrors = fixture.componentInstance.formB.bio().errors();
+    expect(formBBioErrors).toHaveLength(1);
+    expect(formBBioErrors[0]?.message).toBe('Consider adding more detail');
+    expect(formBBioErrors[0]?.kind).toMatch(/^warn:vest:/);
   });
 
   it('defers a sync Vest warning while an async blocking test is pending, then surfaces it together with the settled result', async () => {

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -134,6 +134,25 @@ interface VestRunCacheEntry<TValue> {
   readonly focus: string | undefined;
   readonly runResult: VestResultLike | PromiseLike<VestResultLike>;
   readonly initialResult: VestResultLike | undefined;
+  /**
+   * `true` when this run was deferred via `deferVestRunUntilIdle` because
+   * another field tree had a concurrently pending run against the SAME suite
+   * instance when this one was requested — see
+   * {@link isSuiteContestedByOtherTree}.
+   *
+   * This is NOT the same question as "is this run currently pending" —
+   * it marks HOW the run was scheduled, for the lifetime of this cache entry,
+   * so the async completion pipeline knows to await `runResult` directly
+   * rather than racing it against the suite-wide `ALL_RUNNING_TESTS_FINISHED`
+   * bus event (see the call site in `registerVestValidation`'s `factory`).
+   * That race is what {@link awaitVestRunSettlement} uses to recover a
+   * SUPERSEDED run's promise, but `runResult` here is a plain `Promise` that
+   * does not even call `suite.run()` until the suite is idle — racing it
+   * against the CURRENT bus event (fired by whichever OTHER run made the
+   * suite idle) would resolve with `suite.get()`'s state from BEFORE this
+   * run started, not this run's own outcome.
+   */
+  readonly deferred: boolean;
 }
 
 /**
@@ -153,6 +172,8 @@ interface VestValidationRegistrationOptions<TValue> {
 interface PendingVestValidationPayload {
   readonly runResult: VestResultLike | PromiseLike<VestResultLike>;
   readonly initialSnapshot: VestValidationSnapshot;
+  /** Mirrors {@link VestRunCacheEntry.deferred}. */
+  readonly deferred: boolean;
 }
 
 /**
@@ -402,6 +423,79 @@ function executeVestRun<TValue>(
   }
 
   return suite.run(value, focusArg);
+}
+
+/**
+ * Resolves once `suite` has no test currently in flight.
+ *
+ * Vest suites created via `create()` are single-flight: calling ANY method
+ * that re-executes the suite's callback (`run()`, `only().run()`, and even
+ * `runStatic()` — verified empirically, since `runStatic()`'s persisted
+ * binding re-enters the ORIGINAL suite's runtime context to invoke its
+ * throwaway instance) while a PREVIOUS run on the SAME suite instance is
+ * still pending corrupts that previous run's resolver, per
+ * {@link awaitVestRunSettlement}'s doc comment. There is no supported way to
+ * safely touch a Vest suite instance while it has an in-flight run.
+ *
+ * When the suite exposes `subscribe`/`get` (true for suites created via
+ * Vest's `create()`), this checks `get().isPending()` and, if so, resolves on
+ * the next suite-wide `ALL_RUNNING_TESTS_FINISHED` bus event — a pure
+ * readiness signal, independent of which specific run's resolver ends up
+ * firing it. Suites without `subscribe`/`get` resolve immediately (best
+ * effort; contention avoidance is only guaranteed for real Vest suites).
+ */
+function waitForSuiteIdle<TValue>(
+  suite: Pick<VestRunnableSuite<TValue>, 'subscribe' | 'get'>,
+): PromiseLike<void> {
+  if (
+    typeof suite.subscribe !== 'function' ||
+    typeof suite.get !== 'function'
+  ) {
+    return Promise.resolve();
+  }
+
+  const subscribe = suite.subscribe;
+  if (!suite.get().isPending()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    // `subscribe`'s callback can fire synchronously; capture `unsubscribe` as
+    // `let` so an immediate callback doesn't read it before assignment (same
+    // TDZ hazard `awaitVestRunSettlement` guards against below).
+    let unsubscribe: (() => void) | undefined;
+    unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+      unsubscribe?.();
+      resolve();
+    });
+  });
+}
+
+/**
+ * Runs `suite` for `(value, focus)` only once it is idle, so a run for a
+ * field tree that finds this suite instance CONTESTED by another,
+ * still-pending field tree (see {@link isSuiteContestedByOtherTree}) never
+ * overlaps with that other run. This is the fix for issue #214: rather than
+ * letting two concurrently-pending field trees share one suite's canonical
+ * accumulated result (which Vest keeps ONE of per suite object, not one per
+ * caller), the later-arriving tree's ACTUAL `run()` call is deferred until
+ * the suite has nothing else in flight, guaranteeing its result reflects
+ * ONLY its own data.
+ *
+ * This trades a small amount of latency (the deferred tree's validation
+ * genuinely waits for the other tree's async work to finish before its own
+ * even starts) for full correctness, using only the same `run()` /
+ * `subscribe()` / `get()` surface every other code path already relies on —
+ * no suite-internal API beyond what {@link awaitVestRunSettlement} already
+ * uses.
+ */
+async function deferVestRunUntilIdle<TValue>(
+  suite: Pick<VestRunnableSuite<TValue>, 'run' | 'only' | 'subscribe' | 'get'>,
+  value: TValue,
+  focus: string | readonly string[] | undefined,
+): Promise<VestResultLike> {
+  await waitForSuiteIdle(suite);
+  return executeVestRun(suite, value, focus);
 }
 
 /**
@@ -760,7 +854,10 @@ export interface VestRegisterOptions<TValue = unknown> {
  * {@link VestSuiteAdapter.runVestSuite}.
  */
 export interface RunVestSuiteParams<TValue> {
-  readonly suite: Pick<VestRunnableSuite<TValue>, 'run' | 'only'>;
+  readonly suite: Pick<
+    VestRunnableSuite<TValue>,
+    'run' | 'only' | 'subscribe' | 'get'
+  >;
   readonly fieldTree: ReadonlyFieldTree<TValue>;
   readonly value: TValue;
   readonly focus?: string | readonly string[] | undefined;
@@ -769,9 +866,11 @@ export interface RunVestSuiteParams<TValue> {
 /**
  * Result of a shared, cache-aware single Vest run. `initialResult` is the
  * synchronous `SuiteResult` (or `undefined` when the suite's `run()` returns a
- * raw thenable), `runResult` is the underlying sync-or-async run value, and
- * `fromCache` reports whether this run reused a previously cached execution for
- * the identical `(suite, fieldTree, value, focus)` tuple.
+ * raw thenable — including a run deferred to avoid contention, see
+ * {@link isSuiteContestedByOtherTree}), `runResult` is the underlying
+ * sync-or-async run value, and `fromCache` reports whether this run reused a
+ * previously cached execution for the identical `(suite, fieldTree, value,
+ * focus)` tuple.
  */
 export interface RunVestSuiteResult<TValue> {
   readonly value: TValue;
@@ -861,6 +960,17 @@ export function createVestAdapter(
   // (the README-recommended module-scope pattern) is only reset once the
   // LAST registration tears down -- see `maybeRegisterResetOnDestroy`.
   const resetOnDestroyRefCounts = new WeakMap<object, number>();
+  // Tracks, per suite, which field trees currently have a run PENDING against
+  // it -- see `isSuiteContestedByOtherTree`. A plain (non-weak) Map is
+  // required here (unlike `runCache`) because contention detection needs to
+  // enumerate/count entries, which `WeakMap` cannot do. Entries are removed
+  // as soon as their run settles (`trackPendingVestRun`), so this only ever
+  // holds field trees with a run genuinely in flight -- bounded, self-cleaning
+  // bookkeeping, not a suite-lifetime membership list.
+  const pendingTreesBySuite = new Map<
+    object,
+    Map<ReadonlyFieldTree<unknown>, VestRunCacheEntry<unknown>>
+  >();
 
   /**
    * Retrieves the per-suite validation cache, creating it on first access.
@@ -877,6 +987,99 @@ export function createVestAdapter(
   }
 
   /**
+   * Reports whether `suite` currently has a PENDING, UNFOCUSED (whole-suite)
+   * run for some field tree OTHER than `fieldTree`.
+   *
+   * This is the precise condition under which Vest's shared, reconciled
+   * isolate tree is at risk: the reconciler merges/cancels pending test nodes
+   * from an in-flight run when a NEW `run()` call lands on the SAME suite
+   * before the earlier one settles (see {@link awaitVestRunSettlement}'s doc
+   * comment) -- if that overlap involves two DIFFERENT field trees, either
+   * one's final result can end up reflecting a blend of both trees' data
+   * (issue #214). When no OTHER tree is currently pending, the shared path is
+   * safe and preserves full Vest statefulness (memoization, retained `warn()`
+   * state across runs, etc.) for the common single-tree-per-suite case.
+   *
+   * Deliberately scoped to UNFOCUSED runs only (see the `focus === undefined`
+   * guards at both call sites, {@link trackPendingVestRun} and this
+   * function's caller): a suite backing several `focusCurrentField`/`only`
+   * registrations for DIFFERENT fields of the SAME overall form (each bound
+   * to its own child `ReadonlyFieldTree`) is the documented, intentional
+   * wave-3 (#174) pattern -- Vest's `only()` mode is SUPPOSED to retain other
+   * fields' state on the one shared suite there, and that pattern already has
+   * its own settlement recovery via `awaitVestRunSettlement`'s subscribe/get
+   * race. It is indistinguishable from the issue #214 shape (same suite
+   * object, different `ReadonlyFieldTree` reference) by field-tree identity
+   * alone; `focus` is the one signal the adapter has that tells them apart --
+   * two unrelated forms sharing a suite have no reason to pass a focus field
+   * name, while the multi-field-single-form pattern always does.
+   */
+  function isSuiteContestedByOtherTree(
+    suiteKey: object,
+    fieldTree: ReadonlyFieldTree<unknown>,
+  ): boolean {
+    const pendingTrees = pendingTreesBySuite.get(suiteKey);
+    if (!pendingTrees || pendingTrees.size === 0) {
+      return false;
+    }
+
+    return pendingTrees.size > 1 || !pendingTrees.has(fieldTree);
+  }
+
+  /**
+   * Records `fieldTree` as having a pending, UNFOCUSED run for `suiteKey`
+   * when `entry`'s run has not yet settled, and removes it once the run
+   * settles. No-op for a focused run -- see
+   * {@link isSuiteContestedByOtherTree}'s doc comment for why focused runs
+   * are excluded from contention tracking entirely.
+   *
+   * The removal is guarded by identity (`pendingTrees.get(fieldTree) ===
+   * entry`) so a LATER run for the same field tree -- which replaces this
+   * entry in the run cache before this one settles -- is never accidentally
+   * un-tracked by this entry's own (possibly superseded, possibly
+   * never-firing) settlement callback.
+   */
+  function trackPendingVestRun<TValue>(
+    suiteKey: object,
+    fieldTree: ReadonlyFieldTree<unknown>,
+    entry: VestRunCacheEntry<TValue>,
+    focus: string | readonly string[] | undefined,
+  ): void {
+    if (focus !== undefined) {
+      return;
+    }
+
+    const isPending = !entry.initialResult || entry.initialResult.isPending();
+    if (!isPending) {
+      return;
+    }
+
+    let pendingTrees = pendingTreesBySuite.get(suiteKey);
+    if (!pendingTrees) {
+      pendingTrees = new Map();
+      pendingTreesBySuite.set(suiteKey, pendingTrees);
+    }
+    pendingTrees.set(fieldTree, entry as VestRunCacheEntry<unknown>);
+
+    const untrack = (): void => {
+      const currentPendingTrees = pendingTreesBySuite.get(suiteKey);
+      if (
+        !currentPendingTrees ||
+        currentPendingTrees.get(fieldTree) !== entry
+      ) {
+        return;
+      }
+
+      currentPendingTrees.delete(fieldTree);
+      if (currentPendingTrees.size === 0) {
+        pendingTreesBySuite.delete(suiteKey);
+      }
+    };
+
+    Promise.resolve(entry.runResult).then(untrack, untrack);
+  }
+
+  /**
    * Reuses an existing Vest run for the same suite, Angular field tree, model
    * reference, and focus key; or executes the suite once and caches the result.
    *
@@ -884,14 +1087,27 @@ export function createVestAdapter(
    * synchronous `SuiteResult`), we capture `initialResult` as `undefined` and
    * rely on the async branch to drive completion from the promise. This guards
    * against consumer-wrapped suites that coerce `run()` into a Promise.
+   *
+   * Before executing a NEW run, checks whether `suite` currently has another
+   * field tree's run pending (`isSuiteContestedByOtherTree`) -- i.e. the same
+   * suite instance backs two concurrently-live field trees with overlapping
+   * in-flight validation (issue #214). When contested, the run is deferred
+   * until the suite is idle (`deferVestRunUntilIdle`) so it can never overlap
+   * with -- and thus never observe or corrupt -- the other tree's in-flight
+   * state; otherwise it runs against the suite's normal shared state
+   * immediately, exactly as before.
    */
   function getOrCreateVestRun<TValue>(
-    suite: Pick<VestRunnableSuite<TValue>, 'run' | 'only'>,
+    suite: Pick<
+      VestRunnableSuite<TValue>,
+      'run' | 'only' | 'subscribe' | 'get'
+    >,
     fieldTree: ReadonlyFieldTree<TValue>,
     value: TValue,
     focus: string | readonly string[] | undefined,
   ): VestRunCacheEntry<TValue> & { readonly fromCache: boolean } {
-    const suiteCache = getVestSuiteRunCache(suite as object);
+    const suiteKey = suite as object;
+    const suiteCache = getVestSuiteRunCache(suiteKey);
     const cachedEntry = suiteCache.get(fieldTree as ReadonlyFieldTree<unknown>);
     const focusKey = Array.isArray(focus)
       ? focus.join(VEST_KEY_SEPARATOR)
@@ -907,11 +1123,21 @@ export function createVestAdapter(
         focus: focusKey,
         runResult: cachedEntry.runResult,
         initialResult: cachedEntry.initialResult,
+        deferred: cachedEntry.deferred,
         fromCache: true,
       };
     }
 
-    const runResult = executeVestRun(suite, value, focus);
+    const isContested =
+      focus === undefined &&
+      isSuiteContestedByOtherTree(
+        suiteKey,
+        fieldTree as ReadonlyFieldTree<unknown>,
+      );
+    const runResult = isContested
+      ? deferVestRunUntilIdle(suite, value, focus)
+      : executeVestRun(suite, value, focus);
+
     const nextEntry: VestRunCacheEntry<TValue> = {
       value,
       focus: focusKey,
@@ -921,11 +1147,21 @@ export function createVestAdapter(
       // thenable. Previously we gated `initialResult` with `!isThenable(...)`,
       // which would always be false for Vest 6 suites and forced every
       // validation run through the async pipeline — hiding sync errors until
-      // the next microtask. Check the sync surface directly instead.
+      // the next microtask. Check the sync surface directly instead. A
+      // deferred (contested) run's `runResult` is a plain `Promise` (not
+      // Vest-result-like) until it actually starts, so it correctly falls
+      // into the "no sync result yet" branch below regardless.
       initialResult: isVestResultLike(runResult) ? runResult : undefined,
+      deferred: isContested,
     };
 
     suiteCache.set(fieldTree as ReadonlyFieldTree<unknown>, nextEntry);
+    trackPendingVestRun(
+      suiteKey,
+      fieldTree as ReadonlyFieldTree<unknown>,
+      nextEntry,
+      focus,
+    );
     return { ...nextEntry, fromCache: false };
   }
 
@@ -963,6 +1199,11 @@ export function createVestAdapter(
 
   function invalidate(suite: object): void {
     runCache.delete(suite);
+    // Also drop contention bookkeeping so a reset suite starts from a clean
+    // slate -- otherwise a stale pending marker from a run that never settled
+    // before teardown could permanently (and incorrectly) mark a
+    // subsequently-reused suite as contested.
+    pendingTreesBySuite.delete(suite);
   }
 
   /**
@@ -1092,6 +1333,7 @@ export function createVestAdapter(
           return {
             runResult: entry.runResult,
             initialSnapshot: { errors: [], warnings: [] },
+            deferred: entry.deferred,
           } satisfies PendingVestValidationPayload;
         }
 
@@ -1120,16 +1362,24 @@ export function createVestAdapter(
             entry.initialResult,
             snapshotOptions as VestValidationRegistrationOptions<unknown>,
           ),
+          deferred: entry.deferred,
         } satisfies PendingVestValidationPayload;
       },
       factory: (pendingValidation) => {
         return resource({
           params: pendingValidation,
           loader: async ({ params }) => {
-            const result = await awaitVestRunSettlement(
-              params.runResult,
-              suite,
-            );
+            // A deferred run's `runResult` (see `deferVestRunUntilIdle`) does
+            // not even call `suite.run()` until the suite becomes idle, so
+            // racing it against the suite-wide `ALL_RUNNING_TESTS_FINISHED`
+            // bus event here would resolve with `suite.get()`'s state from
+            // BEFORE this run started (whatever made the suite idle in the
+            // first place), not this run's own outcome. Its plain `Promise`
+            // already resolves correctly on its own once the deferred run
+            // actually completes, so await it directly.
+            const result = params.deferred
+              ? await params.runResult
+              : await awaitVestRunSettlement(params.runResult, suite);
             if (!isVestResultLike(result)) {
               // Throw so this lands in the validator's `onError` handler below,
               // which already encodes the right policy: blocking validators


### PR DESCRIPTION
Closes #214

## Root cause

A Vest suite created with `create()` holds exactly ONE canonical accumulated result per suite *object*. When the same suite instance backs two concurrently-mounted, independent field trees (e.g. a module-scope suite reused by repeated form rows), and both trees have overlapping in-flight async validation, calling `suite.run()` again for the second tree while the first tree's run is still pending reconciles into the SAME shared isolate tree. Vest's reconciler merges/cancels pending test nodes from the earlier run, so one tree's final result can end up reflecting a blend of both trees' data — the exact cross-contamination the issue describes.

## Approach considered and rejected

My first attempt routed the contested run through Vest's `suite.runStatic()` (a per-call throwaway internal instance), since that looked like the natural "give this call its own isolated instance" primitive. I verified empirically (small standalone script against the real `vest` package) that this is unsafe: `runStatic()`'s persisted binding re-enters the *original* suite's runtime context to invoke its throwaway instance, and doing so while the original suite has a genuinely pending run corrupts *that* run's resolver too — the original run's promise then never settles. Vest suites are single-flight; there's no supported way to safely touch a suite instance while it has an in-flight run.

## Fix

Detect when a suite already has another field tree's pending, **unfocused** run in flight (`isSuiteContestedByOtherTree`), and defer the later-arriving tree's actual `suite.run()` call until the suite goes idle (`deferVestRunUntilIdle`), built on the exact same `subscribe`/`get` surface `awaitVestRunSettlement` already relies on. The two runs then never overlap in time, so neither can observe or corrupt the other's state. This trades a small amount of latency (the deferred tree's validation genuinely waits for the other tree's async work to finish) for full correctness, using no suite-internal API beyond what the adapter already used for the wave-3 fix.

**Scoped to unfocused (whole-suite) runs only.** The wave-3 (#174) pattern of several `focusCurrentField`/`only` registrations for *different fields of the same form* (each bound to its own child `ReadonlyFieldTree`) intentionally shares one suite's retained state — Vest's `only()` mode is *supposed* to retain other fields' state there, and that pattern already has its own settlement recovery via the subscribe/get race. It's indistinguishable from the #214 shape (same suite object, different `ReadonlyFieldTree`) by field-tree identity alone; `focus` is the one signal available to tell them apart — two unrelated forms sharing a suite have no reason to pass a focus field name, while the multi-field-single-form pattern always does.

## Wave-3 guarantees preserved

All three wave-3 (#174) guarantees are untouched and their tests stay green:
- Never-permanently-pending (superseded-resolver recovery via `awaitVestRunSettlement`)
- `resetOnDestroy` ref-counting across concurrently-mounted forms sharing a suite
- The NUL `'root'` field sentinel

## Tests

- Flipped the #194 documenting repro (`validate-vest.spec.ts`) from asserting the buggy "known limitation" to asserting full isolation: two concurrently-pending field trees sharing one suite now each report *only* their own outcome, and neither is left permanently pending.
- Added a companion test for the same shape with `includeWarnings: true` plus an async blocking check, to cover the interaction between the deferral logic and the warning-deferral/snapshot-baseline machinery.
- Verified both new/changed tests fail against the pre-fix adapter (via `git stash`) and pass after.

No public API changes — `docs/MIGRATING_BETA_TO_V1.md` documents the fixed (previously broken) behavior alongside the other non-breaking wave-3 Vest fixes.

## Test plan

- [x] `pnpm nx run-many -t test,lint,build --projects=toolkit` — all green (1287 tests)
- [x] `pnpm exec vitest run packages/toolkit/vest` — 38/38 passing, including the flipped isolation test and the preserved wave-3 focused-run regression test
- [x] Confirmed new tests fail on the pre-fix adapter, pass after
- [x] `pnpm exec oxfmt .` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)