### PR TITLE
feat(form-field): ship the assistive empty-row token PR #248 advertised

### DIFF
--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -285,17 +285,20 @@ Scale or collapse the reserved space per form scope:
 
 #### Collapsing content-less rows
 
-`--ngx-form-field-assistive-min-height` always reserves space, whether or not
-the row carries a hint, error, warning or character count. For most consumers
-that is the right default and the simplest override.
+Whether `--ngx-form-field-assistive-min-height` reserves space unconditionally
+depends on `--ngx-form-field-assistive-empty-behavior`. Under the default,
+`reserve`, `--ngx-form-field-assistive-min-height` always reserves space,
+whether or not the row carries a hint, error, warning or character count —
+for most consumers that is the right default and the simplest override.
 
-`--ngx-form-field-assistive-empty-behavior` controls the narrower case: whether
-a row with **no assistive content at all** keeps its reserved height
-(`reserve`, the default — today's rendering, unchanged) or shrinks to zero
-(`collapse`). Reach for `--ngx-form-field-assistive-min-height: 0` first; reach
-for this token only when some fields in a form need the reservation and others
-do not, or when the reservation should disappear only in the fully-empty case
-rather than shrinking every row's baseline height.
+Under `collapse`, that changes for the narrower case of a row with **no
+assistive content at all**: it drops to zero height regardless of what
+`--ngx-form-field-assistive-min-height` is set to, while a row that does
+carry content still reserves normally. Reach for
+`--ngx-form-field-assistive-min-height: 0` first; reach for this token only
+when some fields in a form need the reservation and others do not, or when
+the reservation should disappear only in the fully-empty case rather than
+shrinking every row's baseline height.
 
 ```css
 .my-compact-form {

--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -241,13 +241,14 @@ Displays progress towards a character limit.
 
 Layout container for hint/error and character count alignment.
 
-| Property                                   | Default                                                  | Description                                           |
-| :----------------------------------------- | :------------------------------------------------------- | :---------------------------------------------------- |
-| `--ngx-form-field-assistive-min-height`    | `--ngx-signal-form-feedback-line-height` (`1rem`)        | Reserved line, prevents layout shift when errors show |
-| `--ngx-form-field-assistive-gap`           | `0.5rem`                                                 | Gap between left and right content                    |
-| `--ngx-form-field-assistive-margin-top`    | `0`                                                      | Spacing above assistive row                           |
-| `--ngx-form-field-assistive-margin-bottom` | `0`                                                      | Spacing below assistive row                           |
-| `--ngx-form-field-assistive-transition`    | `min-height 150ms ease-out, margin-block 150ms ease-out` | Animation for reservation changes                     |
+| Property                                    | Default                                                  | Description                                           |
+| :------------------------------------------ | :------------------------------------------------------- | :---------------------------------------------------- |
+| `--ngx-form-field-assistive-min-height`     | `--ngx-signal-form-feedback-line-height` (`1rem`)        | Reserved line, prevents layout shift when errors show |
+| `--ngx-form-field-assistive-gap`            | `0.5rem`                                                 | Gap between left and right content                    |
+| `--ngx-form-field-assistive-margin-top`     | `0`                                                      | Spacing above assistive row                           |
+| `--ngx-form-field-assistive-margin-bottom`  | `0`                                                      | Spacing below assistive row                           |
+| `--ngx-form-field-assistive-transition`     | `min-height 150ms ease-out, margin-block 150ms ease-out` | Animation for reservation changes                     |
+| `--ngx-form-field-assistive-empty-behavior` | `reserve`                                                | `reserve` (default) or `collapse` — see below         |
 
 #### Reserved space
 
@@ -260,6 +261,16 @@ messages grow the row, which is the only accepted shift. Reservation changes use
 a short 150ms `ease-out` transition; motion is disabled for
 `prefers-reduced-motion`.
 
+The reservation is deliberate, not an oversight: a row that collapses when
+empty shifts the field's layout the instant an error or warning appears,
+which is worse for users tracking focus than a permanently reserved line. An
+earlier PR (#248) advertised a `--ngx-form-field-assistive-empty-display`
+token in its description as the opt-out for this behavior; that token was
+never implemented — the PR reversed the change mid-review and merged with a
+stale description. It does not exist in this package. The supported opt-out
+is `--ngx-form-field-assistive-empty-behavior` (below) or, for most cases,
+setting `--ngx-form-field-assistive-min-height: 0` directly.
+
 Scale or collapse the reserved space per form scope:
 
 ```css
@@ -271,6 +282,30 @@ Scale or collapse the reserved space per form scope:
   --ngx-form-field-assistive-min-height: 0;
 }
 ```
+
+#### Collapsing content-less rows
+
+`--ngx-form-field-assistive-min-height` always reserves space, whether or not
+the row carries a hint, error, warning or character count. For most consumers
+that is the right default and the simplest override.
+
+`--ngx-form-field-assistive-empty-behavior` controls the narrower case: whether
+a row with **no assistive content at all** keeps its reserved height
+(`reserve`, the default — today's rendering, unchanged) or shrinks to zero
+(`collapse`). Reach for `--ngx-form-field-assistive-min-height: 0` first; reach
+for this token only when some fields in a form need the reservation and others
+do not, or when the reservation should disappear only in the fully-empty case
+rather than shrinking every row's baseline height.
+
+```css
+.my-compact-form {
+  --ngx-form-field-assistive-empty-behavior: collapse;
+}
+```
+
+Implemented as a CSS container style query (`@container style(...)`), so
+browsers without support simply keep the reserved default — the same
+behavior they already had, not a regression.
 
 ### Fieldset
 

--- a/packages/toolkit/form-field/form-field-wrapper.assistive.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.assistive.browser.spec.ts
@@ -6,6 +6,13 @@ import { NgxFormFieldHint } from '@ngx-signal-forms/toolkit/assistive';
 import { NgxFormFieldWrapper } from './form-field-wrapper';
 
 /**
+ * Resolves the owning `<ngx-form-field-wrapper>` host for a row element, so
+ * tests can set the wrapper-scoped CSS custom properties that control it.
+ */
+const wrapperOf = (row: Element): HTMLElement =>
+  row.closest('ngx-form-field-wrapper') as HTMLElement;
+
+/**
  * Regression coverage for #246: the assistive row reserved 1.25rem plus
  * 0.25rem top/bottom margins on every field, which is more space than a
  * single caption line needs. The row must stay reserved (no layout shift when
@@ -110,5 +117,165 @@ describe('NgxFormFieldWrapper — assistive row reserved space', () => {
 
     const [bare] = assistiveRows(container);
     expect(getComputedStyle(bare).transition).toContain('min-height');
+  });
+});
+
+/**
+ * Regression coverage for #297: PR #248's description advertised
+ * `--ngx-form-field-assistive-empty-display`, a token that was never
+ * shipped. This locks in the token that actually ships,
+ * `--ngx-form-field-assistive-empty-behavior`, defaulting to `reserve`
+ * (today's rendering, unchanged) with an opt-in `collapse` value.
+ */
+describe('NgxFormFieldWrapper — assistive empty-row behavior (#297)', () => {
+  @Component({
+    selector: 'ngx-test-assistive-empty-behavior',
+    imports: [NgxFormFieldWrapper, NgxFormFieldHint, FormField],
+    template: `
+      <ngx-form-field-wrapper [formField]="testForm.bare">
+        <label for="bare">Bare</label>
+        <input id="bare" [formField]="testForm.bare" />
+      </ngx-form-field-wrapper>
+
+      <ngx-form-field-wrapper [formField]="testForm.hinted">
+        <label for="hinted">Hinted</label>
+        <input id="hinted" [formField]="testForm.hinted" />
+        <ngx-form-field-hint>Some guidance</ngx-form-field-hint>
+      </ngx-form-field-wrapper>
+    `,
+  })
+  class Host {
+    protected readonly testForm = form(signal({ bare: '', hinted: '' }));
+  }
+
+  const assistiveRows = (container: Element) =>
+    Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '.ngx-signal-form-field-wrapper__assistive',
+      ),
+    );
+
+  it('defaults to reserving a content-less row at its full height', async () => {
+    const { container } = await render(Host);
+
+    const [bare] = assistiveRows(container);
+
+    expect(bare.getBoundingClientRect().height).toBeCloseTo(16, 1);
+  });
+
+  it('collapses a content-less row to zero when opted in, without affecting a hinted row', async () => {
+    const { container } = await render(Host);
+
+    const [bare, hinted] = assistiveRows(container);
+    const wrapper = wrapperOf(bare);
+    // Disable the reservation transition (as the other override tests in
+    // this file do) so the height change applies synchronously instead of
+    // animating over 150ms.
+    wrapper.style.setProperty('--ngx-form-field-assistive-transition', 'none');
+    wrapper.style.setProperty(
+      '--ngx-form-field-assistive-empty-behavior',
+      'collapse',
+    );
+
+    expect(bare.getBoundingClientRect().height).toBe(0);
+    expect(hinted.getBoundingClientRect().height).toBeGreaterThan(0);
+  });
+
+  it('reverts to the reserved height once content-less collapse is switched back to reserve', async () => {
+    const { container } = await render(Host);
+
+    const [bare] = assistiveRows(container);
+    const wrapper = wrapperOf(bare);
+    wrapper.style.setProperty('--ngx-form-field-assistive-transition', 'none');
+    wrapper.style.setProperty(
+      '--ngx-form-field-assistive-empty-behavior',
+      'collapse',
+    );
+    wrapper.style.setProperty(
+      '--ngx-form-field-assistive-empty-behavior',
+      'reserve',
+    );
+
+    expect(bare.getBoundingClientRect().height).toBeCloseTo(16, 1);
+  });
+
+  /**
+   * The invariant `collapse` exists to protect: a row opted into collapsing
+   * when content-less must NOT collapse once an error or warning actually
+   * renders into it. The CSS `:has()` guard checks the hint slot *and* the
+   * absence of any other left-slot child (the error/warning renderer), so a
+   * rendered error/warning keeps the row reserved even under `collapse`.
+   * Without this test, a regression that collapsed the row out from under a
+   * live announced error/warning would go undetected.
+   */
+  it('does not collapse a row opted into collapse while it shows a blocking error', async () => {
+    const invalidField = signal({
+      invalid: () => true,
+      touched: () => true,
+      errors: () => [{ kind: 'required', message: 'This field is required' }],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field" fieldName="agree">
+        <label for="agree">Agree</label>
+        <input id="agree" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: invalidField },
+      },
+    );
+
+    const row = container.querySelector<HTMLElement>(
+      '.ngx-signal-form-field-wrapper__assistive',
+    )!;
+    const wrapper = wrapperOf(row);
+    wrapper.style.setProperty('--ngx-form-field-assistive-transition', 'none');
+    wrapper.style.setProperty(
+      '--ngx-form-field-assistive-empty-behavior',
+      'collapse',
+    );
+
+    expect(container.querySelector('[id="agree-error"]')).toBeTruthy();
+    expect(row.getBoundingClientRect().height).toBeGreaterThan(0);
+  });
+
+  it('does not collapse a row opted into collapse while it shows a warning', async () => {
+    const warningField = signal({
+      invalid: () => true,
+      touched: () => true,
+      errors: () => [
+        { kind: 'warn:weak-value', message: 'Consider a stronger value' },
+      ],
+    });
+
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field" fieldName="value">
+        <label for="value">Value</label>
+        <input id="value" type="text" />
+      </ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field: warningField },
+      },
+    );
+
+    const wrapper = container.querySelector('ngx-form-field-wrapper');
+    const row = container.querySelector<HTMLElement>(
+      '.ngx-signal-form-field-wrapper__assistive',
+    )!;
+    wrapperOf(row).style.setProperty(
+      '--ngx-form-field-assistive-transition',
+      'none',
+    );
+    wrapperOf(row).style.setProperty(
+      '--ngx-form-field-assistive-empty-behavior',
+      'collapse',
+    );
+
+    expect(
+      wrapper?.classList.contains('ngx-signal-form-field-wrapper--warning'),
+    ).toBe(true);
+    expect(row.getBoundingClientRect().height).toBeGreaterThan(0);
   });
 });

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -1089,10 +1089,64 @@
   flex-shrink: 0;
 }
 
+/*
+ * `.ngx-signal-form-field-wrapper__hint-slot` (see form-field-wrapper.ts) is
+ * a documented structural hook, not an accidental one: it wraps the
+ * projected `ngx-form-field-hint` content inside `.assistive-left` so the
+ * `collapse` empty-row query below can detect "no hint projected" via
+ * `:empty` without being defeated by that wrapper's own always-present
+ * element node.
+ */
+
 /* Hide empty slots to prevent unnecessary spacing */
 .ngx-signal-form-field-wrapper__assistive-left:empty,
 .ngx-signal-form-field-wrapper__assistive-right:empty {
   display: none;
+}
+
+/*
+ * Opt-in: collapse the reserved row instead of keeping it at
+ * `--ngx-form-field-assistive-min-height` when it carries no hint, error,
+ * warning or character count. `reserve` (the default) reproduces today's
+ * rendering exactly — nothing moves unless a consumer opts in (#297).
+ *
+ * A behavioural token, not a `-display` one: the row stays a flex container
+ * either way, so consumers never need to know that detail to use this.
+ *
+ * Implemented as a container style query so unsupported browsers simply
+ * keep the reserved default — a safe fallback, since it is the behaviour
+ * they already had. Baseline "Newly available"; every element is
+ * implicitly a style-query container, so no `container-type` is needed.
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/@container#container_style_queries
+ */
+:host {
+  --_assistive-empty-behavior: var(
+    --ngx-form-field-assistive-empty-behavior,
+    reserve
+  );
+}
+
+@container style(--_assistive-empty-behavior: collapse) {
+  /*
+   * "Content-less" cannot be read off `.assistive-left:empty` directly: its
+   * hint slot is an unconditional wrapper div (toggled via inline
+   * `display`, not structurally removed), so `.assistive-left` always has
+   * at least that one child even when no hint is projected. Check the hint
+   * slot's own emptiness plus the absence of any other left-slot child
+   * (the error/warning renderer, when present) instead.
+   */
+  .ngx-signal-form-field-wrapper__assistive:not(
+    :has(
+      .ngx-signal-form-field-wrapper__assistive-left
+        > :not(.ngx-signal-form-field-wrapper__hint-slot),
+      .ngx-signal-form-field-wrapper__hint-slot:not(:empty),
+      .ngx-signal-form-field-wrapper__assistive-right:not(:empty)
+    )
+  ) {
+    min-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 }
 
 /*

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -4315,5 +4315,22 @@ describe('NgxSignalFormWrapperComponent', () => {
         /\.ngx-signal-form-field-wrapper__assistive-left:empty,\s*\.ngx-signal-form-field-wrapper__assistive-right:empty\s*\{\s*display:\s*none;/,
       );
     });
+
+    // jsdom does not evaluate `@container style()` queries from emulated
+    // component stylesheets, so the runtime collapse/reserve behavior is
+    // asserted in the browser-mode suite (#297). Here we lock in the CSS
+    // *source* so the token contract cannot silently regress in refactors
+    // of this stylesheet.
+    it('resolves --ngx-form-field-assistive-empty-behavior through a public custom property defaulting to reserve', () => {
+      expect(wrapperCssSource).toMatch(
+        /--_assistive-empty-behavior:\s*var\(\s*--ngx-form-field-assistive-empty-behavior,\s*reserve\s*\);/,
+      );
+    });
+
+    it('declares the collapse opt-in for a content-less assistive row in CSS source', () => {
+      expect(wrapperCssSource).toMatch(
+        /@container style\(--_assistive-empty-behavior:\s*collapse\)\s*\{[\s\S]*?\.ngx-signal-form-field-wrapper__assistive:not\(\s*:has\(\s*\.ngx-signal-form-field-wrapper__assistive-left\s*>\s*:not\(\.ngx-signal-form-field-wrapper__hint-slot\),\s*\.ngx-signal-form-field-wrapper__hint-slot:not\(:empty\),\s*\.ngx-signal-form-field-wrapper__assistive-right:not\(:empty\)\s*\)\s*\)\s*\{\s*min-height:\s*0;\s*margin-top:\s*0;\s*margin-bottom:\s*0;/,
+      );
+    });
   });
 });

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -304,7 +304,10 @@ import {
             "
           />
         }
-        <div [style.display]="shouldRenderErrorSlot() ? 'none' : 'contents'">
+        <div
+          class="ngx-signal-form-field-wrapper__hint-slot"
+          [style.display]="shouldRenderErrorSlot() ? 'none' : 'contents'"
+        >
           <ng-content select="ngx-form-field-hint" />
         </div>
       </div>


### PR DESCRIPTION
PR #248 advertised an assistive empty-row token that never shipped. This delivers it under the contract settled on #259: `--ngx-form-field-assistive-empty-behavior`, defaulting to `reserve` (today's behavior — the assistive row keeps its reserved min-height so errors and warnings never shift layout) with `collapse` as an explicit opt-in for content-less rows.

The implementation is a CSS `@container style()` query as progressive enhancement: browsers without support simply keep the reserved rendering, so nothing regresses. Collapse detection needed one template hook — the always-present hint-slot `<div>` now carries a stable, documented structural class (`ngx-signal-form-field-wrapper__hint-slot`), because `:empty` can never match a wrapper that is unconditionally rendered; the guard collapses only when the hint slot is empty AND no other assistive content (error/warning renderer) is mounted.

The invariant the contract cares most about is pinned by browser tests in both directions: a `collapse`-opted row with a visible blocking error does **not** collapse, and neither does a warning-only row. jsdom CSS-source contract tests lock the token's presence and default (jsdom can't evaluate `:has()`/`@container style()`). THEMING.md documents the token, why `reserve` is the default, and notes that #248's `--ngx-form-field-assistive-empty-display` was never shipped.

One debugging note for reviewers: the assistive row animates `min-height` (0.15s), so the browser tests disable `--ngx-form-field-assistive-transition` before reading heights — the same pattern the file already uses elsewhere.

Fixes #297
Refs #259, #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in setting to collapse empty assistive rows in form fields.
  - Empty rows collapse fully when enabled, while rows containing hints, errors, warnings, or character counts retain their space.
  - Existing reserved-space behavior remains the default, with graceful fallback in unsupported browsers.

- **Documentation**
  - Documented the new theming option and clarified that the previously referenced empty-display token is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->