### PR TITLE
feat(form-field): expose the selection touch-target as a public token

### DIFF
--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -693,14 +693,15 @@ Grouped radios and grouped checkboxes that live inside
 These wrappers keep normal inline feedback placement, but swap the usual border
 state for a surfaced background when invalid or warning.
 
-| Property                                      | Default                                                      | Description                                  |
-| :-------------------------------------------- | :----------------------------------------------------------- | :------------------------------------------- |
-| `--ngx-form-field-selection-group-gap`        | `0.75rem`                                                    | Vertical gap between grouped options         |
-| `--ngx-form-field-selection-group-padding`    | `1rem`                                                       | Inner padding of the grouped control surface |
-| `--ngx-form-field-selection-group-radius`     | `0.25rem`                                                    | Border radius of the grouped control surface |
-| `--ngx-form-field-selection-group-bg`         | `transparent`                                                | Base surface background                      |
-| `--ngx-form-field-selection-group-invalid-bg` | `color-mix(in srgb, var(--_invalid-color) 12%, transparent)` | Invalid surface background                   |
-| `--ngx-form-field-selection-group-warning-bg` | `color-mix(in srgb, var(--_warning-color) 12%, transparent)` | Warning surface background                   |
+| Property                                      | Default                                                      | Description                                                                                   |
+| :-------------------------------------------- | :----------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| `--ngx-form-field-selection-group-gap`        | `0.75rem`                                                    | Vertical gap between grouped options                                                          |
+| `--ngx-form-field-selection-group-padding`    | `1rem`                                                       | Inner padding of the grouped control surface                                                  |
+| `--ngx-form-field-selection-group-radius`     | `0.25rem`                                                    | Border radius of the grouped control surface                                                  |
+| `--ngx-form-field-selection-group-bg`         | `transparent`                                                | Base surface background                                                                       |
+| `--ngx-form-field-selection-group-invalid-bg` | `color-mix(in srgb, var(--_invalid-color) 12%, transparent)` | Invalid surface background                                                                    |
+| `--ngx-form-field-selection-group-warning-bg` | `color-mix(in srgb, var(--_warning-color) 12%, transparent)` | Warning surface background                                                                    |
+| `--ngx-form-field-touch-target`               | `2rem`                                                       | Row hit-target size for checkbox, switch, and padded rows — see "Selection target size" below |
 
 Example:
 
@@ -708,6 +709,64 @@ Example:
 .delivery-method-wrapper {
   --ngx-form-field-selection-group-padding: 1rem;
   --ngx-form-field-selection-group-invalid-bg: #fce2e2;
+}
+```
+
+### Selection target size
+
+Checkbox rows, switch rows, and padded custom controls all size their
+interaction area from one shared token: `--_field-touch-target`, default
+`2rem` (32px). It now resolves through a public custom property so a
+consumer can retune density from any ancestor scope:
+
+```css
+--_field-touch-target: var(--ngx-form-field-touch-target, 2rem);
+```
+
+See `--ngx-form-field-touch-target` in the property table above.
+
+**Why 32px, not 24px.** WCAG 2.2 SC 2.5.8 Target Size (Minimum), Level AA,
+requires **24×24 CSS px**. SC 2.5.5 Target Size (Enhanced), Level AAA,
+requires **44×44**. 32px is not a WCAG figure at either level — it is the
+24px AA floor plus deliberate headroom, so a border or a sub-pixel rounding
+error cannot drop the rendered box under the AA minimum. It stays below the
+44px AAA bar; a consumer that wants AAA-level targets sets
+`--ngx-form-field-touch-target: 2.75rem` (44px) explicitly.
+
+**Overriding below 24px forfeits SC 2.5.8.** The token has no built-in
+floor — setting it under `1.5rem` (24px) renders a control that fails the
+WCAG 2.2 AA target-size criterion. That is a valid choice for a density
+mode a product accepts responsibility for, not a toolkit default.
+
+**One shared token, not a selection-only sibling.** The switch row renders
+through the same `--_selection-row-min-block-size` derivation as checkbox
+and selection-group rows and therefore keeps a WCAG-2.2-AA-compliant
+height by default too — a padded custom control has the same touch-target
+problem as a checkbox, so it intentionally is not split into a separate
+token.
+
+**Ownership boundary.** The wrapper guarantees the interaction area of its
+own rows (checkbox, switch, selection-group). Projected group containers,
+`<legend>` elements, and `<fieldset>` markup sit outside the wrapper's
+style encapsulation and are consumer-owned — the consumer applies its own
+sizing and spacing at the app level, the same way it owns
+`--ngx-form-field-selection-group-gap` layout above. `--ngx-form-field-touch-target`
+does not reach into that projected composition.
+
+**Radio rows are consumer-owned too, including a lone radio.** Every
+`<input type="radio">` resolves to the `radio-group` control kind, which
+always renders through the wrapper's selection-cluster layout — the same
+projected, consumer-owned composition described above — regardless of
+whether the radio is actually grouped with siblings. `--ngx-form-field-touch-target`
+does not drive a radio row's height. Where a lone radio's row still measures
+above the 24px AA floor by default, that comes from the selection-cluster's
+own padding token, not from this touch-target contract; a consumer building
+a custom radio-group layout owns its row sizing directly, the same way the
+demo's own grouped-radio composition does.
+
+```css
+.compact-form {
+  --ngx-form-field-touch-target: 1.5rem; /* 24px — AA floor, no headroom */
 }
 ```
 

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -108,7 +108,10 @@
 
   /* Icon/touch targets */
   --_field-icon-size: 1.25rem; /* 20px */
-  --_field-touch-target: 2rem; /* 32px */
+  /* WCAG 2.2 AA target-size contract (32px, deliberate headroom over the
+   * 24px minimum) — public override, rationale, and ownership boundary are
+   * documented in THEMING.md's "Selection target size" section (#253). */
+  --_field-touch-target: var(--ngx-form-field-touch-target, 2rem); /* 32px */
 
   /* Legacy aliases (for backward compatibility) */
   --_field-text-xs: var(--_field-text-caption);

--- a/packages/toolkit/form-field/form-field-wrapper.selection-target-size.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.selection-target-size.browser.spec.ts
@@ -1,0 +1,174 @@
+import { type Signal, signal } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { page, userEvent } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldWrapper } from './form-field-wrapper';
+
+/**
+ * Regression coverage for #253: `--_field-touch-target` (checkbox, switch,
+ * and padded-control row sizing) was private, so a consumer could not retune
+ * selection density from outside the package. This locks in the public
+ * override — `--ngx-form-field-touch-target`, default `2rem` (32px) — and
+ * the resulting rendered geometry.
+ *
+ * 32px is not a WCAG figure itself: SC 2.5.8 Target Size (Minimum, AA) is
+ * 24x24 CSS px; SC 2.5.5 Target Size (Enhanced, AAA) is 44x44. 32px is 24px
+ * plus deliberate headroom so a border or sub-pixel rounding cannot drop the
+ * rendered box under the AA minimum.
+ */
+describe('NgxFormFieldWrapper — selection target size (#253)', () => {
+  type MockField = Signal<{
+    invalid: () => boolean;
+    touched: () => boolean;
+    errors: () => { kind: string; message: string }[];
+  }>;
+
+  const validCheckboxField = (): MockField =>
+    signal({
+      invalid: () => false,
+      touched: () => false,
+      errors: () => [],
+    });
+
+  const invalidTouchedCheckboxField = (): MockField =>
+    signal({
+      invalid: () => true,
+      touched: () => true,
+      errors: () => [{ kind: 'required', message: 'You must agree' }],
+    });
+
+  /** Renders `controlHtml` inside a wrapper bound to `field` and locates the row. */
+  const renderRow = async (field: MockField, controlHtml: string) => {
+    const { container } = await render(
+      `<ngx-form-field-wrapper [formField]="field">${controlHtml}</ngx-form-field-wrapper>`,
+      {
+        imports: [NgxFormFieldWrapper],
+        componentProperties: { field },
+      },
+    );
+
+    return {
+      wrapper: container.querySelector<HTMLElement>('ngx-form-field-wrapper')!,
+      row: container.querySelector<HTMLElement>(
+        '.ngx-signal-form-field-wrapper__content',
+      )!,
+    };
+  };
+
+  const selectionRows = [
+    {
+      name: 'checkbox',
+      html: `<label for="agree">I agree to the terms</label>
+        <input id="agree" type="checkbox" />`,
+    },
+    {
+      name: 'switch',
+      html: `<label for="notifications">Enable notifications</label>
+        <input id="notifications" type="checkbox" role="switch" />`,
+    },
+  ];
+
+  describe.each(selectionRows)('$name row', ({ html }) => {
+    it('keeps the row at least the WCAG 2.5.8 AA minimum (24px) by default, at the 32px toolkit default', async () => {
+      const { row } = await renderRow(validCheckboxField(), html);
+
+      expect(row.getBoundingClientRect().height).toBeGreaterThanOrEqual(24);
+      expect(row.getBoundingClientRect().height).toBeCloseTo(32, 0);
+    });
+
+    it('resizes when --ngx-form-field-touch-target is overridden, staying at or above 24px', async () => {
+      const { wrapper, row } = await renderRow(validCheckboxField(), html);
+      const before = row.getBoundingClientRect().height;
+
+      wrapper.style.setProperty('--ngx-form-field-touch-target', '3rem');
+      const grown = row.getBoundingClientRect().height;
+
+      wrapper.style.setProperty('--ngx-form-field-touch-target', '1.5rem');
+      const shrunk = row.getBoundingClientRect().height;
+
+      expect(before).toBeCloseTo(32, 0);
+      expect(grown).toBeCloseTo(48, 0);
+      expect(shrunk).toBeCloseTo(24, 0);
+      expect(shrunk).toBeGreaterThanOrEqual(24);
+    });
+  });
+
+  it('keeps the checkbox row at or above 24px in its initial valid state', async () => {
+    const { row } = await renderRow(
+      validCheckboxField(),
+      `<label for="agree-valid">I agree to the terms</label>
+      <input id="agree-valid" type="checkbox" />`,
+    );
+
+    expect(row.getBoundingClientRect().height).toBeGreaterThanOrEqual(24);
+  });
+
+  it('keeps the checkbox row at or above 24px while showing a blocking error', async () => {
+    const { wrapper, row } = await renderRow(
+      invalidTouchedCheckboxField(),
+      `<label for="agree-invalid">I agree to the terms</label>
+      <input id="agree-invalid" type="checkbox" />`,
+    );
+    const errorElement = wrapper.querySelector('[id="agree-invalid-error"]');
+
+    expect(errorElement).toBeTruthy();
+    expect(row.getBoundingClientRect().height).toBeGreaterThanOrEqual(24);
+  });
+
+  it('does not change keyboard focus affordances when the touch-target token is overridden', async () => {
+    const { wrapper } = await renderRow(
+      validCheckboxField(),
+      `<label for="agree-focus">I agree to the terms</label>
+      <input id="agree-focus" type="checkbox" />`,
+    );
+    const input = wrapper.querySelector<HTMLInputElement>('#agree-focus');
+
+    await userEvent.click(
+      page.getByRole('checkbox', { name: 'I agree to the terms' }),
+    );
+    expect(document.activeElement).toBe(input);
+    const outlineBefore = getComputedStyle(input!).outlineStyle;
+
+    wrapper.style.setProperty('--ngx-form-field-touch-target', '3rem');
+
+    expect(document.activeElement).toBe(input);
+    expect(getComputedStyle(input!).outlineStyle).toBe(outlineBefore);
+  });
+
+  it("keeps a lone radio row's rendered height at or above 24px, but leaves it consumer-owned (unaffected by --ngx-form-field-touch-target)", async () => {
+    // Deviation from #253's "already shipped" inventory, surfaced here and
+    // in THEMING.md's "Selection target size" section: that inventory
+    // treats `--_selection-row-min-block-size` (which checkbox/switch rows
+    // consume) as already covering selection-group rows generally,
+    // including grouped radios. It does not, for a lone radio specifically.
+    //
+    // `inferNgxSignalFormControlKind` maps every `<input type="radio">` to
+    // the `radio-group` kind unconditionally (no "grouped vs. solo" check).
+    // `isSelectionCluster` in form-field-wrapper.ts then becomes `true`
+    // whenever `semantics.kind === 'radio-group'` — again unconditionally,
+    // with no count gate (unlike checkbox, which only clusters past one
+    // control). The selection-cluster rule in
+    // form-field-wrapper.selection.css sets `.content`/`.main` to
+    // `min-height: 0`, and — because it has equal selector specificity to
+    // the earlier selection-group rule but appears later in the
+    // stylesheet — wins by source order. Net effect: a lone radio's row
+    // never reaches `--_field-touch-target` at all; its `.content` height
+    // below comes entirely from the selection-cluster's own padding token,
+    // not the shared touch-target token. This is intentional per the
+    // "Selection-cluster container and label layout is consumer-owned"
+    // comment in form-field-wrapper.selection.css — not something this
+    // spec re-decides.
+    const { wrapper, row } = await renderRow(
+      validCheckboxField(),
+      `<label for="plan-basic">Basic plan</label>
+      <input id="plan-basic" type="radio" value="basic" />`,
+    );
+    const before = row.getBoundingClientRect().height;
+
+    wrapper.style.setProperty('--ngx-form-field-touch-target', '3rem');
+    const after = row.getBoundingClientRect().height;
+
+    expect(before).toBeGreaterThanOrEqual(24);
+    expect(after).toBe(before);
+  });
+});

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -4332,5 +4332,16 @@ describe('NgxSignalFormWrapperComponent', () => {
         /@container style\(--_assistive-empty-behavior:\s*collapse\)\s*\{[\s\S]*?\.ngx-signal-form-field-wrapper__assistive:not\(\s*:has\(\s*\.ngx-signal-form-field-wrapper__assistive-left\s*>\s*:not\(\.ngx-signal-form-field-wrapper__hint-slot\),\s*\.ngx-signal-form-field-wrapper__hint-slot:not\(:empty\),\s*\.ngx-signal-form-field-wrapper__assistive-right:not\(:empty\)\s*\)\s*\)\s*\{\s*min-height:\s*0;\s*margin-top:\s*0;\s*margin-bottom:\s*0;/,
       );
     });
+
+    // jsdom does not compute the resulting rendered geometry from emulated
+    // component stylesheets, so the runtime override is asserted in the
+    // browser-mode suite (#253). Here we lock in the CSS *source* so the
+    // token contract cannot silently regress in refactors of this
+    // stylesheet.
+    it('resolves --_field-touch-target through a public custom property defaulting to 32px', () => {
+      expect(wrapperCssSource).toMatch(
+        /--_field-touch-target:\s*var\(\s*--ngx-form-field-touch-target,\s*2rem\s*\);/,
+      );
+    });
   });
 });


### PR DESCRIPTION
Exposes the wrapper's selection touch-target as a public token: `--_field-touch-target` now resolves as `var(--ngx-form-field-touch-target, 2rem)`. The default stays 32px — unchanged rendering — but consumers can now raise it (e.g. to 44px for AAA) or lower it, with THEMING.md documenting the WCAG 2.2 figures (24×24 AA floor, 44×44 AAA) and the explicit warning that overriding below 24px forfeits SC 2.5.8.

Browser tests assert checkbox and switch rows render ≥24px at the default and resize when the token is overridden (table-driven over both control kinds), in valid and error-showing states, plus a jsdom CSS-source contract test pinning the public-property resolution.

**One deliberate deviation from the issue's inventory, called out rather than papered over:** #253 assumed selection-group rows (including a lone radio) already consume the touch-target derivation. In reality `inferNgxSignalFormControlKind` maps every `<input type="radio">` to the `radio-group` kind with no solo-vs-grouped gate, which unconditionally makes it a selection *cluster* — and cluster row sizing is consumer-owned by the settled contract (#259), with the cluster rule zeroing the wrapper's min-height by source order. So a lone radio's row is **not** driven by `--ngx-form-field-touch-target`. The spec locks in the real behavior (lone-radio rows render ≥24px from cluster padding and are unaffected by the token), and THEMING.md documents the caveat. Forcing radios onto the token would have re-decided the consumer-owned boundary, which this PR does not do.

The AC's "remove any demo-local target-size-only utility class" was investigated: the only candidate (`.choice-group-field__option` in the demo) is a full option-row layout class for a consumer-owned radiogroup composition, not a target-size patch, so it stays.

Fixes #253
Refs #259, #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
