### PR TITLE
fix(toolkit): Exclude non-interactive fields from optionality, align warning-strategy fallbacks

### DIFF
--- a/packages/toolkit/assistive/form-field-error.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.spec.ts
@@ -13,7 +13,10 @@ import type {
   ErrorDisplayStrategy,
   SubmittedStatus,
 } from '@ngx-signal-forms/toolkit';
-import { NGX_SIGNAL_FORM_FIELD_CONTEXT } from '@ngx-signal-forms/toolkit';
+import {
+  NGX_SIGNAL_FORM_FIELD_CONTEXT,
+  provideNgxSignalFormsConfig,
+} from '@ngx-signal-forms/toolkit';
 import { render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -1347,6 +1350,58 @@ describe('NgxFormFieldError', () => {
 
       // Errors still gated by submit.
       expect(screen.queryByRole('alert')?.textContent?.trim() ?? '').toBe('');
+    });
+
+    it('falls back to NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy for a standalone field with warningStrategy="inherit"', async () => {
+      // Regression test: with no [ngxSignalForm] host to inherit from, an
+      // explicit [warningStrategy]="'inherit'" used to hard-fall-back to
+      // 'on-touch', ignoring provideNgxSignalFormsConfig({ defaultErrorStrategy }).
+      // NgxHeadlessErrorState's own #resolvedStrategy cascade already honors
+      // the config default — the warning-strategy cascade must match it.
+      @Component({
+        selector: 'ngx-test-warning-strategy-config-fallback',
+        imports: [FormField, NgxFormFieldError],
+
+        template: `
+          <input id="password" [formField]="contactForm.password" />
+          <ngx-form-field-error
+            [formField]="contactForm.password"
+            fieldName="password"
+            warningStrategy="inherit"
+          />
+        `,
+      })
+      class StandaloneConfigFallbackHost {
+        readonly #model = signal({ password: 'weak' });
+        readonly contactForm = form(
+          this.#model,
+          schema((path) => {
+            validate(path.password, (ctx) => {
+              const value = ctx.value();
+              if (value.length > 0 && value.length < 8) {
+                return {
+                  kind: 'warn:weak-password',
+                  message: 'Consider 8+ characters',
+                };
+              }
+              return null;
+            });
+          }),
+        );
+      }
+
+      await render(StandaloneConfigFallbackHost, {
+        providers: [
+          provideNgxSignalFormsConfig({ defaultErrorStrategy: 'immediate' }),
+        ],
+      });
+
+      // No [ngxSignalForm] host and an untouched field: without the config
+      // fallback the warning would stay gated behind the hardcoded 'on-touch'
+      // default. With the fallback wired up, the global 'immediate' config
+      // applies and the warning is visible right away.
+      const status = await screen.findByRole('status');
+      expect(status.textContent).toContain('Consider 8+ characters');
     });
   });
 });

--- a/packages/toolkit/assistive/form-field-error.ts
+++ b/packages/toolkit/assistive/form-field-error.ts
@@ -10,6 +10,7 @@ import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   injectFormContext,
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
+  NGX_SIGNAL_FORMS_CONFIG,
   resolveStrategyFromContext,
   showErrors,
   unwrapValue,
@@ -236,6 +237,15 @@ export class NgxFormFieldError {
   readonly #injectedContext = injectFormContext();
 
   /**
+   * Global toolkit config, needed for the same reason: the warning-strategy
+   * cascade below must fall back to `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy`
+   * exactly like `NgxHeadlessErrorState.#resolvedStrategy` does for blocking
+   * errors, so a standalone `ngx-form-field-error` (no `[ngxSignalForm]` host)
+   * still honours `provideNgxSignalFormsConfig({ defaultErrorStrategy })`.
+   */
+  readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG, { optional: true });
+
+  /**
    * Try to inject field context (optional - provided by form field wrapper).
    * Used to automatically resolve field name when not explicitly provided.
    */
@@ -378,7 +388,11 @@ export class NgxFormFieldError {
     () => {
       const explicit = this.warningStrategy();
       if (explicit !== undefined) {
-        return resolveStrategyFromContext(explicit, this.#injectedContext);
+        return resolveStrategyFromContext(
+          explicit,
+          this.#injectedContext,
+          this.#config?.defaultErrorStrategy,
+        );
       }
       return 'immediate';
     },

--- a/packages/toolkit/core/directives/auto-aria.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.spec.ts
@@ -706,6 +706,59 @@ describe('NgxSignalFormAutoAria', () => {
         'contactEmail-error',
       );
     });
+
+    it('omits the warning id when both a blocking error and a warn:* error are present (mutual exclusion)', async () => {
+      // Regression test: `#resolveManagedDescribedByIds` used to compute the
+      // warning id independently of the blocking-error id, diverging from
+      // `createAriaDescribedBySignal`'s DOM-writing mutual exclusion (a
+      // blocking error suppresses the warning id because the default
+      // `NgxFormFieldError` renderer never mounts the `${fieldName}-warning`
+      // live region while a blocking error is also visible).
+      @Component({
+        template:
+          '<input id="email" [formField]="emailControl()" [ngxSignalFormControlAria]="ariaMode()" />',
+        imports: [
+          MockFormFieldDirective,
+          NgxSignalFormAutoAria,
+          NgxSignalFormControlSemanticsDirective,
+        ],
+      })
+      class TestComponent {
+        readonly ariaMode = signal<'auto' | 'manual' | null>(null);
+        emailControl = createMockControl(true, true, [
+          { kind: 'required', message: 'Email is required' },
+          { kind: 'warn:weak-format', message: 'Consider a business email' },
+        ]);
+      }
+
+      const { container, fixture } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const input = container.querySelector('input');
+
+      // Auto mode: only the error id is composed, never the warning id.
+      expect(input?.getAttribute('aria-describedby')).toBe('email-error');
+
+      // Auto → manual: same "clean slate" transition as aria-invalid /
+      // aria-required — the stale toolkit-written managed id is cleared
+      // rather than adopted as the new manual-mode value. The key
+      // regression-relevant assertion is what it does NOT contain: no
+      // `email-warning` id ever leaks in, even transiently.
+      fixture.componentInstance.ariaMode.set('manual');
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(input?.hasAttribute('aria-describedby')).toBe(false);
+
+      // Manual → auto: ownership returns to the toolkit, which recomputes
+      // from scratch. The result must be identical to the original auto-mode
+      // value — no accumulated duplicates, no stray warning id.
+      fixture.componentInstance.ariaMode.set('auto');
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(input?.getAttribute('aria-describedby')).toBe('email-error');
+    });
   });
 
   describe('Edge Cases', () => {

--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -309,11 +309,22 @@ export class NgxSignalFormAutoAria {
 
     const managedIds = [...hintIds];
 
-    if (this.#shouldShowErrors()) {
+    const showsBlockingError = this.#shouldShowErrors();
+
+    if (showsBlockingError) {
       managedIds.push(generateErrorId(snapshot.fieldName));
     }
 
-    if (this.#shouldShowWarnings()) {
+    // Mutually exclusive with the blocking-error id, mirroring
+    // `createAriaDescribedBySignal`'s `!hasBlockingError && ...` guard: the
+    // default `NgxFormFieldError` renderer suppresses its warning live
+    // region whenever a blocking error is also visible, so no
+    // `${fieldName}-warning` element exists in the DOM at that point.
+    // Without this guard, a field with both a blocking error and a `warn:*`
+    // error would have this "which ids does the toolkit own" computation
+    // diverge from the DOM-writing factory — composing a dangling
+    // `${fieldName}-warning` reference (axe `aria-valid-attr-value`).
+    if (!showsBlockingError && this.#shouldShowWarnings()) {
       managedIds.push(generateWarningId(snapshot.fieldName));
     }
 

--- a/packages/toolkit/headless/src/lib/field-optionality.spec.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.spec.ts
@@ -2,7 +2,9 @@ import { Component, signal, type Signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   applyEach,
+  disabled,
   form,
+  hidden,
   required,
   schema,
   type FieldTree,
@@ -150,6 +152,35 @@ describe('summarizeFieldOptionality', () => {
       hasOptional: false,
     });
   });
+
+  it('excludes a required+hidden field from the summary', () => {
+    // A required field hidden via Angular's hidden() must not count toward
+    // the required-field summary — the user can never see or fill it in, so
+    // NgxFormMarkingLegend has nothing to explain about it.
+    const tree = makeForm({ email: '', secret: '' }, (path) => {
+      required(path.email);
+      required(path.secret);
+      hidden(path.secret, () => true);
+    });
+
+    expect(summarizeFieldOptionality(tree)).toEqual({
+      hasRequired: true,
+      hasOptional: false,
+    });
+  });
+
+  it('excludes a required+disabled field from the summary', () => {
+    const tree = makeForm({ email: '', token: '' }, (path) => {
+      required(path.email);
+      required(path.token);
+      disabled(path.token, () => true);
+    });
+
+    expect(summarizeFieldOptionality(tree)).toEqual({
+      hasRequired: true,
+      hasOptional: false,
+    });
+  });
 });
 
 describe('createFieldOptionalitySummary', () => {
@@ -208,6 +239,36 @@ describe('createFieldOptionalitySummary', () => {
     expect(summary.hasRequired()).toBe(true);
 
     model.set({ birthDate: new Date('2000-01-01') });
+    expect(summary.hasRequired()).toBe(true);
+  });
+
+  it('includes a required field reactively once it becomes visible again', () => {
+    const isSecretHidden = signal(true);
+
+    @Component({ template: '' })
+    class Host {
+      readonly model = signal({ email: '', secret: '' });
+      readonly tree = form(
+        this.model,
+        schema<{ email: string; secret: string }>((path) => {
+          required(path.secret);
+          hidden(path.secret, () => isSecretHidden());
+        }),
+      );
+      readonly summary = createFieldOptionalitySummary(() => this.tree);
+    }
+
+    const fixture = TestBed.createComponent(Host);
+    const { summary } = fixture.componentInstance;
+
+    // `secret` is required but hidden — excluded, so the only surviving leaf
+    // (`email`, optional) drives the summary.
+    expect(summary.hasRequired()).toBe(false);
+    expect(summary.hasOptional()).toBe(true);
+
+    // Once `secret` becomes visible again, its required() state is back in
+    // play and the summary updates reactively.
+    isSecretHidden.set(false);
     expect(summary.hasRequired()).toBe(true);
   });
 

--- a/packages/toolkit/headless/src/lib/field-optionality.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.ts
@@ -1,5 +1,6 @@
 import { computed, isDevMode, type Signal } from '@angular/core';
 import type { FieldTree } from '@angular/forms/signals';
+import { isFieldStateInteractive } from '@ngx-signal-forms/toolkit/core';
 
 /**
  * Whether a form tree contains any required and/or any optional leaf field.
@@ -77,10 +78,30 @@ function isContainerNode(
 }
 
 /**
+ * Whether a leaf `FieldTree` is interactive (not `hidden()`, not
+ * `disabled()`) per {@link isFieldStateInteractive}. Guards the nullish /
+ * non-object case defensively — same "default to true" policy as
+ * `isErrorOnInteractiveField` — so a malformed leaf state doesn't crash the
+ * walk; it just isn't filtered out.
+ */
+function isLeafInteractive(leaf: AnyFieldTree): boolean {
+  const state = leaf() as object | null | undefined;
+  if (!state || typeof state !== 'object') return true;
+  return isFieldStateInteractive(state);
+}
+
+/**
  * Yield every leaf (control) `FieldTree` reachable from `node`, depth-first.
  *
  * Container nodes are descended into and never yielded themselves; only leaves
  * carry the `required()` state that marking decisions are based on.
+ *
+ * Non-interactive leaves — `hidden()` or `disabled()` — are skipped entirely,
+ * matching every other interactivity-aware primitive in the toolkit
+ * ({@link isFieldStateInteractive}, `isErrorOnInteractiveField`,
+ * `focusFirstInvalid`). Without this, a `required()` field hidden via
+ * Angular's `hidden()` schema rule would still count toward the
+ * required-field summary even though the user can never see or fill it in.
  *
  * Caveat: an array of primitives (e.g. a `string[]` token field bound to one
  * control) is treated as a container, so its elements — not the array node —
@@ -88,11 +109,13 @@ function isContainerNode(
  * correct; arrays bound as a single control are a known edge that does not
  * contribute its array-level required state.
  *
- * @yields Each leaf (control) `FieldTree` in depth-first order.
+ * @yields Each interactive leaf (control) `FieldTree` in depth-first order.
  */
 function* walkLeaves(node: AnyFieldTree): Generator<AnyFieldTree> {
   if (!isContainerNode(node)) {
-    yield node;
+    if (isLeafInteractive(node)) {
+      yield node;
+    }
     return;
   }
 

--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -130,7 +130,7 @@ First-class adapter for Vest suites. Reads `suite.run()` results and maps blocki
 ```typescript
 validateVest(path, suite); // blocking errors only
 validateVest(path, suite, { includeWarnings: true }); // + warn() as toolkit warnings
-validateVest(path, suite, { resetOnDestroy: false }); // opt out of teardown reset (now the default)
+validateVest(path, suite, { resetOnDestroy: false }); // opt out of teardown reset (true is the default)
 validateVest(path, suite, { only: (ctx) => ctx.value().focusedField });
 validateVest(path.email, suite, { focusCurrentField: true }); // auto-focus the bound field
 ```


### PR DESCRIPTION
## Summary

Implements three verified audit findings on `@ngx-signal-forms/toolkit`, plus a one-line doc correction. Stacks on #218 (targets `feature/improvements`, not `main`).

### 1. `packages/toolkit/headless/src/lib/field-optionality.ts`
`walkLeaves`/`readRequired` did not exclude `hidden()` or `disabled()` leaf fields, unlike every other interactivity-aware primitive (`isFieldStateInteractive`, `isErrorOnInteractiveField`, `focusFirstInvalid`).

**Failure scenario:** a `required()` field hidden via Angular's `hidden()` schema rule still counted toward `NgxFormMarkingLegend`'s required-field summary, even though the user could never see or fill it in.

**Fix:** reuse `isFieldStateInteractive` from `@ngx-signal-forms/toolkit/core` (already imported the same way in `utilities.ts` for `isErrorOnInteractiveField`) and skip non-interactive leaves during the walk. Added specs: required+hidden excluded, required+disabled excluded, and reactive re-inclusion once a field becomes visible again.

### 2. `packages/toolkit/assistive/form-field-error.ts`
`#resolvedWarningStrategy` called `resolveStrategyFromContext(explicit, this.#injectedContext)` **without** the `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy` fallback that `NgxHeadlessErrorState` includes.

**Failure scenario:** `provideNgxSignalFormsConfig({ defaultErrorStrategy: 'immediate' })` + a standalone `<ngx-form-field-error [warningStrategy]="'inherit'">` (no `[ngxSignalForm]` host) diverged from the global config, hard-falling back to `'on-touch'` instead.

**Fix:** inject `NGX_SIGNAL_FORMS_CONFIG` (optional) and pass its `defaultErrorStrategy` as the fallback argument, matching `NgxHeadlessErrorState`'s cascade exactly. Added a spec reproducing the standalone + custom-config scenario — verified to fail without the fix and pass with it.

### 3. `packages/toolkit/core/directives/auto-aria.ts`
`#resolveManagedDescribedByIds()` pushed the warning id whenever `#shouldShowWarnings()` was true, but the DOM-writing `createAriaDescribedBySignal` factory applies a "blocking error suppresses the warning id" mutual exclusion — the two "which ids does the toolkit own" computations diverged when a field has **both** a blocking error and a `warn:*` error.

**Fix:** apply the same mutual-exclusion rule in `#resolveManagedDescribedByIds` (only include the warning id when there is no blocking error). Added a spec for the both-error-kinds case asserting the id bookkeeping stays consistent across an auto → manual → auto mode transition.

### 4. `packages/toolkit/vest/README.md`
One-line fix: a quick-start comment claimed `resetOnDestroy: false` is "now the default." The adapter's actual (and documented, in the options table) default is `true`.

## Test plan
- [x] `pnpm nx run toolkit:test` — 79 test files / 1299 tests pass
- [x] `pnpm nx run toolkit:build` — all entry points build
- [x] `pnpm nx run toolkit:lint` — 0 errors (pre-existing warnings only)
- [x] New specs for findings #1 and #2 independently verified to fail on the pre-fix code and pass on the fix
- [x] `pnpm format` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Warning messages now respect the app’s global form error settings when no form host is present.
  - Auto-generated accessibility descriptions now avoid showing warning and blocking error messages at the same time.

- **Bug Fixes**
  - Fixed warning visibility for standalone form errors so untouched fields can still show the correct status.
  - Improved optionality summaries so hidden or disabled fields are no longer counted as required.
  - Accessibility descriptions now update correctly when switching between automatic and manual modes.

- **Documentation**
  - Clarified the example for reset behavior in the validation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->