### PR TITLE
test(toolkit): axe-scan the seven rendering components

### DIFF
--- a/packages/toolkit/assistive/character-count.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/character-count.a11y.browser.spec.ts
@@ -1,0 +1,77 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, maxLength } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { userEvent } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldCharacterCount } from './character-count';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormFieldCharacterCount`.
+ *
+ * Rendered next to the textarea it counts (its real shipped composition —
+ * see the class doc's "Basic character count" example), with live
+ * announcements enabled so the polite `aria-live` region is present in both
+ * scanned states. The two states produce meaningfully different accessible
+ * output: within the limit no announcement text is rendered, past it the
+ * live region carries the "exceeded" message and the visible count changes
+ * from a lighter to a bold, high-contrast color.
+ */
+describe('NgxFormFieldCharacterCount — WCAG 2.2 AA conformance', () => {
+  it('a count within its limit has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-char-count-ok',
+      imports: [FormField, NgxFormFieldCharacterCount],
+      template: `
+        <label for="bio">Bio</label>
+        <textarea id="bio" [formField]="testForm.bio"></textarea>
+        <ngx-form-field-character-count
+          [formField]="testForm.bio"
+          [liveAnnounce]="true"
+        />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ bio: 'Hello there' });
+      readonly testForm = form(this.#model, (path) => {
+        maxLength(path.bio, 500);
+      });
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.textContent).toContain('11/500');
+    await expectNoA11yViolations(container);
+  });
+
+  it('a count past its limit has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-char-count-exceeded',
+      imports: [FormField, NgxFormFieldCharacterCount],
+      template: `
+        <label for="tweet">Tweet</label>
+        <textarea id="tweet" [formField]="testForm.tweet"></textarea>
+        <ngx-form-field-character-count
+          [formField]="testForm.tweet"
+          [maxLength]="10"
+          [liveAnnounce]="true"
+        />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ tweet: '' });
+      readonly testForm = form(this.#model);
+    }
+
+    const { container } = await render(TestComponent);
+    const textarea = container.querySelector('textarea')!;
+    await userEvent.click(textarea);
+    await userEvent.type(textarea, 'Way past the ten character limit');
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.textContent).toContain('/10');
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/assistive/form-field-error-summary.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.a11y.browser.spec.ts
@@ -1,0 +1,152 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, required, schema } from '@angular/forms/signals';
+import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
+import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
+import { render } from '@testing-library/angular';
+import axe from 'axe-core';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldErrorSummary } from './form-field-error-summary';
+import {
+  expectNoA11yViolations,
+  findAlertContaining,
+  WCAG_22_AA_TAGS,
+} from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormFieldErrorSummary`.
+ *
+ * Scanned in both accessible states: empty (the live region must still be
+ * present per WCAG 4.1.3 — see the wrapper spec's twin) and populated after
+ * a failed submit, which is the summary's documented usage — auto-focusing
+ * onto itself and rendering one clickable entry per invalid field.
+ *
+ * The populated state currently has two real, pre-existing violations in the
+ * default `.ngx-form-field-error-summary__link` styling (`form-field-error-
+ * summary.ts`), tracked in
+ * [#299](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/299):
+ *
+ * - `color-contrast`: the default link color `#dc2626` on the summary's
+ *   `#fef2f2` background resolves to ~4.41:1, just under the 4.5:1 minimum
+ *   for 14px text (WCAG 1.4.3).
+ * - `target-size`: `all: unset` on the link strips its padding, leaving a
+ *   touch target shorter than the 24px minimum (WCAG 2.5.8).
+ *
+ * The second test below asserts on the *exact* violation set rather than
+ * wrapping a whole `it.fails`/`expectNoA11yViolations` call: the render and
+ * the two summary-content checks stay normal hard assertions (so a
+ * functional regression still fails loudly), and only the two known,
+ * tracked rule IDs are allowed through the scan — any other violation, or a
+ * component-driven disappearance of these two once #299 lands, fails the
+ * test and forces this spec to be updated.
+ */
+describe('NgxFormFieldErrorSummary — WCAG 2.2 AA conformance', () => {
+  it('the empty summary before submission has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-summary-empty',
+      imports: [
+        FormField,
+        NgxSignalFormToolkit,
+        NgxFormField,
+        NgxFormFieldErrorSummary,
+      ],
+      template: `
+        <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-submit">
+          <ngx-form-field-error-summary [formTree]="testForm" />
+          <ngx-form-field-wrapper
+            [formField]="testForm.email"
+            fieldName="email"
+          >
+            <label for="email">Email address</label>
+            <input id="email" type="email" [formField]="testForm.email" />
+          </ngx-form-field-wrapper>
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('[role="alert"]')).toBeTruthy();
+    await expectNoA11yViolations(container);
+  });
+
+  it('a populated summary after a failed submit has only the tracked #299 violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-summary-populated',
+      imports: [
+        FormField,
+        NgxSignalFormToolkit,
+        NgxFormField,
+        NgxFormFieldErrorSummary,
+      ],
+      template: `
+        <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-submit">
+          <ngx-form-field-error-summary
+            [formTree]="testForm"
+            [submittedStatus]="'submitted'"
+            summaryLabel="Please fix the following errors:"
+          />
+          <ngx-form-field-wrapper [formField]="testForm.name" fieldName="name">
+            <label for="name">Full name</label>
+            <input id="name" type="text" [formField]="testForm.name" />
+          </ngx-form-field-wrapper>
+          <ngx-form-field-wrapper
+            [formField]="testForm.email"
+            fieldName="email"
+          >
+            <label for="email">Email address</label>
+            <input id="email" type="email" [formField]="testForm.email" />
+          </ngx-form-field-wrapper>
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ name: '', email: '' });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.name, { message: 'Name is required' });
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // Hard functional assertions: the summary rendered and aggregated both
+    // field errors. These fail loudly on any regression regardless of the
+    // tracked styling violations below.
+    const summaryAlert = findAlertContaining(
+      container,
+      'Please fix the following errors',
+    );
+    expect(summaryAlert?.textContent).toContain('Name is required');
+    expect(summaryAlert?.textContent).toContain('Email is required');
+
+    // Accessibility assertion: only the two rule IDs tracked in #299 are
+    // allowed through. `expectNoA11yViolations` isn't used here because it
+    // throws on ANY violation — this test instead asserts the exact
+    // violation set, so it hard-fails on a new/different violation (a real
+    // regression) just as much as it will once the tracked two are fixed
+    // (a signal to update this spec and close #299).
+    const results = await axe.run(container, {
+      runOnly: { type: 'tag', values: [...WCAG_22_AA_TAGS] },
+      resultTypes: ['violations'],
+    });
+    const violationIds = results.violations
+      .map((violation) => violation.id)
+      .toSorted();
+    expect(violationIds).toEqual(['color-contrast', 'target-size']);
+  });
+});

--- a/packages/toolkit/assistive/form-field-error-summary.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.a11y.browser.spec.ts
@@ -76,7 +76,16 @@ describe('NgxFormFieldErrorSummary — WCAG 2.2 AA conformance', () => {
     const { container } = await render(TestComponent);
     await TestBed.inject(ApplicationRef).whenStable();
 
-    expect(container.querySelector('[role="alert"]')).toBeTruthy();
+    // Scope to the summary's own live region, not a bare `[role="alert"]`
+    // query — the wrapped field mounts its own always-present alert region
+    // too (see the class doc's WCAG 4.1.3 note), so an unscoped query would
+    // still pass even if `NgxFormFieldErrorSummary` stopped rendering its
+    // live region entirely.
+    const summaryAlert = container.querySelector(
+      'ngx-form-field-error-summary [role="alert"]',
+    );
+    expect(summaryAlert).toBeTruthy();
+    expect(summaryAlert?.textContent?.trim()).toBe('');
     await expectNoA11yViolations(container);
   });
 

--- a/packages/toolkit/assistive/form-field-error.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-error.a11y.browser.spec.ts
@@ -1,0 +1,142 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  FormField,
+  form,
+  required,
+  schema,
+  validate,
+} from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { userEvent } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldError } from './form-field-error';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormFieldError` used standalone —
+ * i.e. projected directly next to a plain `[formField]` input rather than
+ * through `NgxFormFieldWrapper`'s renderer outlet (the class doc's
+ * "Simplest Usage — no NgxSignalFormToolkit needed" example). The wrapper's
+ * own a11y spec already covers the composed case, so this spec is the only
+ * gate on the bare component. Scanned across all three of its accessible
+ * states, since blocking errors and warnings render under different
+ * implicit live-region roles (alert vs status).
+ */
+describe('NgxFormFieldError (standalone) — WCAG 2.2 AA conformance', () => {
+  it('the initial, error-free state has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-standalone-error-empty',
+      imports: [FormField, NgxFormFieldError],
+      template: `
+        <form (submit)="$event.preventDefault()" novalidate>
+          <label for="email">Email</label>
+          <input id="email" [formField]="testForm.email" />
+          <ngx-form-field-error
+            [formField]="testForm.email"
+            fieldName="email"
+          />
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('[role="alert"]')?.textContent?.trim()).toBe(
+      '',
+    );
+    await expectNoA11yViolations(container);
+  });
+
+  it('a visible blocking error has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-standalone-error-blocking',
+      imports: [FormField, NgxFormFieldError],
+      template: `
+        <form (submit)="$event.preventDefault()" novalidate>
+          <label for="email">Email</label>
+          <input id="email" [formField]="testForm.email" />
+          <ngx-form-field-error
+            [formField]="testForm.email"
+            fieldName="email"
+            strategy="immediate"
+          />
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Email is required',
+    );
+    await expectNoA11yViolations(container);
+  });
+
+  it('a visible warning has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-standalone-error-warning',
+      imports: [FormField, NgxFormFieldError],
+      template: `
+        <form (submit)="$event.preventDefault()" novalidate>
+          <label for="password">Password</label>
+          <input id="password" [formField]="testForm.password" />
+          <ngx-form-field-error
+            [formField]="testForm.password"
+            fieldName="password"
+          />
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ password: '' });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          validate(path.password, (ctx) => {
+            const value = ctx.value();
+            if (value.length > 0 && value.length < 8) {
+              return {
+                kind: 'warn:weak-password',
+                message: 'Consider 8 or more characters',
+              };
+            }
+            return null;
+          });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    const input = container.querySelector<HTMLInputElement>('input#password')!;
+    await userEvent.click(input);
+    await userEvent.type(input, 'abc');
+    await userEvent.tab();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      'Consider 8 or more characters',
+    );
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/assistive/form-field-notification.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-notification.a11y.browser.spec.ts
@@ -1,0 +1,89 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ValidationError } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldNotification } from './form-field-notification';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormFieldNotification`.
+ *
+ * Rendered the way a custom summary block composes it — a `[errors]`-bound
+ * card outside the `NgxFormFieldset` renderer outlet (per the class doc's
+ * "grouped fieldset feedback" / "custom summary cards" usage). Scanned empty
+ * (both live regions must already exist per WCAG 4.1.3 — see the wrapper
+ * spec's twin), with blocking errors (role="alert"), and, separately, with
+ * only warnings (role="status") — the two live regions carry a different
+ * implicit role and only one is ever populated at a time.
+ */
+describe('NgxFormFieldNotification — WCAG 2.2 AA conformance', () => {
+  it('the empty notification has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-notification-empty',
+      imports: [NgxFormFieldNotification],
+      template: `
+        <ngx-form-field-notification [errors]="errors" fieldName="shipping" />
+      `,
+    })
+    class TestComponent {
+      readonly errors = signal<readonly ValidationError[]>([]);
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('[role="alert"]')).toBeTruthy();
+    expect(container.querySelector('[role="status"]')).toBeTruthy();
+    await expectNoA11yViolations(container);
+  });
+
+  it('a populated error notification has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-notification-error',
+      imports: [NgxFormFieldNotification],
+      template: `
+        <ngx-form-field-notification
+          [errors]="errors"
+          fieldName="shipping"
+          title="Shipping address errors"
+        />
+      `,
+    })
+    class TestComponent {
+      readonly errors = signal<readonly ValidationError[]>([
+        { kind: 'required', message: 'Street is required' },
+        { kind: 'required', message: 'City is required' },
+      ]);
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('Street is required');
+    await expectNoA11yViolations(container);
+  });
+
+  it('a populated warning notification has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-notification-warning',
+      imports: [NgxFormFieldNotification],
+      template: `
+        <ngx-form-field-notification [errors]="warnings" fieldName="shipping" />
+      `,
+    })
+    class TestComponent {
+      readonly warnings = signal<readonly ValidationError[]>([
+        { kind: 'warn:po-box', message: 'PO boxes may delay delivery' },
+      ]);
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const status = container.querySelector('[role="status"]');
+    expect(status?.textContent).toContain('PO boxes may delay delivery');
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/assistive/form-marking-legend.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/form-marking-legend.a11y.browser.spec.ts
@@ -1,0 +1,61 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, required, schema } from '@angular/forms/signals';
+import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
+import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormMarkingLegend } from './form-marking-legend';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormMarkingLegend`.
+ *
+ * Rendered the way it ships — once, ahead of the fields it explains — next
+ * to a real required field carrying the marker it describes. The legend
+ * renders identical markup (a plain `<p>`) across marking modes, so one
+ * fixture with a resolvable required field covers its accessible output.
+ */
+describe('NgxFormMarkingLegend — WCAG 2.2 AA conformance', () => {
+  it('the legend paired with a required field has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-marking-legend',
+      imports: [
+        FormField,
+        NgxSignalFormToolkit,
+        NgxFormField,
+        NgxFormMarkingLegend,
+      ],
+      template: `
+        <form [formRoot]="testForm" ngxSignalForm>
+          <ngx-form-marking-legend
+            [formTree]="testForm"
+            showMarkerWhen="required"
+          />
+          <ngx-form-field-wrapper
+            [formField]="testForm.email"
+            fieldName="email"
+          >
+            <label for="email">Email address</label>
+            <input id="email" type="email" [formField]="testForm.email" />
+          </ngx-form-field-wrapper>
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ email: '' });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          required(path.email, { message: 'Email is required' });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('.ngx-form-marking-legend')).toBeTruthy();
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/assistive/hint.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/hint.a11y.browser.spec.ts
@@ -1,0 +1,49 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldHint } from './hint';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormFieldHint`.
+ *
+ * Rendered directly beside its labelled control (its documented "Basic hint
+ * text" usage) rather than through `NgxFormFieldWrapper` — the wrapper's own
+ * a11y spec already covers the wrapper-composed case. `aria-describedby`
+ * linking is wired manually here since there is no wrapper to auto-manage
+ * it, matching how the class doc's standalone example is written.
+ */
+describe('NgxFormFieldHint — WCAG 2.2 AA conformance', () => {
+  it('a hint linked to its control has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-hint',
+      imports: [FormField, NgxFormFieldHint],
+      template: `
+        <label for="phone">Phone number</label>
+        <input
+          id="phone"
+          type="tel"
+          [formField]="testForm.phone"
+          aria-describedby="phone-hint"
+        />
+        <ngx-form-field-hint id="phone-hint">
+          Format: 123-456-7890
+        </ngx-form-field-hint>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ phone: '' });
+      readonly testForm = form(this.#model);
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('#phone-hint')?.textContent).toContain(
+      'Format: 123-456-7890',
+    );
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/form-field/form-fieldset.a11y.browser.spec.ts
+++ b/packages/toolkit/form-field/form-fieldset.a11y.browser.spec.ts
@@ -1,0 +1,141 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, schema, validate } from '@angular/forms/signals';
+import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
+import { NgxFormField } from './index';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import {
+  expectNoA11yViolations,
+  findAlertContaining,
+} from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * WCAG 2.2 AA conformance gate for `NgxFormFieldset`.
+ *
+ * Renders the fieldset the way it actually ships — a native `<fieldset>`
+ * grouping real wrapped fields via `[ngxFormFieldset]`, aggregating a
+ * cross-field error that lives on the group itself (the "passwords must
+ * match" example from the component's own doc comment) rather than an empty
+ * shell. Scanned in both the valid state and the group-error state, since
+ * the notification card only mounts once the fieldset has something to show.
+ */
+describe('NgxFormFieldset — WCAG 2.2 AA conformance', () => {
+  it('a valid group of fields has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-fieldset-valid',
+      imports: [FormField, NgxSignalFormToolkit, NgxFormField],
+      template: `
+        <form [formRoot]="testForm" ngxSignalForm errorStrategy="immediate">
+          <fieldset ngxFormFieldset [field]="testForm.passwords">
+            <legend>Passwords</legend>
+            <ngx-form-field-wrapper
+              [formField]="testForm.passwords.password"
+              fieldName="password"
+            >
+              <label for="password">Password</label>
+              <input
+                id="password"
+                type="password"
+                [formField]="testForm.passwords.password"
+              />
+            </ngx-form-field-wrapper>
+            <ngx-form-field-wrapper
+              [formField]="testForm.passwords.confirm"
+              fieldName="confirm"
+            >
+              <label for="confirm">Confirm password</label>
+              <input
+                id="confirm"
+                type="password"
+                [formField]="testForm.passwords.confirm"
+              />
+            </ngx-form-field-wrapper>
+          </fieldset>
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ passwords: { password: '', confirm: '' } });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          validate(path.passwords, (ctx) => {
+            const { password, confirm } = ctx.value();
+            return password === confirm
+              ? null
+              : { kind: 'passwordMismatch', message: 'Passwords must match' };
+          });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(container.querySelector('fieldset')).toBeTruthy();
+    await expectNoA11yViolations(container);
+  });
+
+  it('a group-level cross-field error has no violations', async () => {
+    @Component({
+      selector: 'ngx-test-a11y-fieldset-error',
+      imports: [FormField, NgxSignalFormToolkit, NgxFormField],
+      template: `
+        <form [formRoot]="testForm" ngxSignalForm errorStrategy="immediate">
+          <fieldset ngxFormFieldset [field]="testForm.passwords">
+            <legend>Passwords</legend>
+            <ngx-form-field-wrapper
+              [formField]="testForm.passwords.password"
+              fieldName="password"
+            >
+              <label for="password">Password</label>
+              <input
+                id="password"
+                type="password"
+                [formField]="testForm.passwords.password"
+              />
+            </ngx-form-field-wrapper>
+            <ngx-form-field-wrapper
+              [formField]="testForm.passwords.confirm"
+              fieldName="confirm"
+            >
+              <label for="confirm">Confirm password</label>
+              <input
+                id="confirm"
+                type="password"
+                [formField]="testForm.passwords.confirm"
+              />
+            </ngx-form-field-wrapper>
+          </fieldset>
+        </form>
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({
+        passwords: { password: 'hunter2', confirm: 'hunter3' },
+      });
+      readonly testForm = form(
+        this.#model,
+        schema((path) => {
+          validate(path.passwords, (ctx) => {
+            const { password, confirm } = ctx.value();
+            return password === confirm
+              ? null
+              : { kind: 'passwordMismatch', message: 'Passwords must match' };
+          });
+        }),
+      );
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // The fieldset notification is one of several role="alert" regions on the
+    // page (each wrapped field also carries its own, empty, error region) —
+    // find the one carrying the group-level message.
+    const groupAlert = findAlertContaining(container, 'Passwords must match');
+    expect(groupAlert).toBeTruthy();
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/testing/a11y.ts
+++ b/packages/toolkit/testing/a11y.ts
@@ -70,3 +70,23 @@ export async function expectNoA11yViolations(
     `Found ${results.violations.length} WCAG 2.2 AA accessibility violation(s):\n${report}`,
   );
 }
+
+/**
+ * Finds the `[role="alert"]` element within `container` whose text content
+ * includes `text`, or `undefined` if none matches.
+ *
+ * Several toolkit surfaces (grouped fieldsets, error summaries) render
+ * alongside per-field error regions that stay mounted-but-empty per the
+ * WCAG 4.1.3 first-insertion pattern (see `expectNoA11yViolations`'s own
+ * doc). A bare `getByRole('alert')` query is ambiguous whenever more than
+ * one such region is present; this narrows to the one actually carrying the
+ * expected message, for asserting on it before running the a11y scan.
+ */
+export function findAlertContaining(
+  container: ParentNode,
+  text: string,
+): HTMLElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[role="alert"]'),
+  ).find((el) => el.textContent?.includes(text));
+}

--- a/packages/toolkit/testing/index.ts
+++ b/packages/toolkit/testing/index.ts
@@ -4,5 +4,9 @@
 // contract. `axe-core` is an optional peer dependency of the toolkit — it is
 // only required if you import from this entry point.
 
-export { expectNoA11yViolations, WCAG_22_AA_TAGS } from './a11y';
+export {
+  expectNoA11yViolations,
+  findAlertContaining,
+  WCAG_22_AA_TAGS,
+} from './a11y';
 export type { WCAG_22_AA_TAG } from './a11y';


### PR DESCRIPTION
Adds WCAG 2.2 AA axe browser scans for the seven rendering components that had none: `NgxFormFieldset`, `NgxFormFieldErrorSummary`, `NgxFormFieldNotification`, `NgxFormMarkingLegend`, `NgxFormFieldCharacterCount`, `NgxFormFieldHint`, and standalone `NgxFormFieldError`. Each spec follows the existing `form-field-wrapper.a11y.browser.spec.ts` idiom — real Signal Forms compositions, `expectNoA11yViolations` from `@ngx-signal-forms/toolkit/testing`, and scans in each component's meaningfully distinct states (empty vs. populated, within vs. past limit, error vs. warning).

The scans caught a real defect: `NgxFormFieldErrorSummary`'s default link styling fails `color-contrast` (≈4.41:1, under the 4.5:1 AA floor) and `target-size` (`all: unset` collapses the touch target), filed as #299 and linked from the spec. The populated-state test keeps scanning: it asserts exactly those two known rule violations are present (and the functional content assertions stay hard), so it fails loudly the moment the CSS is fixed or any new violation appears — nothing is skipped or weakened.

Also adds a small `findAlertContaining` helper to `@ngx-signal-forms/toolkit/testing`, shared by the two specs that must disambiguate multiple `role="alert"` regions.

Fixes #284
Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
