### PR TITLE
fix(a11y): meet color-contrast and target-size on error summary links

### DIFF
--- a/packages/toolkit/assistive/form-field-error-summary.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.a11y.browser.spec.ts
@@ -4,13 +4,11 @@ import { FormField, form, required, schema } from '@angular/forms/signals';
 import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 import { render } from '@testing-library/angular';
-import axe from 'axe-core';
 import { describe, expect, it } from 'vitest';
 import { NgxFormFieldErrorSummary } from './form-field-error-summary';
 import {
   expectNoA11yViolations,
   findAlertContaining,
-  WCAG_22_AA_TAGS,
 } from '@ngx-signal-forms/toolkit/testing';
 
 /**
@@ -21,24 +19,22 @@ import {
  * a failed submit, which is the summary's documented usage — auto-focusing
  * onto itself and rendering one clickable entry per invalid field.
  *
- * The populated state currently has two real, pre-existing violations in the
- * default `.ngx-form-field-error-summary__link` styling (`form-field-error-
- * summary.ts`), tracked in
+ * The populated state previously had two real violations in the default
+ * `.ngx-form-field-error-summary__link` styling (`form-field-error-
+ * summary.ts`), tracked and fixed in
  * [#299](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/299):
  *
- * - `color-contrast`: the default link color `#dc2626` on the summary's
- *   `#fef2f2` background resolves to ~4.41:1, just under the 4.5:1 minimum
- *   for 14px text (WCAG 1.4.3).
- * - `target-size`: `all: unset` on the link strips its padding, leaving a
- *   touch target shorter than the 24px minimum (WCAG 2.5.8).
+ * - `color-contrast`: the default link color was `#dc2626`, which on the
+ *   summary's `#fef2f2` background resolves to ~4.41:1, just under the
+ *   4.5:1 minimum for 14px text (WCAG 1.4.3). The default is now `#b91c1c`
+ *   (~5.9:1).
+ * - `target-size`: `all: unset` on the link stripped its box model, leaving
+ *   a touch target shorter than the 24px minimum (WCAG 2.5.8). The link now
+ *   sets `display: inline-flex` plus a `min-block-size` so the 24x24px
+ *   minimum applies.
  *
- * The second test below asserts on the *exact* violation set rather than
- * wrapping a whole `it.fails`/`expectNoA11yViolations` call: the render and
- * the two summary-content checks stay normal hard assertions (so a
- * functional regression still fails loudly), and only the two known,
- * tracked rule IDs are allowed through the scan — any other violation, or a
- * component-driven disappearance of these two once #299 lands, fails the
- * test and forces this spec to be updated.
+ * Both are fixed, so the populated-state scan below now asserts zero
+ * violations, same as the empty-state scan above it.
  */
 describe('NgxFormFieldErrorSummary — WCAG 2.2 AA conformance', () => {
   it('the empty summary before submission has no violations', async () => {
@@ -89,7 +85,7 @@ describe('NgxFormFieldErrorSummary — WCAG 2.2 AA conformance', () => {
     await expectNoA11yViolations(container);
   });
 
-  it('a populated summary after a failed submit has only the tracked #299 violations', async () => {
+  it('a populated summary after a failed submit has no violations', async () => {
     @Component({
       selector: 'ngx-test-a11y-summary-populated',
       imports: [
@@ -135,7 +131,7 @@ describe('NgxFormFieldErrorSummary — WCAG 2.2 AA conformance', () => {
 
     // Hard functional assertions: the summary rendered and aggregated both
     // field errors. These fail loudly on any regression regardless of the
-    // tracked styling violations below.
+    // accessibility scan below.
     const summaryAlert = findAlertContaining(
       container,
       'Please fix the following errors',
@@ -143,19 +139,6 @@ describe('NgxFormFieldErrorSummary — WCAG 2.2 AA conformance', () => {
     expect(summaryAlert?.textContent).toContain('Name is required');
     expect(summaryAlert?.textContent).toContain('Email is required');
 
-    // Accessibility assertion: only the two rule IDs tracked in #299 are
-    // allowed through. `expectNoA11yViolations` isn't used here because it
-    // throws on ANY violation — this test instead asserts the exact
-    // violation set, so it hard-fails on a new/different violation (a real
-    // regression) just as much as it will once the tracked two are fixed
-    // (a signal to update this spec and close #299).
-    const results = await axe.run(container, {
-      runOnly: { type: 'tag', values: [...WCAG_22_AA_TAGS] },
-      resultTypes: ['violations'],
-    });
-    const violationIds = results.violations
-      .map((violation) => violation.id)
-      .toSorted();
-    expect(violationIds).toEqual(['color-contrast', 'target-size']);
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -156,12 +156,19 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
     .ngx-form-field-error-summary__link {
       all: unset;
       /* all: unset resets display to its initial value (inline), and
-       * min-block-size has no effect on non-replaced inline elements per
-       * spec -- so the WCAG 2.5.8 24x24px target-size minimum below would
-       * be silently ignored without switching to inline-flex here. */
+       * min-block-size/min-inline-size have no effect on non-replaced
+       * inline elements per spec -- so the WCAG 2.5.8 24x24px target-size
+       * minimum below would be silently ignored without switching to
+       * inline-flex here. The minimum is applied in BOTH directions
+       * (block and inline): a short/empty fieldName or message could
+       * otherwise render narrower than 24px even with the block-size
+       * floor in place. justify-content centers short text within the
+       * enforced inline minimum. */
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       min-block-size: var(--ngx-error-summary-link-min-target-size, 1.5rem);
+      min-inline-size: var(--ngx-error-summary-link-min-target-size, 1.5rem);
       padding-inline: var(--ngx-error-summary-link-padding-inline, 0.25rem);
       cursor: pointer;
       /* #b91c1c (Tailwind red-700) on the #fef2f2 summary background

--- a/packages/toolkit/assistive/form-field-error-summary.ts
+++ b/packages/toolkit/assistive/form-field-error-summary.ts
@@ -155,8 +155,19 @@ import { NgxHeadlessErrorSummary } from '@ngx-signal-forms/toolkit/headless';
 
     .ngx-form-field-error-summary__link {
       all: unset;
+      /* all: unset resets display to its initial value (inline), and
+       * min-block-size has no effect on non-replaced inline elements per
+       * spec -- so the WCAG 2.5.8 24x24px target-size minimum below would
+       * be silently ignored without switching to inline-flex here. */
+      display: inline-flex;
+      align-items: center;
+      min-block-size: var(--ngx-error-summary-link-min-target-size, 1.5rem);
+      padding-inline: var(--ngx-error-summary-link-padding-inline, 0.25rem);
       cursor: pointer;
-      color: var(--ngx-error-summary-link-color, #dc2626);
+      /* #b91c1c (Tailwind red-700) on the #fef2f2 summary background
+       * resolves to ~5.9:1, clearing the WCAG 1.4.3 AA minimum of 4.5:1 for
+       * this 14px text -- the previous #dc2626 default only reached ~4.4:1. */
+      color: var(--ngx-error-summary-link-color, #b91c1c);
       text-decoration: underline;
       font-size: 0.875rem;
 

--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -217,6 +217,37 @@ while inline errors and hints retain caption sizing (`0.75rem` / `1rem`). Settin
 `--ngx-signal-form-notification-font-size` and
 `--ngx-signal-form-notification-line-height` to tune grouped cards.
 
+### Error Summary
+
+**Component:** `ngx-form-field-error-summary`
+
+Renders a form-level, clickable list of aggregated validation errors (GOV.UK
+/ WAI error-summary pattern). Each entry is a `<button>` that focuses its
+associated control on click.
+
+| Property                                   | Default   | Description                                                    |
+| :----------------------------------------- | :-------- | :------------------------------------------------------------- |
+| `--ngx-error-summary-border-color`         | `#dc2626` | Card border color                                              |
+| `--ngx-error-summary-bg`                   | `#fef2f2` | Card background color                                          |
+| `--ngx-error-summary-label-color`          | `#991b1b` | Optional summary label text color                              |
+| `--ngx-error-summary-link-color`           | `#b91c1c` | Entry link text color                                          |
+| `--ngx-error-summary-link-hover-color`     | `#991b1b` | Entry link hover color                                         |
+| `--ngx-error-summary-link-min-target-size` | `1.5rem`  | Minimum block-size of each entry link (WCAG 2.5.8 target-size) |
+| `--ngx-error-summary-link-padding-inline`  | `0.25rem` | Horizontal padding on each entry link                          |
+| `--ngx-error-summary-focus-color`          | `#2563eb` | `:focus-visible` outline color on entry links                  |
+
+`--ngx-error-summary-link-color` defaults to `#b91c1c` (Tailwind red-700)
+rather than the `#dc2626` used for the card border: on the summary's
+`#fef2f2` background, `#dc2626` text resolves to ~4.41:1, just under the
+4.5:1 minimum for 14px text (WCAG 1.4.3 AA); `#b91c1c` resolves to ~5.9:1.
+
+Each entry link keeps `all: unset` for the rest of its reset but sets an
+explicit `display: inline-flex` plus `min-block-size` — `all: unset` resets
+`display` to its initial value (`inline`), and `min-height`/`min-block-size`
+has no effect on non-replaced inline elements per spec, so the resulting
+target would silently stay below the WCAG 2.5.8 24x24px minimum without the
+explicit `inline-flex`.
+
 ### Character Count
 
 **Component:** `ngx-form-field-character-count`

--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -225,16 +225,16 @@ Renders a form-level, clickable list of aggregated validation errors (GOV.UK
 / WAI error-summary pattern). Each entry is a `<button>` that focuses its
 associated control on click.
 
-| Property                                   | Default   | Description                                                    |
-| :----------------------------------------- | :-------- | :------------------------------------------------------------- |
-| `--ngx-error-summary-border-color`         | `#dc2626` | Card border color                                              |
-| `--ngx-error-summary-bg`                   | `#fef2f2` | Card background color                                          |
-| `--ngx-error-summary-label-color`          | `#991b1b` | Optional summary label text color                              |
-| `--ngx-error-summary-link-color`           | `#b91c1c` | Entry link text color                                          |
-| `--ngx-error-summary-link-hover-color`     | `#991b1b` | Entry link hover color                                         |
-| `--ngx-error-summary-link-min-target-size` | `1.5rem`  | Minimum block-size of each entry link (WCAG 2.5.8 target-size) |
-| `--ngx-error-summary-link-padding-inline`  | `0.25rem` | Horizontal padding on each entry link                          |
-| `--ngx-error-summary-focus-color`          | `#2563eb` | `:focus-visible` outline color on entry links                  |
+| Property                                   | Default   | Description                                                                                                                    |
+| :----------------------------------------- | :-------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| `--ngx-error-summary-border-color`         | `#dc2626` | Card border color                                                                                                              |
+| `--ngx-error-summary-bg`                   | `#fef2f2` | Card background color                                                                                                          |
+| `--ngx-error-summary-label-color`          | `#991b1b` | Optional summary label text color                                                                                              |
+| `--ngx-error-summary-link-color`           | `#b91c1c` | Entry link text color                                                                                                          |
+| `--ngx-error-summary-link-hover-color`     | `#991b1b` | Entry link hover color                                                                                                         |
+| `--ngx-error-summary-link-min-target-size` | `1.5rem`  | Minimum block-size AND inline-size of each entry link — enforces the 24x24px WCAG 2.5.8 target-size minimum in both directions |
+| `--ngx-error-summary-link-padding-inline`  | `0.25rem` | Horizontal padding on each entry link                                                                                          |
+| `--ngx-error-summary-focus-color`          | `#2563eb` | `:focus-visible` outline color on entry links                                                                                  |
 
 `--ngx-error-summary-link-color` defaults to `#b91c1c` (Tailwind red-700)
 rather than the `#dc2626` used for the card border: on the summary's
@@ -242,11 +242,15 @@ rather than the `#dc2626` used for the card border: on the summary's
 4.5:1 minimum for 14px text (WCAG 1.4.3 AA); `#b91c1c` resolves to ~5.9:1.
 
 Each entry link keeps `all: unset` for the rest of its reset but sets an
-explicit `display: inline-flex` plus `min-block-size` — `all: unset` resets
-`display` to its initial value (`inline`), and `min-height`/`min-block-size`
-has no effect on non-replaced inline elements per spec, so the resulting
-target would silently stay below the WCAG 2.5.8 24x24px minimum without the
-explicit `inline-flex`.
+explicit `display: inline-flex` plus `min-block-size` and `min-inline-size`
+— `all: unset` resets `display` to its initial value (`inline`), and
+`min-height`/`min-block-size`/`min-inline-size` have no effect on
+non-replaced inline elements per spec, so the resulting target would
+silently stay below the WCAG 2.5.8 24x24px minimum without the explicit
+`inline-flex`. Both dimensions are floored (not just block-size) because a
+short or empty `fieldName`/message could otherwise render narrower than
+24px; `justify-content: center` keeps short text centered within the
+enforced minimum width.
 
 ### Character Count
 


### PR DESCRIPTION
Fixes the two WCAG failures axe reports on the populated error summary's links:

- **color-contrast (1.4.3):** the default link color moves from `#dc2626` (4.41:1 against the `#fef2f2` card) to `#b91c1c` (5.91:1). Hover (`#991b1b`, 7.60:1) and the focus outline were verified as well.
- **target-size (2.5.8):** the link keeps `all: unset` but now sets `display: inline-flex` plus `min-block-size: var(--ngx-error-summary-link-min-target-size, 1.5rem)` and `padding-inline: var(--ngx-error-summary-link-padding-inline, 0.25rem)`. The `inline-flex` switch is load-bearing: `all: unset` resets `display` to `inline`, where min-block-size has no effect, so the 24px minimum would silently keep failing.

The a11y browser spec's known-violation carve-out (asserting exactly `['color-contrast', 'target-size']`) is replaced by an unscoped `expectNoA11yViolations` scan, so any styling regression fails loudly again. THEMING.md gains an Error Summary section documenting all `--ngx-error-summary-*` properties, including the two new ones, with the WCAG rationale.

No dark-mode palette was added: like every sibling assistive component, the error summary ships one fixed palette and dark theming is consumer-owned via CSS custom properties (per THEMING.md's theming model), so the single pairing is what renders in both OS modes.

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
