### PR TITLE
feat(form-field): Add warningStrategy input to fieldsets

### DIFF
--- a/docs/WARNINGS_SUPPORT.md
+++ b/docs/WARNINGS_SUPPORT.md
@@ -344,6 +344,47 @@ want to **override** an inherited form-level strategy that would otherwise
 apply. To gate warnings alongside errors, use `warningStrategy="inherit"` (or
 match `strategy` explicitly).
 
+### Fieldsets: `NgxFormFieldset` / `NgxHeadlessFieldset`
+
+`NgxHeadlessFieldset` (and `NgxFormFieldset`, which composes it via
+`hostDirectives`) exposes the same `warningStrategy` input, resolved with the
+same cascade as the wrapper / `NgxFormFieldError`:
+
+- Explicitly set (including `'inherit'`) → resolved against the ambient form
+  context, falling back to `'on-touch'` if there is none.
+- Left unset → `'immediate'` directly, **without** consulting the form
+  context or `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy`.
+
+Before this input existed, `NgxHeadlessFieldset` built a single internal
+"show" signal shared by both blocking errors and warnings, so aggregated
+warnings silently inherited whatever `strategy` the fieldset (or its form
+context) used — a fieldset under `errorStrategy="on-submit"` hid its warnings
+until submit too, unlike the wrapper. `warningStrategy` fixes that: fieldset
+warnings now default to `'immediate'`, matching `NgxFormFieldWrapper`'s
+contract, regardless of what blocking-error strategy is in effect.
+
+**Errors-present visibility**: `NgxHeadlessFieldset.shouldShowWarnings()` is
+no longer suppressed just because `shouldShowErrors()` is `true`. It now
+matches `NgxHeadlessErrorSummary.shouldShowWarnings()` — independent of error
+presence — rather than the old "hide warnings while blocking errors are
+visible" rule, because fieldsets aggregate across a subtree the same way a
+summary does. `NgxFormFieldset`'s rendered grouped-message region is still a
+single slot, though, so it applies "errors take visual priority" itself on
+top of these two independent signals (only one category is ever rendered or
+styled at a time — see `filteredErrorsSignal` and the `--warning` host class
+in `form-fieldset.ts`).
+
+```html
+<ngx-form-fieldset [field]="form.address" strategy="on-submit">
+  <!--
+    Blocking errors on form.address stay hidden until submit (`strategy`),
+    but aggregated warnings surface immediately (`warningStrategy` defaults
+    to 'immediate') — unless a blocking error is *also* currently visible,
+    in which case the fieldset's single message slot shows the error instead.
+  -->
+</ngx-form-fieldset>
+```
+
 ## Styling
 
 ### CSS Custom Properties

--- a/packages/toolkit/form-field/README.md
+++ b/packages/toolkit/form-field/README.md
@@ -230,26 +230,45 @@ aggregation signals without any prebuilt markup, drop down to
 </ngx-form-fieldset>
 ```
 
-| Input                 | Type                                                                     | Default     | Description                                                    |
-| --------------------- | ------------------------------------------------------------------------ | ----------- | -------------------------------------------------------------- |
-| `field`               | `FieldTree` (required)                                                   | —           | Field tree to aggregate                                        |
-| `fields`              | `FieldTree[]`                                                            | `null`      | Explicit field list (overrides tree traversal)                 |
-| `fieldsetId`          | `string`                                                                 | Generated   | ID for ARIA linking                                            |
-| `strategy`            | `ErrorDisplayStrategy`                                                   | Inherited   | Error display strategy                                         |
-| `showErrors`          | `boolean`                                                                | `true`      | Toggle error display                                           |
-| `includeNestedErrors` | `boolean`                                                                | `false`     | Include child field errors via `errorSummary()`                |
-| `errorPlacement`      | `'top' \| 'bottom'`                                                      | `'bottom'`  | Render grouped messages before or after content                |
-| `appearance`          | `'outline' \| 'plain'`                                                   | `'outline'` | Border-and-padding shell or semantic-only grouping             |
-| `feedbackAppearance`  | `'auto' \| 'plain' \| 'notification'`                                    | `'auto'`    | Choose compact grouped text or surfaced notification cards     |
-| `notificationTitle`   | `string`                                                                 | —           | Optional title for notification-style grouped feedback         |
-| `listStyle`           | `'plain' \| 'bullets'`                                                   | `'bullets'` | Grouped message layout                                         |
-| `surfaceTone`         | `'default' \| 'neutral' \| 'info' \| 'success' \| 'warning' \| 'danger'` | `'default'` | Base fieldset surface tint below the legend                    |
-| `validationSurface`   | `'never' \| 'always'`                                                    | `'never'`   | Whether invalid/warning state should tint the fieldset surface |
+| Input                 | Type                                                                     | Default       | Description                                                    |
+| --------------------- | ------------------------------------------------------------------------ | ------------- | -------------------------------------------------------------- |
+| `field`               | `FieldTree` (required)                                                   | —             | Field tree to aggregate                                        |
+| `fields`              | `FieldTree[]`                                                            | `null`        | Explicit field list (overrides tree traversal)                 |
+| `fieldsetId`          | `string`                                                                 | Generated     | ID for ARIA linking                                            |
+| `strategy`            | `ErrorDisplayStrategy`                                                   | Inherited     | Blocking-error display strategy                                |
+| `warningStrategy`     | `ErrorDisplayStrategy`                                                   | `'immediate'` | Warning display strategy, independent of `strategy`            |
+| `showErrors`          | `boolean`                                                                | `true`        | Toggle error display                                           |
+| `includeNestedErrors` | `boolean`                                                                | `false`       | Include child field errors via `errorSummary()`                |
+| `errorPlacement`      | `'top' \| 'bottom'`                                                      | `'bottom'`    | Render grouped messages before or after content                |
+| `appearance`          | `'outline' \| 'plain'`                                                   | `'outline'`   | Border-and-padding shell or semantic-only grouping             |
+| `feedbackAppearance`  | `'auto' \| 'plain' \| 'notification'`                                    | `'auto'`      | Choose compact grouped text or surfaced notification cards     |
+| `notificationTitle`   | `string`                                                                 | —             | Optional title for notification-style grouped feedback         |
+| `listStyle`           | `'plain' \| 'bullets'`                                                   | `'bullets'`   | Grouped message layout                                         |
+| `surfaceTone`         | `'default' \| 'neutral' \| 'info' \| 'success' \| 'warning' \| 'danger'` | `'default'`   | Base fieldset surface tint below the legend                    |
+| `validationSurface`   | `'never' \| 'always'`                                                    | `'never'`     | Whether invalid/warning state should tint the fieldset surface |
 
 ### Error display modes
 
 - **Group-only** (default) — shows only group-level errors. Use when nested fields display their own errors via wrappers.
 - **Aggregated** (`includeNestedErrors`) — collects all nested errors. Use when fields don't have individual error display.
+
+### Warning support
+
+Like `ngx-form-field-wrapper`, the fieldset decouples warning **display timing**
+from blocking-error timing: `warningStrategy` defaults to `'immediate'` so
+aggregated warnings stay visible even when `strategy` is `'on-touch'` or
+`'on-submit'`.
+
+The rendered grouped-message slot (compact text or notification card) is a
+single region, so **visual priority still goes to blocking errors** when both
+are showable at the same time — the fieldset shows the error content and the
+`--invalid` styling, not both categories at once. This matches
+`NgxHeadlessErrorSummary`'s independent error/warning visibility contract at
+the state layer (`fieldset.shouldShowWarnings()` is never suppressed just
+because `fieldset.shouldShowErrors()` is `true`); the "one region, errors win"
+behavior is a `NgxFormFieldset`-specific rendering choice on top of that,
+mirroring the projected `NgxFormFieldError`'s own error/warning priority. See
+[`WARNINGS_SUPPORT.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/WARNINGS_SUPPORT.md#when-warnings-appear--warningstrategy).
 
 ### Fieldset appearances
 

--- a/packages/toolkit/form-field/form-fieldset.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.spec.ts
@@ -188,6 +188,129 @@ describe('NgxFormFieldset', () => {
     expect(warnings[0]?.textContent).toContain('State is optional');
   });
 
+  describe('warningStrategy', () => {
+    it('defaults to "immediate", showing warnings while a blocking "on-submit" strategy still hides errors', async () => {
+      const fieldset = createFieldsetState({
+        errors: () => [
+          { kind: 'required', message: 'City required' },
+          { kind: 'warn:optional', message: 'State is optional' },
+        ],
+        errorSummary: () => [
+          { kind: 'required', message: 'City required' },
+          { kind: 'warn:optional', message: 'State is optional' },
+        ],
+      });
+
+      await render(
+        `<ngx-form-fieldset [field]="fieldset" strategy="on-submit">
+          <div>Content without nested form field</div>
+        </ngx-form-fieldset>`,
+        {
+          imports: [NgxFormFieldset],
+          componentProperties: { fieldset },
+        },
+      );
+
+      // Blocking error is gated behind 'on-submit' and the form has not
+      // been submitted (no submittedStatus bound) — the alert stays empty.
+      const errors = screen.queryAllByRole('alert');
+      expect(errors).not.toHaveLength(0);
+      for (const error of errors) {
+        expect(error.textContent?.trim() ?? '').toBe('');
+      }
+
+      // warningStrategy defaults to 'immediate' independently of `strategy`,
+      // so the warning is visible even though the blocking error is not.
+      const warnings = screen.queryAllByRole('status');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.textContent).toContain('State is optional');
+    });
+
+    it('forwards an explicit warningStrategy="on-submit" override, delaying warnings until submit', async () => {
+      const fieldset = createFieldsetState({
+        errors: () => [{ kind: 'warn:optional', message: 'State is optional' }],
+        errorSummary: () => [
+          { kind: 'warn:optional', message: 'State is optional' },
+        ],
+      });
+      const submittedStatus = signal<'unsubmitted' | 'submitted'>(
+        'unsubmitted',
+      );
+
+      const { fixture } = await render(
+        `<ngx-form-fieldset
+          [field]="fieldset"
+          warningStrategy="on-submit"
+          [submittedStatus]="submittedStatus()"
+        >
+          <div>Content without nested form field</div>
+        </ngx-form-fieldset>`,
+        {
+          imports: [NgxFormFieldset],
+          componentProperties: { fieldset, submittedStatus },
+        },
+      );
+
+      let warnings = screen.queryAllByRole('status');
+      expect(warnings).not.toHaveLength(0);
+      for (const warning of warnings) {
+        expect(warning.textContent?.trim() ?? '').toBe('');
+      }
+
+      submittedStatus.set('submitted');
+      fixture.detectChanges();
+
+      warnings = screen.queryAllByRole('status');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.textContent).toContain('State is optional');
+    });
+
+    it('gives the blocking error visual priority (host class + rendered content) when both are visible at once', async () => {
+      const fieldset = createFieldsetState({
+        errors: () => [
+          { kind: 'required', message: 'City required' },
+          { kind: 'warn:optional', message: 'State is optional' },
+        ],
+        errorSummary: () => [
+          { kind: 'required', message: 'City required' },
+          { kind: 'warn:optional', message: 'State is optional' },
+        ],
+      });
+
+      // Default `strategy` ('on-touch') + touched:true shows the blocking
+      // error, and the default `warningStrategy` ('immediate') shows the
+      // warning at the same time — both are independently visible.
+      const { container } = await render(
+        `<ngx-form-fieldset [field]="fieldset">
+          <div>Content without nested form field</div>
+        </ngx-form-fieldset>`,
+        {
+          imports: [NgxFormFieldset],
+          componentProperties: { fieldset },
+        },
+      );
+
+      const host = container.querySelector('ngx-form-fieldset');
+      expect(
+        host?.classList.contains('ngx-signal-form-fieldset--invalid'),
+      ).toBe(true);
+      // Even though shouldShowWarnings() is independently true, the host
+      // class stays off — errors take visual priority (see the host
+      // binding's inline comment in form-fieldset.ts).
+      expect(
+        host?.classList.contains('ngx-signal-form-fieldset--warning'),
+      ).toBe(false);
+
+      const errors = screen.getAllByRole('alert');
+      expect(errors[0]?.textContent).toContain('City required');
+
+      const warnings = screen.queryAllByRole('status');
+      for (const warning of warnings) {
+        expect(warning.textContent?.trim() ?? '').toBe('');
+      }
+    });
+  });
+
   it('prefers fields override for aggregation', async () => {
     const fieldset = createFieldsetState({
       errors: () => [{ kind: 'required', message: 'Group error' }],

--- a/packages/toolkit/form-field/form-fieldset.ts
+++ b/packages/toolkit/form-field/form-fieldset.ts
@@ -70,7 +70,10 @@ export type NgxFormFieldsetValidationSurface = 'never' | 'always';
  * - **Aggregated Errors**: Collects errors from all nested fields via `errorSummary()`
  * - **Group-Only Mode**: Show only group-level errors when nested fields display their own
  * - **Deduplication**: Same error shown only once even if multiple fields have it
- * - **Warning Support**: Non-blocking warnings (with `warn:` prefix) shown when no errors
+ * - **Warning Support**: Non-blocking warnings (with `warn:` prefix), timed independently
+ *   of blocking errors via `warningStrategy` (defaults to `'immediate'`, mirroring
+ *   `NgxFormFieldWrapper`); the rendered message slot still gives errors visual
+ *   priority when both are present at once (single notification/error region)
  * - **Adaptive Feedback UI**: Notification cards by default, with an optional compact text mode
  * - **Configurable Surface Tones**: Neutral, info, success, warning, or danger base surfaces
  * - **WCAG 2.2 Compliant**: Errors use `role="alert"`, warnings use `role="status"`
@@ -115,6 +118,7 @@ export type NgxFormFieldsetValidationSurface = 'never' | 'always';
         'fields',
         'fieldsetId',
         'strategy',
+        'warningStrategy',
         'submittedStatus',
         'includeNestedErrors',
       ],
@@ -130,8 +134,15 @@ export type NgxFormFieldsetValidationSurface = 'never' | 'always';
   // keep working without rewriting their stylesheets.
   host: {
     '[class.ngx-signal-form-fieldset--invalid]': 'fieldset.shouldShowErrors()',
+    // `NgxHeadlessFieldset.shouldShowWarnings()` is independent of blocking
+    // errors (matches `NgxHeadlessErrorSummary` — see the headless directive's
+    // doc comment). This styled component still gives errors visual priority
+    // — a fieldset with both visible would otherwise show the warning border
+    // color on top of the invalid one (CSS declaration order) and the
+    // notification card only ever renders one category at a time (see
+    // `filteredErrorsSignal` below) — so the guard is applied here instead.
     '[class.ngx-signal-form-fieldset--warning]':
-      'fieldset.shouldShowWarnings()',
+      '!fieldset.shouldShowErrors() && fieldset.shouldShowWarnings()',
     '[class.ngx-signal-form-fieldset--surface-invalid]': 'showInvalidSurface()',
     '[class.ngx-signal-form-fieldset--surface-warning]': 'showWarningSurface()',
     '[class.ngx-signal-form-fieldset--messages-top]': 'isTopPlacement()',
@@ -376,12 +387,25 @@ export class NgxFormFieldset {
   /**
    * Filtered errors signal for NgxFormFieldError.
    *
-   * Passes blocking errors OR warnings, never both.
-   * Warnings are suppressed when errors exist (UX best practice).
+   * Passes blocking errors OR warnings, never both — the rendered
+   * error/notification slot is a single region and errors take visual
+   * priority when both are showable at once.
+   *
+   * Gated on {@link NgxHeadlessFieldset.shouldShowErrors} (visibility), NOT
+   * `aggregatedErrors().length > 0` (presence). Those two diverge now that
+   * `NgxHeadlessFieldset.shouldShowWarnings` is timed independently via
+   * `warningStrategy` (default `'immediate'`): a blocking error can be
+   * *present* but not yet *visible* (e.g. gated behind `strategy="on-submit"`
+   * pre-submit) while a warning is already visible. Gating on presence would
+   * render the hidden blocking-error content instead of the visible warning
+   * the moment both exist — gating on `shouldShowErrors()` keeps this in
+   * lockstep with the `--invalid`/`--warning` host classes and
+   * `describedByIds()`, which already check visibility the same way.
    */
   protected readonly filteredErrorsSignal = computed(() => {
-    const blocking = this.fieldset.aggregatedErrors();
-    return blocking.length > 0 ? blocking : this.fieldset.aggregatedWarnings();
+    return this.fieldset.shouldShowErrors()
+      ? this.fieldset.aggregatedErrors()
+      : this.fieldset.aggregatedWarnings();
   });
 
   protected readonly displayedMessagesSignal = computed(() => {

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -149,18 +149,21 @@ Selector: `[ngxHeadlessFieldset]` · Export: `fieldset`
 
 Aggregates error state across multiple fields for group validation.
 
-| Input                 | Type                           | Description                                   |
-| --------------------- | ------------------------------ | --------------------------------------------- |
-| `field`               | `FieldTree` (required)         | Primary field group                           |
-| `fields`              | `readonly FieldTree[] \| null` | Optional explicit field list — see note below |
-| `fieldsetId`          | `string`                       | For ARIA linking                              |
-| `strategy`            | `ErrorDisplayStrategy`         | Override strategy                             |
-| `submittedStatus`     | `SubmittedStatus`              | Override for `'on-submit'` strategy           |
-| `includeNestedErrors` | `boolean`                      | Include child errors (default: `false`)       |
+| Input                 | Type                           | Description                                        |
+| --------------------- | ------------------------------ | -------------------------------------------------- |
+| `field`               | `FieldTree` (required)         | Primary field group                                |
+| `fields`              | `readonly FieldTree[] \| null` | Optional explicit field list — see note below      |
+| `fieldsetId`          | `string`                       | For ARIA linking                                   |
+| `strategy`            | `ErrorDisplayStrategy`         | Override blocking-error strategy                   |
+| `warningStrategy`     | `ErrorDisplayStrategy`         | Override warning strategy (default: `'immediate'`) |
+| `submittedStatus`     | `SubmittedStatus`              | Override for `'on-submit'` strategy                |
+| `includeNestedErrors` | `boolean`                      | Include child errors (default: `false`)            |
 
 > `fields` distinguishes "not provided" from "provided but empty": `null`/unbound (default) aggregates the fieldset's own errors; an explicitly bound `[]` aggregates nothing rather than falling back — useful when a dynamically computed field list legitimately becomes empty.
 
-Signals: `isValid()`, `isInvalid()`, `isTouched()`, `isDirty()`, `isPending()`, `aggregatedErrors()`, `aggregatedWarnings()`, `resolvedErrors()`, `resolvedWarnings()`, `hasErrors()`, `hasWarnings()`, `shouldShowErrors()`, `shouldShowWarnings()`, `resolvedStrategy()`, `resolvedSubmittedStatus()`, `resolvedFieldsetId()`.
+Signals: `isValid()`, `isInvalid()`, `isTouched()`, `isDirty()`, `isPending()`, `aggregatedErrors()`, `aggregatedWarnings()`, `resolvedErrors()`, `resolvedWarnings()`, `hasErrors()`, `hasWarnings()`, `shouldShowErrors()`, `shouldShowWarnings()`, `resolvedStrategy()`, `resolvedWarningStrategy()`, `resolvedSubmittedStatus()`, `resolvedFieldsetId()`.
+
+`warningStrategy` times `shouldShowWarnings()` independently of `strategy`/`shouldShowErrors()` — it defaults straight to `'immediate'` when unset (bypassing the form context and `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy` entirely), matching `NgxFormFieldWrapper.warningStrategy` / `NgxFormFieldError.warningStrategy`'s contract exactly. `shouldShowWarnings()` is also no longer suppressed just because `shouldShowErrors()` is `true` — it matches `NgxHeadlessErrorSummary.shouldShowWarnings()`'s independent error/warning visibility instead (fieldsets aggregate the same way a summary does). Consumers that render errors and warnings in a single slot (like `NgxFormFieldset`) apply "errors take visual priority" themselves on top of these two independent signals.
 
 Render `resolvedErrors()` / `resolvedWarnings()` (not `aggregatedErrors()[i].message`) — `ValidationError.message` is `undefined` for framework-default errors (e.g. `required(path.x)` with no `message` option), so the resolved signals apply the same 3-tier message priority as `NgxHeadlessErrorState.resolvedErrors`:
 

--- a/packages/toolkit/headless/src/lib/fieldset.spec.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.spec.ts
@@ -462,4 +462,180 @@ describe('NgxHeadlessFieldset', () => {
     const resolved = screen.getByTestId('fieldset-id').textContent ?? '';
     expect(resolved.trim().startsWith('fieldset-')).toBe(true);
   });
+
+  describe('warningStrategy', () => {
+    it('defaults warnings to "immediate" even when the blocking-error strategy is "on-submit"', async () => {
+      @Component({
+        selector: 'ngx-test-fieldset-warning-default-immediate',
+
+        imports: [FormRoot, NgxSignalForm, NgxHeadlessFieldset],
+        template: `
+          <form
+            [formRoot]="addressForm"
+            ngxSignalForm
+            errorStrategy="on-submit"
+          >
+            <fieldset
+              ngxHeadlessFieldset
+              #fieldset="fieldset"
+              [field]="addressForm.address"
+              includeNestedErrors
+            >
+              <span data-testid="resolved-warning-strategy">
+                {{ fieldset.resolvedWarningStrategy() }}
+              </span>
+              <span data-testid="show-warnings">
+                {{ fieldset.shouldShowWarnings() }}
+              </span>
+              <span data-testid="show-errors">
+                {{ fieldset.shouldShowErrors() }}
+              </span>
+            </fieldset>
+          </form>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ address: { street: '', city: '' } });
+        readonly addressForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.address.street, { message: 'Required' });
+            validate(path.address.street, (ctx) => {
+              const value = ctx.value();
+              if (!value) {
+                return {
+                  kind: 'warn:street-optional',
+                  message: 'Street can be left blank',
+                };
+              }
+              return null;
+            });
+          }),
+        );
+      }
+
+      await render(TestComponent);
+
+      // Blocking-error strategy is 'on-submit' and the form has not been
+      // submitted, so blocking errors stay hidden...
+      expect(screen.getByTestId('show-errors')).toHaveTextContent('false');
+      // ...but the warning defaults to 'immediate' independently, so it
+      // surfaces right away — matching NgxFormFieldWrapper's contract.
+      expect(screen.getByTestId('resolved-warning-strategy')).toHaveTextContent(
+        'immediate',
+      );
+      expect(screen.getByTestId('show-warnings')).toHaveTextContent('true');
+    });
+
+    it('honours an explicit warningStrategy="on-submit" override, delaying warnings until submit', async () => {
+      @Component({
+        selector: 'ngx-test-fieldset-warning-explicit-on-submit',
+
+        imports: [NgxHeadlessFieldset],
+        template: `
+          <fieldset
+            ngxHeadlessFieldset
+            #fieldset="fieldset"
+            [field]="addressForm.address"
+            includeNestedErrors
+            warningStrategy="on-submit"
+            [submittedStatus]="submittedStatus()"
+          >
+            <span data-testid="show-warnings">
+              {{ fieldset.shouldShowWarnings() }}
+            </span>
+          </fieldset>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ address: { street: '', city: '' } });
+        readonly addressForm = form(
+          this.#model,
+          schema((path) => {
+            validate(path.address.street, (ctx) => {
+              const value = ctx.value();
+              if (!value) {
+                return {
+                  kind: 'warn:street-optional',
+                  message: 'Street can be left blank',
+                };
+              }
+              return null;
+            });
+          }),
+        );
+        readonly submittedStatus = signal<'unsubmitted' | 'submitted'>(
+          'unsubmitted',
+        );
+      }
+
+      const { fixture } = await render(TestComponent);
+
+      // Warning stays hidden until the explicit override's own submit gate
+      // is satisfied.
+      expect(screen.getByTestId('show-warnings')).toHaveTextContent('false');
+
+      fixture.componentInstance.submittedStatus.set('submitted');
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(screen.getByTestId('show-warnings')).toHaveTextContent('true');
+    });
+
+    it('shows warnings and errors independently, even when both are visible at once', async () => {
+      @Component({
+        selector: 'ngx-test-fieldset-warning-error-interplay',
+
+        imports: [NgxHeadlessFieldset],
+        template: `
+          <fieldset
+            ngxHeadlessFieldset
+            #fieldset="fieldset"
+            [field]="addressForm.address"
+            includeNestedErrors
+            strategy="immediate"
+          >
+            <span data-testid="show-errors">
+              {{ fieldset.shouldShowErrors() }}
+            </span>
+            <span data-testid="show-warnings">
+              {{ fieldset.shouldShowWarnings() }}
+            </span>
+            <span data-testid="warning-count">
+              {{ fieldset.aggregatedWarnings().length }}
+            </span>
+          </fieldset>
+        `,
+      })
+      class TestComponent {
+        readonly #model = signal({ address: { street: '', city: '' } });
+        readonly addressForm = form(
+          this.#model,
+          schema((path) => {
+            required(path.address.street, { message: 'Required' });
+            validate(path.address.city, (ctx) => {
+              const value = ctx.value();
+              if (!value) {
+                return {
+                  kind: 'warn:city-optional',
+                  message: 'City can be left blank',
+                };
+              }
+              return null;
+            });
+          }),
+        );
+      }
+
+      await render(TestComponent);
+
+      // Both are gated by 'immediate'-family strategies, so both are
+      // visible at once — shouldShowWarnings is no longer suppressed just
+      // because shouldShowErrors is true (matches
+      // NgxHeadlessErrorSummary.shouldShowWarnings).
+      expect(screen.getByTestId('show-errors')).toHaveTextContent('true');
+      expect(screen.getByTestId('show-warnings')).toHaveTextContent('true');
+      expect(screen.getByTestId('warning-count')).toHaveTextContent('1');
+    });
+  });
 });

--- a/packages/toolkit/headless/src/lib/fieldset.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.ts
@@ -55,7 +55,7 @@ export interface FieldsetStateSignals {
   readonly hasWarnings: Signal<boolean>;
   /** Whether to show errors based on strategy */
   readonly shouldShowErrors: Signal<boolean>;
-  /** Whether to show warnings based on strategy */
+  /** Whether to show warnings based on {@link resolvedWarningStrategy} */
   readonly shouldShowWarnings: Signal<boolean>;
   /**
    * Resolved error display strategy. Always a concrete strategy
@@ -63,6 +63,11 @@ export interface FieldsetStateSignals {
    * resolved against the form context / config default before exposure.
    */
   readonly resolvedStrategy: Signal<ResolvedErrorDisplayStrategy>;
+  /**
+   * Resolved warning display strategy, independent of {@link resolvedStrategy}
+   * (which only governs blocking errors). Always a concrete strategy.
+   */
+  readonly resolvedWarningStrategy: Signal<ResolvedErrorDisplayStrategy>;
   /** Resolved submitted status (from input override, form context, or default) */
   readonly resolvedSubmittedStatus: Signal<SubmittedStatus>;
   /** Fieldset validation state flags */
@@ -85,7 +90,8 @@ export interface FieldsetStateSignals {
  *
  * - **Aggregated Errors**: Collects errors from all nested fields via `errorSummary()`
  * - **Deduplication**: Same error shown only once even if multiple fields have it
- * - **Warning Support**: Non-blocking warnings (with `warn:` prefix)
+ * - **Warning Support**: Non-blocking warnings (with `warn:` prefix), timed independently
+ *   of blocking errors via `warningStrategy` (defaults to `'immediate'`)
  * - **Strategy Aware**: Respects error display strategy from form context
  * - **State Flags**: Exposes invalid, valid, touched, dirty, pending states
  * - **Nested Control**: `includeNestedErrors` toggles between aggregated and direct errors
@@ -167,6 +173,30 @@ export class NgxHeadlessFieldset<
   readonly strategy = input<ErrorDisplayStrategy | undefined>();
 
   /**
+   * Warning display strategy override, independent of {@link strategy}
+   * (which only governs blocking errors). Mirrors the contract already
+   * established by `NgxFormFieldWrapper.warningStrategy` /
+   * `NgxFormFieldError.warningStrategy`: non-blocking warnings default to
+   * `'immediate'` so advisory feedback stays visible even while blocking
+   * errors are gated by `'on-touch'` / `'on-submit'`.
+   *
+   * Resolution order differs from {@link strategy} on purpose:
+   * - Explicitly set (including `'inherit'`) → resolved against the ambient
+   *   form context (`resolveStrategyFromContext`), falling back to
+   *   `'on-touch'` if there is none.
+   * - Left unset (`undefined`) → `'immediate'` directly, WITHOUT consulting
+   *   the form context or `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy`.
+   *
+   * This asymmetry (vs. {@link strategy}'s context/config cascade) is
+   * intentional and matches the wrapper/error-renderer contract exactly —
+   * an unset `warningStrategy` must not silently inherit an ambient
+   * `'on-submit'` strategy meant for blocking errors.
+   *
+   * @default `'immediate'`
+   */
+  readonly warningStrategy = input<ErrorDisplayStrategy | undefined>();
+
+  /**
    * Form submission status override.
    * If not provided, inherits from form context.
    */
@@ -211,6 +241,23 @@ export class NgxHeadlessFieldset<
   );
 
   /**
+   * Resolved warning display strategy. See the {@link warningStrategy} input
+   * doc for the resolution cascade — deliberately narrower than
+   * {@link resolvedStrategy}'s: an unset input defaults straight to
+   * `'immediate'` rather than falling through to the form context or global
+   * config default.
+   */
+  readonly resolvedWarningStrategy = computed<ResolvedErrorDisplayStrategy>(
+    () => {
+      const explicit = this.warningStrategy();
+      if (explicit !== undefined) {
+        return resolveStrategyFromContext(explicit, this.#formContext);
+      }
+      return 'immediate';
+    },
+  );
+
+  /**
    * Resolved submitted status, exposed as a concrete {@link SubmittedStatus}
    * on the public API. Falls back to `'unsubmitted'` when no explicit input
    * is provided and no form context is available — this keeps standalone
@@ -235,6 +282,18 @@ export class NgxHeadlessFieldset<
   readonly #showErrorsSignal = showErrors(
     this.#fieldsetState,
     this.resolvedStrategy,
+    this.resolvedSubmittedStatus,
+  );
+
+  /**
+   * Show warnings signal based on {@link resolvedWarningStrategy}, timed
+   * independently of {@link resolvedStrategy}. Without this, warnings would
+   * be stuck behind whatever timing the blocking-error strategy uses (e.g.
+   * `'on-submit'`), the exact asymmetry `warningStrategy` exists to fix.
+   */
+  readonly #showWarningsSignal = showErrors(
+    this.#fieldsetState,
+    this.resolvedWarningStrategy,
     this.resolvedSubmittedStatus,
   );
 
@@ -296,14 +355,25 @@ export class NgxHeadlessFieldset<
   );
 
   /**
-   * Whether to show warnings (when no errors present).
+   * Whether to show warnings, timed by {@link resolvedWarningStrategy}.
+   *
+   * **Independent of {@link shouldShowErrors}** — this directive used to
+   * suppress warnings outright whenever blocking errors were visible. That
+   * was inconsistent with `NgxHeadlessErrorSummary.shouldShowWarnings`
+   * (`error-summary.ts`), which never gates warning visibility on error
+   * presence because a summary aggregates across a whole subtree and a
+   * warnings-only region shouldn't have its `hasErrors() === false` case
+   * accidentally coupled to a sibling's blocking errors. Fieldsets aggregate
+   * the same way, so this directive now matches that contract: consumers
+   * that want "errors take visual priority" (e.g. a single message slot
+   * that can only render one category at a time, or CSS state classes)
+   * apply that priority themselves — see `NgxFormFieldset`'s
+   * `filteredErrorsSignal` and its `--warning` host class, which explicitly
+   * guard on `!shouldShowErrors()` for that reason.
    */
-  readonly shouldShowWarnings = computed(() => {
-    if (this.shouldShowErrors()) {
-      return false;
-    }
-    return this.#showErrorsSignal() && this.hasWarnings();
-  });
+  readonly shouldShowWarnings = computed(
+    () => this.#showWarningsSignal() && this.hasWarnings(),
+  );
 
   readonly #flags = createFieldStateFlags(this.#fieldsetState);
 


### PR DESCRIPTION
## Summary

`NgxHeadlessFieldset` built a single internal show-signal that gated **both** blocking errors and warnings behind the same resolved `errorStrategy`. `NgxFormFieldWrapper` / `NgxFormFieldError` already decouple warning timing from blocking-error timing via a dedicated `warningStrategy` input (default `'immediate'`), so a fieldset under `errorStrategy="on-submit"` hid its aggregated warnings until submit while a wrapper on the same form showed them immediately. This PR closes that asymmetry.

- **Add `warningStrategy` input** (+ `resolvedWarningStrategy`) to `NgxHeadlessFieldset`, resolved with the same cascade already used by `NgxFormFieldWrapper.warningStrategy` / `NgxFormFieldError.warningStrategy`: explicit input (resolved against form context when set, including `'inherit'`) → `'immediate'` default when unset. The unset case deliberately does **not** fall through to the form context or `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy` — matching the wrapper's contract exactly.
- **Default rationale**: `'immediate'` keeps advisory warnings visible from the first keystroke regardless of the blocking-error strategy, which is the whole point of decoupling the two — the alternative (inheriting the ambient strategy) would silently suppress warnings on the majority of real-world forms configured with `'on-touch'`/`'on-submit'` error timing.
- **Forward `warningStrategy`** through `NgxFormFieldset`'s `hostDirectives` inputs.

### Coherent semantics for point 3 (errors-present visibility)

`NgxHeadlessFieldset.shouldShowWarnings()` used to suppress warnings outright whenever blocking errors were visible. That was inconsistent with `NgxHeadlessErrorSummary.shouldShowWarnings()`, which has always treated error/warning visibility **independently** (documented in `error-summary.ts`). Since fieldsets aggregate across a subtree the same way a summary does, I made the fieldset match the summary's contract: `shouldShowWarnings()` is no longer coupled to `shouldShowErrors()`.

`NgxFormFieldset`'s rendered grouped-message region is still a single slot though, so it now applies "errors take visual priority" itself, explicitly, on top of the two independent headless signals:
- `filteredErrorsSignal` now gates on `shouldShowErrors()` (visibility) instead of `aggregatedErrors().length > 0` (presence) — needed because a blocking error can now be *present* but not yet *visible* (e.g. `on-submit` pre-submit) while a warning is already visible; gating on presence would have rendered the hidden error content instead of the visible warning.
- The `--warning` host class now guards on `!shouldShowErrors() && shouldShowWarnings()` instead of `shouldShowWarnings()` alone, so the warning border color can't paint over the invalid one when both are visible at once.

### Tests

- `packages/toolkit/headless/src/lib/fieldset.spec.ts`: default `'immediate'` warnings under `errorStrategy="on-submit"`, explicit `warningStrategy="on-submit"` override delaying warnings until submit, and errors/warnings shown independently when both are visible.
- `packages/toolkit/form-field/form-fieldset.spec.ts`: same three scenarios through the styled `NgxFormFieldset`, including a regression check that the host class and rendered content still give errors visual priority.

### Docs

- `packages/toolkit/form-field/README.md` — fieldset inputs table + new "Warning support" subsection.
- `packages/toolkit/headless/README.md` — `NgxHeadlessFieldset` inputs table + signal list, with a note on the independent-visibility contract.
- `docs/WARNINGS_SUPPORT.md` — new "Fieldsets: NgxFormFieldset / NgxHeadlessFieldset" subsection.

Stacks on #218 (base branch is `feature/improvements`, not `main`).

## Test plan

- [x] `pnpm nx run toolkit:build` passes
- [x] `pnpm nx run toolkit:test` passes (1300/1300, including 6 new test cases across the two fieldset specs)
- [x] `pnpm nx run toolkit:lint` passes (only pre-existing, unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)