### PR TITLE
ci(workflow): shard demo e2e and optimize CI execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
       matrix:
         shard-index: [1, 2, 3, 4]
     env:
+      NX_NO_CLOUD: 'true'
       NX_DAEMON: 'false'
       SHARD_TOTAL: '4'
       PW_WORKERS: '2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,6 @@ jobs:
         run: pnpm exec playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
-      - name: Cache oxc binaries
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/oxc
-          key: oxc-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            oxc-${{ runner.os }}-
-
       - name: Configure Nx Cloud access
         id: nx_cloud
         env:
@@ -156,11 +148,10 @@ jobs:
         run: pnpm exec oxlint . --format=github
         continue-on-error: true
 
-      # Distributed via Nx Agents when Nx Cloud is enabled (see "Start Nx
-      # Cloud distributed task execution" above); otherwise nx-safe.sh runs
-      # everything locally, same as when Nx Cloud is unavailable mid-run.
-      - name: Run affected tasks
-        run: bash .github/scripts/nx-safe.sh pnpm exec nx affected -t lint test test-browser build e2e-ci --parallel=3 --outputStyle=static
+      # Keep the critical path focused on fast checks + smaller e2e suites.
+      # The heavy demo-e2e suite is sharded in a separate parallel job.
+      - name: Run affected tasks (excluding demo-e2e)
+        run: bash .github/scripts/nx-safe.sh pnpm exec nx affected -t lint test test-browser build e2e-ci --exclude=demo-e2e --parallel=4 --outputStyle=static
 
       - name: Generate lint report
         if: ${{ always() }}
@@ -172,8 +163,8 @@ jobs:
         with:
           name: test-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            apps/demo-e2e/playwright-report/
-            dist/.playwright/apps/demo-e2e/test-output/
+            apps/*-e2e/playwright-report/
+            dist/.playwright/apps/*-e2e/test-output/
             coverage/packages/toolkit/browser/
             lint-report.json
           if-no-files-found: ignore
@@ -182,8 +173,70 @@ jobs:
       # https://nx.dev/ci/features/self-healing-ci
       # continue-on-error: fix-ci requires Nx Cloud, may fail if quota exceeded
       - run: pnpm exec nx fix-ci --outputStyle=static
-        if: ${{ always() && !inputs.skip_cloud && steps.nx_cloud.outputs.enabled == 'true' }}
+        if: ${{ always() && !inputs.skip_cloud && steps.nx_cloud.outputs.enabled == 'true' && env.NX_NO_CLOUD != 'true' }}
         continue-on-error: true
+
+  demo-e2e-sharded:
+    name: Demo E2E (sharded)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard-index: [1, 2, 3, 4]
+    env:
+      NX_DAEMON: 'false'
+      SHARD_TOTAL: '4'
+      PW_WORKERS: '2'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: tree:0
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v6
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+
+      - name: Run demo-e2e shard
+        env:
+          SHARD_INDEX: ${{ matrix.shard-index }}
+        run: bash .github/scripts/nx-safe.sh pnpm exec nx run demo-e2e:e2e-ci-shard --outputStyle=static
+
+      - name: Upload demo-e2e shard artifacts
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: demo-e2e-shard-${{ matrix.shard-index }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            apps/demo-e2e/playwright-report/
+            dist/.playwright/apps/demo-e2e/test-output/
+          if-no-files-found: ignore
+          retention-days: 14
 
   # Proves the published toolkit stays design-system-free as the reference
   # demo apps (#40 - Material/PrimeNG/Spartan) land. Two assertions:

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ playwright-report/
 build.log
 
 .claude/worktrees
+.worktrees/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 .nx/polygraph
@@ -69,4 +70,4 @@ build.log
 .nx/migrate-runs
 
 # graphify knowledge graph output
-graphify-out/.worktrees/
+graphify-out/

--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+.worktrees/**

--- a/apps/demo-e2e/playwright.config.ts
+++ b/apps/demo-e2e/playwright.config.ts
@@ -10,7 +10,8 @@ process.env['NO_PROXY'] ??= 'localhost,127.0.0.1';
 
 const baseURL = process.env['BASE_URL'] ?? 'http://127.0.0.1:4600';
 const isCI = Boolean(process.env['CI']);
-const ciWorkers = Number(process.env['PW_WORKERS'] ?? '2');
+const parsedCiWorkers = Number.parseInt(process.env['PW_WORKERS'] ?? '', 10);
+const ciWorkers = parsedCiWorkers > 0 ? parsedCiWorkers : 2;
 
 /**
  * Read environment variables from file.

--- a/apps/demo-e2e/playwright.config.ts
+++ b/apps/demo-e2e/playwright.config.ts
@@ -10,6 +10,7 @@ process.env['NO_PROXY'] ??= 'localhost,127.0.0.1';
 
 const baseURL = process.env['BASE_URL'] ?? 'http://127.0.0.1:4600';
 const isCI = Boolean(process.env['CI']);
+const ciWorkers = Number(process.env['PW_WORKERS'] ?? '2');
 
 /**
  * Read environment variables from file.
@@ -32,6 +33,7 @@ export default defineConfig({
   updateSnapshots: isCI ? 'none' : 'missing',
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
+  workers: isCI ? ciWorkers : undefined,
   reporter: [
     ['list'],
     ['html', { open: 'never', outputFolder: 'playwright-report' }],

--- a/apps/demo-e2e/project.json
+++ b/apps/demo-e2e/project.json
@@ -16,7 +16,8 @@
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "e2e-toolkit": {
@@ -54,7 +55,15 @@
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
+      }
+    },
+    "e2e-ci-shard": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-e2e"],
+      "options": {
+        "command": "pnpm exec playwright test --config apps/demo-e2e/playwright.config.ts --project=chromium --shard=${SHARD_INDEX:-1}/${SHARD_TOTAL:-4}"
       }
     },
     "a11y": {
@@ -64,7 +73,8 @@
         "{workspaceRoot}/dist/.a11y/demo-e2e"
       ],
       "options": {
-        "config": "{projectRoot}/playwright.a11y.config.ts"
+        "config": "{projectRoot}/playwright.a11y.config.ts",
+        "skipInstall": true
       }
     }
   }

--- a/apps/demo-e2e/project.json
+++ b/apps/demo-e2e/project.json
@@ -63,7 +63,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-e2e"],
       "options": {
-        "command": "pnpm exec playwright test --config apps/demo-e2e/playwright.config.ts --project=chromium --shard=${SHARD_INDEX:-1}/${SHARD_TOTAL:-4}"
+        "command": "bash -lc 'pnpm exec playwright test --config apps/demo-e2e/playwright.config.ts --project=chromium --shard=${SHARD_INDEX:-1}/${SHARD_TOTAL:-4}'"
       }
     },
     "a11y": {

--- a/apps/demo-material-e2e/project.json
+++ b/apps/demo-material-e2e/project.json
@@ -16,14 +16,16 @@
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-material-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "e2e-ci": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-material-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "a11y": {
@@ -33,7 +35,8 @@
         "{workspaceRoot}/dist/.a11y/demo-material-e2e"
       ],
       "options": {
-        "config": "{projectRoot}/playwright.a11y.config.ts"
+        "config": "{projectRoot}/playwright.a11y.config.ts",
+        "skipInstall": true
       }
     }
   }

--- a/apps/demo-primeng-e2e/project.json
+++ b/apps/demo-primeng-e2e/project.json
@@ -16,14 +16,16 @@
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-primeng-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "e2e-ci": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-primeng-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "a11y": {
@@ -33,7 +35,8 @@
         "{workspaceRoot}/dist/.a11y/demo-primeng-e2e"
       ],
       "options": {
-        "config": "{projectRoot}/playwright.a11y.config.ts"
+        "config": "{projectRoot}/playwright.a11y.config.ts",
+        "skipInstall": true
       }
     }
   }

--- a/apps/demo-spartan-e2e/project.json
+++ b/apps/demo-spartan-e2e/project.json
@@ -16,14 +16,16 @@
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-spartan-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "e2e-ci": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/demo-spartan-e2e"],
       "options": {
-        "config": "{projectRoot}/playwright.config.ts"
+        "config": "{projectRoot}/playwright.config.ts",
+        "skipInstall": true
       }
     },
     "a11y": {
@@ -33,7 +35,8 @@
         "{workspaceRoot}/dist/.a11y/demo-spartan-e2e"
       ],
       "options": {
-        "config": "{projectRoot}/playwright.a11y.config.ts"
+        "config": "{projectRoot}/playwright.a11y.config.ts",
+        "skipInstall": true
       }
     }
   }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
   ignorePatterns: [
     '.angular',
     '.nx',
+    '.worktrees',
     '.agents',
     '.github/skills',
     '**/dist',


### PR DESCRIPTION
## Summary
- move heavy demo-e2e coverage out of the main affected-task step
- add a sharded demo-e2e CI job (4 shards) to shorten the critical path
- skip Playwright install checks in Nx e2e and a11y targets where CI already installs browsers
- gate nx fix-ci behind runtime cloud availability and remove ineffective oxc cache step
- ignore local .worktrees in Nx and lint discovery to keep local validation stable

## Why
The previous CI run spent most time in one monolithic affected-task step and degraded to local execution when Nx Cloud was unavailable. This change reduces single-step bottlenecks and improves fallback behavior while preserving coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by adjusting test execution, increasing parallelism, and separating the heavy end-to-end suite into its own parallel job.
  * Expanded test artifact uploads so Playwright reports and outputs are captured for more end-to-end projects.
  * Prevented unnecessary install steps during end-to-end and accessibility runs to speed up execution.
  * Refined CI conditions so certain maintenance steps only run when cloud features are enabled.
* **Chores**
  * Updated ignore rules for additional generated working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->