### PR TITLE
docs(skills): refresh ngx-signal-forms toolkit skills for v1.0.0 (rc.11)

### DIFF
--- a/.agents/skills/ngx-signal-forms/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ngx-signal-forms
-description: Guides use of @ngx-signal-forms/toolkit across the root and secondary entry points for Angular Signal Forms, including form enhancers, control semantics, wrappers, assistive feedback, grouped notifications, headless primitives, Vest integration, debugger UI, and migration to the current public API. Use when working with @ngx-signal-forms/toolkit, ngxSignalForm, ngxSignalFormControl, wrappers or fieldsets, error summaries or grouped notifications, assistive or headless state directives, Vest validation, debugger surfaces, or beta/RC-to-current API migrations.
+description: Guides use of @ngx-signal-forms/toolkit (now at the v1.0.0 public API, rc.11 in preparation) across the root and secondary entry points for Angular Signal Forms, including form enhancers, control semantics, wrappers, assistive feedback, grouped notifications, headless primitives, Vest integration, the axe-core accessibility test harness, debugger UI, and migration to the current public API. Use when working with @ngx-signal-forms/toolkit, ngxSignalForm, ngxSignalFormControl, wrappers or fieldsets, error summaries or grouped notifications, assistive or headless state directives, Vest validation, accessibility (a11y/WCAG) test assertions, debugger surfaces, or beta/RC-to-current API migrations.
 ---
 
 # ngx-signal-forms Toolkit
@@ -19,6 +19,7 @@ Use this skill when the task involves:
 - Displaying validation errors, grouped notifications, hints, or character counts
 - Building custom form controls with full markup control
 - Integrating Vest validation suites
+- Asserting no WCAG 2.2 AA violations in component specs (accessibility test harness)
 - Adding a dev-time debugger panel
 - Configuring global error messages or form appearance
 
@@ -31,6 +32,7 @@ Use this skill when the task involves:
 | `@ngx-signal-forms/toolkit/assistive`  | Standalone errors, grouped notifications, hints, summaries |
 | `@ngx-signal-forms/toolkit/headless`   | Renderless state, notification, and summary directives     |
 | `@ngx-signal-forms/toolkit/vest`       | Vest validation adapter (optional)                         |
+| `@ngx-signal-forms/toolkit/testing`    | axe-core WCAG 2.2 AA test harness for specs (optional)     |
 
 **Internal UI (Demo/Development Only):**
 
@@ -50,6 +52,7 @@ Use this skill when the task involves:
 | Standalone errors, grouped notifications, hints, counters         | [assistive/SKILL.md](assistive/SKILL.md)   |
 | Custom markup with full DOM control                               | [headless/SKILL.md](headless/SKILL.md)     |
 | Vest suite integration                                            | [vest/SKILL.md](vest/SKILL.md)             |
+| Accessibility test assertions, axe-core, WCAG spec checks         | [testing/SKILL.md](testing/SKILL.md)       |
 | Dev-time form inspection                                          | [debugger/SKILL.md](debugger/SKILL.md)     |
 
 ## Shared References
@@ -69,6 +72,7 @@ Need a styled label+input+error shell?                      → form-field
 Need standalone errors, grouped notifications, or hints?    → assistive
 Need full DOM control for custom design systems?            → headless
 Using Vest validation suites?                               → vest
+Asserting no WCAG 2.2 AA violations in a spec?              → testing
 Adding a debug panel during development?                    → debugger
 ```
 

--- a/.agents/skills/ngx-signal-forms/assistive/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/assistive/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Sub-skill of ngx-signal-forms for the @ngx-signal-forms/toolkit/assistive entry point — inline error display, grouped notifications, form-level error summaries, helper hint text, character counters, and assistive layout rows used without a full field wrapper. Not independently invocable; the hub SKILL.md routes here.
+description: Sub-skill of ngx-signal-forms for the @ngx-signal-forms/toolkit/assistive entry point — inline error display, grouped notifications, form-level error summaries, the form-level required/optional marking legend, helper hint text, and character counters used without a full field wrapper. Not independently invocable; the hub SKILL.md routes here.
 ---
 
 # Toolkit Assistive
@@ -29,17 +29,15 @@ The assistive entry point provides accessible feedback rendering that sits betwe
    - Omit `maxLength` when a `maxLength` validator on the field provides it.
    - Use `colorThresholds` to customize warning/danger thresholds (default: 80% warning, 95% danger).
 
-5. **`NgxFormFieldAssistiveRow`** — groups hint text and character count into a single stable row when both appear below the same input.
-
-6. **`NgxFormFieldNotification`** — grouped validation notification for fieldsets, summary cards, or custom sections:
+5. **`NgxFormFieldNotification`** — grouped validation notification for fieldsets, summary cards, or custom sections:
 
 - Provide `[errors]` as a signal of aggregated `ValidationError[]`.
 - Provide `fieldName` when the grouped block needs deterministic `aria-describedby` IDs.
-- Use `tone="auto"` for content-driven routing: any blocking error forces `role="alert"`; all-warning lists become `role="status"`.
-- Optional `title` renders above the messages; `listStyle` controls bullets vs stacked paragraphs.
+- Tone routing is automatic and content-driven — there is no `tone` input: any blocking error surfaces the `role="alert"` container; a warning-only list surfaces the `role="status"` container; an empty list hides both.
+- Optional `title` renders above the messages; `listStyle` (`'plain' | 'bullets'`, default `'bullets'`) controls stacked paragraphs vs a bullet list.
 - Prefer this over `NgxFormFieldErrorSummary` when you already own the grouping logic and want both warning and blocking surfaces.
 
-7. **`NgxFormFieldErrorSummary`** — form-level error summary (GOV.UK pattern):
+6. **`NgxFormFieldErrorSummary`** — form-level error summary (GOV.UK pattern):
    - Place at the top of the form, between any server status banners and the first field.
    - Always provide `[formTree]` — pass the form tree directly (e.g., `[formTree]="myForm"`), not `myForm()`.
    - `summaryLabel` defaults to `'Please fix the following errors:'`. Override with a meaningful label.
@@ -49,19 +47,24 @@ The assistive entry point provides accessible feedback rendering that sits betwe
 
 - Uses `role="alert"` and relies on the role's implicit live-region semantics (no explicit `aria-live` / `aria-atomic`).
 
+7. **`NgxFormMarkingLegend`** (`<ngx-form-marking-legend>`) — form-level legend that explains the required/optional marker (e.g. "* indicates a required field"), the companion to the per-field markers rendered by the `form-field` wrapper:
+   - Place it once wherever it reads well; there is no automatic injection.
+   - `[formTree]` is optional — it falls back to the ambient `form[formRoot][ngxSignalForm]` context. Pass it explicitly when used outside a form host.
+   - `showMarkerWhen` (`'required' | 'optional' | 'none'`), `text`, `requiredMarker`, and `optionalMarker` all fall back to `NgxSignalFormsConfig`, so by default the legend matches whatever the fields render.
+   - Mode- and content-aware: it hides when the form has no field of the relevant kind, and renders nothing in `'none'` mode. It is plain visible text (not `aria-hidden`) with no `role`/live region.
+
 8. Keep warning and error semantics distinct. Errors use `role="alert"` (assertive); warnings use `role="status"` (polite). Do not homogenize them.
 
 ## Error Summary Usage Example
 
 ```typescript
-import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { form, FormField } from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 import { NgxFormFieldErrorSummary } from '@ngx-signal-forms/toolkit/assistive';
 
 @Component({
   selector: 'app-registration-form',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, NgxSignalFormToolkit, NgxFormFieldErrorSummary],
   template: `
     <form [formRoot]="registrationForm" ngxSignalForm errorStrategy="on-submit">
@@ -89,35 +92,30 @@ export class RegistrationFormComponent {
 ## Standalone Usage Example
 
 ```typescript
-import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { form, FormField, required, maxLength } from '@angular/forms/signals';
 import {
   NgxFormFieldError,
   NgxFormFieldHint,
   NgxFormFieldCharacterCount,
-  NgxFormFieldAssistiveRow,
 } from '@ngx-signal-forms/toolkit/assistive';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 
 @Component({
   selector: 'app-bio-field',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormField,
     NgxSignalFormToolkit,
     NgxFormFieldError,
     NgxFormFieldHint,
     NgxFormFieldCharacterCount,
-    NgxFormFieldAssistiveRow,
   ],
   template: `
     <form [formRoot]="profileForm" ngxSignalForm>
       <label for="bio">Bio</label>
       <textarea id="bio" [formField]="profileForm.bio"></textarea>
-      <ngx-form-field-assistive-row>
-        <ngx-form-field-hint>Briefly describe yourself.</ngx-form-field-hint>
-        <ngx-form-field-character-count [formField]="profileForm.bio" />
-      </ngx-form-field-assistive-row>
+      <ngx-form-field-hint>Briefly describe yourself.</ngx-form-field-hint>
+      <ngx-form-field-character-count [formField]="profileForm.bio" />
       <ngx-form-field-error [formField]="profileForm.bio" fieldName="bio" />
     </form>
   `,
@@ -144,14 +142,14 @@ import {
 
 `NgxFormFieldError` automatically renders warnings with `role="status"` — no manual ARIA needed.
 
-`NgxFormFieldNotification` follows the same separation at the grouped level. With `tone="auto"`, mixed or blocking lists stay assertive; all-warning lists stay polite. This prevents accidentally downgrading real errors or over-announcing non-blocking guidance.
+`NgxFormFieldNotification` follows the same separation at the grouped level, automatically and content-driven (no `tone` input): any blocking error routes to the assertive `role="alert"` container, a warning-only list to the polite `role="status"` container, and an empty list hides both. This prevents accidentally downgrading real errors or over-announcing non-blocking guidance.
 
 ## Error Handling
 
 - If errors don't display: check that `fieldName` is provided when the component is used standalone.
 - If character count doesn't update: verify the field value is a string and `[formField]` is bound.
 - If hints don't appear in `aria-describedby`: confirm the component is inside a `ngx-form-field-wrapper` or use `NgxHeadlessFieldName` to wire it manually.
-- If a grouped notification announces with the wrong urgency: keep `tone="auto"` unless you have a strong UX reason to force a warning-only presentation.
+- If a grouped notification announces with the wrong urgency: check the `[errors]` list you pass in — routing is content-driven, so a stray blocking error will force the assertive `role="alert"` container. There is no `tone` input to override it.
 - For grouped summaries or fieldset-level output, switch to `form-field/SKILL.md` (`NgxFormFieldset`).
 - If error summary does not show: verify `ngxSignalForm` is applied to the `<form>` element so context is active, or provide `strategy` and `submittedStatus` explicitly.
 - If error summary entries don't focus controls on click: ensure the bound `<input>` / `<textarea>` / `<select>` has a stable `id` attribute — `focusBoundControl()` requires it.

--- a/.agents/skills/ngx-signal-forms/assistive/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/assistive/SKILL.md
@@ -47,7 +47,7 @@ The assistive entry point provides accessible feedback rendering that sits betwe
 
 - Uses `role="alert"` and relies on the role's implicit live-region semantics (no explicit `aria-live` / `aria-atomic`).
 
-7. **`NgxFormMarkingLegend`** (`<ngx-form-marking-legend>`) — form-level legend that explains the required/optional marker (e.g. "* indicates a required field"), the companion to the per-field markers rendered by the `form-field` wrapper:
+7. **`NgxFormMarkingLegend`** (`<ngx-form-marking-legend>`) — form-level legend that explains the required/optional marker (e.g. "\* indicates a required field"), the companion to the per-field markers rendered by the `form-field` wrapper:
    - Place it once wherever it reads well; there is no automatic injection.
    - `[formTree]` is optional — it falls back to the ambient `form[formRoot][ngxSignalForm]` context. Pass it explicitly when used outside a form host.
    - `showMarkerWhen` (`'required' | 'optional' | 'none'`), `text`, `requiredMarker`, and `optionalMarker` all fall back to `NgxSignalFormsConfig`, so by default the legend matches whatever the fields render.

--- a/.agents/skills/ngx-signal-forms/core/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/core/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Sub-skill of ngx-signal-forms for the core @ngx-signal-forms/toolkit entry point — form[formRoot] vs ngxSignalForm decision, auto-ARIA, control semantics, preset providers, error visibility strategies, submittedStatus/showErrors wiring, global config, error-message registries, warning helpers, submission helpers, and immutable array utilities. Not independently invocable; the hub SKILL.md routes here.
+description: Sub-skill of ngx-signal-forms for the core @ngx-signal-forms/toolkit entry point — form[formRoot] vs ngxSignalForm decision, auto-ARIA, control semantics, preset providers, error visibility strategies, submittedStatus/showErrors wiring, global config, error-message registries, warning helpers, submission helpers, immutable array utilities, required-marker config, Standard Schema (Zod) aria-required, and error/hint renderer overrides. Not independently invocable; the hub SKILL.md routes here.
 ---
 
 # Toolkit Core
@@ -67,14 +67,13 @@ The toolkit is an enhancement layer, not a replacement. Angular Signal Forms own
 ## Core Pattern
 
 ```typescript
-import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { form, FormField, required, email } from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 
 @Component({
   selector: 'app-example',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `
     <form [formRoot]="userForm" ngxSignalForm errorStrategy="on-submit">
@@ -154,6 +153,12 @@ patchState(store, (s) => ({
   ),
 }));
 ```
+
+## Required Markers, Standard Schema & Renderer Overrides
+
+- **Configure required/optional markers.** Global config takes `showMarkerWhen: FieldMarkingMode` (`'required' | 'optional' | 'none'`) plus `requiredMarker` / `optionalMarker` / `requiredLegendText` / `optionalLegendText`. `MarkerKind` is the non-`none` subset (`'required' | 'optional'`) and `ResolvedMarker` is the resolved shape. Render the form-level marker explanation with `NgxFormMarkingLegend` (`<ngx-form-marking-legend>`) from `@ngx-signal-forms/toolkit/assistive`.
+- **Surface `aria-required` for Standard Schema (Zod) fields.** Fields validated only through `validateStandardSchema()` (Zod, Valibot, ArkType, …) never register Angular's `required()` metadata, so `FieldState.required()` stays `false` and neither auto-ARIA's `aria-required` nor the `'required'` auto-marker fires. Call `requiredFromStandardSchema(path.field, Schema)` once per field, next to the `validateStandardSchema()` call, to close that gap. Types: `StandardSchemaLike`, `StandardSchemaLikeIssue`, `StandardSchemaLikeResult`.
+- **Swap error/hint rendering.** `provideFormFieldErrorRenderer()` / `provideFormFieldHintRenderer()` (and their `*ForComponent` variants) replace how the wrapper renders error and hint content, injected through the `NGX_FORM_FIELD_ERROR_RENDERER` / `NGX_FORM_FIELD_HINT_RENDERER` tokens. See `../references/api.md` for the override signatures (`NgxFormFieldErrorRendererOverride`, `NgxFormFieldHintRendererOverride`, `NgxFormFieldErrorPlacement`).
 
 ## Error Handling
 

--- a/.agents/skills/ngx-signal-forms/debugger/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/debugger/SKILL.md
@@ -41,19 +41,13 @@ The debugger is a **development-only** tool that makes invisible form state visi
 ## Usage
 
 ```typescript
-import {
-  Component,
-  ChangeDetectionStrategy,
-  signal,
-  isDevMode,
-} from '@angular/core';
+import { Component, signal, isDevMode } from '@angular/core';
 import { form, FormField, required } from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 import { NgxSignalFormDebuggerToolkit } from '@ngx-signal-forms/debugger';
 
 @Component({
   selector: 'app-debug-form',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, NgxSignalFormToolkit, NgxSignalFormDebuggerToolkit],
   template: `
     <div class="split-layout">
@@ -83,8 +77,9 @@ export class DebugFormComponent {
 standalone status chips the panel composes internally. Use them directly when
 you want a compact inline indicator (e.g., next to a submit button) without
 the full panel. They're included in `NgxSignalFormDebuggerToolkit` — import the
-bundle and drop the directives into your template. Badge appearance options:
-`'solid' | 'outline'`; variants: `'neutral' | 'success' | 'warning' | 'danger'`.
+bundle and drop the directives into your template. Badge inputs: `variant`
+(`'solid' | 'outline' | 'ghost'`, default `'solid'`) and `appearance`
+(`'neutral' | 'info' | 'success' | 'warning' | 'danger'`, default `'neutral'`).
 
 ## What the Debugger Shows
 

--- a/.agents/skills/ngx-signal-forms/form-field/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/form-field/SKILL.md
@@ -25,10 +25,10 @@ The form-field entry point provides a pre-styled field shell (label + control + 
 
 3. **Error placement:**
    - Default for wrapper: `errorPlacement="bottom"`
-   - Default for fieldset: `errorPlacement="top"`
+   - Default for fieldset: `errorPlacement="bottom"` — set `errorPlacement="top"` when the group summary should sit directly below the legend.
    - Override per wrapper or per fieldset as needed — these are independent controls.
 
-4. **Field marking:** Use `showMarkerWhen` (`'required' | 'optional' | 'none'`) on the wrapper or globally via `provideNgxSignalFormsConfig({ showMarkerWhen: 'required' })`. Add `<ngx-form-marking-legend>` to explain the marker.
+4. **Field marking:** Use `showMarkerWhen` (`'required' | 'optional' | 'none'`), plus optional `requiredMarker` / `optionalMarker`, on the wrapper or globally via `provideNgxSignalFormsConfig({ showMarkerWhen: 'required' })`. Markers render in every appearance and don't affect `aria-required`. Add the form-level `<ngx-form-marking-legend>` (from `@ngx-signal-forms/toolkit/assistive`) once per form to explain what the marker means.
 
 5. **Use `NgxFormFieldset` for grouped sections:**
    - Pass the **parent field tree** to `[fieldsetField]`.
@@ -102,14 +102,13 @@ The form-field entry point provides a pre-styled field shell (label + control + 
 ## Basic Usage
 
 ```typescript
-import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { form, FormField, required, email } from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 
 @Component({
   selector: 'app-profile-form',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `
     <form [formRoot]="profileForm" ngxSignalForm errorStrategy="on-submit">
@@ -152,7 +151,7 @@ export class ProfileFormComponent {
 ## Grouped Fieldset
 
 ```html
-<!-- Group-level error summary at the top (fieldset default) -->
+<!-- Group-level error summary (add errorPlacement="top" to move it above the fields) -->
 <ngx-form-fieldset [fieldsetField]="form.address" fieldsetId="address">
   <legend>Address</legend>
 

--- a/.agents/skills/ngx-signal-forms/headless/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/headless/SKILL.md
@@ -39,7 +39,9 @@ For ready-to-render components with built-in markup, use `assistive/SKILL.md` or
 
 5. **Use `NgxHeadlessFieldset`** for aggregated group state — validity, errors, and warnings across a field tree without rebuilding the traversal.
 
-6. **Use `NgxHeadlessNotification`** when you already have aggregated `ValidationError[]` and need a grouped live-region surface that can route to either assertive or polite announcement semantics without giving up DOM control.
+6. **Use `NgxHeadlessNotification`** when you already have aggregated `ValidationError[]` and need a grouped live-region surface. Tone is content-driven (no `tone` input): any blocking error raises the assertive `role="alert"` container, a warning-only list raises the polite `role="status"` container — you keep full DOM control.
+
+7. **Reach for the field-optionality helpers** (`createFieldOptionalitySummary`, `summarizeFieldOptionality`, type `FieldOptionality`) when a custom component needs to know whether a field is required/optional to render a marker or legend. See `../references/api.md` for signatures.
 
 ## Error Summary Directive Pattern
 
@@ -74,7 +76,7 @@ For a styled out-of-the-box error summary without warnings, use `NgxFormFieldErr
 
 ## Grouped Notification Directive Pattern
 
-Use `ngxHeadlessNotification` when a fieldset, summary card, or custom block already owns the grouped `ValidationError[]` list and only needs tone resolution, message lookup, and deterministic IDs.
+Use `ngxHeadlessNotification` when a fieldset, summary card, or custom block already owns the grouped `ValidationError[]` list and only needs content-driven tone routing, message lookup, and deterministic IDs. It exposes only `errors` (required) and `fieldName` — there is no `tone` input.
 
 ```html
 <section
@@ -101,7 +103,7 @@ Use `ngxHeadlessNotification` when a fieldset, summary card, or custom block alr
 </section>
 ```
 
-`tone="auto"` is the safe default. Any blocking error forces the assertive container; all-warning lists use the polite container. This preserves urgency semantics even when callers pass a mismatched tone.
+Tone is fully content-driven — there is no input to set. `resolvedTone()` returns `'error'` whenever any blocking error is present (raising the assertive `role="alert"` container) and `'warning'` for an all-warning list (raising the polite `role="status"` container); an empty list hides both. This preserves urgency semantics automatically.
 
 ## Template Directive Pattern
 
@@ -133,12 +135,11 @@ Use `ngxHeadlessNotification` when a fieldset, summary card, or custom block alr
 ## Host Directive Pattern (Reusable Design-System Component)
 
 ```typescript
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgxHeadlessErrorState } from '@ngx-signal-forms/toolkit/headless';
 
 @Component({
   selector: 'ds-form-field',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
       directive: NgxHeadlessErrorState,
@@ -236,5 +237,5 @@ createUniqueId('my-field'); // 'my-field-1', 'my-field-2', ...
 
 - If IDs are inconsistent: add explicit `fieldName` instead of relying on implicit host `id` detection.
 - If `'on-submit'` errors don't appear: ensure the form uses `form[formRoot][ngxSignalForm]` so submitted status and toolkit context are available.
-- If a grouped notification resolves to the wrong live region: check whether the error list includes any blocking errors — `tone="auto"` intentionally prefers `role="alert"` whenever one is present.
+- If a grouped notification resolves to the wrong live region: check whether the error list includes any blocking errors — tone is content-driven, so `role="alert"` is used whenever any blocking error is present, regardless of intent.
 - If the component is recreating the full wrapper layout: stop and use `form-field/SKILL.md` instead.

--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -62,6 +62,14 @@ provideNgxSignalFormControlPresets(presets: NgxSignalFormControlPresetOverrides)
 provideNgxSignalFormControlPresetsForComponent(presets: NgxSignalFormControlPresetOverrides): Provider[]
 provideErrorMessages(configOrFactory: ErrorMessageRegistry | (() => ErrorMessageRegistry)): Provider
 provideFieldLabels(configOrFactory: FieldLabelMap | (() => (rawFieldPath: string) => string)): Provider
+
+// Swap how the wrapper / fieldset renders the error and hint slots. Pass
+// `{ component }` to set a standalone renderer component; pass `{}` to inherit
+// a parent scope's renderer. See `docs/CUSTOM_WRAPPERS.md`.
+provideFormFieldErrorRenderer(override: NgxFormFieldErrorRendererOverride): EnvironmentProviders
+provideFormFieldErrorRendererForComponent(override: NgxFormFieldErrorRendererOverride): Provider[]
+provideFormFieldHintRenderer(override: NgxFormFieldHintRendererOverride): EnvironmentProviders
+provideFormFieldHintRendererForComponent(override: NgxFormFieldHintRendererOverride): Provider[]
 ```
 
 **Control semantics preset providers:**
@@ -149,6 +157,7 @@ Migration note for `defaultFormFieldAppearance`:
 
 ```typescript
 type SignalLike<T> = Signal<T> | (() => T);
+type ReactiveOrStatic<T> = SignalLike<T> | T; // a plain value or a reactive source
 type ResolvedErrorDisplayStrategy = 'immediate' | 'on-touch' | 'on-submit';
 type ErrorDisplayStrategy = ResolvedErrorDisplayStrategy | 'inherit';
 type FormFieldAppearance = 'standard' | 'outline' | 'plain';
@@ -156,6 +165,12 @@ type FormFieldAppearanceInput = FormFieldAppearance | 'inherit';
 type FormFieldOrientation = 'vertical' | 'horizontal';
 type FormFieldOrientationInput = FormFieldOrientation | 'inherit';
 type SubmittedStatus = 'unsubmitted' | 'submitting' | 'submitted';
+type FieldMarkingMode = 'required' | 'optional' | 'none';
+type MarkerKind = Exclude<FieldMarkingMode, 'none'>; // 'required' | 'optional'
+interface ResolvedMarker {
+  readonly kind: MarkerKind;
+  readonly text: string;
+}
 type ErrorVisibilityState = Pick<FieldState<unknown>, 'invalid' | 'touched'>;
 type ErrorReadableState = Pick<
   FieldState<unknown>,
@@ -189,6 +204,26 @@ const NGX_SIGNAL_FORMS_CONFIG: InjectionToken<NgxSignalFormsConfig>;
 const NGX_SIGNAL_FORM_CONTROL_PRESETS: InjectionToken<NgxSignalFormControlPresetRegistry>;
 const NGX_SIGNAL_FORM_CONTEXT: InjectionToken<NgxSignalFormContext>;
 const NGX_SIGNAL_FORM_FIELD_CONTEXT: InjectionToken<NgxSignalFormFieldContext>;
+const NGX_FORM_FIELD_ERROR_RENDERER: InjectionToken<NgxFormFieldErrorRenderer | null>;
+const NGX_FORM_FIELD_HINT_RENDERER: InjectionToken<NgxFormFieldHintRenderer | null>;
+```
+
+**Renderer-override types** (for the providers/tokens above — a renderer is a `{ component }` wrapper around a standalone component that owns the error/hint slot markup):
+
+```typescript
+interface NgxFormFieldErrorRenderer {
+  readonly component: Type<unknown>;
+}
+interface NgxFormFieldHintRenderer {
+  readonly component: Type<unknown>;
+}
+interface NgxFormFieldErrorRendererOverride {
+  readonly component?: Type<unknown>; // omit `component` to inherit a parent scope
+}
+interface NgxFormFieldHintRendererOverride {
+  readonly component?: Type<unknown>;
+}
+type NgxFormFieldErrorPlacement = 'top' | 'bottom';
 ```
 
 > `NGX_ERROR_MESSAGES` and `NGX_FIELD_LABEL_RESOLVER` are internal tokens used by sibling entry points inside the toolkit package. Use `provideErrorMessages()` and `provideFieldLabels()` instead.
@@ -234,6 +269,13 @@ inferNgxSignalFormControlKind(element): NgxSignalFormControlKind | null
 isNgxSignalFormControlKind(value): value is NgxSignalFormControlKind
 isNgxSignalFormControlLayout(value): value is NgxSignalFormControlLayout
 isNgxSignalFormControlAriaMode(value): value is NgxSignalFormControlAriaMode
+isFormFieldAppearance(value): value is FormFieldAppearance
+isFormFieldOrientation(value): value is FormFieldOrientation
+
+// Field-name normalization
+normalizeFieldName(fieldName): string | null // trim; empty/whitespace/nullish → null
+resolveFieldNameFromCandidates(...candidates): string | null // first non-null normalized candidate wins
+isElementCssVisible(element): boolean // used by field identity / focus management
 
 interface AriaDescribedByChainOptions {
   readonly baseIds?: readonly string[];     // hint or helper IDs to prepend
@@ -282,6 +324,55 @@ updateNested(array, index, nestedKey, nestedIndex, updater): array
 unwrapValue(signalOrValue): value
 ```
 
+### Standard Schema required markers
+
+Surfaces `aria-required` for fields validated by a Standard Schema (Zod, Valibot, etc.) instead of Angular's `required()`. Call it inside a schema definition, like `required()`:
+
+```typescript
+requiredFromStandardSchema(field, schema): void
+// e.g. within a form schema:
+//   requiredFromStandardSchema(path.firstName, TravelerSchema);
+
+// Narrowed structural contract — only reads `~standard.validate`:
+interface StandardSchemaLike<TInput = unknown> {
+  readonly '~standard': {
+    readonly validate: (value: unknown) =>
+      | StandardSchemaLikeResult<TInput>
+      | PromiseLike<StandardSchemaLikeResult<TInput>>;
+  };
+}
+interface StandardSchemaLikeIssue {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>;
+}
+interface StandardSchemaLikeResult<TInput> {
+  readonly issues?: ReadonlyArray<StandardSchemaLikeIssue>;
+  readonly value?: TInput;
+}
+```
+
+### Advanced / custom-wrapper exports
+
+These are public but only needed when building custom wrappers or low-level primitives — most consumers never touch them.
+
+```typescript
+// Low-level error-visibility factory (backs NgxSignalFormAutoAria and headless
+// factories). Reach for it when hand-rolling a directive that needs the same
+// strategy/submittedStatus resolution.
+createErrorVisibility(options: CreateErrorVisibilityOptions): ControlVisibilitySignal
+// CreateErrorVisibilityOptions: { strategy?, submittedStatus?, configDefault?, injector? }
+
+// Services
+NgxFieldIdentity        // resolves/tracks a control's field identity
+NgxControlPresetRegistry // resolves control-semantics preset defaults
+
+// Third-party wrapper hint-registry contract (link projected hints into
+// aria-describedby without auto-ARIA querying the DOM). See docs/CUSTOM_WRAPPERS.md.
+const NGX_SIGNAL_FORM_HINT_REGISTRY: InjectionToken<NgxSignalFormHintRegistry>;
+interface NgxSignalFormHintDescriptor { readonly id: string; readonly fieldName: string | null }
+interface NgxSignalFormHintRegistry { readonly hints: Signal<readonly NgxSignalFormHintDescriptor[]> }
+```
+
 ---
 
 ## Entry Point: `@ngx-signal-forms/toolkit/assistive`
@@ -293,7 +384,7 @@ import {
   NgxFormFieldNotification, // <ngx-form-field-notification>
   NgxFormFieldHint, // <ngx-form-field-hint>
   NgxFormFieldCharacterCount, // <ngx-form-field-character-count>
-  NgxFormFieldAssistiveRow, // <ngx-form-field-assistive-row>
+  NgxFormMarkingLegend, // <ngx-form-marking-legend>
   warningError,
   isWarningError,
   isBlockingError,
@@ -314,26 +405,35 @@ import {
 ### Other assistive exports
 
 - `NgxFormFieldHint` — static descriptive hint content
-- `NgxFormFieldAssistiveRow` — stable row container for hint + character count
+- `NgxFormFieldListStyle` (`'plain' | 'bullets'`) — shared list-style union. `NgxFormFieldErrorListStyle` and `NgxFormFieldNotificationListStyle` are `@deprecated` aliases of it.
+- `NgxCharacterCountValue` + `NgxCharacterCountAnnouncement*` types — character-count announcement formatting hooks.
+
+### NgxFormMarkingLegend inputs
+
+Selector: `ngx-form-marking-legend`
+
+| Input            | Type                                 | Notes                                                                        |
+| ---------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| `formTree`       | `FieldTree<unknown>`                 | Optional — falls back to ambient `ngxSignalForm` form context                |
+| `showMarkerWhen` | `FieldMarkingMode`                   | Override marking mode; falls back to config `showMarkerWhen`                  |
+| `text`           | string                               | Override legend text entirely (`{marker}` is substituted)                    |
+| `requiredMarker` | string                               | Override the required marker used for `{marker}`; falls back to config       |
+| `optionalMarker` | string                               | Override the optional marker used for `{marker}`; falls back to config       |
+
+Renders the form-level legend explaining what the required/optional markers mean. Mode-aware: hides when the form has no field of the relevant kind, and renders nothing in `'none'` mode. Plain visible text — no `role` or live region (required state still reaches AT via each control's `aria-required`).
 
 ### NgxFormFieldNotification inputs
 
 Selector: `ngx-form-field-notification`
 
-| Input       | Type                        | Default     | Notes                                                                |
-| ----------- | --------------------------- | ----------- | -------------------------------------------------------------------- |
-| `errors`    | `Signal<ValidationError[]>` | required    | Grouped validation messages to render                                |
-| `fieldName` | string                      | optional    | Generates deterministic error/warning container ids when provided    |
-| `tone`      | `NgxNotificationTone`       | `'auto'`    | `'auto'` routes blocking lists to alert, all-warning lists to status |
-| `title`     | string                      | optional    | Optional heading rendered above the messages                         |
-| `listStyle` | `plain` or `bullets`        | `'bullets'` | Bullet list or stacked paragraph rendering                           |
+| Input       | Type                                       | Default     | Notes                                                             |
+| ----------- | ------------------------------------------ | ----------- | ----------------------------------------------------------------- |
+| `errors`    | `Signal<readonly ValidationError[]>`       | required    | Grouped validation messages to render (bound via host directive)  |
+| `fieldName` | string                                     | optional    | Generates deterministic error/warning container ids when provided |
+| `title`     | string                                     | optional    | Optional heading rendered above the messages                      |
+| `listStyle` | `NgxFormFieldListStyle` (`plain`/`bullets`) | `'bullets'`  | Bullet list or stacked paragraph rendering                        |
 
-Thin styled shell over `NgxHeadlessNotification`. Uses dual stable live regions: `role="alert"` for blocking content, `role="status"` for warning-only content.
-
-Migration aliases still exist for compatibility, but prefer the shared names:
-
-- `NgxFormFieldNotificationListStyle` → prefer `NgxFormFieldListStyle`
-- `NgxFormFieldNotificationTone` → prefer `NgxNotificationTone` from `@ngx-signal-forms/toolkit/headless`
+`errors` and `fieldName` are forwarded to the composed `NgxHeadlessNotification` host directive. There is **no `tone` input** — the routing is content-driven: any blocking error renders the `role="alert"` container, a warning-only list renders the `role="status"` container, and an empty list keeps both hidden. Uses dual stable live regions so the role is never re-assigned at the same tick content is inserted.
 
 ### NgxFormFieldErrorSummary inputs
 
@@ -376,11 +476,11 @@ For full DOM control over the error summary (incl. warning entries), use `NgxHea
 
 ```typescript
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
-// Bundle: [NgxFormFieldWrapper,
-//          NgxSignalFormAutoAria,
+// Bundle: [NgxSignalFormAutoAria,
+//          NgxSignalFormControlSemanticsDirective,
+//          NgxFormFieldWrapper,
 //          NgxFormFieldHint, NgxFormFieldCharacterCount,
-//          NgxFormFieldAssistiveRow, NgxFormFieldError,
-//          NgxFormFieldset]
+//          NgxFormFieldError, NgxFormFieldset]
 
 import {
   NgxFormFieldWrapper,
@@ -412,7 +512,7 @@ import {
 | `strategy`            | ErrorDisplayStrategy | Inherited                 |
 | `showErrors`          | boolean              | `true`                    |
 | `includeNestedErrors` | boolean              | `false`                   |
-| `errorPlacement`      | `'top' \| 'bottom'`  | `'top'`                   |
+| `errorPlacement`      | `'top' \| 'bottom'`  | `'bottom'`                |
 
 ---
 
@@ -429,13 +529,14 @@ import { NgxHeadlessToolkit } from '@ngx-signal-forms/toolkit/headless';
 
 Directive-level types and constants also available from this entry point:
 
+- `createErrorMessageSignal(field, options?): Signal<readonly ResolvedFieldError[]>` — reactive primitive that resolves a field's errors (with the 3-tier message cascade + stable IDs) for custom rendering. Options: `CreateErrorMessageSignalOptions`; `IncludeWarningsOption` (`false` blocking-only \| `true` blocking then warnings \| `'only'` warnings) selects the subset; `ResolvedFieldError` is `{ kind, message, id, error }`.
 - `ErrorStateSignals`, `ResolvedError` — from `NgxHeadlessErrorState`
 - `FieldsetStateSignals` — from `NgxHeadlessFieldset`
 - `CharacterCountStateSignals`, `CharacterCountLimitState` — from `NgxHeadlessCharacterCount`
 - `DEFAULT_WARNING_THRESHOLD` (80), `DEFAULT_DANGER_THRESHOLD` (95) — default thresholds
 - `ErrorSummaryEntry`, `ErrorSummarySignals` — from `NgxHeadlessErrorSummary`
 - `FieldNameStateSignals` — from `NgxHeadlessFieldName`
-- `NgxNotificationTone`, `NotificationStateSignals`, `ResolvedNotificationMessage` — from `NgxHeadlessNotification`
+- `NotificationStateSignals`, `ResolvedNotificationMessage` — from `NgxHeadlessNotification`
 
 ### NgxHeadlessErrorState
 
@@ -505,11 +606,10 @@ Signals: `resolvedFieldName()` (`string | null`), `errorId` (`Signal<string | nu
 
 Selector: `[ngxHeadlessNotification]` | Export: `#notification="notificationState"`
 
-Inputs:
+Inputs (no `tone` — routing is content-driven):
 
-- `errors` (required) — `Signal<readonly ValidationError[]>`
+- `errors` (required) — `ReactiveOrStatic<readonly ValidationError[]>` (plain array or signal/getter; unwrapped internally)
 - `fieldName` — `string | null | undefined`
-- `tone` — `'auto' | 'error' | 'warning'` (default `'auto'`)
 
 Signals/methods (implements `NotificationStateSignals`):
 
@@ -540,6 +640,16 @@ humanizeFieldPath(fieldName: string): string
 resolveFieldNameFromError(error, resolver?): string
 focusBoundControlFromError(error): void
 toErrorSummaryEntry(error, registry?, options?, labelResolver?): ErrorSummaryEntryData
+
+// Field optionality — does a form tree have any required / any optional leaf?
+summarizeFieldOptionality(tree): FieldOptionality // synchronous; reactive when read inside a computed()
+createFieldOptionalitySummary(treeSource: () => FieldTree | null | undefined): {
+  readonly hasRequired: Signal<boolean>;
+  readonly hasOptional: Signal<boolean>;
+}
+// FieldOptionality: { readonly hasRequired: boolean; readonly hasOptional: boolean }
+// Both flags can be true (mixed form); an empty / leaf-less form reports false for both.
+// Backs NgxFormMarkingLegend's mode-aware show/hide.
 ```
 
 ### Headless utility/result types
@@ -645,6 +755,42 @@ const isVestWarning = (kind: string) =>
 See `packages/toolkit/vest/README.md` for the full suite-lifecycle rationale
 (why `resetOnDestroy` matters for module-scope suites, async thenable handling,
 `only()` selector patterns).
+
+---
+
+## Entry Point: `@ngx-signal-forms/toolkit/testing`
+
+A small consumer-facing accessibility test harness. `axe-core` is an **optional peer dependency** of the toolkit — it is only required if you import from this entry point (intended for Vitest browser-mode specs after rendering a component fixture).
+
+```typescript
+import {
+  expectNoA11yViolations,
+  WCAG_22_AA_TAGS,
+  type WCAG_22_AA_TAG,
+} from '@ngx-signal-forms/toolkit/testing';
+```
+
+```typescript
+// Runs an axe-core audit and HARD-FAILS (throws) on any WCAG 2.2 AA violation.
+// One call per rendered fixture scans the whole subtree.
+expectNoA11yViolations(
+  context?: axe.ElementContext,   // default: document.body
+  options?: axe.RunOptions,       // merged over the WCAG 2.2 AA defaults
+): Promise<void>
+
+// axe-core tag set mapping to WCAG 2.2 AA (additive across versions):
+WCAG_22_AA_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'] as const
+// No `wcag22a`: the two new 2.2 Level A criteria (Consistent Help, Redundant
+// Entry) are non-automatable, so automated scans cover only a subset of full
+// 2.2 AA conformance.
+type WCAG_22_AA_TAG = (typeof WCAG_22_AA_TAGS)[number]
+```
+
+```typescript
+// Example (Vitest browser mode)
+await render(MyFormComponent);
+await expectNoA11yViolations(); // throws with a formatted report on any violation
+```
 
 ---
 

--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -428,7 +428,7 @@ Selector: `ngx-form-field-notification`
 
 | Input       | Type                                       | Default     | Notes                                                             |
 | ----------- | ------------------------------------------ | ----------- | ----------------------------------------------------------------- |
-| `errors`    | `Signal<readonly ValidationError[]>`       | required    | Grouped validation messages to render (bound via host directive)  |
+| `errors`    | `ReactiveOrStatic<readonly ValidationError[]>` | required    | Grouped validation messages (plain array or signal/getter); bound via host directive |
 | `fieldName` | string                                     | optional    | Generates deterministic error/warning container ids when provided |
 | `title`     | string                                     | optional    | Optional heading rendered above the messages                      |
 | `listStyle` | `NgxFormFieldListStyle` (`plain`/`bullets`) | `'bullets'`  | Bullet list or stacked paragraph rendering                        |

--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -412,13 +412,13 @@ import {
 
 Selector: `ngx-form-marking-legend`
 
-| Input            | Type                                 | Notes                                                                        |
-| ---------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
-| `formTree`       | `FieldTree<unknown>`                 | Optional — falls back to ambient `ngxSignalForm` form context                |
-| `showMarkerWhen` | `FieldMarkingMode`                   | Override marking mode; falls back to config `showMarkerWhen`                  |
-| `text`           | string                               | Override legend text entirely (`{marker}` is substituted)                    |
-| `requiredMarker` | string                               | Override the required marker used for `{marker}`; falls back to config       |
-| `optionalMarker` | string                               | Override the optional marker used for `{marker}`; falls back to config       |
+| Input            | Type                 | Notes                                                                  |
+| ---------------- | -------------------- | ---------------------------------------------------------------------- |
+| `formTree`       | `FieldTree<unknown>` | Optional — falls back to ambient `ngxSignalForm` form context          |
+| `showMarkerWhen` | `FieldMarkingMode`   | Override marking mode; falls back to config `showMarkerWhen`           |
+| `text`           | string               | Override legend text entirely (`{marker}` is substituted)              |
+| `requiredMarker` | string               | Override the required marker used for `{marker}`; falls back to config |
+| `optionalMarker` | string               | Override the optional marker used for `{marker}`; falls back to config |
 
 Renders the form-level legend explaining what the required/optional markers mean. Mode-aware: hides when the form has no field of the relevant kind, and renders nothing in `'none'` mode. Plain visible text — no `role` or live region (required state still reaches AT via each control's `aria-required`).
 
@@ -426,12 +426,12 @@ Renders the form-level legend explaining what the required/optional markers mean
 
 Selector: `ngx-form-field-notification`
 
-| Input       | Type                                       | Default     | Notes                                                             |
-| ----------- | ------------------------------------------ | ----------- | ----------------------------------------------------------------- |
+| Input       | Type                                           | Default     | Notes                                                                                |
+| ----------- | ---------------------------------------------- | ----------- | ------------------------------------------------------------------------------------ |
 | `errors`    | `ReactiveOrStatic<readonly ValidationError[]>` | required    | Grouped validation messages (plain array or signal/getter); bound via host directive |
-| `fieldName` | string                                     | optional    | Generates deterministic error/warning container ids when provided |
-| `title`     | string                                     | optional    | Optional heading rendered above the messages                      |
-| `listStyle` | `NgxFormFieldListStyle` (`plain`/`bullets`) | `'bullets'`  | Bullet list or stacked paragraph rendering                        |
+| `fieldName` | string                                         | optional    | Generates deterministic error/warning container ids when provided                    |
+| `title`     | string                                         | optional    | Optional heading rendered above the messages                                         |
+| `listStyle` | `NgxFormFieldListStyle` (`plain`/`bullets`)    | `'bullets'` | Bullet list or stacked paragraph rendering                                           |
 
 `errors` and `fieldName` are forwarded to the composed `NgxHeadlessNotification` host directive. There is **no `tone` input** — the routing is content-driven: any blocking error renders the `role="alert"` container, a warning-only list renders the `role="status"` container, and an empty list keeps both hidden. Uses dual stable live regions so the role is never re-assigned at the same tick content is inserted.
 

--- a/.agents/skills/ngx-signal-forms/references/demo-map.md
+++ b/.agents/skills/ngx-signal-forms/references/demo-map.md
@@ -15,12 +15,16 @@ Repository paths in `apps/demo/src/app/` organized by the current live demo. Use
 
 - `03-headless/fieldset-utilities/fieldset-utilities.form.ts` — Aggregated group state, summary utilities, and state flags for custom markup
 - `03-headless/fieldset-utilities/fieldset-utilities.page.ts` — Headless UI patterns and grouped-state explanation
+- `03-headless/error-message-signal/` — `createErrorMessageSignal` with a swappable `errorMessages` registry that re-resolves blocking/warning messages reactively
 
 ## 04 — Form Field Wrapper
 
 - `04-form-field-wrapper/complex-forms/` — Production-style nested objects, arrays, and dense layouts
   - Includes a dedicated fieldset example (`fieldset.form.ts` / `fieldset.model.ts` / `fieldset.validations.ts`) demonstrating `NgxFormFieldset` grouped summaries
 - `04-form-field-wrapper/custom-controls/` — Wrapper integration with custom `FormValueControl` components, checkbox opt-in via `ngxSignalFormControl`, slider with manual ARIA and `buildAriaDescribedBy`, and component-scoped control presets via `provideNgxSignalFormControlPresetsForComponent`
+- `04-form-field-wrapper/field-marking/` — Required/optional marker config (`showMarkerWhen`, `requiredMarker`, `optionalMarker`) plus the `NgxFormMarkingLegend` form-level legend explaining the markers
+- `04-form-field-wrapper/fieldset-appearance/` — `NgxFormFieldset` appearance controls: `NgxFormFieldsetAppearance`, `NgxFormFieldsetFeedbackAppearance`, `NgxFormFieldsetSurfaceTone`, `NgxFormFieldsetValidationSurface`
+- `04-form-field-wrapper/labelless-fields/` — Wrappers for controls with no redundant `<label>` (accessible name via `aria-label` / `aria-labelledby`), compared with vs without label across appearances
 
 Horizontal `FormFieldOrientation` is exercised via the shared `ui/orientation-toggle` component wired into multiple 05-advanced demos — there's no dedicated page yet. `provideNgxSignalFormsConfig({ defaultFormFieldOrientation: 'horizontal' })` drives the default; per-wrapper `orientation="horizontal"` overrides it.
 
@@ -31,6 +35,9 @@ Horizontal `FormFieldOrientation` is exercised via the shared `ui/orientation-to
 - `05-advanced/advanced-wizard/` — Multi-step flow with NgRx Signals + Zod
 - `05-advanced/async-validation/` — Remote/pending validation flows
 - `05-advanced/cross-field-validation/` — Dependent sibling validation rules
+- `05-advanced/field-state-patterns/` — Choosing between `dirty`/`touched`/`pristine` and other field-state signals
+- `05-advanced/store-binding/` — Binding a form to an NgRx SignalStore (`delegatedStoreField`)
+- `05-advanced/zod-validation/` — Zod-only baseline validation via `validateStandardSchema(path, schema)` (Standard Schema)
 - `05-advanced/vest-validation/` — Vest-only business validation
 - `05-advanced/zod-vest-validation/` — Structural validation plus business rules
 

--- a/.agents/skills/ngx-signal-forms/references/pitfalls.md
+++ b/.agents/skills/ngx-signal-forms/references/pitfalls.md
@@ -92,6 +92,48 @@ Only add ARIA manually for headless usage where you control the markup explicitl
 If you explicitly opt a control into `ngxSignalFormControlAria="manual"`, the
 toolkit preserves your existing ARIA attributes instead of generating them.
 
+## `aria-required` on Standard Schema (Zod) Fields Needs `requiredFromStandardSchema`
+
+```typescript
+// Wrong — validateStandardSchema alone never sets REQUIRED metadata, so
+// FieldState.required() stays false: no aria-required, no required marker.
+form(model, (path) => {
+  validateStandardSchema(path, TravelerSchema);
+});
+
+// Correct — register required-ness per field alongside the schema (#215)
+import { requiredFromStandardSchema } from '@ngx-signal-forms/toolkit';
+
+form(model, (path) => {
+  validateStandardSchema(path, TravelerSchema);
+  requiredFromStandardSchema(path.firstName, TravelerSchema);
+  requiredFromStandardSchema(path.lastName, TravelerSchema);
+});
+```
+
+Standard Schema (Zod, Valibot, ArkType, …) has no runtime way to ask "is this
+key required?", so `validateStandardSchema()` registers tree-level errors only —
+it never touches `REQUIRED` metadata. Call `requiredFromStandardSchema()` once
+per field for auto-ARIA `aria-required` and the `showMarkerWhen: 'required'`
+marker to fire. Native `required()` validators already do this; only
+schema-validated fields need the extra call.
+
+## Notification Tone Is Content-Driven — There Is No `tone` Input
+
+```html
+<!-- Wrong — `tone` is not an input on the notification -->
+<ngx-form-field-notification [errors]="field().errors()" tone="auto" />
+
+<!-- Correct — tone is resolved from the errors themselves -->
+<ngx-form-field-notification [errors]="field().errors()" fieldName="email" />
+```
+
+`NgxFormFieldNotification` (assistive) and `NgxHeadlessNotification` (headless)
+route tone automatically from content: any blocking error raises the error
+container (`role="alert"`); a warning-only list raises the warning container
+(`role="status"`); an empty list hides both. Do not try to set a tone — there is
+no such input.
+
 ## Wrapper Identity — Always Provide `id`
 
 ```html
@@ -297,3 +339,13 @@ pitfall only applies to standalone callers of `showErrors()` or
 `createShowErrorsComputed()` outside that context (custom utilities,
 hand-rolled components, services). Either pass the status, or move the work
 inside the form context so inheritance can do it for you.
+
+## Vest — Sharing One Suite Across Concurrent Forms Is Safe by Default
+
+A module-scope Vest suite mounted in two forms at once (list/detail, wizard step
+beside a summary, two open tabs) is safe: `validateVest()` reference-counts its
+registrations and only calls `suite.reset()` when the **last** surviving mount's
+injection context tears down (`resetOnDestroy: true`, the default). Destroying
+one mount leaves a sibling mount's `only()`-run state and in-flight async runs
+untouched (#201, #214, #216). Pass `{ resetOnDestroy: false }` only when you
+deliberately want suite state to persist across mounts.

--- a/.agents/skills/ngx-signal-forms/references/signal-forms.md
+++ b/.agents/skills/ngx-signal-forms/references/signal-forms.md
@@ -2,7 +2,7 @@
 
 The toolkit builds on top of Angular Signal Forms. This reference covers the Angular-native layer that toolkit consumers need.
 
-Angular Signal Forms is available in `@angular/core >= 21.1` and imported from `@angular/forms/signals`.
+Angular Signal Forms is **stable** as of Angular 22 (it shipped as a developer preview in v21.1) and is imported from `@angular/forms/signals`. `submit()` returns `Promise<boolean>` and `markAsTouched()` cascades to descendants.
 
 ## Setup
 

--- a/.agents/skills/ngx-signal-forms/testing/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/testing/SKILL.md
@@ -1,0 +1,77 @@
+---
+description: Sub-skill of ngx-signal-forms for the @ngx-signal-forms/toolkit/testing entry point — an axe-core accessibility test harness (expectNoA11yViolations, WCAG_22_AA_TAGS) for asserting no WCAG 2.2 AA violations in Vitest browser-mode component specs. Not independently invocable; the hub SKILL.md routes here.
+---
+
+# Toolkit Testing
+
+Implements the `@ngx-signal-forms/toolkit/testing` entry point.
+
+Read `../references/api.md` for the full export list and exact signatures.
+
+`axe-core` is an **optional peer dependency** — it is only required when you
+import from this entry point. Install it as a devDependency alongside your test
+runner.
+
+## Principle
+
+Toolkit components are published primitives, so accessibility violations in them
+are bugs. `expectNoA11yViolations` runs axe-core against a rendered fixture and
+**hard-fails (throws)** on any WCAG 2.2 AA violation — it is an assertion, not a
+report. Use it inside Vitest browser-mode specs after rendering a component
+fixture. One call per fixture scans the whole DOM subtree.
+
+## API
+
+```typescript
+import {
+  expectNoA11yViolations,
+  WCAG_22_AA_TAGS, // ['wcag2a','wcag2aa','wcag21a','wcag21aa','wcag22aa']
+  type WCAG_22_AA_TAG,
+} from '@ngx-signal-forms/toolkit/testing';
+```
+
+- `expectNoA11yViolations(context?, options?)` — `context` defaults to
+  `document.body`, so a bare `await expectNoA11yViolations()` covers the whole
+  render. `options` is an axe `RunOptions` object **merged over** the WCAG 2.2 AA
+  defaults — use it to disable rules that don't apply to a fixture (e.g.
+  `color-contrast` for intentionally unstyled controls).
+- `WCAG_22_AA_TAGS` — the axe tag set the harness runs. There is no `wcag22a`
+  tag: the two new 2.2 Level A criteria are non-automatable, so automated
+  scanning covers only a subset of full 2.2 AA conformance.
+
+## Workflow
+
+1. Render the component fixture (Angular `TestBed` + `ComponentFixture`) in a
+   Vitest browser-mode spec, and drive it into the state you want to audit.
+2. `await expectNoA11yViolations()` — or pass a specific element/context to
+   scope the scan to a subtree.
+3. Merge axe `RunOptions` only when a fixture legitimately can't satisfy a rule.
+
+## Example
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+import { MyFieldComponent } from './my-field.component';
+
+it('has no WCAG 2.2 AA violations when showing an error', async () => {
+  const fixture = TestBed.createComponent(MyFieldComponent);
+  fixture.componentRef.setInput('touched', true);
+  await fixture.whenStable();
+
+  // Unstyled test host has no theme, so contrast checks don't apply.
+  await expectNoA11yViolations(fixture.nativeElement, {
+    rules: { 'color-contrast': { enabled: false } },
+  });
+});
+```
+
+## Error Handling
+
+- If the import fails to resolve `axe-core`: add `axe-core` as a devDependency —
+  it is an optional peer dep, not bundled.
+- If a scan flags `color-contrast` on a bare test host: disable that rule via
+  `options` rather than styling the fixture.
+- If the assertion passes but you expected coverage of a 2.2 Level A criterion
+  (Consistent Help, Redundant Entry): those are non-automatable — verify them
+  manually.

--- a/.agents/skills/ngx-signal-forms/vest/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/vest/SKILL.md
@@ -115,6 +115,14 @@ persist across mounts:
 validateVest(path, signupSuite, { resetOnDestroy: false });
 ```
 
+**Concurrent mounts are safe.** Registrations against the same suite are
+reference-counted, so mounting a module-scope suite in two forms at once (a
+list/detail view, a wizard step beside a summary, two open tabs) does not reset
+one mount out from under the other — the suite only resets when the **last**
+surviving registration tears down. Concurrently-pending field trees that share
+one suite are isolated per run, so an in-flight async run or retained `only()`
+state on a sibling mount stays untouched.
+
 ### Focused runs with `only`
 
 When the suite callback uses `only(fieldName)` (or `suite.only(field).run(...)`),


### PR DESCRIPTION
Refreshes the `.agents/skills/ngx-signal-forms/` skill set so it matches the current `@ngx-signal-forms/toolkit` source on the v1.0.0 line (rc.11 in preparation). Every symbol was grep-verified against the entry-point barrels before documenting.

## Corrections (removed drift)
- **Phantom symbols deleted:** `NgxFormFieldAssistiveRow` and the `NgxNotificationTone` / `NgxFormFieldNotificationTone` aliases — none exist in the shipped API.
- **Notifications are content-driven:** removed the deleted `tone` input from `NgxFormFieldNotification` / `NgxHeadlessNotification` docs and examples; documented the automatic `role="alert"` (blocking) vs `role="status"` (warning-only) routing.
- **Fixed defaults/values:** fieldset `errorPlacement` default is `'bottom'` (was documented as `'top'`); debugger badge `variant`/`appearance` value sets were swapped and incomplete.
- **`signal-forms.md`** now states Signal Forms is stable as of Angular 22.

## New API documented
- **Testing entry point** `@ngx-signal-forms/toolkit/testing` (`expectNoA11yViolations`, `WCAG_22_AA_TAGS`) — new `testing/SKILL.md`, hub routing, and an api.md section.
- `NgxFormMarkingLegend` + `FieldMarkingMode` / `MarkerKind` / `ResolvedMarker`.
- `requiredFromStandardSchema` (Zod / Standard Schema `aria-required`) + a pitfall.
- Error/hint renderer-override providers + tokens; headless field-optionality helpers.

## Angular 22 best practices in examples
- Dropped the now-redundant explicit `changeDetection: ChangeDetectionStrategy.OnPush` (OnPush is the default in Angular 22) and its unused imports — mirroring how `standalone: true` is omitted. Examples were already clean of legacy control flow, decorators, NgModules, and constructor DI.

Docs-only change (no toolkit source or package version touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toolkit testing entry point with an axe-core-based accessibility harness for Vitest browser-mode component specs (WCAG 2.2 AA).
  * Documented advanced form utilities including required/optional marker support, error/hint renderer override providers, and new headless helpers.

* **Bug Fixes**
  * Clarified notification urgency and live-region behavior as content-driven (no tone input), improving error-summary and grouped notification consistency.
  * Updated examples to match current defaults (e.g., fieldset error placement now defaults to bottom).

* **Documentation**
  * Refreshed public API references, skill guides, demo map, and common pitfalls; updated Angular Signal Forms stability notes and debugger badge option lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->