### PR TITLE
docs: Correct API docs against source, dedupe guides, add use-case FAQ

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,8 +7,10 @@ This document describes the compatibility contract for
 
 - Package: `@ngx-signal-forms/toolkit`
 - Current peer dependencies:
+  - `@angular/common >=22.0.0 <23.0.0`
   - `@angular/core >=22.0.0 <23.0.0`
   - `@angular/forms >=22.0.0 <23.0.0`
+  - `axe-core >=4.5.0` (optional)
   - `vest >=6.0.0 <7.0.0` (optional)
 
 ## Angular compatibility
@@ -59,12 +61,11 @@ field). Consumers should use an active LTS Node version compatible with
 Angular 22 and their package manager/tooling stack.
 
 The repository currently validates and publishes with the following Node
-versions:
+version:
 
-| Use case         | Version used in automation |
-| ---------------- | -------------------------- |
-| CI workflow      | Node 22 (maintenance LTS)  |
-| Publish workflow | Node 24 (active LTS)       |
+| Use case               | Version used in automation                                          |
+| ---------------------- | ------------------------------------------------------------------- |
+| CI + Publish workflows | Node, from [`.node-version`](./.node-version) (currently `24.18.0`) |
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ advanced and specialized cases — pull them in when you hit that specific need.
 | Use with Angular Material           | Custom wrapper on `mat-form-field`                               | [`demo-material`](./apps/demo-material/README.md)                                                                                                          |
 | Use with Spartan Components         | Custom wrapper on `BrnField` + `helm`                            | [`demo-spartan`](./apps/demo-spartan/README.md)                                                                                                            |
 | Use with PrimeNG                    | Projected-control wrapper (`pInputText`, …)                      | [`demo-primeng`](./apps/demo-primeng/README.md)                                                                                                            |
+| Assert WCAG 2.2 AA in my own specs  | [`/testing`](./packages/toolkit/testing/README.md) entry point   | [`form-field-wrapper.a11y.browser.spec.ts`](./packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts)                                         |
 
 ---
 
@@ -427,6 +428,18 @@ npm install @ngx-signal-forms/toolkit vest@6.2.7
 [`zod-vest-validation` (code)](./apps/demo/src/app/05-advanced/zod-vest-validation) · [live](https://ngx-signal-forms.github.io/ngx-signal-forms/validation/zod-vest-validation/) ·
 **[Migrating from `ngx-vest-forms`](./docs/MIGRATING_FROM_NGX_VEST_FORMS.md)**
 
+### `@ngx-signal-forms/toolkit/testing` — assert WCAG 2.2 AA in your specs
+
+A small consumer-facing test harness that wraps `axe-core` for asserting the
+toolkit's accessibility contract in your own specs. Optional — only loaded
+when you import this entry point — and depends on the optional peer
+`axe-core` (`>=4.5.0`).
+
+Most-used exports: `expectNoA11yViolations()`, `WCAG_22_AA_TAGS`.
+
+**[→ Testing docs](./packages/toolkit/testing/README.md)** ·
+**Example:** [`form-field-wrapper.a11y.browser.spec.ts`](./packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts)
+
 ## Validation strategies
 
 Angular validators, Zod/OpenAPI Standard Schema, and Vest are **complementary, not
@@ -550,6 +563,10 @@ The short version — each one is expanded with do/don't examples in the
 
 ## FAQ
 
+The questions below cover what the toolkit _is_. For hands-on "how do I build X?"
+questions — dynamic arrays, server-side errors, wizards, custom datepickers, i18n,
+unit testing, and more — see the **[use-case FAQ](./docs/FAQ.md)**.
+
 <details>
 <summary><strong>Does this replace Angular Signal Forms?</strong></summary>
 
@@ -631,7 +648,7 @@ Yes — three runnable reference wrappers ship in the repo:
 - [`apps/demo-spartan`](./apps/demo-spartan/README.md) — wraps Spartan's `BrnField` host directive and bridges `BrnFieldA11yService` so Brain's `aria-describedby` host binding consumes the toolkit's id composition.
 - [`apps/demo-primeng`](./apps/demo-primeng/README.md) — a projected-control wrapper where direct inputs (`pInputText`, …) use `NgxSignalFormAutoAria` like the canonical wrapper; host components such as `p-select` use a narrow compatibility shim until PrimeNG's own Signal Forms story matures.
 
-All three follow the four contracts in [`docs/CUSTOM_WRAPPERS.md`](./docs/CUSTOM_WRAPPERS.md); the Material and Spartan wrappers also mirror the surface of the future `@ngx-signal-forms/material` and `@ngx-signal-forms/spartan` packages (per [ADR-0002](./docs/decisions/0002-ngx-mat-forms-package-shape.md)).
+All three follow the four contracts in [`docs/CUSTOM_WRAPPERS.md`](./docs/CUSTOM_WRAPPERS.md), which also notes that the Material and Spartan wrappers mirror the surface of the future `@ngx-signal-forms/material` and `@ngx-signal-forms/spartan` packages; the Material package shape itself is decided in [ADR-0002](./docs/decisions/0002-ngx-mat-forms-package-shape.md).
 
 </details>
 
@@ -716,6 +733,7 @@ screen-reader testing) before claiming conformance.
 
 **Guides**
 
+- [Use-case FAQ](./docs/FAQ.md) — "how do I build X?" answers linking the right API, doc, and demo
 - [Best practices](./docs/BEST_PRACTICES.md) — the five practices, with do/don't examples and a review checklist
 - [Angular vs toolkit](./docs/ANGULAR_VS_TOOLKIT.md) — what the toolkit adds, with a before/after example
 - [Validation strategies](./docs/VALIDATION_STRATEGY.md) — when to use Angular validators, Zod, or Vest

--- a/apps/demo-material/README.md
+++ b/apps/demo-material/README.md
@@ -219,13 +219,11 @@ Material's ARIA ownership.
 
 ### Warnings under `submission.action`
 
-Angular Signal Forms' native `submit()` only runs `submission.action`
-when the field tree is not `invalid()` — and `invalid()` is `true` for
-**any** validation result on the tree, including the toolkit's
-non-blocking `warn:*` results. Left unpatched, a warning (e.g.
-`warn:short-name` on the contact form's `name` field) would silently
-prevent submission and route straight to `onInvalid`, contradicting the
-"gentle warning, not a blocker" contract warnings are supposed to have.
+Angular Signal Forms' native `submit()` blocks `submission.action` on
+any validation result on the tree, including the toolkit's non-blocking
+`warn:*` results — see the [toolkit README](../../packages/toolkit/README.md#warning-support)'s
+warning-support table for `hasOnlyWarnings()` / `submitWithWarnings()`
+and why that matters.
 
 The contact form's declarative `{ submission }` therefore sets
 `ignoreValidators: 'all'` and gates the actual submit logic on
@@ -252,9 +250,7 @@ This mirrors `apps/demo-primeng`'s profile form and is the pattern
 [`apps/demo`'s advanced section](../demo/src/app/05-advanced/README.md)
 documents as preferred for warning-tolerant submission when you're
 using declarative `{ submission }` rather than calling `submit()` /
-`submitWithWarnings()` by hand — see the
-[toolkit README](../../packages/toolkit/README.md)'s submission
-helpers table for `hasOnlyWarnings()` / `submitWithWarnings()`.
+`submitWithWarnings()` by hand.
 
 ### Warnings and Material's `ErrorStateMatcher`
 
@@ -442,6 +438,6 @@ writing:
 
 | Package               | Version  |
 | --------------------- | -------- |
-| `@angular/material`   | `22.0.3` |
-| `@angular/cdk`        | `22.0.3` |
+| `@angular/material`   | `22.0.4` |
+| `@angular/cdk`        | `22.0.4` |
 | `@angular/animations` | `22.0.5` |

--- a/apps/demo-spartan/README.md
+++ b/apps/demo-spartan/README.md
@@ -435,8 +435,8 @@ same convention for the same reason.
 | ------------------- | --------------------- |
 | `@spartan-ng/brain` | `1.0.4`               |
 | `@spartan-ng/cli`   | (catalog: `spartan:`) |
-| `@ng-icons/core`    | `>=32.0.0 <34.0.0`    |
-| `@ng-icons/lucide`  | `>=32.0.0 <34.0.0`    |
+| `@ng-icons/core`    | `>=33.4.0 <34.0.0`    |
+| `@ng-icons/lucide`  | `>=33.4.0 <34.0.0`    |
 | `tw-animate-css`    | (catalog: `spartan:`) |
 
 The toolkit itself is consumed in-tree via the workspace tsconfig path

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -139,6 +139,11 @@ pnpm nx build demo
 pnpm nx e2e demo-e2e
 ```
 
+> The plain `e2e` target has no port-preflight step and can hang locally on
+> port 4600 conflicts. For local runs prefer
+> `pnpm nx run demo-e2e:e2e-toolkit` or `pnpm nx run demo-e2e:e2e-demo-app`,
+> which clear the port before starting Playwright.
+
 ### Navigate Examples
 
 1. Start at **Getting Started** for the toolkit-first baseline

--- a/apps/demo/src/app/02-toolkit-core/README.md
+++ b/apps/demo/src/app/02-toolkit-core/README.md
@@ -37,8 +37,6 @@ Older standalone pages (accessibility comparison, field-state inspection) are no
 - [your-first-form](../01-getting-started/your-first-form/README.md) — accessibility onboarding.
 - Debugger panels inside the active demos — runtime field state.
 
-Archived folders remain in the repo for reference.
-
 ## ➡️ Next steps
 
 - Continue to **[03-headless](../03-headless/README.md)** — renderless primitives for design systems that can't adopt the wrapper.

--- a/apps/demo/src/app/03-headless/error-message-signal/README.md
+++ b/apps/demo/src/app/03-headless/error-message-signal/README.md
@@ -63,4 +63,4 @@ Swapping `activeRegistry` causes all three signal instances to re-resolve their 
 ## ➡️ Related
 
 - [Headless section README](../README.md) — overview of all headless demos
-- [packages/toolkit/headless/README.md](../../../../../packages/toolkit/headless/README.md) — `createErrorMessageSignal` API reference
+- [packages/toolkit/headless/README.md](../../../../../../packages/toolkit/headless/README.md) — `createErrorMessageSignal` API reference

--- a/apps/demo/src/app/04-form-field-wrapper/README.md
+++ b/apps/demo/src/app/04-form-field-wrapper/README.md
@@ -18,6 +18,10 @@ This section demonstrates the batteries-included path: one component (`ngx-form-
   - What you'll learn: `feedbackAppearance` · `surfaceTone` · `validationSurface` · `listStyle` · `includeNestedErrors` trade-offs in one place.
 - **[custom-controls](./custom-controls/README.md)** — star rating, native switch, and slider integrated into the wrapper.
   - What you'll learn: `FormValueControl` contract (no `ControlValueAccessor`) · `ngxSignalFormControl="slider"` with `ariaMode: 'manual'` · component-scoped presets.
+- **[field-marking](./field-marking/README.md)** — the toolkit's required/optional marker modes and the form-aware `NgxFormMarkingLegend`.
+  - What you'll learn: `showMarkerWhen` modes (`required`/`optional`/`none`) · configurable marker text · legend auto-hide when no relevant field exists.
+- **[labelless-fields](./labelless-fields/README.md)** — where the wrapper's reserved label row can legitimately collapse.
+  - What you'll learn: `aria-label`-only accessible names · `role="group"` field grouping · keeping the error region at full wrapper width around narrowed inputs.
 
 ## 🧠 Core concepts
 
@@ -34,7 +38,7 @@ This section demonstrates the batteries-included path: one component (`ngx-form-
 
 ## 📦 Consolidated from earlier demos
 
-Older isolated pages (`basic-usage`, `fieldset-grouping`) are no longer routed. Their teaching goals live inside `complex-forms` now. Archived folders remain in the repo for reference.
+Older isolated pages (`basic-usage`, `fieldset-grouping`) were removed. Their teaching goals live inside `complex-forms` now.
 
 ## ➡️ Next steps
 

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md
@@ -11,7 +11,7 @@ Angular Signal Forms replaces the legacy `ControlValueAccessor` boilerplate with
 - `ngxSignalFormControl="switch"` — native checkbox switch semantics (inline row layout).
 - `ngxSignalFormControl="checkbox"` — opt-in checkbox semantics for a standard checkbox.
 - `ngxSignalFormControl="slider"` — custom slider with `layout: 'custom'` and `ariaMode: 'manual'` so the control owns its own `aria-describedby` chain.
-- Component-scoped control presets inherited via `provideNgxSignalFormControlPresets()`.
+- Component-scoped control presets inherited via `provideNgxSignalFormControlPresetsForComponent()`.
 
 ## Form model
 

--- a/apps/demo/src/app/04-form-field-wrapper/fieldset-appearance/README.md
+++ b/apps/demo/src/app/04-form-field-wrapper/fieldset-appearance/README.md
@@ -35,4 +35,4 @@ A focused showroom for `NgxFormFieldset` that makes the grouped-feedback present
 
 - [Complex Forms](../complex-forms/README.md) — long-form composition with nested sections and arrays.
 - [Fieldset + Utilities](../../03-headless/fieldset-utilities/README.md) — headless equivalent when you want to own the markup.
-- [Toolkit form-field README](../../../../../packages/toolkit/form-field/README.md) — public API reference for wrapper and fieldset inputs.
+- [Toolkit form-field README](../../../../../../packages/toolkit/form-field/README.md) — public API reference for wrapper and fieldset inputs.

--- a/apps/demo/src/app/04-form-field-wrapper/labelless-fields/README.md
+++ b/apps/demo/src/app/04-form-field-wrapper/labelless-fields/README.md
@@ -2,7 +2,7 @@
 
 ## Intent
 
-Not every field needs a visible `<label>`. This demo shows where the `NgxFormField` wrapper's reserved label space can legitimately collapse — search bars, grouped fields under a shared heading, card-labelled inputs — while still exposing an accessible name via `aria-label`.
+Not every field needs a visible `<label>`. This demo shows where the `NgxFormField` wrapper's reserved label space can legitimately collapse — search bars and card-labelled inputs via `aria-label`, or grouped fields under a shared heading via `role="group"` + `aria-labelledby`.
 
 ## Toolkit features showcased
 

--- a/apps/demo/src/app/04-form-field-wrapper/labelless-fields/README.md
+++ b/apps/demo/src/app/04-form-field-wrapper/labelless-fields/README.md
@@ -1,0 +1,60 @@
+# Labelless Form Fields
+
+## Intent
+
+Not every field needs a visible `<label>`. This demo shows where the `NgxFormField` wrapper's reserved label space can legitimately collapse — search bars, grouped fields under a shared heading, card-labelled inputs — while still exposing an accessible name via `aria-label`.
+
+## Toolkit features showcased
+
+- `NgxSignalFormToolkit` (`ngxSignalForm`) — root directive for auto-ARIA and form context.
+- `NgxFormField` wrapper (`ngx-form-field-wrapper`) — collapses the reserved label row (standard/plain) or floating-label padding (outline) when no `<label>` is projected, across both orientations.
+- Prefix/suffix projection — search icon prefix, `$` prefix and `.00` suffix on the amount field.
+- `role="group"` + `aria-labelledby` — grouping the three phone-number parts under one heading instead of three labels.
+- Error messages that keep the wrapper's full width even when the input itself is narrowed via CSS (age, ZIP).
+- `createOnInvalidHandler()` — used in the form's `onInvalid` submission handler.
+
+## Form model
+
+- Signal model: `signal<LabellessFieldsModel>()` with `searchQuery`, `phoneCountry` / `phoneNumber` / `phoneExtension`, `amount`, `comparison`, `age`, `zipCode`, `otp`.
+- Schema: `form(model, labellessFieldsSchema, { submission })`.
+
+## Validation rules
+
+### Errors
+
+- Phone group — `phoneCountry` required; `phoneNumber` min length 7.
+- Amount — `min(path.amount, 1)`, "Amount must be greater than 0".
+- Age — required, `min` 18, `max` 120.
+- Zip code — pattern `12345` or `12345-6789`.
+- OTP — pattern requiring exactly six digits.
+
+### Warnings
+
+- None.
+
+## Strong suites
+
+- The reference for deciding when a label is genuinely redundant versus when omitting one hurts usability.
+- Proves the wrapper's layout collapse works identically across all three appearances and both orientations.
+- Pairs narrow inputs (`max-width` on the `<input>`, not the wrapper) with deliberately long error copy to show the error region always keeps the wrapper's full width.
+
+## Key files
+
+- [labelless-fields.form.ts](labelless-fields.form.ts) — component, model wiring, and the CSS that narrows individual inputs.
+- [labelless-fields.html](labelless-fields.html) — the five labelless patterns (search, grouped phone, card-labelled amount, with/without comparison, narrow inputs).
+- [labelless-fields.validations.ts](labelless-fields.validations.ts) — validation schema with the wide error messages.
+- [labelless-fields.page.ts](labelless-fields.page.ts) — page wrapper, appearance/orientation controls, and debugger.
+
+## How to test
+
+1. Run the demo and navigate to `/form-field-wrapper/labelless-fields`.
+2. Inspect the **Search** input's accessible name (DevTools Accessibility pane) → it's "Search", from `aria-label`, not the placeholder.
+3. Type `555` in **phone number**, tab away → "Phone number must be at least 7 digits"; leave country code empty → "Country code is required".
+4. Tab off **Amount** and **Age** without values → "Amount must be greater than 0" and "Must be 18 or older" both render at full wrapper width despite the narrow inputs.
+5. Type `1234` in **Zip** → "Format: 12345 or 12345-6789"; type `12345` in **passcode** → "Enter all six digits".
+6. Switch orientation to horizontal → the label column collapses for every labelless field; compare against section 4's "with vs without label" pair.
+
+## Related
+
+- [Field Marking](../field-marking/README.md) — another per-field wrapper micro-behavior demo (required/optional markers).
+- [Submission Patterns](../../05-advanced/submission-patterns/README.md) — declarative submission and the GOV.UK-style error summary.

--- a/apps/demo/src/app/05-advanced/README.md
+++ b/apps/demo/src/app/05-advanced/README.md
@@ -26,6 +26,8 @@ This is the production frontier of the demo app. Each demo here stands on its ow
   - What you'll learn: schema-level cross-field rules · reactive re-validation · field-vs-group error placement.
 - **[server-integration](./server-integration/README.md)** — `resource()` prefill + declarative submission + server errors mapped onto `TreeValidationResult`.
   - What you'll learn: `resource()`-driven prefill · form-level vs. field-level server errors · the auto-clear semantics of submission errors · `reset(value)` after a successful save.
+- **[store-binding](./store-binding/README.md)** — honest two-way binding between a Signal Form and an `@ngrx/signals` store via `linkedSignal`, contrasted with the wizard's draft/commit buffer.
+  - What you'll learn: `linkedSignal({ source, computation })` read seam · overriding `set`/`update` to write straight through to `patchState` · when live binding beats draft/commit.
 
 ## 🧠 Core concepts
 

--- a/apps/demo/src/app/05-advanced/field-state-patterns/README.md
+++ b/apps/demo/src/app/05-advanced/field-state-patterns/README.md
@@ -1,0 +1,58 @@
+# Field State Patterns
+
+## Intent
+
+Angular 22 made `{ when }` the consistent shape for driving dynamic field state — the same context object validators already use. This demo shows when to reach for `hidden`, `disabled`, or `readonly` on a visible field, and how the toolkit wrappers keep each state legible without hand-rolled ARIA.
+
+## Toolkit features showcased
+
+- `hidden(path, { when })` — drops the invite-code field out of the form entirely until invite-only onboarding is active.
+- `disabled(path, { when })` — keeps the mobile-number field visible but inert until SMS notifications are selected.
+- `readonly(path, { when })` — locks the work-email field for display/copy once it's identity-provider managed, without hiding it.
+- Consistent `{ when }` syntax — the same context (`ctx.valueOf(path.*)`) drives both these state functions and ordinary `required(path, { when, message })` rules.
+- `NgxSignalFormToolkit` (`ngxSignalForm`) + `NgxFormField` wrapper — hidden/disabled/readonly states render correctly without custom ARIA plumbing.
+- `ngxSignalFormControl="checkbox"` — explicit control semantics for the two toggles.
+- `form(model, schema, { submission: { action, onInvalid } })` with `createOnInvalidHandler()` — declarative submission lifecycle.
+
+## Form model
+
+- Signal model: `signal<FieldStatePatternsModel>()` with `workEmail`, `contactPreference` (`'email' | 'sms'`), `mobileNumber`, `inviteOnly`, `inviteCode`, `managedByIdentityProvider`.
+- Initial state: `workEmail` prefilled (`ada@company.com`), `contactPreference` set to `'email'`, all other fields empty/`false`.
+- Schema: `form(model, fieldStatePatternsSchema, { submission })`.
+
+## Validation rules
+
+### Errors
+
+- Work email — required; must be a valid email address; `readonly` when `managedByIdentityProvider` is checked.
+- Mobile number — `disabled` unless `contactPreference` is `'sms'`; required with message "SMS notifications need a mobile number" when it is.
+- Invite code — `hidden` unless `inviteOnly` is checked; required with message "Enter the invite code from your onboarding email" when it is.
+
+### Warnings
+
+- None.
+
+## Strong suites
+
+- The canonical reference for choosing between `hidden`, `disabled`, and `readonly` for a conditional workflow field.
+- Makes the shared `{ when }` shape between field-state functions and validators concrete in one schema.
+- The live state readout under the form shows exactly how each signal flips as inputs change.
+
+## Key files
+
+- [field-state-patterns.form.ts](field-state-patterns.form.ts) — schema with `hidden`/`disabled`/`readonly` rules, the form component, and the state-readout panel.
+- [field-state-patterns.page.ts](field-state-patterns.page.ts) — page wrapper, appearance/orientation controls, and debugger.
+
+## How to test
+
+1. Run the demo and navigate to `/advanced-scenarios/field-state-patterns`.
+2. Switch **Notification preference** to `SMS` → Mobile number becomes editable and `mobileNumber.disabled()` flips to `false`; submit with it empty → "SMS notifications need a mobile number".
+3. Check **Invite-only onboarding** → the Invite code field appears and `inviteCode.hidden()` flips to `false`; submit empty → "Enter the invite code from your onboarding email".
+4. Check **Managed by identity provider** → Work email locks (visible but uneditable) and `workEmail.readonly()` flips to `true`.
+5. Uncheck it, clear **Work email** → "Work email is required"; type `ada@` → "Enter a valid work email address".
+6. Click **Reset** → everything returns to the initial state (email prefilled, SMS off, invite code hidden).
+
+## Related
+
+- [Cross-Field Validation](../cross-field-validation/README.md) — dependent, sibling-aware validation rules.
+- [Zod + Vest Validation](../zod-vest-validation/README.md) — layering structural and policy validation on top of field-state rules.

--- a/apps/demo/src/app/05-advanced/submission-patterns/README.md
+++ b/apps/demo/src/app/05-advanced/submission-patterns/README.md
@@ -10,7 +10,7 @@ Manual submission plumbing — disabling buttons, tracking loading, catching err
 - `[formRoot]` directive — orchestrates `preventDefault`, `novalidate`, submitting state, and invalid-submit handling.
 - `createOnInvalidHandler()` — focuses the first invalid field on failed submit.
 - `<ngx-form-field-error-summary>` — strategy-aware, aggregated, clickable error summary (`role="alert"`, using the role's implicit assertive live-region semantics).
-- `focusBoundControl()` — click-to-focus from the summary into the control.
+- Click-to-focus via Angular's native `focusBoundControl()`, invoked internally by the error summary.
 - `humanizeFieldPath` + `provideFieldLabels()` — readable field names in the summary.
 - `submitting()` signal — drives the submit button's disabled/loading UI.
 - `[submittedStatus]` public binding — shows passing submitted state explicitly while still reading from toolkit context.

--- a/apps/demo/src/app/05-advanced/vest-validation/README.md
+++ b/apps/demo/src/app/05-advanced/vest-validation/README.md
@@ -60,7 +60,7 @@ When your form rules are mostly business policy (tier-specific limits, referral 
 
 ## Migration
 
-If you are coming from `ngx-vest-forms`, see [`docs/MIGRATING_FROM_NGX_VEST_FORMS.md`](../../../../../docs/MIGRATING_FROM_NGX_VEST_FORMS.md) for the API mapping.
+If you are coming from `ngx-vest-forms`, see [`docs/MIGRATING_FROM_NGX_VEST_FORMS.md`](../../../../../../docs/MIGRATING_FROM_NGX_VEST_FORMS.md) for the API mapping.
 
 ## Related
 

--- a/apps/demo/src/app/shared/wizard/README.md
+++ b/apps/demo/src/app/shared/wizard/README.md
@@ -68,21 +68,32 @@ Combine template projection with `@defer` for maximum lazy loading:
 </ngx-wizard>
 ```
 
-### Validation with preventDefault
+### Validation with canNavigate
 
-Use the `stepChange` event to validate before navigation:
+`stepChange`'s `preventDefault()` is only checked _synchronously_, immediately
+after the event is emitted — an `await` inside the handler is always too
+late. For guards that need to validate asynchronously, bind the `canNavigate`
+input instead; it is awaited by `goToStep()` before the step actually
+changes:
+
+```html
+<ngx-wizard [(currentStep)]="currentStep" [canNavigate]="guardStep">
+  ...
+</ngx-wizard>
+```
 
 ```typescript
-protected async onStepChange(event: WizardNavigationEvent): Promise<void> {
-  // Validate current step before allowing navigation forward
+protected guardStep: WizardCanNavigate = async (event) => {
+  // Only validate when moving forward
   if (event.toIndex > event.fromIndex) {
     const isValid = await this.validateStep(event.fromStep);
     if (!isValid) {
-      event.preventDefault();
       this.focusFirstError();
     }
+    return isValid;
   }
-}
+  return true;
+};
 ```
 
 ### Custom Navigation
@@ -108,15 +119,16 @@ Disable built-in navigation and provide your own:
 
 #### WizardComponent Inputs
 
-| Input            | Type       | Default      | Description                                |
-| ---------------- | ---------- | ------------ | ------------------------------------------ |
-| `currentStep`    | `string`   | `''`         | Current active step ID (two-way bindable)  |
-| `completedSteps` | `string[]` | `[]`         | Array of completed step IDs                |
-| `showNavigation` | `boolean`  | `true`       | Show built-in navigation buttons           |
-| `previousLabel`  | `string`   | `'Previous'` | Previous button text                       |
-| `nextLabel`      | `string`   | `'Next'`     | Next button text                           |
-| `submitLabel`    | `string`   | `'Submit'`   | Submit button text                         |
-| `allowStepClick` | `boolean`  | `true`       | Allow clicking step indicators to navigate |
+| Input            | Type                        | Default      | Description                                                                                 |
+| ---------------- | --------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `currentStep`    | `string`                    | `''`         | Current active step ID (two-way bindable)                                                   |
+| `completedSteps` | `string[]`                  | `[]`         | Array of completed step IDs                                                                 |
+| `showNavigation` | `boolean`                   | `true`       | Show built-in navigation buttons                                                            |
+| `previousLabel`  | `string`                    | `'Previous'` | Previous button text                                                                        |
+| `nextLabel`      | `string`                    | `'Next'`     | Next button text                                                                            |
+| `submitLabel`    | `string`                    | `'Submit'`   | Submit button text                                                                          |
+| `allowStepClick` | `boolean`                   | `true`       | Allow clicking step indicators to navigate                                                  |
+| `canNavigate`    | `WizardCanNavigate \| null` | `null`       | Async-aware guard checked before every navigation; return `false`/`Promise<false>` to block |
 
 #### WizardComponent Outputs
 

--- a/docs/ANGULAR_PUBLIC_API_POLICY.md
+++ b/docs/ANGULAR_PUBLIC_API_POLICY.md
@@ -6,7 +6,7 @@ This document defines the ownership boundary between Angular Signal Forms and `@
 
 ### Angular Owns (Form Engine)
 
-These APIs are part of Angular's `@angular/forms/signals` package. The toolkit consumes them but never reimplements them:
+These APIs are part of Angular's `@angular/forms/signals` package. The toolkit consumes them but never reimplements them. Two entries (marked `*`) live in the separate `@angular/forms/signals/compat` subpath, not `@angular/forms/signals` itself:
 
 | API                        | Purpose                                             |
 | -------------------------- | --------------------------------------------------- |
@@ -20,13 +20,15 @@ These APIs are part of Angular's `@angular/forms/signals` package. The toolkit c
 | `errors()`                 | Direct validation errors for a field                |
 | `formFieldBindings`        | Track bound FormField directives                    |
 | `provideSignalFormsConfig` | Configure status classes, submit behavior           |
-| `NG_STATUS_CLASSES`        | CSS class bindings for field states                 |
+| `NG_STATUS_CLASSES` *      | CSS class bindings for field states                 |
 | `FormValueControl<T>`      | Interface for custom value controls                 |
 | `FormCheckboxControl`      | Interface for checkbox-like controls                |
 | `FormUiControl`            | Interface for UI-only controls                      |
-| `compatForm()`             | Bridge to existing reactive forms                   |
+| `compatForm()` *           | Bridge to existing reactive forms                   |
 | `FieldTree<T>`             | Reactive view of a data signal node                 |
 | `FieldState<T>`            | Runtime state interface (valid, touched, etc.)      |
+
+\* Imported from `@angular/forms/signals/compat`, not `@angular/forms/signals`.
 
 ### Toolkit Owns (Enhancement Layer)
 
@@ -37,7 +39,7 @@ These APIs are part of `@ngx-signal-forms/toolkit`. They build on top of Angular
 | `ngxSignalForm` directive | `toolkit`            | Form-level context: error strategy, submitted status |
 | Auto-ARIA directive       | `toolkit`            | Automatic `aria-invalid`, `aria-describedby`         |
 | Error display strategies  | `toolkit`            | `'on-touch'`, `'on-submit'`, `'immediate'`           |
-| Error message registry    | `toolkit`            | App-wide `NGX_ERROR_MESSAGES` provider               |
+| Error message registry    | `toolkit`            | App-wide registry via `provideErrorMessages()`       |
 | `focusFirstInvalid()`     | `toolkit`            | Focus first invalid field via `errorSummary()`       |
 | Submission helpers        | `toolkit`            | `createSubmittedStatusTracker()`                     |
 | Headless error state      | `toolkit/headless`   | Strategy-aware error/warning signals                 |
@@ -92,9 +94,7 @@ The toolkit uses duck-typing when accessing Angular Signal Forms internals that 
 
 ## Angular Version Baseline
 
-- **Tested baseline**: Angular 22.0.x
-- **Signal Forms status**: Stable as of Angular 22 (`@publicApi 22.0`) — semver-protected within the major
-- **Toolkit stance**: We follow Angular's public API surface. A future Angular **major** can still reshape Signal Forms; the toolkit will adapt when it does.
+Tracks the same Angular 22 baseline and stability contract as [Compatibility](../COMPATIBILITY.md#angular-signal-forms-status).
 
 ## Internal `/core` secondary entry point
 

--- a/docs/ANGULAR_VS_TOOLKIT.md
+++ b/docs/ANGULAR_VS_TOOLKIT.md
@@ -35,45 +35,9 @@ adds nothing you'd miss. Adopting it later requires no rewrites because your
 
 ### Side-by-side: the same field, with and without the toolkit
 
-#### Without the toolkit
-
-```html
-<form [formRoot]="userForm">
-  <label for="email">Email</label>
-  <input
-    id="email"
-    [formField]="userForm.email"
-    [attr.aria-invalid]="userForm.email().invalid() ? 'true' : null"
-    [attr.aria-describedby]="
-      userForm.email().invalid() &&
-      (userForm.email().touched() || userForm().touched())
-        ? 'email-error'
-        : null
-    "
-  />
-  @if ( userForm.email().invalid() && (userForm.email().touched() ||
-  userForm().touched()) ) {
-  <span id="email-error" role="alert">
-    {{ userForm.email().errors()[0].message }}
-  </span>
-  }
-  <button type="submit">Submit</button>
-</form>
-```
-
-#### With the toolkit
-
-```html
-<form [formRoot]="userForm" ngxSignalForm>
-  <ngx-form-field-wrapper [formField]="userForm.email">
-    <label for="email">Email</label>
-    <input id="email" [formField]="userForm.email" type="email" />
-  </ngx-form-field-wrapper>
-  <button type="submit">Send</button>
-</form>
-```
-
-The wrapper handles ARIA wiring, error timing, `role="alert"` vs
+See [the root README's side-by-side comparison](../README.md#see-the-difference)
+for the same email field written with plain Signal Forms versus with the
+toolkit. The wrapper handles ARIA wiring, error timing, `role="alert"` vs
 `role="status"`, and hint/counter projection automatically. Angular still owns
 `form()`, `submit()`, validation, and field state — the toolkit removes the UX
 boilerplate around them.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -167,8 +167,10 @@ and [custom wrappers](./CUSTOM_WRAPPERS.md) for third-party design systems.
   `minLength`, …).
 - Put shared contract/shape rules in Zod / OpenAPI Standard Schema via
   `validateStandardSchema()`.
-- Express conditional business policy — and advisory `warn()` guidance — in
-  Vest via `validateVest()`.
+- Express conditional business policy in Vest via `validateVest()`, and
+  advisory `warn()` guidance via
+  `validateVest(path, suite, { includeWarnings: true })` (or
+  `validateVestWarnings()`).
 
 **Don't**
 

--- a/docs/COMPLEX_NESTED_FORMS.md
+++ b/docs/COMPLEX_NESTED_FORMS.md
@@ -63,7 +63,10 @@ surfaces it — use [`validateTree()`](https://angular.dev/guide/forms/signals/c
 without a `fieldTree` keeps it at the group level:
 
 ```typescript
-import { required, validateTree } from '@angular/forms/signals';
+import { signal } from '@angular/core';
+import { form, required, validateTree } from '@angular/forms/signals';
+
+const model = signal({ passwords: { password: '', confirm: '' } });
 
 form(model, (path) => {
   required(path.passwords.password, { message: 'Password is required' });
@@ -165,25 +168,6 @@ root README.
 
 ## Field labels for deep paths
 
-Error summaries on nested forms default to humanized paths:
-
-```text
-ng.form0.address.postalCode  →  Address / Postal code
-facts.0.offenses.1.article   →  Facts / 0 / Offenses / 1 / Article
-```
-
-For long forms this is usually not what you want. Override globally with `provideFieldLabels()`. The map form does an **exact
-path lookup** — it does not support wildcards, so it's best for flat or
-small-group forms:
-
-```typescript
-provideFieldLabels({
-  'address.postalCode': 'Postcode',
-  'address.street': 'Straat',
-  'credentials.confirmPassword': 'Confirm password',
-});
-```
-
 For deeply nested arrays where paths vary by index (`facts.0.offenses.1.article`),
 pass a **factory** that returns a custom resolver and do the pattern matching
 yourself:
@@ -203,9 +187,9 @@ provideFieldLabels(() => (fieldPath) => {
 });
 ```
 
-For i18n, inject your translation service inside the same factory. See the
-[WARNINGS_SUPPORT advanced section](./WARNINGS_SUPPORT.md#advanced-error-flow-and-message-resolution)
-for the full resolver API.
+See [WARNINGS_SUPPORT's field label resolution](./WARNINGS_SUPPORT.md#field-label-resolution)
+for the default humanized-path format, the exact-match map form, and the
+full resolver API — including how to inject a translation service for i18n.
 
 ---
 
@@ -237,9 +221,14 @@ own fieldset so errors aggregate per row:
 }
 ```
 
-> `track $index` plus indexed access (`form.lineItems[i]`) matches the pattern
-> used in the [`complex-forms`](../apps/demo/src/app/04-form-field-wrapper/complex-forms)
-> demo — the toolkit's own reference for array fieldsets.
+> `track $index` plus indexed access (`form.lineItems[i]`) keeps each row's
+> fieldset bound to the correct array element as rows are added or removed.
+> The [`complex-forms`](../apps/demo/src/app/04-form-field-wrapper/complex-forms)
+> demo shows a related but different pattern for its `skills` and `contacts`
+> arrays: one fieldset wraps the whole `@for` loop for array-level
+> aggregation, with a `ngx-form-field-wrapper` per item inside. Reach for a
+> per-row fieldset (as above) when each row needs its own aggregated error
+> feedback instead.
 
 A root `ngx-form-field-error-summary` still picks up every row's errors and
 links to the exact field.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,47 +43,25 @@ The constraint that bites hardest:
 2. Edit its `project.json` and add the appropriate `scope:*` + `type:*` tags.
 3. Run `pnpm nx run-many -t lint` to confirm boundaries hold.
 
-## Demo app budgets
+## Demo app bundle size
 
-> **The toolkit's own size budget lives in `packages/toolkit/ng-package.json`
-> and `packages/toolkit/tsconfig.lib.prod.json`. Do not change it when adding
-> a demo app.** Each demo app gets its own `budgets` block.
+There is currently no automated bundle-size budget for the toolkit package or
+for any `apps/demo-*` app — `packages/toolkit/ng-package.json` only configures
+the `ng-packagr` output path and entry file, and
+`packages/toolkit/tsconfig.lib.prod.json` only sets compiler options; neither
+enforces a size limit, and no workflow or `project.json` in the repo declares
+a `budgets` block.
 
-When adding a new demo app under `apps/demo-*` (e.g. `apps/demo-material`,
-`apps/demo-primeng`, `apps/demo-spartan` per #40), declare its budgets in the
-app's own configuration so the demo's design-system bundle size doesn't
-distort the toolkit's perf signal. Use this template inside the app's build
-target configuration in `apps/demo-<name>/project.json`:
+`apps/demo-material`, `apps/demo-primeng`, and `apps/demo-spartan` are the
+existing reference demo apps (tracked by #40). Their `build` targets use
+`nx:run-commands` wrapping `vite build --mode production` rather than the
+Angular CLI application builder, so the builder's
+`configurations.production.budgets` option has no effect in this workspace —
+adding one to a demo app's `project.json` would be silently ignored.
 
-```jsonc
-{
-  "targets": {
-    "build": {
-      "configurations": {
-        "production": {
-          // ...other production options...
-          "budgets": [
-            {
-              "type": "initial",
-              "maximumWarning": "1mb",
-              "maximumError": "2mb",
-            },
-            {
-              "type": "anyComponentStyle",
-              "maximumWarning": "8kb",
-              "maximumError": "16kb",
-            },
-          ],
-        },
-      },
-    },
-  },
-}
-```
-
-Tune the thresholds per design system. Material apps will run hotter than
-Spartan apps; that's expected. Set the warning at the steady-state size and
-the error 30-50% higher to leave room for new examples.
+If you want to add bundle-size guardrails for a demo app or for the toolkit
+itself, it needs to be a Vite-based mechanism (e.g. a `rollup-plugin-visualizer`
+report or a custom size-check script), not an Angular CLI budgets block.
 
 ## Toolkit isolation guarantees
 

--- a/docs/CSS_FRAMEWORK_INTEGRATION.md
+++ b/docs/CSS_FRAMEWORK_INTEGRATION.md
@@ -291,10 +291,8 @@ Angular Material has its own form infrastructure. When using `mat-form-field`:
 
 ```typescript
 // app.config.ts
-import {
-  provideSignalFormsConfig,
-  NG_STATUS_CLASSES,
-} from '@angular/forms/signals';
+import { provideSignalFormsConfig } from '@angular/forms/signals';
+import { NG_STATUS_CLASSES } from '@angular/forms/signals/compat';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/docs/CUSTOM_CONTROLS.md
+++ b/docs/CUSTOM_CONTROLS.md
@@ -295,7 +295,7 @@ Use whichever import fits your component best:
 
 ## FAQ
 
-### Does RC2 switch alignment support break native switches?
+### Does explicit switch control semantics break existing native switches?
 
 No — not for the normal native switch pattern.
 
@@ -409,8 +409,7 @@ projected control's `id` attribute. For custom and third-party controls,
 **one of these must resolve to a non-empty string** for `aria-describedby`
 linkage to work.
 
-From v1 RC onward, missing identity is handled **gracefully rather than
-fatally**:
+Missing identity is handled **gracefully rather than fatally**:
 
 - `resolvedFieldName()`, `errorId()`, and `warningId()` return `null`.
 - The wrapper, error component, and headless directives skip their

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -268,7 +268,7 @@ return computed signals. None of them read DOM, none of them call `inject()`,
 and none of them know about manual-mode opt-out. That's deliberate: the
 manual-mode escape hatch lives in the directive shell that wires the
 factories, not in the factories themselves. (See
-[ADR-0002](decisions/0002-aria-primitives-as-factories.md) for the rationale.)
+[ADR-0005](decisions/0005-aria-primitives-as-factories.md) for the rationale.)
 
 ### Worked example
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -122,12 +122,11 @@ async onSubmit() {
 
 `reset()` only clears interaction state and (optionally) value — it does not re-run your HTTP load;
 re-fetch and `model.set(...)` if you want server-canonical values back. You can also drive the
-model from `resource()`/`httpResource()` instead of an imperative `set`. There is no dedicated
-fetch→prefill→edit→submit→reset demo yet; the closest are field-state-patterns (prefilled + Reset
-button) and store-binding (store-backed reset).
+model from `resource()`/`httpResource()` instead of an imperative `set` — the server-integration
+demo shows the full fetch→prefill→edit→submit→reset flow with `resource()`.
 
 **See:** [packages/toolkit/README.md](../packages/toolkit/README.md) ·
-[docs/MIGRATING_FROM_NGX_VEST_FORMS.md](./MIGRATING_FROM_NGX_VEST_FORMS.md) ·
+[demo: server-integration](../apps/demo/src/app/05-advanced/server-integration/README.md) ·
 [demo: field-state-patterns](../apps/demo/src/app/05-advanced/field-state-patterns/README.md) ·
 [demo: store-binding](../apps/demo/src/app/05-advanced/store-binding/README.md)
 
@@ -427,14 +426,15 @@ submit(this.form, {
 });
 ```
 
-Show the general (non-field) error as a separate banner/toast from your catch block. If you want the
-error to **auto-clear as the user edits** the field, use the alternative pattern: hold the server
-errors in a signal and read it in a normal `validate(path.email, () => serverErrors()['email'] ?
-{ kind: 'server', message: … } : null)` — `validate()` re-runs on every edit, so the error clears
-itself (there is no `customError()` factory; validators just return `{ kind, message }`). No demo
-exercises the multi-field mapping end-to-end yet.
+An error returned with **no** `fieldTree` attaches to the root — render it as a form-level banner
+by reading `form().errors()`. Submission errors **auto-clear when the owning field's value
+changes**: the email error clears as the user edits email, and a root-attached banner clears on
+_any_ edit (the root's value is the whole model). If you need different clearing behavior, the
+alternative is holding server errors in a signal read by a normal `validate(path.email, () =>
+serverErrors()['email'] ? { kind: 'server', message: … } : null)`, which re-runs on every edit.
+The server-integration demo exercises the full mapping end-to-end.
 
-**See:** [docs/WARNINGS_SUPPORT.md](./WARNINGS_SUPPORT.md) ·
+**See:** [demo: server-integration](../apps/demo/src/app/05-advanced/server-integration/README.md) ·
 [demo: submission-patterns](../apps/demo/src/app/05-advanced/submission-patterns/README.md) ·
 [demo: async-validation](../apps/demo/src/app/05-advanced/async-validation/README.md)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,578 @@
+# FAQ — building real forms with `@ngx-signal-forms/toolkit`
+
+This is a **use-case FAQ**: how do I actually do _X_ when building a form with Angular Signal
+Forms and this toolkit. Each answer is short and links the canonical doc plus a runnable demo. For
+conceptual "what is this / why / how does it differ from Angular's built-ins" questions, see the
+[root README FAQ](../README.md#faq) and [docs/ANGULAR_VS_TOOLKIT.md](./ANGULAR_VS_TOOLKIT.md).
+
+Throughout: primitives like `form`, `submit`, `validate`, `hidden`, `disabled`, `debounce`,
+`validateHttp`, `validateStandardSchema`, `applyEach`, and the control contracts are **Angular
+core** (`@angular/forms/signals`); everything else is the **toolkit**
+(`@ngx-signal-forms/toolkit` and its `/form-field`, `/assistive`, `/headless`, `/vest`, `/testing`
+entry points).
+
+## Table of contents
+
+- **[Getting started](#getting-started)**
+  - [How do I show validation errors only after the user leaves a field (on blur) instead of while they type?](#how-do-i-show-validation-errors-only-after-the-user-leaves-a-field-on-blur-instead-of-while-they-type)
+  - [How do I wire up a `<select>`, a radio group, and a checkbox group with `[formField]`?](#how-do-i-wire-up-a-select-a-radio-group-and-a-checkbox-group-with-formfield)
+- **[Errors, submit & UX](#errors-submit--ux)**
+  - [How do I reset my form after a successful submit, and prefill it from an HTTP call?](#how-do-i-reset-my-form-after-a-successful-submit-and-prefill-it-from-an-http-call)
+  - [How do I disable the submit button while the form is invalid or a submit is in flight?](#how-do-i-disable-the-submit-button-while-the-form-is-invalid-or-a-submit-is-in-flight)
+  - [What does `createOnInvalidHandler()` do on a failed submit, and can I customize it?](#what-does-createoninvalidhandler-do-on-a-failed-submit-and-can-i-customize-it)
+  - [Can I set the error-display strategy once app-wide and override it per form or per field?](#can-i-set-the-error-display-strategy-once-app-wide-and-override-it-per-form-or-per-field)
+- **[Custom controls & design systems](#custom-controls--design-systems)**
+  - [How do I make my own design-system inputs work inside the wrapper (aria-invalid, aria-describedby, error timing)?](#how-do-i-make-my-own-design-system-inputs-work-inside-the-wrapper-aria-invalid-aria-describedby-error-timing)
+  - [We don't want the toolkit's wrapper markup at all — how do I build my own with the headless APIs?](#we-dont-want-the-toolkits-wrapper-markup-at-all--how-do-i-build-my-own-with-the-headless-apis)
+  - [How do I theme the built-in wrapper with our brand tokens?](#how-do-i-theme-the-built-in-wrapper-with-our-brand-tokens)
+  - [How do I integrate a third-party datepicker (value/change API, not a native input)?](#how-do-i-integrate-a-third-party-datepicker-valuechange-api-not-a-native-input)
+- **[Complex & dynamic forms](#complex--dynamic-forms)**
+  - [How do I build a dynamic form array (e.g. invoice line items you can add/remove)?](#how-do-i-build-a-dynamic-form-array-eg-invoice-line-items-you-can-addremove)
+  - [How do I hide/disable a group of fields based on another field, so hidden fields stop blocking validity?](#how-do-i-hidedisable-a-group-of-fields-based-on-another-field-so-hidden-fields-stop-blocking-validity)
+  - [For a multi-step wizard, how do I validate only the current step before "Next", with one form model?](#for-a-multi-step-wizard-how-do-i-validate-only-the-current-step-before-next-with-one-form-model)
+  - [How do I two-way sync my form model with an NgRx SignalStore without update loops?](#how-do-i-two-way-sync-my-form-model-with-an-ngrx-signalstore-without-update-loops)
+- **[Validation](#validation)**
+  - [How do I do debounced async validation (e.g. username availability) and show the pending state?](#how-do-i-do-debounced-async-validation-eg-username-availability-and-show-the-pending-state)
+  - [After submit my API returns field errors like `{ email: 'already taken' }` — how do I map them onto fields?](#after-submit-my-api-returns-field-errors-like--email-already-taken---how-do-i-map-them-onto-fields)
+  - [How do I reuse a Zod schema as the validation source, and how do Zod issues become field errors?](#how-do-i-reuse-a-zod-schema-as-the-validation-source-and-how-do-zod-issues-become-field-errors)
+  - [Can I keep my existing Vest suites, and how do warnings map onto the toolkit?](#can-i-keep-my-existing-vest-suites-and-how-do-warnings-map-onto-the-toolkit)
+- **[i18n, a11y & testing](#i18n-a11y--testing)**
+  - [How do I translate error messages and field labels with Transloco/`$localize`?](#how-do-i-translate-error-messages-and-field-labels-with-translocolocalize)
+  - [How do I render an accessible error summary that links to each invalid field on submit?](#how-do-i-render-an-accessible-error-summary-that-links-to-each-invalid-field-on-submit)
+  - [How do I unit-test a form component (set value, touch, assert rendered error + `aria-invalid`) in Vitest/TestBed?](#how-do-i-unit-test-a-form-component-set-value-touch-assert-rendered-error--aria-invalid-in-vitesttestbed)
+- **[Migration](#migration)**
+  - [I'm migrating from Reactive Forms — what replaces `setValue`/`patchValue`, `valueChanges`, `markAllAsTouched`, and `ValidatorFn`, and can I migrate one form at a time?](#im-migrating-from-reactive-forms--what-replaces-setvaluepatchvalue-valuechanges-markallastouched-and-validatorfn-and-can-i-migrate-one-form-at-a-time)
+
+---
+
+## Getting started
+
+### How do I show validation errors only after the user leaves a field (on blur) instead of while they type?
+
+You already have it — the toolkit's built-in default is `'on-touch'`, so a plain
+`ngx-form-field-wrapper` shows a field's errors only after that field is blurred. No configuration
+needed. If a field shows errors _while typing_, something upstream set `'immediate'`. The three
+values are `'immediate'` (while typing), `'on-touch'` (after blur), `'on-submit'` (after a submit
+attempt), resolved most-specific-first: field input → form directive → component provider → app
+provider → built-in default. To be explicit or override, set `strategy` on the wrapper or
+`errorStrategy` on the form directive:
+
+```html
+<form [formRoot]="userForm" ngxSignalForm errorStrategy="on-touch">
+  <ngx-form-field-wrapper [formField]="userForm.email" strategy="on-submit"
+    >…</ngx-form-field-wrapper
+  >
+</form>
+```
+
+Warnings have an independent `warningStrategy` (default `'immediate'`) that this doesn't affect.
+
+**See:** [docs/BEST_PRACTICES.md](./BEST_PRACTICES.md) ·
+[packages/toolkit/form-field/README.md](../packages/toolkit/form-field/README.md) ·
+[demo: error-display-modes](../apps/demo/src/app/02-toolkit-core/error-display-modes/README.md) ·
+[demo: your-first-form](../apps/demo/src/app/01-getting-started/your-first-form/README.md)
+
+### How do I wire up a `<select>`, a radio group, and a checkbox group with `[formField]`?
+
+A native `<select>` needs zero extra wiring — bind `[formField]="form.x"` and wrap it in
+`<ngx-form-field-wrapper>` exactly like a text `<input>`; `<input>`, `<textarea>`, and `<select>`
+are the default native families that get auto-ARIA (`aria-invalid`/`aria-required`/
+`aria-describedby`) identically. For a **radio or checkbox group**, bind every input to the _same_
+`[formField]="form.field"` (distinct `value`s, `name` for radios) inside one wrapper, and use a
+neutral `<span ngxFormFieldLabel>` instead of `<label>` since the wrapper labels the group
+container. The wrapper auto-detects the cluster and applies group-level ARIA and error styling —
+the UX contract matches a text field even though the plumbing is group-level, not per-input. A
+_single_ boolean checkbox (not a group) needs `ngxSignalFormControl="checkbox"` (or `"switch"`) so
+the wrapper treats it as that family.
+
+**See:** [packages/toolkit/form-field/README.md](../packages/toolkit/form-field/README.md) ·
+[docs/CUSTOM_CONTROLS.md](./CUSTOM_CONTROLS.md) ·
+[demo: complex-forms](../apps/demo/src/app/04-form-field-wrapper/complex-forms/README.md) ·
+[demo: custom-controls](../apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md)
+
+---
+
+## Errors, submit & UX
+
+### How do I reset my form after a successful submit, and prefill it from an HTTP call?
+
+The model `signal` you pass into `form(model, schema)` is the single source of truth, so both
+operations are just writes to (or resets of) that state.
+
+- **Prefill from HTTP:** load the record, then `model.set(record)`. Because the model is the
+  source of truth, prefer building the whole object once and setting it, rather than patching
+  field-by-field.
+- **Reset after submit:** Angular's `FieldState.reset(value?)` clears `touched`/`dirty` on the
+  field and its descendants; pass a value to also set the model back to a known state. Call it on
+  the root: `this.form().reset(initialValues)`.
+
+```ts
+readonly #model = signal<Profile>(EMPTY_PROFILE);
+protected readonly form = form(this.#model, profileSchema);
+
+async load(id: string) {
+  this.#model.set(await firstValueFrom(this.http.get<Profile>(`/api/profile/${id}`))); // prefill
+}
+
+async onSubmit() {
+  const ok = await submit(this.form, { action: async (f) => { /* … */ } });
+  if (ok) this.form().reset(this.#model()); // clear touched/dirty, keep saved values
+}
+```
+
+`reset()` only clears interaction state and (optionally) value — it does not re-run your HTTP load;
+re-fetch and `model.set(...)` if you want server-canonical values back. You can also drive the
+model from `resource()`/`httpResource()` instead of an imperative `set`. There is no dedicated
+fetch→prefill→edit→submit→reset demo yet; the closest are field-state-patterns (prefilled + Reset
+button) and store-binding (store-backed reset).
+
+**See:** [packages/toolkit/README.md](../packages/toolkit/README.md) ·
+[docs/MIGRATING_FROM_NGX_VEST_FORMS.md](./MIGRATING_FROM_NGX_VEST_FORMS.md) ·
+[demo: field-state-patterns](../apps/demo/src/app/05-advanced/field-state-patterns/README.md) ·
+[demo: store-binding](../apps/demo/src/app/05-advanced/store-binding/README.md)
+
+### How do I disable the submit button while the form is invalid or a submit is in flight?
+
+For a plain form, Angular Signal Forms gives you the two signals directly — no toolkit helper
+needed. `submitting()` is native Angular state that is `true` for the duration of a running
+`submit()` action:
+
+```html
+<button
+  type="submit"
+  [disabled]="userForm().invalid() || userForm().submitting()"
+>
+  Save
+</button>
+```
+
+If your form uses **non-blocking warnings**, don't hand-roll the gating — use the toolkit's
+`canSubmitWithWarnings(form)`, which returns a `Signal<boolean>` that is `false` while
+`submitting()` or `pending()` is true _and_ while any **blocking** error remains, but lets
+warning-only forms through:
+
+```html
+<button type="submit" [disabled]="!canSubmit()">Save</button>
+```
+
+```ts
+protected readonly canSubmit = canSubmitWithWarnings(this.userForm);
+```
+
+Pair it with `submitWithWarnings(form, action)` in the click handler — it marks all fields touched,
+waits for validation to settle, guards against double-submits, and runs `action` only when no
+blocking errors remain.
+
+**See:** [docs/BEST_PRACTICES.md](./BEST_PRACTICES.md) ·
+[docs/WARNINGS_SUPPORT.md](./WARNINGS_SUPPORT.md) ·
+[docs/ANGULAR_VS_TOOLKIT.md](./ANGULAR_VS_TOOLKIT.md) ·
+[demo: submission-patterns](../apps/demo/src/app/05-advanced/submission-patterns/README.md)
+
+### What does `createOnInvalidHandler()` do on a failed submit, and can I customize it?
+
+It builds the `onInvalid` callback for `form(model, schema, { submission: { action, onInvalid } })`.
+On a failed submit it focuses the **first invalid, interactive field** (internally
+`focusFirstInvalid(form)`), deliberately skipping errors on hidden/disabled fields and orphan
+errors with no field. It _is_ customizable via an options object: `focusFirstInvalid` (default
+`true`; set `false` to suppress auto-focus) and `afterInvalid: (field) => void` (runs after focus —
+e.g. announce a message or scroll):
+
+```ts
+onInvalid: createOnInvalidHandler({
+  afterInvalid: () => this.announce('Please fix the errors'),
+});
+```
+
+For fully custom behavior, skip the helper and write your own `onInvalid`, optionally calling
+`focusFirstInvalid(form)` yourself.
+
+**See:** [packages/toolkit/README.md](../packages/toolkit/README.md) ·
+[demo: submission-patterns](../apps/demo/src/app/05-advanced/submission-patterns/README.md)
+
+### Can I set the error-display strategy once app-wide and override it per form or per field?
+
+Yes. Set the default with `provideNgxSignalFormsConfig({ defaultErrorStrategy: 'on-touch' })` in
+your app config. Every presentation setting resolves through one precedence chain (most specific
+wins): field/component input → form directive (`ngxSignalForm`) → component-scoped provider
+(`provideNgxSignalFormsConfigForComponent`) → app provider → built-in default. So: override a whole
+form with `errorStrategy` on `<form [formRoot] ngxSignalForm>`, a single field with `strategy` on
+`<ngx-form-field-wrapper>`, or a feature subtree with the `…ForComponent` provider. All accept the
+same `ErrorDisplayStrategy` values (`'immediate' | 'on-touch' | 'on-submit' | 'inherit'`);
+`'inherit'` (or omitting the input) falls through to the next tier.
+
+**See:** [packages/toolkit/README.md](../packages/toolkit/README.md) ·
+[demo: global-configuration](../apps/demo/src/app/05-advanced/global-configuration/README.md) ·
+[demo: error-display-modes](../apps/demo/src/app/02-toolkit-core/error-display-modes/README.md)
+
+---
+
+## Custom controls & design systems
+
+### How do I make my own design-system inputs work inside the wrapper (aria-invalid, aria-describedby, error timing)?
+
+Implement Angular Signal Forms' native control contracts on your components, then project them
+inside `ngx-form-field-wrapper` like any input. A value-bearing control (text field, dropdown)
+implements `FormValueControl<T>` — expose `value = model<T>()`, optionally `touch = output()`, a
+`focus()` method, and `disabled`/`invalid` signal inputs (no ControlValueAccessor). A toggle
+implements `FormCheckboxControl` (`checked = model(false)`), or just wrap a native
+`input[type=checkbox][role=switch]`. Bind with `[formField]="form.x"`; `NgxSignalFormAutoAria` then
+writes `aria-invalid`/`aria-required`/`aria-describedby` on the bound host. If your widget already
+manages its own ARIA (common when the focusable element is buried in its template), opt the host
+out with `ngxSignalFormControlAria="manual"` and use `appearance="plain"` so the wrapper still
+supplies label/hint/error content without fighting the widget. Give the control a stable `id` (or
+set `fieldName` on the wrapper) so error/warning IDs resolve, and import
+`NgxSignalFormToolkit`/`NgxSignalFormAutoAria` in the component that renders the `[formField]` host
+(standalone imports are template-scoped).
+
+**See:** [docs/CUSTOM_CONTROLS.md](./CUSTOM_CONTROLS.md) ·
+[packages/toolkit/form-field/README.md](../packages/toolkit/form-field/README.md) ·
+[demo: custom-controls](../apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md)
+
+### We don't want the toolkit's wrapper markup at all — how do I build my own with the headless APIs?
+
+The `/headless` entry point is exactly this. Import from
+`@ngx-signal-forms/toolkit/headless`: apply `[ngxHeadlessErrorState]` to your wrapper element for
+`hasErrors()`, `shouldShowErrors()`, `resolvedErrors()`, and stable `errorId`/`warningId` signals —
+or call `createErrorMessageSignal(() => form.field, { fieldName })` directly with no directive at
+all. `[ngxHeadlessFieldset]` aggregates errors/touched/dirty/pending across descendant fields;
+`createErrorState`, `createCharacterCount`, and `createFieldStateFlags` are plain factories for the
+same state. You render 100% of the markup and wire ARIA yourself from those signals — nothing is
+rendered for you, and everything composes via `hostDirectives`. For ARIA you can either use
+`NgxSignalFormAutoAria` or compose it yourself from the pure factories `createAriaInvalidSignal`,
+`createAriaRequiredSignal`, `createAriaDescribedBySignal`, and `createHintIdsSignal`.
+
+**See:** [packages/toolkit/headless/README.md](../packages/toolkit/headless/README.md) ·
+[docs/CUSTOM_WRAPPERS.md](./CUSTOM_WRAPPERS.md) ·
+[demo: error-message-signal](../apps/demo/src/app/03-headless/error-message-signal/README.md) ·
+[demo: fieldset-utilities](../apps/demo/src/app/03-headless/fieldset-utilities/README.md)
+
+### How do I theme the built-in wrapper with our brand tokens?
+
+Entirely through CSS custom properties — no forking, and you never touch the `:has()`-based
+`appearance="outline"` selectors directly. Start with the semantic scale on `ngx-form-field-wrapper`
+(`--ngx-form-field-color-primary`, `-color-error`, `-color-warning`, `-color-border`, …); overriding
+these cascades into focus rings, borders, and backgrounds. Two prefixes exist:
+`--ngx-form-field-*` for wrapper chrome and `--ngx-signal-form-*` for cross-cutting feedback text
+(error/warning color/background shared by every helper surface). THEMING.md has ready-made "match my
+brand", Bootstrap/Tailwind mapping, and dark-mode recipes. This is a deep topic; treat the guide as
+canonical rather than re-deriving tokens.
+
+**See:** [packages/toolkit/form-field/THEMING.md](../packages/toolkit/form-field/THEMING.md) ·
+[docs/MIGRATING_CSS_VARS.md](./MIGRATING_CSS_VARS.md) ·
+[docs/CSS_FRAMEWORK_INTEGRATION.md](./CSS_FRAMEWORK_INTEGRATION.md)
+
+### How do I integrate a third-party datepicker (value/change API, not a native input)?
+
+Write a thin adapter that implements `FormValueControl<Date | null>` on your datepicker host:
+expose `value = model<Date | null>(null)` and sync it to/from the third-party widget's own
+value/change events, add a `focus()` method (needed for `focusFirstInvalid()` and error-summary
+navigation), and optional `touch`/`disabled`/`invalid`. Bind it with the standard
+`[formField]="form.birthDate"`. Because the widget owns its own visuals and ARIA, pair it with
+`ngxSignalFormControlAria="manual"` and `appearance="plain"` so the toolkit supplies label/hint/
+error content and field-identity IDs without clashing. Handle any type mismatch (e.g. `Date` vs
+ISO string) inside the adapter's read/write path. There is no runnable datepicker demo yet — the
+adapter pattern generalizes from the `FormValueControl` examples in custom-controls; the Material
+app's README also notes date-picker ARIA gotchas.
+
+**See:** [docs/CUSTOM_CONTROLS.md](./CUSTOM_CONTROLS.md) ·
+[demo: custom-controls](../apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md) ·
+[demo-material README](../apps/demo-material/README.md)
+
+---
+
+## Complex & dynamic forms
+
+### How do I build a dynamic form array (e.g. invoice line items you can add/remove)?
+
+Keep the array in your model signal — add/remove is just a `signal.update(rows => [...])`
+mutation; there's no special array API. Loop with `@for`, wrap each row in its own
+`<ngx-form-fieldset [field]="form.lineItems[i]">` so errors aggregate per row, and put
+`<ngx-form-field-wrapper [formField]="form.lineItems[i].description">` inside it. Per-row validation
+is Angular Signal Forms' job: use `applyEach(path.lineItems, (row) => validate(row.qty, …))` (or
+`validateStandardSchema`) in the schema; the toolkit layers display/ARIA on top and inherits the
+error strategy so you don't re-wire it per row.
+
+```html
+@for (item of form.lineItems; track $index; let i = $index) {
+<ngx-form-fieldset [field]="form.lineItems[i]">
+  <ngx-form-field-wrapper [formField]="form.lineItems[i].description">
+    <input
+      [id]="'line-' + i + '-desc'"
+      [formField]="form.lineItems[i].description"
+    />
+  </ngx-form-field-wrapper>
+</ngx-form-fieldset>
+}
+```
+
+A root `<ngx-form-field-error-summary [formTree]="form">` still collects every row's errors and
+deep-links to the field. Index-based IDs/labels recompute consistently on insert/remove; the docs
+don't yet call out a keyed (stable-row-id) alternative if you delete from the middle a lot.
+
+**See:** [docs/COMPLEX_NESTED_FORMS.md](./COMPLEX_NESTED_FORMS.md) ·
+[demo: complex-forms](../apps/demo/src/app/04-form-field-wrapper/complex-forms/README.md)
+
+### How do I hide/disable a group of fields based on another field, so hidden fields stop blocking validity?
+
+Use Angular Signal Forms' native `hidden(path, { when })` and `disabled(path, { when })` schema
+rules from `@angular/forms/signals`, applied at whatever level you want — a single field or a whole
+nested object path:
+
+```ts
+form(model, (path) => {
+  hidden(path.shippingAddress, {
+    when: ({ valueOf }) => valueOf(path.sameAsBilling),
+  });
+});
+```
+
+A `hidden()` subtree is excluded from the parent's validity computation, so its empty/invalid
+required fields no longer block `form().valid()` or `submit()` — this is core Signal Forms behavior,
+not something the toolkit re-implements. On the UI side `NgxFormFieldWrapper` mirrors `hidden()` to
+the host's `[hidden]` attribute, and `focusFirstInvalid()`/auto-ARIA automatically skip
+hidden/disabled fields. The field-state-patterns demo shows the shared `{ when }` syntax on leaf
+fields; applying it to a whole nested group isn't demoed yet but works identically.
+
+**See:** [demo: field-state-patterns](../apps/demo/src/app/05-advanced/field-state-patterns/README.md) ·
+[docs/BEST_PRACTICES.md](./BEST_PRACTICES.md) ·
+[docs/VALIDATION_STRATEGY.md](./VALIDATION_STRATEGY.md)
+
+### For a multi-step wizard, how do I validate only the current step before "Next", with one form model?
+
+Keep one `form()` model spanning all steps, bind each step's template to its slice, and gate
+navigation on that slice's validity. The reusable wizard component fires a `(stepChange)` event
+_before_ the step changes; validate the step being left and call `event.preventDefault()` to cancel:
+
+```ts
+async onStepChange(event: WizardNavigationEvent) {
+  if (event.toIndex > event.fromIndex) {
+    this.form.step1().markAsTouched();            // surface this step's errors
+    if (this.form.step1().invalid()) event.preventDefault();
+  }
+}
+```
+
+Run whole-form validation at the end by touching everything (`submit()` marks all fields touched
+internally) before the final action. Honest gap: the maintained `advanced-wizard` demo uses a
+_form-per-step_ + NgRx architecture rather than one shared model, so treat it as a reference for
+step orchestration, not for the single-model pattern above.
+
+**See:** [demo: wizard component](../apps/demo/src/app/shared/wizard/README.md) ·
+[demo: advanced-wizard](../apps/demo/src/app/05-advanced/advanced-wizard/README.md)
+
+### How do I two-way sync my form model with an NgRx SignalStore without update loops?
+
+Use `linkedSignal({ source, computation })` as the **read** seam (projects the store slice into a
+writable handle that re-evaluates when the store changes) and route all **writes** through
+`patchState`/store methods — not the linked signal's own `.set`. Do **not** mirror form and store
+with `effect()`; that's the loop-causing anti-pattern the read/write seam replaces. For large forms
+that need cancelable editing, use the draft/commit variant instead: bind the form to a draft copy
+and `commit()` draft→committed on save. The store-binding demo is the runnable live-sync reference
+(keystroke sync + a "simulate remote sync" round-trip); advanced-wizard shows draft/commit.
+
+**See:** [demo: store-binding](../apps/demo/src/app/05-advanced/store-binding/README.md) ·
+[demo: advanced-wizard](../apps/demo/src/app/05-advanced/advanced-wizard/README.md) ·
+[docs/COMPLEX_NESTED_FORMS.md](./COMPLEX_NESTED_FORMS.md)
+
+---
+
+## Validation
+
+### How do I do debounced async validation (e.g. username availability) and show the pending state?
+
+Use Angular Signal Forms' async primitives inside the schema, not manual RxJS. `debounce(path.field,
+ms)` throttles re-validation, and `validateHttp(path, { request, onSuccess, onError })` fires the
+request and auto-cancels stale in-flight calls when the value changes — no `switchMap` needed:
+
+```ts
+form(model, (path) => {
+  debounce(path.username, 300);
+  validateHttp(path.username, {
+    request: ({ value }) => `/api/username-available?u=${value()}`,
+    onError: () => ({ kind: 'taken', message: 'Username is taken' }),
+  });
+});
+```
+
+The field exposes a `pending()` signal; project a loading indicator into the wrapper's `<span
+suffix>` slot with `@if (form.username().pending())`, and disable submit while `pending()` is true.
+The async-validation demo is the canonical runnable reference.
+
+**See:** [demo: async-validation](../apps/demo/src/app/05-advanced/async-validation/README.md) ·
+[docs/VALIDATION_STRATEGY.md](./VALIDATION_STRATEGY.md)
+
+### After submit my API returns field errors like `{ email: 'already taken' }` — how do I map them onto fields?
+
+The real mechanism Angular supports is the submission **action's return value**: an action returns
+`Promise<TreeValidationResult>`, which is either "success" (`null`/`undefined`) or one-or-many
+validation errors, and each error may carry a `fieldTree` pointing at the field it belongs to. So a
+caught server response becomes per-field errors by returning them from the action:
+
+```ts
+submit(this.form, {
+  action: async (form) => {
+    try {
+      await this.api.save(form().value());
+      return; // success
+    } catch (e) {
+      // e.fieldErrors === { email: 'already taken', … }
+      return Object.entries(e.fieldErrors).map(([key, message]) => ({
+        kind: 'server',
+        message,
+        fieldTree: (form as Record<string, any>)[key](), // target the field
+      }));
+    }
+  },
+});
+```
+
+Show the general (non-field) error as a separate banner/toast from your catch block. If you want the
+error to **auto-clear as the user edits** the field, use the alternative pattern: hold the server
+errors in a signal and read it in a normal `validate(path.email, () => serverErrors()['email'] ?
+{ kind: 'server', message: … } : null)` — `validate()` re-runs on every edit, so the error clears
+itself (there is no `customError()` factory; validators just return `{ kind, message }`). No demo
+exercises the multi-field mapping end-to-end yet.
+
+**See:** [docs/WARNINGS_SUPPORT.md](./WARNINGS_SUPPORT.md) ·
+[demo: submission-patterns](../apps/demo/src/app/05-advanced/submission-patterns/README.md) ·
+[demo: async-validation](../apps/demo/src/app/05-advanced/async-validation/README.md)
+
+### How do I reuse a Zod schema as the validation source, and how do Zod issues become field errors?
+
+You don't need a toolkit adapter — Angular Signal Forms has native Standard Schema support (Zod,
+Valibot, ArkType). Call `validateStandardSchema(path, yourZodSchema)` once at the **root** path
+inside your `form(model, (path) => {…})` callback; Zod validates the whole tree, its `issues[].path`
+map to the matching nested fields, and each issue's `.message` becomes that field's error (rendered
+by `ngx-form-field-wrapper`/`ngx-form-field-error`). It composes with Angular's own validators and
+with `validateVest(...)` on the same path. One gotcha: Standard Schema can't expose which keys are
+required, so `aria-required`/the required marker won't fire for Zod-required fields unless you also
+call the toolkit's `requiredFromStandardSchema(path.field, zodSchema)` per field.
+
+**See:** [docs/VALIDATION_STRATEGY.md](./VALIDATION_STRATEGY.md) ·
+[demo: zod-validation](../apps/demo/src/app/05-advanced/zod-validation/README.md) ·
+[demo: zod-vest-validation](../apps/demo/src/app/05-advanced/zod-vest-validation/README.md)
+
+### Can I keep my existing Vest suites, and how do warnings map onto the toolkit?
+
+Yes — your `test()`/`enforce()`/`warn()` bodies carry over almost unchanged; the required step is
+upgrading Vest 5.x → 6.x first (the `/vest` adapter needs Vest 6, which implements Standard Schema).
+Drop the `ngxVestForm`/`ngModel`/`validationConfig` shell and instead call `validateVest(path, suite,
+{ includeWarnings: true })` inside your `form(...)` schema (or `validateStandardSchema(path, suite)`
+if you only need blocking validation). Angular Signal Forms has no native non-blocking concept, so
+the toolkit maps Vest `warn()` results to errors with a `warn:vest:` kind prefix, rendered with
+`role="status"` and an independent `warningStrategy`. Because Signal Forms still counts warnings
+toward `invalid()`, submit warning-only forms via `canSubmitWithWarnings`/`submitWithWarnings` (or
+`hasOnlyWarnings(form().errorSummary())` with `submission: { ignoreValidators: 'all' }`).
+
+**See:** [docs/MIGRATING_FROM_NGX_VEST_FORMS.md](./MIGRATING_FROM_NGX_VEST_FORMS.md) ·
+[docs/WARNINGS_SUPPORT.md](./WARNINGS_SUPPORT.md) ·
+[packages/toolkit/vest/README.md](../packages/toolkit/vest/README.md) ·
+[demo: vest-validation](../apps/demo/src/app/05-advanced/vest-validation/README.md)
+
+---
+
+## i18n, a11y & testing
+
+### How do I translate error messages and field labels with Transloco/`$localize`?
+
+Both go through provider factories that you can wire to your translation service.
+`provideErrorMessages(factory)` registers a message registry (keys are camelCase error kinds, values
+are a string or `(params) => string`); `provideFieldLabels(factory)` does the same for field
+labels/paths. Use the factory form so you can `inject()` your translation service:
+
+```ts
+provideFieldLabels(() => {
+  const t = inject(TranslateService);
+  return (path) => t.instant(`fields.${path}`) || humanizeFieldPath(path);
+});
+```
+
+Validators keep emitting plain `{ kind, message }`; the toolkit resolves display text via a 3-tier
+cascade (validator `message` → registry → built-in fallback), exposed declaratively
+(`ngx-form-field-error`, wrapper) and programmatically (`createErrorMessageSignal`,
+`resolveValidationErrorMessage`). Honest gaps: the worked i18n example in the docs is written for
+`provideFieldLabels` (apply the same shape to `provideErrorMessages`), there is no i18n demo, and
+whether an already-rendered message re-renders on a runtime language switch is not documented as a
+guarantee.
+
+**See:** [docs/WARNINGS_SUPPORT.md](./WARNINGS_SUPPORT.md) ·
+[packages/toolkit/README.md](../packages/toolkit/README.md) ·
+[packages/toolkit/headless/README.md](../packages/toolkit/headless/README.md)
+
+### How do I render an accessible error summary that links to each invalid field on submit?
+
+There's a built-in primitive — don't build it from raw signals. Use `<ngx-form-field-error-summary
+[formTree]="form" summaryLabel="…" />` from `@ngx-signal-forms/toolkit/assistive` (or the headless
+`ngxHeadlessErrorSummary` if you want to own the markup). It aggregates every invalid field, renders
+as an assertive `role="alert"` live region when strategy-visible, and its entries move focus to the
+matching control on click. Pair it with `submission: { onInvalid: createOnInvalidHandler() }` and the
+`[formRoot] ngxSignalForm` directive, which handle `preventDefault`, submitting state, and focusing
+the first invalid field. Use `provideFieldLabels()` to turn raw paths into human/translated names in
+the summary.
+
+**See:** [packages/toolkit/assistive/README.md](../packages/toolkit/assistive/README.md) ·
+[demo: submission-patterns](../apps/demo/src/app/05-advanced/submission-patterns/README.md) ·
+[demo: fieldset-utilities](../apps/demo/src/app/03-headless/fieldset-utilities/README.md)
+
+### How do I unit-test a form component (set value, touch, assert rendered error + `aria-invalid`) in Vitest/TestBed?
+
+Render the component with TestBed, drive state through the model signal and the field's own methods,
+then assert on the toolkit's documented, stable id/attribute contract: error containers use
+`{fieldName}-error`, and the bound input carries `aria-invalid="true"` and an `aria-describedby`
+that chains to that id. Blocking errors render inside a `role="alert"` element.
+
+```ts
+const fixture = TestBed.createComponent(LoginForm);
+const cmp = fixture.componentInstance;
+
+cmp.model.update((m) => ({ ...m, email: 'not-an-email' })); // set value
+cmp.form.email().markAsTouched(); // trigger 'on-touch' visibility
+fixture.detectChanges();
+await fixture.whenStable();
+
+const input = fixture.nativeElement.querySelector('#email');
+expect(input.getAttribute('aria-invalid')).toBe('true');
+expect(fixture.nativeElement.querySelector('#email-error')).toHaveTextContent(
+  /valid email/i,
+);
+```
+
+To assert a submit-time path, call Angular's `submit(cmp.form, { action })` (it marks every field
+touched). For accessibility, the toolkit ships `expectNoA11yViolations()` from
+`@ngx-signal-forms/toolkit/testing` (axe-core WCAG 2.2 AA) for use in a Vitest browser-mode spec
+after rendering a fixture. Honest gap: no dedicated component-testing guide or example spec exists
+yet — the mechanics above are assembled from the id/ARIA contract plus Angular's own testing
+conventions.
+
+**See:** [packages/toolkit/README.md](../packages/toolkit/README.md) ·
+[packages/toolkit/headless/README.md](../packages/toolkit/headless/README.md) ·
+[docs/decisions/0004-wcag22-testing-strategy.md](./decisions/0004-wcag22-testing-strategy.md)
+
+---
+
+## Migration
+
+### I'm migrating from Reactive Forms — what replaces `setValue`/`patchValue`, `valueChanges`, `markAllAsTouched`, and `ValidatorFn`, and can I migrate one form at a time?
+
+Mappings (Signal Forms + this toolkit):
+
+- **`setValue`/`patchValue`** → write the model signal: `model.set(next)` / `model.update(m => …)`.
+  The model is the source of truth.
+- **`valueChanges`** → read the model reactively: `computed(() => model())`, or `effect(() =>
+someside(model()))`.
+- **`markAllAsTouched`** → `form().markAsTouched()` cascades to every descendant; Angular's
+  `submit()` also marks everything touched internally.
+- **custom `ValidatorFn`** → schema functions: `validate()`/`validateAsync()` for sync/async field
+  rules, `validateStandardSchema()` for Zod/contract schemas, `validateVest()` for business policy.
+- **coexistence** → `compatForm()` (from `@angular/forms/signals/compat`) lets a Signal Form model
+  embed existing Reactive `FormControl` instances as leaf values, so you can absorb Reactive
+  controls incrementally rather than rewrite a whole form at once.
+
+Honest gap: there is **no dedicated Reactive Forms migration guide or demo** yet (the existing
+migration docs cover ngx-vest-forms and the toolkit beta→v1), and `compatForm()` has no worked
+example in this repo — the mappings above are the pattern, verified against the Angular 22 types.
+
+**See:** [../README.md](../README.md) ·
+[docs/ANGULAR_VS_TOOLKIT.md](./ANGULAR_VS_TOOLKIT.md) ·
+[docs/VALIDATION_STRATEGY.md](./VALIDATION_STRATEGY.md) ·
+[docs/ANGULAR_PUBLIC_API_POLICY.md](./ANGULAR_PUBLIC_API_POLICY.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -339,16 +339,19 @@ fields; applying it to a whole nested group isn't demoed yet but works identical
 ### For a multi-step wizard, how do I validate only the current step before "Next", with one form model?
 
 Keep one `form()` model spanning all steps, bind each step's template to its slice, and gate
-navigation on that slice's validity. The reusable wizard component fires a `(stepChange)` event
-_before_ the step changes; validate the step being left and call `event.preventDefault()` to cancel:
+navigation on that slice's validity. The reusable wizard component's async-aware guard is the
+`canNavigate` input (`(event) => boolean | Promise<boolean>`) — return `false` to block. Don't use
+`(stepChange)` + `event.preventDefault()` for validation: `preventDefault()` is only respected
+synchronously, so an `await` before it is too late. Validate the slice of the step being _left_:
 
 ```ts
-async onStepChange(event: WizardNavigationEvent) {
-  if (event.toIndex > event.fromIndex) {
-    this.form.step1().markAsTouched();            // surface this step's errors
-    if (this.form.step1().invalid()) event.preventDefault();
-  }
-}
+// <ngx-wizard [canNavigate]="guardStep" …>
+protected readonly guardStep: WizardCanNavigate = (event) => {
+  if (event.toIndex <= event.fromIndex) return true; // always allow going back
+  const step = this.formForStep(event.fromStep);     // step id → form slice (e.g. form.account)
+  step().markAsTouched();                            // surface this step's errors
+  return step().valid();
+};
 ```
 
 Run whole-form validation at the end by touching everything (`submit()` marks all fields touched

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -414,12 +414,13 @@ submit(this.form, {
     try {
       await this.api.save(form().value());
       return; // success
-    } catch (e) {
-      // e.fieldErrors === { email: 'already taken', … }
-      return Object.entries(e.fieldErrors).map(([key, message]) => ({
+    } catch (err) {
+      const { fieldErrors } = err as ApiError; // { email: 'already taken', … }
+      // `fieldTree` targets the field itself (form.email), not its state (form.email()).
+      return Object.entries(fieldErrors).map(([field, message]) => ({
         kind: 'server',
         message,
-        fieldTree: (form as Record<string, any>)[key](), // target the field
+        fieldTree: form[field as keyof Profile],
       }));
     }
   },
@@ -558,8 +559,8 @@ Mappings (Signal Forms + this toolkit):
 
 - **`setValue`/`patchValue`** → write the model signal: `model.set(next)` / `model.update(m => …)`.
   The model is the source of truth.
-- **`valueChanges`** → read the model reactively: `computed(() => model())`, or `effect(() =>
-someside(model()))`.
+- **`valueChanges`** → read the model reactively: `computed(() => model())`, or run a side effect
+  with `effect(() => this.autosave(model()))`.
 - **`markAllAsTouched`** → `form().markAsTouched()` cascades to every descendant; Angular's
   `submit()` also marks everything touched internally.
 - **custom `ValidatorFn`** → schema functions: `validate()`/`validateAsync()` for sync/async field

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -122,9 +122,11 @@ Notes:
 
 In beta and the early RCs, `@ngx-signal-forms/toolkit/core` was
 importable from consumer code, which accidentally exposed a lot of
-`@internal` plumbing (`NGX_SIGNAL_FORM_HINT_REGISTRY`,
-`NGX_SIGNAL_FORM_ARIA_MODE`, `DEFAULT_NGX_SIGNAL_FORMS_CONFIG`, hint
-descriptor types, etc.).
+`@internal` plumbing (`DEFAULT_NGX_SIGNAL_FORMS_CONFIG`, etc.).
+`NGX_SIGNAL_FORM_HINT_REGISTRY`, `NGX_SIGNAL_FORM_ARIA_MODE`, and the hint
+descriptor types were later promoted to the stable root barrel and are
+legitimate public exports today — check `packages/toolkit/index.ts` if
+you're unsure whether a given `/core` symbol is still internal.
 
 Starting in v1, the published `package.json` no longer exposes the
 `./core` export. Modern Node/TypeScript resolvers return
@@ -136,17 +138,12 @@ Starting in v1, the published `package.json` no longer exposes the
 - `packages/toolkit/index.ts` is the authoritative list of the stable
   public surface, enumerated by hand (the exact export count drifts as the
   API grows — check that file directly rather than trusting a number here).
-- CSS custom properties — two prefix families remain stable and split by
-  role: `--ngx-signal-form-*` covers cross-cutting feedback concerns
-  (e.g. `--ngx-signal-form-feedback-font-size`,
-  `--ngx-signal-form-error-color`, `--ngx-signal-form-fieldset-*`) and
-  `--ngx-form-field-*` covers wrapper-level chrome
-  (e.g. `--ngx-form-field-color-primary`, `--ngx-form-field-focus-color`).
-  **Several tokens were renamed or collapsed during the rc cycle** — the
-  full before/after table is in
-  [`MIGRATING_CSS_VARS.md`](./MIGRATING_CSS_VARS.md). See
+- CSS custom properties — the two-prefix (`--ngx-signal-form-*` /
+  `--ngx-form-field-*`) theming convention is unchanged; see
   [`packages/toolkit/form-field/THEMING.md`](../packages/toolkit/form-field/THEMING.md#architecture-semantic-layering)
-  for the full layering.
+  for the full layering. **Several tokens were renamed or collapsed during
+  the rc cycle** — the full before/after table is in
+  [`MIGRATING_CSS_VARS.md`](./MIGRATING_CSS_VARS.md).
 
 If you were reaching into `/core` for something that is **not**
 re-exported from root, it was `@internal` and is not part of the v1
@@ -265,9 +262,9 @@ components.
 | ----------------------------------- | --------------------------------------------------------------------- |
 | `FieldsetErrorPlacement`            | `NgxFormFieldErrorPlacement`                                          |
 | `FormFieldErrorPlacement`           | `NgxFormFieldErrorPlacement`                                          |
-| `FieldsetFeedbackAppearance`        | `NgxFieldsetFeedbackAppearance`                                       |
-| `FieldsetSurfaceTone`               | `NgxFieldsetSurfaceTone`                                              |
-| `FieldsetValidationSurface`         | `NgxFieldsetValidationSurface`                                        |
+| `FieldsetFeedbackAppearance`        | `NgxFormFieldsetFeedbackAppearance`                                   |
+| `FieldsetSurfaceTone`               | `NgxFormFieldsetSurfaceTone`                                          |
+| `FieldsetValidationSurface`         | `NgxFormFieldsetValidationSurface`                                    |
 | `NgxFormFieldNotificationListStyle` | `NgxFormFieldListStyle` _(shared)_                                    |
 | `NgxFormFieldErrorListStyle`        | `NgxFormFieldListStyle` _(shared, old name kept as deprecated alias)_ |
 
@@ -314,8 +311,8 @@ provideNgxSignalFormControlPresets({
 });
 ```
 
-The other kinds (`checkbox`, `switch`, `slider`, `composite`,
-`standalone`) are unchanged.
+The other kinds (`checkbox`, `switch`, `radio-group`, `slider`,
+`composite`) are unchanged.
 
 ### 4d. Orientation is part of the public wrapper contract
 
@@ -736,12 +733,12 @@ case set `warningStrategy="inherit"` (or match `strategy` explicitly).
 
 ### `NgxFormFieldError` — new inputs
 
-| Input             | Type                        | Purpose                                                             |
-| ----------------- | --------------------------- | ------------------------------------------------------------------- |
-| `errors`          | `Signal<ValidationError[]>` | Render pre-aggregated errors (e.g. fieldset-level). Takes priority. |
-| `warningStrategy` | `ErrorDisplayStrategy`      | See above                                                           |
-| `listStyle`       | `'plain' \| 'bullets'`      | Visual rendering of the message list                                |
-| `submittedStatus` | `SubmittedStatus`           | Manual override for `'on-submit'` timing                            |
+| Input             | Type                                           | Purpose                                                                                                                       |
+| ----------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `errors`          | `ReactiveOrStatic<readonly ValidationError[]>` | Render pre-aggregated errors (e.g. fieldset-level); accepts a plain array or a signal (unwrapped internally). Takes priority. |
+| `warningStrategy` | `ErrorDisplayStrategy`                         | See above                                                                                                                     |
+| `listStyle`       | `'plain' \| 'bullets'`                         | Visual rendering of the message list                                                                                          |
+| `submittedStatus` | `SubmittedStatus`                              | Manual override for `'on-submit'` timing                                                                                      |
 
 ### Fieldset (component + headless directive)
 
@@ -749,10 +746,11 @@ case set `warningStrategy="inherit"` (or match `strategy` explicitly).
   descendant-field errors instead of only direct group-level errors.
 - New `submittedStatus` input on the headless fieldset directive to support
   `'on-submit'` strategy without a form-level `ngxSignalForm`.
-- **Headless output rename (breaking for direct consumers):** the directive's
-  `submittedStatus` output is now `resolvedSubmittedStatus`, and `strategy` is
-  surfaced as `resolvedStrategy`. If you were reading either output from a
-  template reference or through Angular's output API, update the binding name.
+- **Headless signal rename (breaking for direct consumers):** the directive's
+  `submittedStatus` signal is now exposed as `resolvedSubmittedStatus`, and
+  `strategy` is surfaced as `resolvedStrategy`. If you were reading either
+  signal from a template reference variable or via dependency injection,
+  update the property name.
 - **`errorPlacement` default flipped from `'top'` to `'bottom'`** (breaking).
   Grouped summaries now render after the projected field content by default,
   which matches dense review-style layouts. This is a DOM-order change, not
@@ -1054,11 +1052,8 @@ leaf is counted consistently whether it's `null` or populated.
 
 - **Sweep your stylesheets for renamed/removed CSS custom properties**
   if you themed the toolkit — see
-  [`MIGRATING_CSS_VARS.md`](./MIGRATING_CSS_VARS.md). Common renames:
-  `-border` → `-border-color`; `-list-style-type` + `-list-style-position`
-  → `-list-style` shorthand; `-padding-horizontal` shortcuts →
-  `-padding-inline-start` / `-inline-end` pairs; legacy
-  `--ngx-form-field-outline-*` aliases removed.
+  [`MIGRATING_CSS_VARS.md`](./MIGRATING_CSS_VARS.md) for the full
+  before/after tables and a sanity-check grep command.
 
 ---
 

--- a/docs/MIGRATING_FROM_NGX_VEST_FORMS.md
+++ b/docs/MIGRATING_FROM_NGX_VEST_FORMS.md
@@ -261,46 +261,13 @@ A pragmatic migration path is:
 
 That usually lets you reduce legacy `ngx-vest-forms` surface area faster while preserving the value of your existing Vest suites.
 
-Recommended split:
-
-- **Angular Signal Forms validators**
-  - small UI-local rules
-  - simple required / email / min / max / minLength / maxLength checks
-  - form-state-driven rules such as disabled / readonly / hidden behavior
-- **OpenAPI / Zod / Standard Schema**
-  - required fields
-  - email format
-  - min/max length
-  - number bounds
-  - enums
-  - backend contract shape
-- **Vest**
-  - cross-field business rules
-  - conditional policy rules
-  - async business validations
-  - advisory `warn()` guidance
-
-This is especially useful during migration because it gives you a stable rule boundary:
-
-- Zod handles the **data contract**
-- Vest handles the **business meaning**
-
-In practice, that means you can often migrate like this:
-
-- replace simple template-driven validation with Angular validators and/or generated or hand-written Zod schemas
-- keep the existing Vest logic only for the rules that are still genuinely business-specific
-- gradually shrink the old Vest surface instead of rewriting everything at once
-
-Typical migration layering:
-
-1. keep **small local field rules** in Angular validators
-2. move **shared contract rules** to Zod / OpenAPI Standard Schema when available
-3. keep **complex business policy** in Vest
+That gives you a stable rule boundary during migration: keep small local field rules in Angular validators, move shared contract rules to Zod / OpenAPI Standard Schema when available, and keep complex business policy in Vest — replace simple template-driven validation first, then gradually shrink the old Vest surface instead of rewriting everything at once.
 
 See also:
 
 - [`apps/demo/src/app/05-advanced/zod-vest-validation/README.md`](../apps/demo/src/app/05-advanced/zod-vest-validation/README.md)
-- [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#combining-with-zod--standard-schema)
+- [Choosing a validation strategy](./VALIDATION_STRATEGY.md) — the full three-layer decision guide, recommended layering order, and a worked example
+- [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#when-to-use-vest)
 
 ### Remove framework-specific `field` plumbing first
 
@@ -320,20 +287,12 @@ Keep the business rules. Remove the adapter-era ceremony.
 
 ### Keep `warn()`, but update submit handling
 
-Vest `warn()` still maps well to the toolkit.
-
-The important difference is Angular Signal Forms currently treats all `ValidationError` objects as blocking during `submit()`, including toolkit-style warnings.
-
-If warning-only forms should still submit:
-
-1. use `<form [formRoot]="myForm">`
-2. configure `submission: { ignoreValidators: 'all', action }`
-3. gate the action with `hasOnlyWarnings(myForm().errorSummary())`
+Vest `warn()` still maps well to the toolkit, but Angular Signal Forms treats all `ValidationError` objects — including toolkit-style warnings — as blocking during `submit()`. Use the toolkit's warning-aware submit helpers so warning-only forms can still submit.
 
 See also:
 
-- [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md)
-- [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md)
+- [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#using-angular-submit-with-warnings)
+- [`docs/WARNINGS_SUPPORT.md`](./WARNINGS_SUPPORT.md#form-submission-behavior)
 
 ## Advanced features that need deliberate review
 

--- a/docs/PACKAGE_ARCHITECTURE.md
+++ b/docs/PACKAGE_ARCHITECTURE.md
@@ -133,13 +133,15 @@ import { validateVest } from '@ngx-signal-forms/toolkit/vest';
 @angular/core (peer)
 @angular/forms/signals (peer)
 vest ^6 (optional peer for /vest)
+axe-core ^4.5 (optional peer for /testing)
         ↓
 @ngx-signal-forms/toolkit
 ├── root (core public API)
 ├── /assistive
 ├── /form-field
 ├── /headless
-└── /vest
+├── /vest
+└── /testing
 ```
 
 ### Internal-only debugger

--- a/docs/WARNINGS_SUPPORT.md
+++ b/docs/WARNINGS_SUPPORT.md
@@ -683,7 +683,7 @@ The toolkit resolves the visible error message through a 3-tier priority system:
 
 ```text
 1. Validator message    → error.message (set in schema definition)
-2. Registry message     → NGX_ERROR_MESSAGES provider (app-wide defaults)
+2. Registry message     → registry from provideErrorMessages() (app-wide defaults)
 3. Fallback             → "Invalid" (last resort)
 ```
 
@@ -708,6 +708,23 @@ provideErrorMessages({
   email: 'Please enter a valid email',
   minLength: ({ minLength }) => `At least ${minLength} characters required`,
   maxLength: ({ maxLength }) => `At most ${maxLength} characters allowed`,
+});
+```
+
+For i18n, pass a factory instead of a static object. It runs in an injection
+context, so you can `inject()` a translation service and build the registry
+from it:
+
+```typescript
+provideErrorMessages(() => {
+  const translate = inject(TranslateService);
+
+  return {
+    required: translate.instant('validation.required'),
+    email: translate.instant('validation.email'),
+    minLength: ({ minLength }) =>
+      translate.instant('validation.minLength', { minLength }),
+  };
 });
 ```
 

--- a/docs/decisions/0005-aria-primitives-as-factories.md
+++ b/docs/decisions/0005-aria-primitives-as-factories.md
@@ -1,4 +1,4 @@
-# ADR-0002: ARIA primitives are factories, not directives
+# ADR-0005: ARIA primitives are factories, not directives
 
 ## Status
 

--- a/libs/debugger/README.md
+++ b/libs/debugger/README.md
@@ -109,7 +109,7 @@ ngx-signal-form-debugger {
 
 ## Related documentation
 
-- [Toolkit core](../README.md) — error strategies, ARIA, submission helpers
+- [Toolkit core](../../packages/toolkit/README.md) — error strategies, ARIA, submission helpers
 
 ## License
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -182,18 +182,10 @@ field / component input
   ?? built-in default
 ```
 
-The **form context (`ngxSignalForm`)** tier carries only the form-owned settings
-— **error strategy** and **submitted status**. Appearance, orientation, markers,
-control presets, and renderers have no form-context equivalent, so they skip that
-tier and resolve `input ?? provider config ?? default`. A setting only consults a
-tier that can supply it; missing tiers fall through.
-
-Inheritance merges with nullish `??` **per key**: override one key and the rest
-still inherit, and an explicit falsy value is respected (`requiredMarker: ''`
-clears the marker; omitting the key inherits it). Every "you can override this"
-in the sections below is a link in this chain — see the
+See the
 [root README](https://github.com/ngx-signal-forms/ngx-signal-forms#how-settings-resolve-the-cascade)
-for the adopter-level walkthrough.
+for the full walkthrough (per-tier details, nullish-merge semantics). Every
+"you can override this" in the sections below is a link in this chain.
 
 ### Field marking
 
@@ -217,6 +209,8 @@ the relevant kind:
   <!-- fields… -->
 </form>
 ```
+
+`NgxFormMarkingLegend` is available from `@ngx-signal-forms/toolkit/assistive`.
 
 Per-field / per-legend overrides are available via the `showMarkerWhen`,
 `requiredMarker`, and `optionalMarker` inputs on both
@@ -367,7 +361,7 @@ provideFieldLabels(() => {
 | `createErrorVisibility(field, opts?)`                  | One call: `Signal<boolean>` with strategy + submitted status auto-read from the DI context |
 | `showErrors(field, strategy, status?)`                 | `Signal<boolean>` — whether errors should show now                                         |
 | `shouldShowErrors(invalid, touched, strategy, status)` | Pure boolean strategy helper                                                               |
-| `combineShowErrors(...signals)`                        | Combines multiple visibility signals                                                       |
+| `combineShowErrors(signals)`                           | Combines an array of visibility signals, e.g. `combineShowErrors([sigA, sigB])`            |
 | `createShowErrorsComputed(field, strategy, status?)`   | Lower-level extraction for custom UIs                                                      |
 | `readDirectErrors(state)`                              | Direct `errors()` of a field/group only — excludes nested-field errors                     |
 
@@ -376,13 +370,13 @@ provideFieldLabels(() => {
 Building blocks for custom wrappers and headless UIs that want to join the
 [cascade](#how-settings-resolve-the-cascade) exactly like the built-in surfaces:
 
-| Function                                                       | Description                                                              |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `resolveErrorDisplayStrategy(input, context?, configDefault?)` | Pure resolution: input ?? context ?? config default ?? `'on-touch'`      |
-| `resolveStrategyFromContext(input)`                            | `Signal` resolution of a directive's strategy input against form context |
-| `resolveSubmittedStatusFromContext(input)`                     | Same cascade for `SubmittedStatus`                                       |
-| `injectFormContext()`                                          | Get the `ngxSignalForm` context, or `undefined`                          |
-| `injectFieldControl(element, injector?)`                       | Resolve the bound `FieldTree` for an element from the form context       |
+| Function                                                         | Description                                                                |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `resolveErrorDisplayStrategy(input, context?, configDefault?)`   | Pure resolution: input ?? context ?? config default ?? `'on-touch'`        |
+| `resolveStrategyFromContext(input, formContext, configDefault?)` | Resolved strategy value (call inside your own `computed()` for reactivity) |
+| `resolveSubmittedStatusFromContext(input)`                       | Same cascade for `SubmittedStatus`                                         |
+| `injectFormContext()`                                            | Get the `ngxSignalForm` context, or `undefined`                            |
+| `injectFieldControl(element, injector?)`                         | Resolve the bound `FieldTree` for an element from the form context         |
 
 ### Focus management
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -374,7 +374,7 @@ Building blocks for custom wrappers and headless UIs that want to join the
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | `resolveErrorDisplayStrategy(input, context?, configDefault?)`   | Pure resolution: input ?? context ?? config default ?? `'on-touch'`        |
 | `resolveStrategyFromContext(input, formContext, configDefault?)` | Resolved strategy value (call inside your own `computed()` for reactivity) |
-| `resolveSubmittedStatusFromContext(input)`                       | Same cascade for `SubmittedStatus`                                         |
+| `resolveSubmittedStatusFromContext(input, formContext)`          | Same cascade for `SubmittedStatus`                                         |
 | `injectFormContext()`                                            | Get the `ngxSignalForm` context, or `undefined`                            |
 | `injectFieldControl(element, injector?)`                         | Resolve the bound `FieldTree` for an element from the form context         |
 

--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -94,14 +94,10 @@ Grouped validation notification with an optional title.
 | `fieldName` | `string`                             | Optional id base for `aria-describedby` linkage |
 | `title`     | `string`                             | Optional title above the grouped messages       |
 | `listStyle` | `'plain' \| 'bullets'`               | Stacked paragraphs or bullet list               |
-| `tone`      | `'auto' \| 'error' \| 'warning'`     | Currently a no-op — see below                   |
 
-- Tone is always **content-driven**, regardless of the `tone` value passed:
-  any blocking (non-`warn:`) error routes the group to `role="alert"`; an
-  all-warning list routes to the polite `role="status"` container.
-- The `tone` input does not currently force either outcome. It is retained
-  as a stable API surface for possible future expansion (e.g. explicit
-  tone forcing) — do not rely on it to change rendering today.
+- Tone is always **content-driven** — there is no `tone` input: any blocking
+  (non-`warn:`) error routes the group to `role="alert"`; an all-warning list
+  routes to the polite `role="status"` container.
 - Intended for grouped fieldset summaries or custom headless summary cards
 
 ### NgxFormFieldErrorSummary
@@ -115,12 +111,13 @@ Form-level error summary with clickable entries that focus the invalid control.
 />
 ```
 
-| Input             | Type                   | Description                        |
-| ----------------- | ---------------------- | ---------------------------------- |
-| `formTree`        | `FieldTree` (required) | Root form to aggregate errors from |
-| `summaryLabel`    | `string`               | Label above the error list         |
-| `strategy`        | `ErrorDisplayStrategy` | When to show errors                |
-| `submittedStatus` | `SubmittedStatus`      | Manual override for `'on-submit'`  |
+| Input             | Type                   | Description                                                                                             |
+| ----------------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `formTree`        | `FieldTree` (required) | Root form to aggregate errors from                                                                      |
+| `summaryLabel`    | `string`               | Label above the error list                                                                              |
+| `strategy`        | `ErrorDisplayStrategy` | When to show errors                                                                                     |
+| `submittedStatus` | `SubmittedStatus`      | Manual override for `'on-submit'`                                                                       |
+| `autoFocus`       | `boolean`              | Auto-focus the summary on first appearance under `'on-submit'` (default `true`); set `false` to opt out |
 
 Override field names with `provideFieldLabels()` from `@ngx-signal-forms/toolkit`.
 
@@ -209,42 +206,14 @@ while consumers override only the public `--ngx-*` properties.
 :root {
   --ngx-signal-form-error-color: #db1818;
   --ngx-signal-form-warning-color: #a16207;
-  --ngx-signal-form-notification-error-color: #db1818;
-  --ngx-signal-form-notification-error-border-color: color-mix(
-    in srgb,
-    var(--ngx-signal-form-notification-error-color) 50%,
-    transparent
-  );
   --ngx-signal-form-notification-error-bg: #fdebeb;
-  --ngx-signal-form-notification-border-radius: 0.5rem;
-  --ngx-signal-form-notification-padding: 1rem;
-  --ngx-signal-form-feedback-font-size: 0.75rem;
-  --ngx-signal-form-feedback-line-height: 1rem;
-  --ngx-signal-form-feedback-margin-top: 0.125rem;
-  --ngx-form-field-hint-color: rgba(50, 65, 85, 0.75);
-  --ngx-form-field-char-count-color-ok: rgba(50, 65, 85, 0.75);
-  --ngx-form-field-char-count-color-warning: #a16207;
-  --ngx-form-field-char-count-color-danger: #db1818;
 }
 ```
 
-`ngx-form-field-notification` is full-width by default. The card keeps internal
-padding for readability, while fieldset-level horizontal positioning should be
-controlled with the dedicated `--ngx-signal-form-fieldset-notification-inset-*`
-tokens when used inside `ngx-form-fieldset`.
-
-The default light-theme error surface now matches the Figma design token
-directly: `#fdebeb`.
-
-### Dark mode
-
-Built-in dark defaults are driven by the `prefers-color-scheme: dark` media
-query only — they do not detect a `.dark` class on an ancestor element.
-(`:host-context()`, which would be needed for that, is non-standard and
-unsupported in Firefox and Safari.) Apps using a class-based dark-mode
-strategy must override the public `--ngx-signal-form-error-*` /
-`--ngx-signal-form-warning-*` / `--ngx-signal-form-notification-*` custom
-properties themselves, scoped to their `.dark` selector.
+See the [Theming guide](../form-field/THEMING.md) for the complete list of
+`--ngx-*` custom properties (error/warning/notification/hint/char-count
+tokens, dark-mode overrides, and the fieldset-level
+`--ngx-signal-form-fieldset-notification-inset-*` positioning tokens).
 
 ## Related documentation
 

--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -146,7 +146,7 @@ Provides context or instructions for a field.
 | `--ngx-form-field-hint-color`                | `rgba(50, 65, 85, 0.75)` | Hint text color             |
 | `--ngx-form-field-hint-font-size`            | `var(--...feedback...)`  | Text size                   |
 | `--ngx-form-field-hint-line-height`          | `var(--...feedback...)`  | Line height                 |
-| `--ngx-form-field-hint-align`                | `right`                  | Text alignment (left/right) |
+| `--ngx-form-field-hint-align`                | `left`                   | Text alignment (left/right) |
 | `--ngx-form-field-hint-padding-inline-start` | `var(--...feedback...)`  | Start-edge padding          |
 | `--ngx-form-field-hint-padding-inline-end`   | `var(--...feedback...)`  | End-edge padding            |
 
@@ -283,13 +283,13 @@ fallbacks throughout the stylesheet.
 - `--ngx-signal-form-fieldset-legend-color` — default `var(--...fieldset-color...)`; legend text color in default state
 - `--ngx-signal-form-fieldset-legend-font-size` — default `0.875rem`; legend font size
 - `--ngx-signal-form-fieldset-legend-line-height` — default `1.25rem`; legend line height
-- `--ngx-signal-form-fieldset-legend-font-weight` — default `600`; legend font weight
+- `--ngx-signal-form-fieldset-legend-font-weight` — default `500`; legend font weight
 - `--ngx-signal-form-fieldset-legend-letter-spacing` — default `0`; legend letter spacing
 - `--ngx-signal-form-fieldset-legend-bg` — default `transparent`; legend background that stays separate from the surfaced content
 - `--ngx-signal-form-fieldset-legend-border-radius` — default `0.25rem`; legend background radius
 - `--ngx-signal-form-fieldset-invalid-border-color` — default `#db1818`; border color when errors are shown
 - `--ngx-signal-form-fieldset-warning-border-color` — default `#a16207`; border color when warnings are shown
-- `--ngx-signal-form-fieldset-invalid-surface-bg` — default `var(--...notification-error-bg...)`; error-tinted background below the legend
+- `--ngx-signal-form-fieldset-invalid-surface-bg` — default `var(--...invalid-bg...)`; error-tinted background below the legend
 - `--ngx-signal-form-fieldset-warning-surface-bg` — default `var(--...notification-warning-bg...)`; warning-tinted background below the legend
 - `--ngx-signal-form-fieldset-invalid-legend-color` — default `var(--...invalid-border...)`; legend color in error state
 - `--ngx-signal-form-fieldset-warning-legend-color` — default `var(--...warning-border...)`; legend color in warning state
@@ -315,7 +315,7 @@ fallbacks throughout the stylesheet.
 - `--ngx-signal-form-fieldset-color` — default internal text tone; primary fieldset text color
 - `--ngx-signal-form-fieldset-muted-color` — default internal muted text tone; secondary fieldset text color
 - `--ngx-signal-form-fieldset-legend-padding` — default internal spacing pair; padding applied to the projected `<legend>`
-- `--ngx-signal-form-fieldset-invalid-bg` — default `var(--_fieldset-notification-error-bg)`; error-tinted fill behind grouped content (pairs with `-invalid-surface-bg` when the invalid surface should differ)
+- `--ngx-signal-form-fieldset-invalid-bg` — default `var(--...bg-danger-surface...)` (`#fbdddd`); error-tinted fill behind grouped content (pairs with `-invalid-surface-bg` when the invalid surface should differ)
 - `--ngx-signal-form-fieldset-message-margin-top` — default `var(--_fieldset-gap)`; top margin for the grouped message container
 - `--ngx-signal-form-fieldset-message-margin-bottom` — default `var(--_fieldset-gap)`; bottom margin for the grouped message container
 - `--ngx-signal-form-fieldset-content-offset` — default `0`; horizontal offset applied to the surface/content area relative to the fieldset edge

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -153,7 +153,7 @@ Aggregates error state across multiple fields for group validation.
 | --------------------- | ------------------------------ | -------------------------------------------------- |
 | `field`               | `FieldTree` (required)         | Primary field group                                |
 | `fields`              | `readonly FieldTree[] \| null` | Optional explicit field list — see note below      |
-| `fieldsetId`          | `string`                       | For ARIA linking                                   |
+| `fieldsetId`          | `string` (optional)            | For ARIA linking                                   |
 | `strategy`            | `ErrorDisplayStrategy`         | Override blocking-error strategy                   |
 | `warningStrategy`     | `ErrorDisplayStrategy`         | Override warning strategy (default: `'immediate'`) |
 | `submittedStatus`     | `SubmittedStatus`              | Override for `'on-submit'` strategy                |
@@ -189,7 +189,8 @@ Tone-aware grouped validation state for custom notification cards and summary bl
 | ----------- | ------------------------------------ | --------------------------------------- |
 | `errors`    | `Signal<readonly ValidationError[]>` | Grouped validation messages             |
 | `fieldName` | `string \| null`                     | Base id for generated error/warning ids |
-| `tone`      | `'auto' \| 'error' \| 'warning'`     | Resolve role/tone for grouped messaging |
+
+Tone is fully content-driven — there is no `tone` input. Any blocking (non-`warn:`) error resolves the group to `'error'` (`role="alert"`); an all-warning list resolves to `'warning'` (polite `role="status"`).
 
 Signals: `resolvedMessages()`, `resolvedTone()`, `showErrorContainer()`, `showWarningContainer()`, `errorContainerId()` (nullable), `warningContainerId()` (nullable).
 

--- a/packages/toolkit/testing/README.md
+++ b/packages/toolkit/testing/README.md
@@ -1,0 +1,90 @@
+# @ngx-signal-forms/toolkit/testing
+
+> WCAG 2.2 AA accessibility test harness for `@ngx-signal-forms/toolkit`.
+
+## Why this entry point exists
+
+The toolkit's ARIA wiring, live-region roles, and error-display markup are
+checked against the WCAG 2.2 AA axe-core ruleset as a hard-fail gate in the
+toolkit's own test suite (see [Accessibility](../../../README.md#accessibility)
+in the root README). This entry point publishes the same assertion helper so
+you can run the identical check against your own forms and custom wrappers.
+
+It has no dependency on the rest of the toolkit's public API — import it
+directly wherever you render a fixture in a test.
+
+## Install
+
+`axe-core` is an optional peer dependency of `@ngx-signal-forms/toolkit`; it
+is only required if you import from this entry point.
+
+```bash
+npm install --save-dev axe-core@^4.5.0
+```
+
+## Import
+
+```typescript
+import {
+  expectNoA11yViolations,
+  WCAG_22_AA_TAGS,
+} from '@ngx-signal-forms/toolkit/testing';
+```
+
+## Usage
+
+`expectNoA11yViolations` runs an axe-core audit against an element (or the
+whole `document.body` by default) and throws when any WCAG 2.2 AA violation
+is found. Call it once per rendered fixture in a Vitest browser-mode spec —
+it scans the whole subtree:
+
+```typescript
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+it('has no accessibility violations', async () => {
+  const { container } = await render(MyFormComponent);
+
+  await expectNoA11yViolations(container);
+});
+```
+
+Pass extra axe `RunOptions` as a second argument to merge over the WCAG 2.2
+AA defaults, e.g. to waive a rule for a fixture that intentionally renders
+unstyled controls:
+
+```typescript
+await expectNoA11yViolations(container, {
+  rules: { 'color-contrast': { enabled: false } },
+});
+```
+
+## `WCAG_22_AA_TAGS`
+
+The axe-core tag set `expectNoA11yViolations` scans with by default:
+
+```typescript
+export const WCAG_22_AA_TAGS = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+  'wcag22aa',
+] as const;
+```
+
+WCAG is additive across versions, so the full 2.2 AA surface is the union of
+every prior level/version tag — there is no separate `wcag22a` tag because
+axe-core has no automated rule for either new 2.2 Level A criterion
+(Consistent Help, Redundant Entry); both must be verified manually. Automated
+scanning with this tag set therefore covers only a subset of full WCAG 2.2 AA
+conformance — see [Accessibility](../../../README.md#accessibility) in the
+root README for what the toolkit's own automation does and does not cover.
+
+## Related documentation
+
+- [Toolkit core](../README.md) — error strategies, ARIA, configuration
+- [Root README — Accessibility](../../../README.md#accessibility) — what the toolkit verifies in CI and what remains your responsibility
+
+## License
+
+MIT © [ngx-signal-forms](https://github.com/ngx-signal-forms/ngx-signal-forms)

--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -33,7 +33,7 @@ The adapter reads Vest's full `run()` result, mapping blocking errors **and** `w
 
 ## Installation
 
-Vest is an optional peer dependency (`>=6.0.0`). Install it only when using this entry point.
+Vest is an optional peer dependency (`>=6.0.0 <7.0.0`). Install it only when using this entry point.
 
 ```bash
 pnpm add @ngx-signal-forms/toolkit vest
@@ -143,7 +143,7 @@ Blocking errors and warnings are read from the same Vest run — enabling warnin
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `includeWarnings`   | `false` | Surface `warn()` results as toolkit warnings (`kind` prefixed with `warn:vest:`).                                                                                                                                                                                                     |
 | `resetOnDestroy`    | `true`  | Call `suite.reset()` via `DestroyRef.onDestroy()` when the hosting injection context tears down. Enabled by default for module-scope suites; pass `{ resetOnDestroy: false }` only to deliberately persist suite state across mounts (see [Suite lifecycle](#suite-lifecycle) below). |
-| `only`              | _none_  | Selector `(ctx) => string \| string[] \| undefined` that threads a field name into `suite.run(value, fieldName)` (or `suite.only(field).run(value)` where the suite exposes that shorthand).                                                                                          |
+| `only`              | _none_  | Selector `(ctx) => string \| string[] \| undefined` that threads a field name into `suite.only(field).run(value)` when the suite exposes `only` (falling back to `suite.run(value, fieldName)` otherwise).                                                                            |
 | `focusCurrentField` | `false` | Derive the focused Vest field name automatically from the field this validator is bound to (`ctx.pathKeys()`, dotted — e.g. `items.0.sku`). Ignored when `only` is provided; falls back to a whole-suite run when bound to the form root.                                             |
 
 ### Exported constants
@@ -285,28 +285,11 @@ Use Angular Signal Forms validators for simple, field-local rules (`required`, `
 - Async checks like "username already taken"
 - Rules you want to reuse outside an Angular form
 
-For most projects, the cleanest layering is:
-
-1. **Angular validators** for simple local rules
-2. **Zod / OpenAPI Standard Schema** for shared contract validation
-3. **Vest** for business-policy rules and `warn()` guidance
-
-### Combining with Zod / Standard Schema
-
-```typescript
-const checkoutForm = form(model, (path) => {
-  // Angular validators — small UI-local rules
-  required(path.email, { message: 'Email is required' });
-
-  // Zod / OpenAPI — contract and structural validation
-  validateStandardSchema(path, CheckoutSchema);
-
-  // Vest — business rules and warn() guidance
-  validateVest(path, checkoutBusinessSuite, { includeWarnings: true });
-});
-```
-
-Keep each layer focused. Don't duplicate the same rule in multiple layers.
+For the full three-layer decision guide (Angular validators vs. Zod / OpenAPI
+Standard Schema vs. Vest), the recommended layering order, and a worked example
+combining all three, see
+[Choosing a validation strategy](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/VALIDATION_STRATEGY.md).
+Keep each layer focused — don't duplicate the same rule in multiple layers.
 
 ## Suite lifecycle
 
@@ -423,8 +406,15 @@ wins — `focusCurrentField` is ignored when `only` is provided.
 Angular treats every `ValidationError` as blocking. For forms that should allow warnings:
 
 1. Set `ignoreValidators: 'all'` in the `submission` config
-2. Inside `action`, check `hasOnlyWarnings(form().errorSummary())` — `errorSummary()` yields only the fields that errored, so it is not a full-tree enumeration (use the tree walker for that)
+2. Inside `action`, check `hasOnlyWarnings(form().errorSummary())` — `errorSummary()` yields only the fields that errored, so it is not a full-tree enumeration of every field
 3. Return early and focus the first invalid field when blocking errors remain
+
+The Quick start example above hand-rolls this exact pattern. The toolkit also ships
+[`submitWithWarnings(form, action)`](../README.md#warning-support), a ready-made
+helper that marks the form touched, waits for validation to settle, and invokes
+`action` only when no blocking errors remain — reach for it directly (e.g. from a
+button click handler) instead of re-implementing the `ignoreValidators` /
+`hasOnlyWarnings` breakdown, unless you need that finer control.
 
 ## Related documentation
 


### PR DESCRIPTION
## What

Full documentation audit driven by a 36-agent review: every user-facing doc was verified against the actual toolkit source, and 22 realistic developer questions were reader-tested against the docs alone to find what a new user can't answer.

### Corrections (51 findings, all re-verified before fixing)
- **Fabricated/wrong APIs removed:** `tone` input documented on both notification components but never implemented; `combineShowErrors(...signals)` → takes an array; `resolveStrategyFromContext` wrong signature and return type; `NgxFormMarkingLegend` import entry point; wizard `preventDefault()` example that cannot work (replaced with `canNavigate`)
- **Wrong values fixed:** THEMING defaults (`hint-align`, legend font weight, fieldset invalid backgrounds), `NG_STATUS_CLASSES` import (`/compat`), migration guide's v1 rename tables, demo-app pinned versions, COMPATIBILITY peer list (added `@angular/common`, `axe-core`) and Node table, CONTRIBUTING size-budget claims
- **ADR collision:** two docs were both numbered ADR-0002 — aria-primitives renumbered to ADR-0005
- **Stale content:** "archived folders remain" claims, missing demos in section lists, missing `autoFocus` input row
- **Redundancy trimmed:** settings-cascade explanation now canonical in the root README only; duplicated warning-submit recipes, CSS-var conventions, and layering lists collapsed to links (net −346 lines)

### New
- **`docs/FAQ.md`** — use-case FAQ: 22 reader-tested "how do I build X?" questions with answers verified against the toolkit barrels and installed Angular 22 types (incl. server-error mapping via the submission action's `TreeValidationResult`, `reset()`, `compatForm()`), TOC, canonical doc + demo links, linked from the README
- **`packages/toolkit/testing/README.md`** — the `/testing` entry point was completely undiscoverable; now documented here + in the root README table
- **Missing demo READMEs** for `labelless-fields` and `field-state-patterns`; all 9 broken relative links fixed (link check now runs 0 broken across 72 files)

Demo gaps surfaced by the reader tests are filed as follow-up issues rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `@ngx-signal-forms/toolkit/testing` documentation entry point for an axe-core–backed WCAG 2.2 AA accessibility harness.
  * Added new demo and guide coverage for advanced form patterns (store binding, field state patterns, wizard guarded navigation) and updated submit/warnings guidance.

* **Documentation**
  * Expanded the use-case FAQ, improved multiple cross-links, and refreshed migration/best-practice guidance (including warnings and complex/nested forms).
  * Updated compatibility notes and repository/tooling baselines.

* **Style / Theming**
  * Adjusted default styling tokens for hints and fieldset invalid/legend presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->