### PR TITLE
fix(build): make strip-internal-exports fail loudly on dangling /core refs

### DIFF
--- a/packages/toolkit/scripts/strip-internal-exports.mjs
+++ b/packages/toolkit/scripts/strip-internal-exports.mjs
@@ -44,10 +44,24 @@ const RELATIVE_DTS_SPECIFIER = './ngx-signal-forms-toolkit-core.js';
 const CORE_FESM_BASENAME = 'ngx-signal-forms-toolkit-core.mjs';
 const CORE_DTS_BASENAME = 'ngx-signal-forms-toolkit-core.d.ts';
 
+const escapeRegExp = (/** @type {string} */ value) =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+
+// Matches the package-name specifier under either quote style (`'…'` or
+// `"…"`), including inside inline `import("…").Type` type references that
+// `tsc` emits double-quoted. The backreference (`\1`) ties the closing quote
+// to whichever quote opened the match, so a mismatched pair never matches.
+const QUOTED_SPECIFIER_PATTERN = new RegExp(
+  `(['"])${escapeRegExp(PACKAGE_CORE_SPECIFIER)}\\1`,
+  'gu',
+);
+
 /** @type {string[]} */
 const rewrittenMjs = [];
 /** @type {string[]} */
 const rewrittenDts = [];
+/** @type {string[]} */
+const danglingReferences = [];
 
 const rewriteImportSpecifier = (
   /** @type {string} */ dir,
@@ -63,11 +77,23 @@ const rewriteImportSpecifier = (
     const content = readFileSync(filePath, 'utf8');
     if (!content.includes(PACKAGE_CORE_SPECIFIER)) continue;
     const rewritten = content.replaceAll(
-      `'${PACKAGE_CORE_SPECIFIER}'`,
-      `'${newSpecifier}'`,
+      QUOTED_SPECIFIER_PATTERN,
+      (/** @type {string} */ _match, /** @type {string} */ quote) =>
+        `${quote}${newSpecifier}${quote}`,
     );
-    writeFileSync(filePath, rewritten);
-    bucket.push(name);
+    if (rewritten !== content) {
+      writeFileSync(filePath, rewritten);
+      bucket.push(name);
+    }
+    // The gate above is a cheap substring pre-check; this is the real
+    // post-condition. A file can still contain the raw specifier after the
+    // rewrite if it appears in a form the regex above does not recognize
+    // (e.g. split across a template literal). Publishing with that
+    // reference intact would throw `ERR_PACKAGE_PATH_NOT_EXPORTED` the
+    // moment `"./core"` is stripped from `exports`, so treat it as fatal.
+    if (rewritten.includes(PACKAGE_CORE_SPECIFIER)) {
+      danglingReferences.push(filePath);
+    }
   }
 };
 
@@ -85,6 +111,17 @@ rewriteImportSpecifier(
   RELATIVE_DTS_SPECIFIER,
   rewrittenDts,
 );
+
+if (danglingReferences.length > 0) {
+  console.error(
+    `[toolkit] ERROR: ${danglingReferences.length} file(s) still reference '${PACKAGE_CORE_SPECIFIER}' after the rewrite pass:`,
+  );
+  for (const filePath of danglingReferences) console.error(`  ${filePath}`);
+  console.error(
+    '[toolkit] Aborting before stripping "./core" from the exports map — publishing now would throw ERR_PACKAGE_PATH_NOT_EXPORTED on import.',
+  );
+  process.exit(1);
+}
 
 /** @typedef {{ exports?: Record<string, unknown> }} PackageJsonLike */
 

--- a/packages/toolkit/scripts/strip-internal-exports.mjs
+++ b/packages/toolkit/scripts/strip-internal-exports.mjs
@@ -68,7 +68,7 @@ const rewriteImportSpecifier = (
   /** @type {string} */ skipBaseName,
   /** @type {string} */ extension,
   /** @type {string} */ newSpecifier,
-  /** @type {readonly string[]} */ bucket,
+  /** @type {string[]} */ bucket,
 ) => {
   for (const name of readdirSync(dir)) {
     if (!name.endsWith(extension)) continue;
@@ -114,7 +114,7 @@ rewriteImportSpecifier(
 
 if (danglingReferences.length > 0) {
   console.error(
-    `[toolkit] ERROR: ${danglingReferences.length} file(s) still reference '${PACKAGE_CORE_SPECIFIER}' after the rewrite pass:`,
+    `[toolkit] ERROR: ${danglingReferences.length} dangling reference(s) to '${PACKAGE_CORE_SPECIFIER}' survived the rewrite pass:`,
   );
   for (const filePath of danglingReferences) console.error(`  ${filePath}`);
   console.error(

--- a/packages/toolkit/scripts/strip-internal-exports.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-exports.spec.ts
@@ -155,12 +155,12 @@ describe('strip-internal-exports.mjs', () => {
     await mkdir(fesmDir, { recursive: true });
     await mkdir(typesDir, { recursive: true });
 
-    // A form the rewrite regex cannot recognize (specifier split across a
-    // template literal) — simulates a dangling reference that survives the
-    // rewrite pass.
+    // A form the rewrite regex cannot recognize (backtick-quoted, not
+    // single- or double-quoted) — simulates a dangling reference that
+    // survives the rewrite pass.
     writeFileSync(
       join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
-      'export * from `@ngx-signal-forms/toolkit/core`;\n',
+      'const CORE = `@ngx-signal-forms/toolkit/core`;\nexport { CORE };\n',
     );
     writeFileSync(
       join(fesmDir, 'ngx-signal-forms-toolkit-core.mjs'),
@@ -184,12 +184,24 @@ describe('strip-internal-exports.mjs', () => {
       }),
     );
 
-    expect(() =>
+    let failure: { status: number | null; stderr: string } | undefined;
+    try {
       execFileSync(process.execPath, [scriptPath], {
         cwd: workDir,
         stdio: 'pipe',
-      }),
-    ).toThrow('Command failed');
+        encoding: 'utf8',
+      });
+    } catch (error) {
+      const execError = error as { status: number | null; stderr: string };
+      failure = { status: execError.status, stderr: execError.stderr };
+    }
+
+    // Assert on exit status and the script's own stderr report rather than
+    // Node's `execFileSync` error message, which is not stable across
+    // Node versions.
+    expect(failure).toBeDefined();
+    expect(failure?.status).not.toBe(0);
+    expect(failure?.stderr).toContain('dangling');
 
     // The exports map must survive untouched — stripping it while a dangling
     // reference remains would publish a package that breaks on import.

--- a/packages/toolkit/scripts/strip-internal-exports.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-exports.spec.ts
@@ -83,4 +83,121 @@ describe('strip-internal-exports.mjs', () => {
     expect(dts).not.toMatch(/'\.\/ngx-signal-forms-toolkit-core'/);
     expect(dts).toContain(`from './ngx-signal-forms-toolkit-core.js'`);
   });
+
+  // Regression test for #283: `tsc` emits inline `import("…").Type`
+  // references double-quoted. The old rewrite only matched single-quoted
+  // specifiers, so a double-quoted one survived the rewrite untouched while
+  // the success gate (a bare substring check) still counted the file as
+  // rewritten and let the run strip `"./core"` from `exports` anyway —
+  // publishing a package that throws `ERR_PACKAGE_PATH_NOT_EXPORTED` on
+  // import while reporting success.
+  it('rewrites double-quoted core specifiers instead of silently skipping them', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'strip-internal-exports-'));
+    const distRoot = join(workDir, 'dist/packages/toolkit');
+    const fesmDir = join(distRoot, 'fesm2022');
+    const typesDir = join(distRoot, 'types');
+    await mkdir(fesmDir, { recursive: true });
+    await mkdir(typesDir, { recursive: true });
+
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      `export * from "@ngx-signal-forms/toolkit/core";\n`,
+    );
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit-core.mjs'),
+      `export {};\n`,
+    );
+    // A `tsc`-style inline type reference, double-quoted.
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      `export declare const x: import("@ngx-signal-forms/toolkit/core").Foo;\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(distRoot, 'package.json'),
+      JSON.stringify({
+        exports: {
+          '.': './fesm2022/ngx-signal-forms-toolkit.mjs',
+          './core': './fesm2022/ngx-signal-forms-toolkit-core.mjs',
+        },
+      }),
+    );
+
+    execFileSync(process.execPath, [scriptPath], { cwd: workDir });
+
+    const dts = readFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      'utf8',
+    );
+    const mjs = readFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      'utf8',
+    );
+    const pkg = JSON.parse(
+      readFileSync(join(distRoot, 'package.json'), 'utf8'),
+    );
+
+    expect(mjs).toContain(`from "./ngx-signal-forms-toolkit-core.mjs"`);
+    expect(dts).toContain(`import("./ngx-signal-forms-toolkit-core.js").Foo`);
+    expect(dts).not.toContain('@ngx-signal-forms/toolkit/core');
+    // The rewrite succeeded, so it is safe to strip "./core" from exports.
+    expect(pkg.exports['./core']).toBeUndefined();
+  });
+
+  it('fails loudly instead of stripping "./core" when a dangling reference survives the rewrite', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'strip-internal-exports-'));
+    const distRoot = join(workDir, 'dist/packages/toolkit');
+    const fesmDir = join(distRoot, 'fesm2022');
+    const typesDir = join(distRoot, 'types');
+    await mkdir(fesmDir, { recursive: true });
+    await mkdir(typesDir, { recursive: true });
+
+    // A form the rewrite regex cannot recognize (specifier split across a
+    // template literal) — simulates a dangling reference that survives the
+    // rewrite pass.
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit.mjs'),
+      'export * from `@ngx-signal-forms/toolkit/core`;\n',
+    );
+    writeFileSync(
+      join(fesmDir, 'ngx-signal-forms-toolkit-core.mjs'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit.d.ts'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      `export {};\n`,
+    );
+    writeFileSync(
+      join(distRoot, 'package.json'),
+      JSON.stringify({
+        exports: {
+          '.': './fesm2022/ngx-signal-forms-toolkit.mjs',
+          './core': './fesm2022/ngx-signal-forms-toolkit-core.mjs',
+        },
+      }),
+    );
+
+    expect(() =>
+      execFileSync(process.execPath, [scriptPath], {
+        cwd: workDir,
+        stdio: 'pipe',
+      }),
+    ).toThrow('Command failed');
+
+    // The exports map must survive untouched — stripping it while a dangling
+    // reference remains would publish a package that breaks on import.
+    const pkg = JSON.parse(
+      readFileSync(join(distRoot, 'package.json'), 'utf8'),
+    );
+    expect(pkg.exports['./core']).toBe(
+      './fesm2022/ngx-signal-forms-toolkit-core.mjs',
+    );
+  });
 });


### PR DESCRIPTION
`strip-internal-exports` could report a rewrite it never performed: the success gate was a bare substring check, but the rewrite only matched **single-quoted** specifiers. A double-quoted occurrence of `@ngx-signal-forms/toolkit/core` (the form `tsc` emits for inline `import("…").Type` references) passed the gate, was counted as rewritten, and survived untouched — after which the script still stripped `./core` from the `exports` map, publishing a package that throws `ERR_PACKAGE_PATH_NOT_EXPORTED` on the consumer's first import.

Three changes close that hole:

- The rewrite now matches either quote style with one backreferenced pattern (`(['"])@ngx-signal-forms/toolkit/core\1`), so quote style is no longer load-bearing.
- Summary counts increment only when a file's content actually changed, not when it merely matched the substring gate.
- A post-condition scan aborts non-zero — listing the offending files, **before** `package.json` is touched — if any non-core `.mjs`/`.d.ts` still contains the raw specifier. The `exports` key is never stripped while a dangling reference survives.

Regression specs cover the double-quoted rewrite and the failure path (asserting `./core` survives in `exports` when the scan trips); the existing single-quoted spec is unchanged. Verified against the real build: `nx run toolkit:post-build` still rewrites 4 FESM bundles + 2 type declarations and strips `./core`.

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package preparation by correctly rewriting internal core references in JavaScript and declaration files.
  * Prevented incomplete package exports from being published when unresolved internal references remain.
  * Added clearer error reporting for affected files and package-resolution failures.

* **Tests**
  * Added coverage for quoted references and failure scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->