### PR TITLE
test(form-field): axe-scan the wrapper's selection-cluster and layout configurations

### DIFF
--- a/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
@@ -556,7 +556,7 @@ describe('form-field wrapper — WCAG 2.2 AA conformance', () => {
       // — never a dangling `plan-warning`.
       expect(wrapper).toHaveAttribute('aria-describedby', 'plan-error');
       const statusRegion = container.querySelector('[role="status"]');
-      expect(statusRegion).not.toHaveAttribute('id', 'plan-warning');
+      expect(statusRegion).not.toHaveAttribute('id');
       expect(statusRegion?.textContent?.trim()).toBe('');
       await expectNoA11yViolations(container);
     });

--- a/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
@@ -1,12 +1,49 @@
-import { ApplicationRef, Component, signal } from '@angular/core';
+import { ApplicationRef, Component, signal, type Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { FormField, form, required, schema } from '@angular/forms/signals';
+import {
+  FormField,
+  form,
+  hidden,
+  required,
+  schema,
+  validate,
+} from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 import { render } from '@testing-library/angular';
 import { page, userEvent } from 'vitest/browser';
 import { describe, expect, it } from 'vitest';
 import { NgxFormField } from './index';
 import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+
+/**
+ * Builds a standalone test component for a fixture below. Every fixture
+ * needs the same three directives (`[formField]`, `[formRoot]`/
+ * `ngxSignalForm`, the wrapper itself) and exposes a single `testForm`
+ * property to its template — only the markup and the `form()` model behind
+ * it change from fixture to fixture, so both are supplied by the caller
+ * instead of repeating a full `@Component` declaration per test.
+ *
+ * `buildForm` runs inside the class field initializer (not at the call
+ * site) so `form()` executes during Angular's own component construction,
+ * which is an injection context — building it eagerly in the test body
+ * throws NG0203.
+ */
+function defineFixtureComponent<TForm extends object>(
+  selector: string,
+  template: string,
+  buildForm: () => TForm,
+): Type<{ readonly testForm: TForm }> {
+  @Component({
+    selector,
+    imports: [FormField, NgxSignalFormToolkit, NgxFormField],
+    template,
+  })
+  class FixtureComponent {
+    readonly testForm = buildForm();
+  }
+
+  return FixtureComponent;
+}
 
 /**
  * WCAG 2.2 AA conformance gate for the form-field wrapper composition.
@@ -95,5 +132,547 @@ describe('form-field wrapper — WCAG 2.2 AA conformance', () => {
       .element(page.getByRole('alert'))
       .toHaveTextContent('Name is required');
     await expectNoA11yViolations(container);
+  });
+
+  /**
+   * Issue #285: the wrapper's only prior axe coverage rendered a labelled
+   * text input — every other configuration it can reach (selection
+   * clusters, top-placed messages, outline appearance, the hidden safety
+   * net) was unscanned. The selection-cluster path matters most: it takes
+   * over as the group host (`role="radiogroup"` / `role="group"`),
+   * generates the projected legend's id, and composes `aria-describedby`
+   * from the error/warning ids itself — including a guard against emitting
+   * a dangling `${fieldName}-warning` reference (see
+   * `selectionClusterDescribedBy` in `form-field-wrapper.ts`) that was
+   * asserted by nothing before this suite.
+   */
+  describe('selection clusters', () => {
+    /** Shared by both radio-group fixtures — same DOM, different model. */
+    const RADIO_CLUSTER_TEMPLATE = `
+      <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-touch">
+        <ngx-form-field-wrapper
+          [formField]="testForm.deliveryMethod"
+          fieldName="delivery-method"
+        >
+          <span ngxFormFieldLabel>Delivery method</span>
+          <div>
+            <label>
+              <input
+                id="delivery-standard"
+                type="radio"
+                [formField]="testForm.deliveryMethod"
+                value="standard"
+              />
+              Standard
+            </label>
+            <label>
+              <input
+                id="delivery-express"
+                type="radio"
+                [formField]="testForm.deliveryMethod"
+                value="express"
+              />
+              Express
+            </label>
+          </div>
+        </ngx-form-field-wrapper>
+      </form>
+    `;
+
+    /**
+     * Shared by both checkbox-cluster fixtures below. Two distinct boolean
+     * fields — not one field bound to both checkboxes — so each control can
+     * carry independent checked state, the DOM shape a real "I have read
+     * the terms" / "I agree to the terms" pair actually produces. The
+     * wrapper tracks exactly one `formField` for its own error/aria state,
+     * so `consentRead` is the field that drives the cluster's
+     * `aria-invalid`/`aria-describedby`; `consentAgree` is still an
+     * independent, separately required control in the error fixture, it
+     * just isn't the field this particular wrapper instance watches.
+     */
+    const CHECKBOX_CLUSTER_TEMPLATE = `
+      <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-touch">
+        <ngx-form-field-wrapper
+          [formField]="testForm.consentRead"
+          fieldName="consent"
+        >
+          <span ngxFormFieldLabel>Consent</span>
+          <div>
+            <label>
+              <input
+                id="consent-read"
+                type="checkbox"
+                [formField]="testForm.consentRead"
+              />
+              I have read the terms
+            </label>
+            <label>
+              <input
+                id="consent-agree"
+                type="checkbox"
+                [formField]="testForm.consentAgree"
+              />
+              I agree to the terms
+            </label>
+          </div>
+        </ngx-form-field-wrapper>
+      </form>
+    `;
+
+    it('a radio-group cluster in its valid state has no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-radio-valid',
+        RADIO_CLUSTER_TEMPLATE,
+        () =>
+          form(
+            signal({ deliveryMethod: 'standard' }),
+            schema((path) => {
+              required(path.deliveryMethod, {
+                message: 'Delivery method is required',
+              });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      await expect
+        .element(page.getByRole('radiogroup', { name: 'Delivery method' }))
+        .toBeVisible();
+      await expectNoA11yViolations(container);
+    });
+
+    it('a radio-group cluster showing a required error has no violations, and its accessible name resolves through the generated legend id', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-radio-error',
+        RADIO_CLUSTER_TEMPLATE,
+        () =>
+          form(
+            signal({ deliveryMethod: '' }),
+            schema((path) => {
+              required(path.deliveryMethod, {
+                message: 'Delivery method is required',
+              });
+            }),
+          ),
+      );
+
+      const { container, fixture } = await render(TestComponent);
+
+      // Mark the field touched programmatically rather than via keyboard:
+      // every radio in an unchecked group is individually tabbable, so
+      // simulating "touch without selecting" through `userEvent.tab()` is
+      // timing-dependent on how many radios are present. Marking touched
+      // directly reveals the required error under `on-touch` while the
+      // value stays empty, which is the state under test.
+      fixture.componentInstance.testForm.deliveryMethod().markAsTouched();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      const legend = container.querySelector('[ngxFormFieldLabel]');
+      expect(wrapper).toHaveAttribute(
+        'aria-labelledby',
+        'delivery-method-label',
+      );
+      expect(legend).toHaveAttribute('id', 'delivery-method-label');
+
+      // A regression in label wiring fails this named assertion, not just
+      // an axe rule.
+      await expect
+        .element(page.getByRole('radiogroup', { name: 'Delivery method' }))
+        .toBeVisible();
+      await expect
+        .element(page.getByRole('alert'))
+        .toHaveTextContent('Delivery method is required');
+      await expectNoA11yViolations(container);
+    });
+
+    it('a multi-control checkbox cluster in its valid state has no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-checkbox-cluster-valid',
+        CHECKBOX_CLUSTER_TEMPLATE,
+        () => form(signal({ consentRead: true, consentAgree: true })),
+      );
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('role', 'group');
+      await expectNoA11yViolations(container);
+    });
+
+    it('a multi-control checkbox cluster showing a required error has no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-checkbox-cluster-error',
+        CHECKBOX_CLUSTER_TEMPLATE,
+        () =>
+          form(
+            signal({ consentRead: false, consentAgree: false }),
+            schema((path) => {
+              required(path.consentRead, { message: 'Consent is required' });
+              required(path.consentAgree, { message: 'Consent is required' });
+            }),
+          ),
+      );
+
+      const { container, fixture } = await render(TestComponent);
+
+      // Mark the field touched programmatically (see the radio-group error
+      // fixture above for why) — reveals the required error under the
+      // default `on-touch` strategy while consent stays unchecked.
+      fixture.componentInstance.testForm.consentRead().markAsTouched();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      await expect
+        .element(page.getByRole('alert'))
+        .toHaveTextContent('Consent is required');
+
+      // KNOWN VIOLATION, filed as
+      // https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300 (not
+      // fixed here — see the module doc comment above this `describe` block
+      // on the toolkit's scope guard for newly discovered defects): a
+      // required checkbox cluster puts `aria-required="true"` on the wrapper
+      // host alongside `role="group"`. `group` does not support
+      // `aria-required` in the ARIA spec (only `radiogroup` does among the
+      // roles this wrapper emits), so axe's `aria-allowed-attr` rule fires
+      // here — confirmed via the rendered wrapper: `role="group"
+      // aria-required="true"`. Scoped out here so the rest of the WCAG 2.2 AA
+      // gate stays a hard failure; remove this exclusion once #300 lands.
+      await expectNoA11yViolations(container, {
+        rules: { 'aria-allowed-attr': { enabled: false } },
+      });
+    });
+
+    it('two unnamed clusters skip label wiring instead of colliding on the same fallback id, and still have no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-unnamed-clusters',
+        `
+          <form [formRoot]="testForm" ngxSignalForm>
+            <ngx-form-field-wrapper [formField]="testForm.first">
+              <span ngxFormFieldLabel>Choose A</span>
+              <div>
+                <label>
+                  <input type="radio" [formField]="testForm.first" value="1" />
+                  One
+                </label>
+                <label>
+                  <input type="radio" [formField]="testForm.first" value="2" />
+                  Two
+                </label>
+              </div>
+            </ngx-form-field-wrapper>
+
+            <ngx-form-field-wrapper [formField]="testForm.second">
+              <span ngxFormFieldLabel>Choose B</span>
+              <div>
+                <label>
+                  <input
+                    type="radio"
+                    [formField]="testForm.second"
+                    value="3"
+                  />
+                  Three
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    [formField]="testForm.second"
+                    value="4"
+                  />
+                  Four
+                </label>
+              </div>
+            </ngx-form-field-wrapper>
+          </form>
+        `,
+        () => form(signal({ first: '1', second: '3' })),
+      );
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrappers = container.querySelectorAll('ngx-form-field-wrapper');
+      const legends = container.querySelectorAll('[ngxFormFieldLabel]');
+      expect(wrappers).toHaveLength(2);
+      // Neither cluster got labelled — the fallback id is skipped entirely
+      // (rather than both wrappers colliding on the same generated id) once
+      // `resolvedFieldName` can't derive a name from either an explicit
+      // `fieldName` input or a control `id`.
+      for (const wrapper of Array.from(wrappers)) {
+        expect(wrapper).not.toHaveAttribute('aria-labelledby');
+      }
+      for (const legend of Array.from(legends)) {
+        expect(legend).not.toHaveAttribute('id');
+      }
+      await expectNoA11yViolations(container);
+    });
+  });
+
+  /**
+   * `selectionClusterDescribedBy` composes the cluster's `aria-describedby`
+   * itself rather than delegating to auto-aria, and its comment names the
+   * exact axe rule (`aria-valid-attr-value`) a dangling `${fieldName}-warning`
+   * reference would violate. These two fixtures exercise the guard in both
+   * directions: a warning shown on its own timing, and a warning suppressed
+   * because a blocking error takes over the reference instead.
+   */
+  describe('warning / error aria-describedby composition on a selection cluster', () => {
+    it('a warning-only cluster under a non-immediate warning strategy composes aria-describedby to the warning id, with no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-cluster-warning-only',
+        `
+          <form [formRoot]="testForm" ngxSignalForm>
+            <ngx-form-field-wrapper
+              [formField]="testForm.plan"
+              fieldName="plan"
+              warningStrategy="on-touch"
+            >
+              <span ngxFormFieldLabel>Plan</span>
+              <div>
+                <label>
+                  <input
+                    id="plan-basic"
+                    type="radio"
+                    [formField]="testForm.plan"
+                    value="basic"
+                  />
+                  Basic
+                </label>
+                <label>
+                  <input
+                    id="plan-pro"
+                    type="radio"
+                    [formField]="testForm.plan"
+                    value="pro"
+                  />
+                  Pro
+                </label>
+              </div>
+            </ngx-form-field-wrapper>
+          </form>
+        `,
+        () =>
+          form(
+            signal({ plan: '' }),
+            schema((path) => {
+              validate(path.plan, (ctx) => {
+                if (ctx.value() === 'basic') {
+                  return {
+                    kind: 'warn:basic-plan-limited',
+                    message: 'Basic plan has limited features',
+                  };
+                }
+                return null;
+              });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent);
+
+      await userEvent.click(page.getByRole('radio', { name: 'Basic' }));
+      await userEvent.tab();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      await expect
+        .element(page.getByRole('status'))
+        .toHaveTextContent('Basic plan has limited features');
+      expect(wrapper).toHaveAttribute('aria-describedby', 'plan-warning');
+      await expectNoA11yViolations(container);
+    });
+
+    it('a cluster with both a blocking error and a warning composes aria-describedby to the error id only, with no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-cluster-error-and-warning',
+        `
+          <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-touch">
+            <ngx-form-field-wrapper
+              [formField]="testForm.plan"
+              fieldName="plan"
+              warningStrategy="immediate"
+            >
+              <span ngxFormFieldLabel>Plan</span>
+              <div>
+                <label>
+                  <input
+                    id="plan-deprecated"
+                    type="radio"
+                    [formField]="testForm.plan"
+                    value="deprecated"
+                  />
+                  Deprecated
+                </label>
+                <label>
+                  <input
+                    id="plan-pro-2"
+                    type="radio"
+                    [formField]="testForm.plan"
+                    value="pro"
+                  />
+                  Pro
+                </label>
+              </div>
+            </ngx-form-field-wrapper>
+          </form>
+        `,
+        () =>
+          form(
+            signal({ plan: '' }),
+            schema((path) => {
+              validate(path.plan, (ctx) => {
+                if (ctx.value() === 'deprecated') {
+                  return [
+                    {
+                      kind: 'not-available',
+                      message: 'This plan is no longer available',
+                    },
+                    {
+                      kind: 'warn:legacy-plan',
+                      message: 'Consider switching plans',
+                    },
+                  ];
+                }
+                return null;
+              });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent);
+
+      await userEvent.click(page.getByRole('radio', { name: 'Deprecated' }));
+      await userEvent.tab();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      await expect
+        .element(page.getByRole('alert'))
+        .toHaveTextContent('This plan is no longer available');
+      // Errors suppress the warning live region's content and id entirely,
+      // so the composed `aria-describedby` must reference only the error id
+      // — never a dangling `plan-warning`.
+      expect(wrapper).toHaveAttribute('aria-describedby', 'plan-error');
+      const statusRegion = container.querySelector('[role="status"]');
+      expect(statusRegion).not.toHaveAttribute('id', 'plan-warning');
+      expect(statusRegion?.textContent?.trim()).toBe('');
+      await expectNoA11yViolations(container);
+    });
+  });
+
+  describe('layout, appearance, and visibility configurations', () => {
+    it('errorPlacement="top" showing an error has no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-top-placement',
+        `
+          <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-touch">
+            <ngx-form-field-wrapper
+              [formField]="testForm.username"
+              fieldName="username"
+              errorPlacement="top"
+            >
+              <label for="username">Username</label>
+              <input id="username" [formField]="testForm.username" />
+            </ngx-form-field-wrapper>
+          </form>
+        `,
+        () =>
+          form(
+            signal({ username: '' }),
+            schema((path) => {
+              required(path.username, { message: 'Username is required' });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent);
+
+      await userEvent.click(page.getByRole('textbox', { name: 'Username' }));
+      await userEvent.tab();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      await expect
+        .element(page.getByRole('alert'))
+        .toHaveTextContent('Username is required');
+      await expectNoA11yViolations(container);
+    });
+
+    it('appearance="outline" in its invalid state has no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-outline',
+        `
+          <form [formRoot]="testForm" ngxSignalForm errorStrategy="on-touch">
+            <ngx-form-field-wrapper
+              [formField]="testForm.email"
+              fieldName="email"
+              appearance="outline"
+            >
+              <label for="email-outline">Email address</label>
+              <input
+                id="email-outline"
+                type="email"
+                [formField]="testForm.email"
+                placeholder=" "
+              />
+            </ngx-form-field-wrapper>
+          </form>
+        `,
+        () =>
+          form(
+            signal({ email: '' }),
+            schema((path) => {
+              required(path.email, { message: 'Email is required' });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent);
+
+      await userEvent.click(
+        page.getByRole('textbox', { name: 'Email address' }),
+      );
+      await userEvent.tab();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveClass('ngx-signal-forms-outline');
+      await expect
+        .element(page.getByRole('alert'))
+        .toHaveTextContent('Email is required');
+      await expectNoA11yViolations(container);
+    });
+
+    it('a field hidden via schema hidden() has no violations', async () => {
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-hidden',
+        `
+          <form [formRoot]="testForm" ngxSignalForm>
+            <ngx-form-field-wrapper
+              [formField]="testForm.secret"
+              fieldName="secret"
+            >
+              <label for="secret">Secret</label>
+              <input id="secret" [formField]="testForm.secret" />
+            </ngx-form-field-wrapper>
+          </form>
+        `,
+        () =>
+          form(
+            signal({ secret: '' }),
+            schema((path) => {
+              hidden(path.secret, { when: () => true });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('hidden', '');
+      await expectNoA11yViolations(container);
+    });
   });
 });


### PR DESCRIPTION
Extends the form-field wrapper's WCAG 2.2 AA conformance spec with ten axe fixtures covering the configurations that had no scan: radio-group and multi-checkbox selection clusters (valid and error states), unnamed clusters (no `fieldName`, no control `id` — the safe-fallback path), warning-only composition under a non-immediate `warningStrategy`, error+warning combined (asserting `aria-describedby` composes to only the `-error` id while the warning region stays unreferenced), `errorPlacement="top"`, `appearance="outline"`, and a `hidden()`-schema field.

Beyond the axe passes, the cluster fixtures pin named contracts: the radio group's accessible name must resolve through the generated legend id, and both directions of the describedby composition are asserted (the dangling-reference guard's other half). The checkbox cluster binds two independent `required()` fields — a realistic multi-checkbox shape rather than two inputs sharing one boolean.

The scans caught a real defect: the wrapper host emits `aria-required="true"` alongside `role="group"`, which ARIA only permits on `radiogroup` — axe's `aria-allowed-attr` fires at critical impact. Filed as #300 and linked from the spec; only that single rule is scoped out, for that single test, with every other assertion intact.

Fixes #285
Refs #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
