### PR TITLE
docs(decisions): ADR-0008 — a Vest suite's input is the bound path's value

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,12 +119,17 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   relative to that path. There is no second value source: Angular's
   `FieldContext` exposes no parent or root accessor, so a registration cannot
   reach past its own path to fetch the model. This is why `focusCurrentField`
-  and field-scoped registration were **deleted** rather than repaired — they
-  bound a suite to a leaf while the suite expected the model, so
-  `suite.run(<the field's string>)` made every `data.x` read `undefined` and
-  produced a blocking error that never cleared, on a valid value. Do not
+  and field-scoped registration are to be **deleted** rather than repaired —
+  they bind a suite to a leaf while the suite expects the model, so
+  `suite.run(<the field's string>)` makes every `data.x` read `undefined` and
+  produces a blocking error that never clears, on a valid value. Do not
   reintroduce a "bind here, read the model from over there" shape: the
   descendant relation between the two paths is not expressible in TypeScript, so
   its central invariant cannot be enforced. Automatic per-field focus is a
   _root-level_ concern instead — see
   [ADR-0008](docs/decisions/0008-vest-suite-input-is-the-bound-path.md).
+  This rule is **decided but not yet implemented**: the package still ships
+  `focusCurrentField` and derives Vest field names root-relative. Removing both
+  is open work, tracked in
+  [#287](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/287) and
+  [#291](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/291).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,26 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   records known axe violations. The CI `a11y` job diffs the current run against
   this file; new violations trigger auto-issue creation and a baseline update.
   Synonym to avoid: "known violations list" (ambiguous — use "a11y baseline").
+- **Bound path** — the `SchemaPath` a Vest registration is attached to
+  (`validateVest(path.address, suite)` → the bound path is `path.address`). It
+  fixes two things at once: where the resulting errors attach, and what the
+  suite input is. Synonym to avoid: "field path" (that is the Vest-side name,
+  see **Vest field name**).
+- **Suite input** — the value a Vest suite's callback receives. **The bound
+  path's value _is_ the suite input.** Binding to the form root gives the suite
+  the whole model; binding to a subtree gives it that subtree's value, and is
+  correct only when the suite is authored for that shape. Synonyms to avoid:
+  "model" (misleading once a subtree is bound), "form value".
+- **Vest field name** — the string a Vest `test()` is registered under, e.g.
+  `test('city', …)`. **Relative to the bound path**, never to the form root,
+  because the suite only ever sees the suite input. A name that resolves to no
+  field is either a **virtual Vest field name** or an authoring bug, split by
+  shape: an unresolvable _first_ segment is virtual; a valid prefix with an
+  invalid tail (`address.cityy`) is a typo and fails hard in dev mode.
+- **Virtual Vest field name** — a Vest field name that deliberately matches no
+  field in the suite input, used to carry a form-level error
+  (`test('passwordMatch', 'Passwords must match', …)`). It attaches to the bound
+  field. Legitimate and silent — the toolkit must not treat it as an error.
 
 ## Key concepts
 
@@ -93,3 +113,18 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   hand-enumerates the public surface rather than re-exporting `/core`
   wholesale, so `@internal` plumbing stays out of the shipped `.d.ts`. A symbol
   tagged `@public` inside `/core` is only public if the root barrel lists it.
+
+- **A Vest registration binds a path and a suite that must agree.** The
+  **bound path**'s value is the **suite input**, and **Vest field names** are
+  relative to that path. There is no second value source: Angular's
+  `FieldContext` exposes no parent or root accessor, so a registration cannot
+  reach past its own path to fetch the model. This is why `focusCurrentField`
+  and field-scoped registration were **deleted** rather than repaired — they
+  bound a suite to a leaf while the suite expected the model, so
+  `suite.run(<the field's string>)` made every `data.x` read `undefined` and
+  produced a blocking error that never cleared, on a valid value. Do not
+  reintroduce a "bind here, read the model from over there" shape: the
+  descendant relation between the two paths is not expressible in TypeScript, so
+  its central invariant cannot be enforced. Automatic per-field focus is a
+  _root-level_ concern instead — see
+  [ADR-0008](docs/decisions/0008-vest-suite-input-is-the-bound-path.md).

--- a/docs/decisions/0008-vest-suite-input-is-the-bound-path.md
+++ b/docs/decisions/0008-vest-suite-input-is-the-bound-path.md
@@ -1,0 +1,127 @@
+# ADR-0008: A Vest Suite's Input Is the Bound Path's Value
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-08
+
+## Context
+
+Issue [#287](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/287) reported that `validateVest`'s single generic conflates two different types:
+
+```ts
+export function validateVest<TValue>(
+  path: VestFieldPath<TValue>, //     TValue = the bound field's value type
+  suite: VestRunnableSuite<TValue>, // TValue = the suite's input type
+  options: ValidateVestOptions<TValue> = {},
+): void;
+```
+
+The issue framed this as a typing defect and proposed splitting the generic into `<TModel, TField>`. Reviewing the package showed the typing defect is a **symptom**, and that the proposed fix would have made the underlying defect worse.
+
+### What actually happens
+
+`registerVestValidation` feeds `ctx.value()` — the **bound path's** value — straight into `suite.run()`:
+
+```ts
+validateTree(path, (ctx) => {
+  const { fieldTree, value } = ctx;
+  const entry = getOrCreateVestRun(
+    suite,
+    fieldTree,
+    value(),
+    resolveFocus(ctx),
+  );
+  // …
+});
+```
+
+So the README-documented per-field pattern (`README.md:135`, `:395`) hands a **string** to a suite authored for the model. Reproduced:
+
+```ts
+const suite = create((data: { email: string; password: string }) => {
+  test('email', 'Email is required', () => enforce(data.email).isNotBlank());
+});
+
+form(model, (path) => {
+  validateVest(path.email, suite, { focusCurrentField: true });
+});
+
+model.set({ email: 'ada@example.com', password: 'hunter2hunter2' });
+```
+
+```text
+suite.run received:  ["", "ada@example.com"]
+email errors AFTER valid input:
+  [{ kind: 'vest:email:email-is-required:0', message: 'Email is required' }]
+```
+
+`data.email` on a string primitive is always `undefined`, so `enforce(undefined).isNotBlank()` fails forever. A **valid value carries a permanent blocking error**. The only thing preventing adoption was that the pattern does not typecheck — which is precisely what #287 proposed to remove.
+
+A second defect shares the root cause. Vest field names were derived **root-relative** (`ctx.pathKeys().join('.')`) but resolved back to a field by walking from the **bound** tree, with `catch { return fieldTree; }` swallowing every miss. Reproduced: a suite testing `address.city`, bound to `path.address`, attaches its error to the `address` group instead of `address.city` — rendering beside the wrong control and pointing `aria-describedby` at the wrong control.
+
+### Why no second value source exists
+
+A field-scoped registration cannot fetch the model on its own. Angular 22.1's `FieldContext` (`RootFieldContext` / `ChildFieldContext` / `ItemFieldContext`) and `ReadonlyFieldState` expose no parent or root accessor — verified against the installed `.d.ts`. `ctx.valueOf(path)` requires a `SchemaPath` handed in from the enclosing `form()` callback. So any "bind to the field, run on the model" design **must** take a second path from the caller.
+
+### Alternatives considered
+
+**Split the generic and require a model path** — `validateVest(path.email, suite, { model: path })`, or the object form `validateVest({ field, model, suite })`. Rejected on two grounds:
+
+1. **The central invariant is unenforceable.** `field` must be a descendant of `model`. `SchemaPath` carries no type-level descendant relation, so `{ field: formA.email, model: formB }` typechecks whenever the value types line up. An object form makes the invariant visible but no more checkable — the same class of defect this ADR exists to remove.
+2. **It makes the reactive dependency worse.** Reading `ctx.valueOf(modelPath)` makes the whole model the dependency, so N field registrations each re-run on every keystroke anywhere in the form: N focused suite runs, N cache entries, N sequential `only().run()` calls against one stateful suite, per change. One root registration is one run.
+
+**Suite-per-field** — author a separate suite per field so the field's value legitimately is the suite input. This is what the existing specs quietly do (`create((email: string, field?: string) => …)`). Rejected: it defeats the point of Vest, whose suites are model-scoped and whose `only()` exists to focus one model within one suite.
+
+### Adoption evidence
+
+`focusCurrentField` and field-scoped registration had **zero live call sites**. All 35 `validateVest` call sites in the repository bind the form root; the only 5 field-bound occurrences anywhere are documentation and JSDoc. No group-bound site exists. Every documented suite takes the whole model plus an optional focus name — `create((data: Model, field?: string) => { only(field); … })` — which is the root-registration idiom.
+
+## Decision
+
+**The bound path's value _is_ the suite input.** A Vest registration binds one path and one suite, and they must agree.
+
+Consequences, in order:
+
+1. **Delete `focusCurrentField`** and the root-relative name derivation (`deriveVestFieldNameFromContext`) it existed to serve. With derivation gone, `filterEntriesForBoundField` is never called with a name and is deleted as dead.
+2. **Subtree binding stays legal**, and is correct whenever the suite is authored for that subtree's value — `validateVest(path.address, create((addr: { city: string }) => test('city', …)))` works. What is deleted is the _mismatch_, not the capability.
+3. **Vest field names are relative to the bound path.** Resolution walks from the bound tree, which is now the only base there is — the encode/decode disagreement dissolves rather than needing a chosen base.
+4. **An unresolvable name is split by shape.** An unresolvable _first_ segment is a **virtual Vest field name** (a deliberate form-level error such as `test('passwordMatch', …)`) and attaches to the bound field, silently and legitimately. A valid prefix with an invalid tail (`address.cityy`), or a proxy probe that throws, is an authoring bug: **hard error in dev mode**, `console.error` plus attach-to-bound in production. The blanket `catch { return fieldTree; }` is removed.
+5. **The suite contract is made enforceable.** `run`, `only`, `getErrors` and `getWarnings` move from method-shorthand to readonly function-property position, because method parameters stay bivariant even under `strictFunctionTypes` — that bivariance is _why_ `VestRunnableSuite<SignupModel>` was assignable to `VestRunnableSuite<string>` and why the broken pattern compiled. `only` takes Vest 6.3.2's real `FieldExclusion<F> = Maybe<OneOrMoreOf<F>>` (which admits `false` and readonly arrays) instead of `string | string[]`.
+6. **No generic split.** With the path and the suite agreeing, one type parameter is correct. #287's proposed `<TModel, TField>` signature is not implemented; the issue's premise dissolves.
+
+Automatic per-field focus — the capability `focusCurrentField` was reaching for — is a **root-level** concern: one registration on the root, with the toolkit deriving the active field's dotted path from its own field-identity and touch tracking. That is tracked as separate research in #293, not as a repair of the deleted shape.
+
+## Consequences
+
+### Positive
+
+- The documented per-field pattern stops producing a permanent blocking error on a valid value.
+- The interface states one thing: _this suite validates this path's value._ Misuse becomes a type error at the call site rather than silent wrong behaviour at runtime.
+- Group-bound registrations stop mis-attributing child errors to the group, which removes an `aria-describedby` correctness hazard (WCAG 1.3.1).
+- Three modules of complexity are deleted, not moved: the focus derivation, the bound-field entry filter, and the blanket `catch`.
+- The four `TS2345` spec errors blocking [#286](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/286) are resolved by deletion, and the contract fix clears five further `TS2769` errors.
+
+### Negative
+
+- **Breaking, with no deprecation path.** `focusCurrentField` is removed outright. The project is pre-`v1.0.0` (`1.0.0-rc.11`, v1.0.0 never shipped), so no alias or overload is kept.
+- Automatic focus names for array items (`items.0.sku`) are lost until the root-level replacement is designed. A manual `only` selector reading a consumer-tracked "active item" value remains available and is what the docs already teach.
+- A dev-mode throw on a malformed Vest field name propagates through change detection, so the form render fails loudly. This is intentional but is a harder failure mode than anything the package did before.
+
+### Neutral
+
+- The run coordinator (cache, contention detection, FIFO queue, settlement — roughly 500 of `vest-adapter.ts`'s 1614 lines) is **not** retired by this decision. Contention is a two-mount concern: one module-scope suite, two field trees. Giving it its own interface is tracked in #295.
+
+## Related
+
+- [ADR-0006](0006-one-cascade-seam.md) — the same "one contract, one place" reasoning applied to error-visibility timing.
+- [#287](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/287) — re-scoped around this decision: suite input rule, `focusCurrentField` deletion, enforceable suite contract.
+- [#291](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/291) — the unresolvable-name rule from decision point 4.
+- [#292](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/292) — threading Vest's typed field-name union through the focus selector.
+- [#293](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/293) — research: automatic per-field focus at the root, the deliberate replacement for `focusCurrentField`.
+- [#294](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/294) — coverage of the exported interface, including the untested shared adapter singleton.
+- [#295](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/295) — giving the run coordinator its own interface.
+- [#286](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/286) — spec typecheck target; nine of its errors are resolved by #287.

--- a/docs/decisions/0008-vest-suite-input-is-the-bound-path.md
+++ b/docs/decisions/0008-vest-suite-input-is-the-bound-path.md
@@ -2,7 +2,14 @@
 
 ## Status
 
-Accepted
+Accepted — not yet implemented.
+
+The decision below is settled and is what the implementing work must follow, but
+the package still has the old behaviour: `focusCurrentField` and
+`deriveVestFieldNameFromContext` are present until
+[#287](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/287) lands.
+The Decision and Consequences sections are written declaratively because they
+state the ruling, not the current state of the code.
 
 ## Date
 
@@ -39,7 +46,7 @@ validateTree(path, (ctx) => {
 });
 ```
 
-So the README-documented per-field pattern (`README.md:135`, `:395`) hands a **string** to a suite authored for the model. Reproduced:
+So the README-documented per-field pattern (`packages/toolkit/vest/README.md:135`, `:395`) hands a **string** to a suite authored for the model. Reproduced:
 
 ```ts
 const suite = create((data: { email: string; password: string }) => {


### PR DESCRIPTION
Records the decision that came out of re-scoping #287, and adds the vocabulary it settles to `CONTEXT.md`. Docs only — no code changes.

#287 was filed as a typing defect: `validateVest`'s single generic stands for both the bound field's type and the suite's input type, so the per-field pattern the README documents does not typecheck against a real Vest suite. The proposed fix was to split the generic into `<TModel, TField>`.

Investigating that turned up the reason it does not typecheck. A field-scoped registration feeds the **bound field's** value into `suite.run()`, so a model-scoped suite bound to `path.email` receives the email string:

```text
suite.run received:  ["", "ada@example.com"]
email errors AFTER valid input:
  [{ kind: 'vest:email:email-is-required:0', message: 'Email is required' }]
```

`data.email` on a string primitive is always `undefined`, so the field carries a blocking error that never clears — on a valid value. The type error was the only thing keeping that pattern out of use, which is precisely what the proposed split would have removed.

**The decision: the bound path's value _is_ the suite input.** Binding a subtree stays legal wherever the suite is authored for that subtree's value; what goes away is the mismatch — `focusCurrentField` and the root-relative field-name derivation it existed to serve. One type parameter remains correct, so there is no generic split.

Two alternatives are recorded as rejected, both worth a look during review since they are the shapes a future reader is most likely to re-propose:

- **Take a model path from the caller** (`{ model: path }`, or an object form). Its central invariant — the bound field must be a descendant of the model — is not expressible in TypeScript, so it cannot be enforced. It also makes the whole model the reactive dependency, turning N field registrations into N focused suite runs per keystroke where one root registration is one run.
- **A suite per field**, which is what the current specs quietly do. It defeats the point of Vest, whose suites are model-scoped.

`CONTEXT.md` gains four glossary terms — **bound path**, **suite input**, **Vest field name**, **virtual Vest field name** — plus a key-concepts entry recording why the deleted shape should not be reinvented. Worth landing ahead of the implementation work: the six issues below link to this ADR, and `AGENTS.md` points every agent at `CONTEXT.md` first, so the briefs read as jargon until this vocabulary is on `main`.

Status is `Accepted` while the code still has the old behaviour, matching how ADR-0006 sits today.

Refs #287, #286, #291, #292, #293, #294, #295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added glossary entries defining bound paths, suite inputs, Vest field names, and virtual field names.
  - Documented field binding, name resolution, validation, and error-attachment semantics.
  - Added an architecture decision record clarifying suite input requirements, field-name resolution, virtual fields, and focus behavior.
  - Clarified supported subtree binding and documented related compatibility considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->