### PR TITLE
refactor(vest): give the run coordinator its own interface

### DIFF
--- a/docs/decisions/0009-vest-run-coordination-is-its-own-seam.md
+++ b/docs/decisions/0009-vest-run-coordination-is-its-own-seam.md
@@ -1,0 +1,97 @@
+# ADR-0009: Vest run coordination is its own seam
+
+## Status
+
+Accepted — implemented for issue
+[#295](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/295).
+Coordination lives in `packages/toolkit/vest/src/vest-run-coordinator.ts`;
+`vest-adapter.ts` keeps registration.
+
+## Date
+
+2026-08-09
+
+## Context
+
+Roughly a third of `vest-adapter.ts` implemented run coordination:
+
+- a two-level identity cache keyed on suite and Angular field tree, then
+  gated on value identity and focus equality
+- detection of a suite contested by a second field tree
+- a FIFO queue serialising contested unfocused runs
+- a settlement race between the suite's returned promise and its
+  `ALL_RUNNING_TESTS_FINISHED` bus event
+
+None of it had an interface. It was reachable only by registering through
+`validateTree` / `validateAsync` and driving a rendered component, so the
+documented FIFO ordering and single-execution guarantees carried zero direct
+assertions. The module also mixed coordination with path binding, focus
+resolution, field-name resolution, and result mapping.
+
+Two consequences followed from the missing seam:
+
+1. Three casts existed purely to fit values through `unknown`-keyed caches
+   (`suite as object` twice, `fieldTree as ReadonlyFieldTree<unknown>` once).
+2. The documented degraded behaviour for a suite **without** `subscribe` /
+   `get` was untestable, because every spec spread a real `create()` suite
+   that has them.
+
+## Decision
+
+Coordination gets its own interface **inside** the module. It is an internal
+seam, not a new public entry point: `validateVest`, `validateVestWarnings`,
+`createVestAdapter`, `sharedVestAdapter` and the adapter interface are
+unchanged, and `./index.ts` exports exactly the same names.
+
+```ts
+interface VestRunCoordinator {
+  request<TValue>(request: VestRunRequest<TValue>): VestRunHandle<TValue>;
+  invalidate(suite: object): void;
+}
+```
+
+Three decision points shape it.
+
+### 1. The cache key is an argument, not a reconstruction
+
+The cache key used to be rebuilt at the call site from the suite object plus
+the validator's bound `ReadonlyFieldTree`. It is now
+`VestRunCacheKey = object` — an opaque identity the coordinator only ever
+compares and uses as a `WeakMap` key. Registration passes `ctx.fieldTree`, so
+the per-(suite, field tree) semantics are byte-for-byte the same; a spec
+passes `{}`.
+
+This is what deletes the casts: with an opaque key there is nothing to widen
+to `ReadonlyFieldTree<unknown>`, and an interface-typed `suite` is assignable
+to `object` without help.
+
+### 2. The suite contract belongs with the coordinator
+
+`VestRunnableSuite`, `VestResultLike` and `VestFieldExclusion` moved to
+`vest-run-coordinator.ts` and are re-exported from `vest-adapter.ts`, which
+stays their documented public home. `subscribe` / `get` stay optional: their
+absence is a stated part of the coordinator's contract (best-effort
+settlement, no idle signal), so it must be reachable by a hand-rolled suite
+in a spec.
+
+### 3. Settlement is the coordinator's, exposed as a lazy promise
+
+`VestRunHandle.settled()` encapsulates the choice the resource loader used to
+make: await a deferred run's own promise directly, or race an immediate run
+against the suite bus. Registration now just awaits the handle. It is a
+function rather than an eager property so a request that never reaches the
+async phase costs no bus subscription.
+
+## Consequences
+
+- FIFO ordering, single execution across the sync and async phases, cache
+  invalidation, focus keying and the no-`subscribe`/`get` settlement path are
+  asserted directly in `vest-run-coordinator.spec.ts` with no `TestBed`, no
+  rendering, and no Angular validators.
+- Registration keeps only what is properly its own: bind the path, resolve
+  the focus, map results to validation errors, attach them.
+- Caching and contention **semantics** are unchanged — this ADR records an
+  exposure, not a redesign. The existing `validate-vest.spec.ts` and
+  `vest-adapter.spec.ts` pass untouched, which is the evidence.
+- Further splitting (field-name resolution, result mapping) stays open. One
+  seam at a time.

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -8,9 +8,28 @@ import {
   validateAsync,
   validateTree,
 } from '@angular/forms/signals';
-import type { SuiteResult } from 'vest';
+import {
+  createVestRunCoordinator,
+  isVestResultLike,
+  VEST_KEY_SEPARATOR,
+  type VestFieldExclusion,
+  type VestResultLike,
+  type VestRunCoordinator,
+  type VestRunHandle,
+  type VestRunnableSuite,
+} from './vest-run-coordinator';
 
 /* oxlint-disable @typescript-eslint/prefer-readonly-parameter-types -- Angular Signal Forms validator callbacks and lightweight path parsing helpers operate on framework/runtime types that are not modeled as readonly. */
+
+// The Vest suite contract and the run coordinator's own types live in
+// `./vest-run-coordinator`, which owns the cache, contention detection, FIFO
+// queue, and settlement machinery. They are re-exported here because
+// `./vest-adapter` is their documented public home (see `./index.ts`).
+export type {
+  VestFieldExclusion,
+  VestResultLike,
+  VestRunnableSuite,
+} from './vest-run-coordinator';
 
 /**
  * Public constant kind prefix used for Vest `warn()` messages surfaced through
@@ -26,25 +45,6 @@ export const VEST_WARNING_KIND_PREFIX = 'warn:vest:';
  * both shapes with a single source of truth.
  */
 export const VEST_ERROR_KIND_PREFIX = 'vest:';
-
-/**
- * Vest 6.3.2's real field-exclusion argument, mirrored locally because the
- * public `vest` package entrypoint exports the `only()` *hook function* but
- * not the `FieldExclusion<F>` type it (and `Suite.only()`) accept — that type
- * lives in `vest-utils`, a transitive dependency this package does not
- * declare directly.
- *
- * Matches Vest's real shape: `FieldExclusion<F> = Maybe<OneOrMoreOf<F>>` (a
- * field name, a list of field names, or `undefined` for "no exclusion —
- * everything runs"), plus the `false` variant Vest's `only()` hook also
- * accepts to focus on nothing. `readonly F[]` (rather than `F[]`) admits
- * readonly arrays without a cast at the call site.
- */
-export type VestFieldExclusion<F extends string = string> =
-  | F
-  | readonly F[]
-  | undefined
-  | false;
 
 /**
  * Callback supplied via {@link VestRegisterOptions.only} to enable per-field
@@ -101,121 +101,6 @@ interface VestValidationSnapshot {
 }
 
 /**
- * Minimal subset of Vest's public result API required by the adapter.
- *
- * The overloads intentionally mirror Vest's selector behavior more precisely
- * than a plain `Pick<SuiteResult, ...>` so internal helpers can stay strict
- * about whole-suite versus field-scoped result shapes.
- */
-export interface VestResultLike extends Pick<SuiteResult, 'isPending'> {
-  readonly getErrors: {
-    (): VestFailureMessages;
-    (fieldName: string): VestFieldMessages;
-  };
-  readonly getWarnings: {
-    (): VestFailureMessages;
-    (fieldName: string): VestFieldMessages;
-  };
-}
-
-/**
- * Narrow runtime contract used by the adapter. The local type preserves the
- * documented Promise-like behavior of async `run()` results without requiring
- * the full generic `Suite` surface in consumers.
- */
-export interface VestRunnableSuite<TValue> {
-  /**
-   * Declared as a readonly function property (not method shorthand) so its
-   * parameter is contravariant under `strictFunctionTypes` — method
-   * parameters stay bivariant regardless of that flag, which is what
-   * previously let a suite typed for one value (e.g. the whole model) be
-   * assigned where a suite for a narrower value (e.g. a single field) was
-   * expected. See ADR-0008.
-   *
-   * `fieldName` is deliberately `string` (not `string | string[]`, and not
-   * {@link VestFieldExclusion}): a real Vest suite's own `run()` signature is
-   * derived from its callback's second parameter, which the documented
-   * idiom types as plain `field?: string` (`create((data, field?: string) =>
-   * {...})`). Contravariance means widening this beyond what real suites
-   * declare would make an ordinary `create()` suite fail assignment here —
-   * the same reasoning as {@link only}'s narrower-than-{@link
-   * VestFieldExclusion} parameter type. Multi-field and `false` focus both
-   * go through `only` instead — see {@link executeVestRun}.
-   */
-  readonly run: (
-    value: TValue,
-    fieldName?: string,
-  ) => VestResultLike | PromiseLike<VestResultLike>;
-  reset?: () => void;
-  /**
-   * Declared as a readonly function property for the same contravariance
-   * reason as {@link run}.
-   *
-   * Deliberately narrower than {@link VestFieldExclusion} (which the
-   * public-facing {@link VestOnlyFieldSelector} and
-   * {@link RunVestSuiteParams.focus} DO use): Vest 6.3.2's real
-   * `Suite.only()` method itself only accepts `FieldExclusion<F>` (a field
-   * name, a list of field names, or `undefined`) — no `false`, no readonly
-   * arrays. Widening this member's parameter type to match
-   * {@link VestFieldExclusion} would make a real, unwrapped `create()` suite
-   * (whose own `only` is that narrower type) fail structural assignment to
-   * this interface, breaking the common case this whole contract exists to
-   * describe. The adapter narrows a wider `VestFieldExclusion` value down to
-   * this shape before ever calling `suite.only(...)` — see
-   * {@link executeVestRun}.
-   */
-  readonly only?: (
-    field: string | string[],
-  ) => Pick<VestRunnableSuite<TValue>, 'run'>;
-  /**
-   * Optional Vest bus subscription (`suite.subscribe`). Used alongside {@link
-   * get} to recover from a superseded run — see
-   * {@link awaitVestRunSettlement}. Suites created via Vest's `create()`
-   * expose this; hand-rolled suite shapes may omit it.
-   */
-  subscribe?: (
-    event: 'ALL_RUNNING_TESTS_FINISHED',
-    callback: () => void,
-  ) => () => void;
-  /**
-   * Optional synchronous accessor for the suite's current accumulated result
-   * (`suite.get`). Used alongside {@link subscribe} to recover from a
-   * superseded run — see {@link awaitVestRunSettlement}.
-   */
-  get?: () => VestResultLike;
-}
-
-/**
- * Cached Vest run keyed by suite instance and Angular field tree so sync and
- * async validation can share a single suite execution.
- */
-interface VestRunCacheEntry<TValue> {
-  readonly value: TValue;
-  readonly focus: string | undefined;
-  readonly runResult: VestResultLike | PromiseLike<VestResultLike>;
-  readonly initialResult: VestResultLike | undefined;
-  /**
-   * `true` when this run was deferred via `deferVestRunUntilIdle` because
-   * another field tree had a concurrently pending run against the SAME suite
-   * instance when this one was requested — see
-   * {@link isSuiteContestedByOtherTree}.
-   *
-   * This is NOT the same question as "is this run currently pending" —
-   * it marks HOW the run was scheduled, for the lifetime of this cache entry,
-   * so the async completion pipeline knows to await `runResult` directly
-   * rather than racing it against the suite-wide `ALL_RUNNING_TESTS_FINISHED`
-   * bus event (see the call site in `registerVestValidation`'s `factory`).
-   * That race is what {@link awaitVestRunSettlement} uses to recover a
-   * SUPERSEDED run's promise, but `runResult` here is a plain `Promise` that
-   * does not even call `suite.run()` until the suite is idle — racing it
-   * against the CURRENT bus event (fired by whichever OTHER run made the
-   * suite idle) would resolve with `suite.get()`'s state from BEFORE this
-   * run started, not this run's own outcome.
-   */
-  readonly deferred: boolean;
-}
-
-/**
  * Internal registration flags that decide whether blocking errors, warnings, or
  * both should be mapped into Angular Signal Forms.
  */
@@ -229,10 +114,9 @@ interface VestValidationRegistrationOptions<TValue> {
  * Resource payload for pending Vest async validation.
  */
 interface PendingVestValidationPayload {
-  readonly runResult: VestResultLike | PromiseLike<VestResultLike>;
+  /** The coordinated run's settlement promise -- see {@link VestRunHandle}. */
+  readonly settled: () => PromiseLike<unknown>;
   readonly initialSnapshot: VestValidationSnapshot;
-  /** Mirrors {@link VestRunCacheEntry.deferred}. */
-  readonly deferred: boolean;
 }
 
 /**
@@ -243,29 +127,8 @@ interface ResolvedVestValidationPayload {
   readonly initialSnapshot: VestValidationSnapshot;
 }
 
-/**
- * Strongly typed per-suite cache used to share a single Vest run between the
- * sync and async Angular validation phases.
- */
-type VestRunCache = WeakMap<
-  ReadonlyFieldTree<unknown>,
-  VestRunCacheEntry<unknown>
->;
-
 const VEST_PATH_SEGMENT = /[^.[\]]+/gu;
 const VEST_KIND_SEGMENT_MAX_LEN = 48;
-const resolveQueueTail = (): void => {};
-
-/**
- * Internal composite-key separator. A NUL code point can never appear in a Vest
- * field path, message, or focus name, so it composes collision-free keys for the
- * baseline dedupe map and the focus cache key. Declared with an explicit
- * `\u0000` escape in a named constant (rather than a literal control character
- * embedded in template strings) so the separator stays visible and
- * tooling/formatter/diff-safe.
- */
-const VEST_KEY_SEPARATOR = '\u0000';
-
 /**
  * Internal sentinel `fieldPath` meaning "attach directly to the validator's
  * own bound field tree" rather than resolving a child field by name.
@@ -278,33 +141,6 @@ const VEST_KEY_SEPARATOR = '\u0000';
  * the validator-bound field instead of resolved to the `root` child field.
  */
 const VEST_ROOT_FIELD_SENTINEL = `${VEST_KEY_SEPARATOR}root${VEST_KEY_SEPARATOR}`;
-
-/**
- * Internal sentinel run-cache focus key for a "focus nothing" run —
- * {@link isVestFocusNothing}'s `true` case (the toolkit's own `false`
- * sentinel, or an empty field-name list) — distinguishing it from a `focus
- * === undefined` ("whole suite") run in the cache-hit comparison. Composed
- * the same way as {@link VEST_ROOT_FIELD_SENTINEL} so it can never collide
- * with a real, string- or array-derived focus key. Both `false` and `[]`
- * share this ONE key (rather than each computing their own) because they
- * are the SAME semantic request — see {@link isVestFocusNothing}'s doc
- * comment for why a bare `focus.join(...)` on `[]` is unsafe (it collides
- * with a field literally named `''`).
- */
-const VEST_FOCUS_NOTHING_SENTINEL = `${VEST_KEY_SEPARATOR}nothing${VEST_KEY_SEPARATOR}`;
-
-/**
- * Runtime guard for the subset of Vest's public result object that the adapter
- * consumes.
- */
-function isVestResultLike(value: unknown): value is VestResultLike {
-  return (
-    value !== null &&
-    (typeof value === 'object' || typeof value === 'function') &&
-    typeof Reflect.get(value, 'getErrors') === 'function' &&
-    typeof Reflect.get(value, 'getWarnings') === 'function'
-  );
-}
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
   return (
@@ -568,234 +404,6 @@ function resolveVestValidationFieldTree(
 }
 
 /**
- * Reports whether `focus` is a deliberate "run nothing" selection — the
- * toolkit's own `false` sentinel, or an empty field-name list.
- *
- * Vest cannot express this through either `suite.only()` or the legacy
- * `suite.run(value, fieldName)` form. Empirically verified against
- * `vest@6.3.2`: `suite.only([])`, `suite.only(false)`, and `suite.only('')`
- * all run the WHOLE suite — Vest treats an empty/falsy exclusion list as "no
- * filter", identically to calling `suite.run(value)` with no focus at all —
- * so there is no reliable, documented way to map "focus nothing" onto
- * `suite.only()`. (The one construction that DOES run zero tests —
- * `suite.only(['a-field-name-that-cannot-exist'])` — depends on the adapter
- * fabricating a name guaranteed never to collide with a real Vest field,
- * which nothing in Vest's public contract promises stays true.) Rather than
- * silently doing the OPPOSITE of what the caller asked for,
- * {@link executeVestRun} throws when this is `true`.
- */
-function isVestFocusNothing(focus: VestFieldExclusion): focus is false {
-  // Declared as `focus is false` (rather than plain `boolean`) purely so
-  // callers get a narrowed `focus` afterward — this function is used both
-  // where that matters (`executeVestRun`, which throws in the `true` branch
-  // without touching `focus` again) and where it doesn't (the cache-key
-  // ternary below). An empty array satisfying this predicate is NOT
-  // literally `false`, but every caller either throws or discards `focus`
-  // in that branch, so the imprecision is harmless.
-  return focus === false || (Array.isArray(focus) && focus.length === 0);
-}
-
-/**
- * Executes `suite.run()` using the appropriate focused-run targeting.
- *
- * Prefers the Vest 6 canonical `suite.only(field).run(value)` form — that
- * matches the upgrade-guide idiom where focus logic is kept out of the suite
- * body. Falls back to the legacy `suite.run(value, fieldName)` form only when
- * the suite does not expose `only` (e.g. consumer-wrapped suites that
- * surface a `run`-only adapter).
- */
-function executeVestRun<TValue>(
-  suite: Pick<VestRunnableSuite<TValue>, 'run' | 'only'>,
-  value: TValue,
-  focus: VestFieldExclusion,
-): VestResultLike | PromiseLike<VestResultLike> {
-  if (focus === undefined) {
-    return suite.run(value);
-  }
-
-  if (isVestFocusNothing(focus)) {
-    throw new Error(
-      '[ngx-signal-forms] A Vest `only` selector returned `false` (or an ' +
-        'empty field-name list), requesting a "focus nothing" run. Vest has ' +
-        'no reliable way to express that through `suite.only()` or ' +
-        '`suite.run(value, fieldName)` — both treat an empty selection as ' +
-        '"run the whole suite", the opposite of what was requested. Return ' +
-        'a field name, a list of field names, or `undefined` for a ' +
-        'whole-suite run.',
-    );
-  }
-
-  if (typeof suite.only === 'function') {
-    // `suite.only` (see {@link VestRunnableSuite.only}'s doc comment) only
-    // accepts `string | string[]` — no readonly arrays. Clone a readonly
-    // array into a mutable one.
-    const focusArg: string | string[] =
-      typeof focus === 'string' ? focus : [...focus];
-    const focused = suite.only(focusArg);
-    return focused.run(value);
-  }
-
-  // No `only` shorthand: fall back to `suite.run(value, fieldName)`, whose
-  // second argument (see {@link VestRunnableSuite.run}'s doc comment) is a
-  // single `string` — this legacy path predates multi-field focus, which is
-  // expressed through `only` above and collapses to the first field name.
-  return suite.run(value, typeof focus === 'string' ? focus : focus[0]);
-}
-
-/**
- * Resolves once `suite` has no test currently in flight.
- *
- * Vest suites created via `create()` are single-flight: calling ANY method
- * that re-executes the suite's callback (`run()`, `only().run()`, and even
- * `runStatic()` — verified empirically, since `runStatic()`'s persisted
- * binding re-enters the ORIGINAL suite's runtime context to invoke its
- * throwaway instance) while a PREVIOUS run on the SAME suite instance is
- * still pending corrupts that previous run's resolver, per
- * {@link awaitVestRunSettlement}'s doc comment. There is no supported way to
- * safely touch a Vest suite instance while it has an in-flight run.
- *
- * When the suite exposes `subscribe`/`get` (true for suites created via
- * Vest's `create()`), this checks `get().isPending()` and, if so, resolves on
- * the next suite-wide `ALL_RUNNING_TESTS_FINISHED` bus event — a pure
- * readiness signal, independent of which specific run's resolver ends up
- * firing it. Suites without `subscribe`/`get` resolve immediately (best
- * effort; contention avoidance is only guaranteed for real Vest suites).
- */
-function waitForSuiteIdle<TValue>(
-  suite: Pick<VestRunnableSuite<TValue>, 'subscribe' | 'get'>,
-): PromiseLike<void> {
-  if (
-    typeof suite.subscribe !== 'function' ||
-    typeof suite.get !== 'function'
-  ) {
-    return Promise.resolve();
-  }
-
-  const subscribe = suite.subscribe;
-  if (!suite.get().isPending()) {
-    return Promise.resolve();
-  }
-
-  return new Promise((resolve) => {
-    // `subscribe`'s callback can fire synchronously; capture `unsubscribe` as
-    // `let` so an immediate callback doesn't read it before assignment (same
-    // TDZ hazard `awaitVestRunSettlement` guards against below).
-    let unsubscribe: (() => void) | undefined;
-    unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
-      unsubscribe?.();
-      resolve();
-    });
-  });
-}
-
-/**
- * Runs `suite` for `(value, focus)` after the previous queued run has settled
- * and once the suite is idle. Calls `onRunStarted` synchronously after this
- * contender's own `suite.run()` begins, so its queue tail cannot be released
- * by an earlier contender's idle event.
- *
- * This trades a small amount of latency (the deferred tree's validation
- * genuinely waits for the other tree's async work to finish before its own
- * even starts) for full correctness, using only the same `run()` /
- * `subscribe()` / `get()` surface every other code path already relies on —
- * no suite-internal API beyond what {@link awaitVestRunSettlement} already
- * uses.
- */
-async function deferVestRunUntilIdle<TValue>(
-  suite: Pick<VestRunnableSuite<TValue>, 'run' | 'only' | 'subscribe' | 'get'>,
-  value: TValue,
-  focus: VestFieldExclusion,
-  previousRun: PromiseLike<void>,
-  onRunStarted: (
-    runResult: VestResultLike | PromiseLike<VestResultLike>,
-  ) => void,
-): Promise<VestResultLike> {
-  await previousRun;
-  await waitForSuiteIdle(suite);
-  const runResult = executeVestRun(suite, value, focus);
-  onRunStarted(runResult);
-  return runResult;
-}
-
-/**
- * Awaits a Vest run's settlement, recovering from a superseded resolver.
- *
- * Vest 6's `suite.run()` promise resolves via a single resolver tracked per
- * suite root isolate: `ALL_RUNNING_TESTS_FINISHED` fires `root.data.resolver()`
- * once, and any LATER `suite.run()` call on the SAME suite instance replaces
- * that resolver before the earlier call's promise ever settles. Two
- * registrations of the same suite with different `only` focus (e.g. two
- * root-bound validators each focused on a different field) each call `run()`
- * independently, so the earlier one's promise can be superseded and never
- * settle — leaving that field `pending()` forever.
- *
- * When the suite exposes `subscribe`/`get` (true for suites created via
- * Vest's `create()`), race the run's own promise against the suite-wide
- * `ALL_RUNNING_TESTS_FINISHED` bus event, which only fires once ALL pending
- * tests — including this run's — have finished, regardless of which `run()`
- * call's resolver ends up firing it. On that event, `suite.get()` returns the
- * suite's current accumulated result, which by then reflects this run's
- * outcome. Suites without `subscribe`/`get` fall back to the original
- * (potentially superseded) promise unchanged.
- */
-function awaitVestRunSettlement<TValue>(
-  runResult: VestResultLike | PromiseLike<VestResultLike>,
-  suite: Pick<VestRunnableSuite<TValue>, 'subscribe' | 'get'>,
-): PromiseLike<unknown> {
-  if (
-    typeof suite.subscribe !== 'function' ||
-    typeof suite.get !== 'function'
-  ) {
-    return Promise.resolve(runResult);
-  }
-  const subscribe = suite.subscribe;
-  const get = suite.get;
-
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    // Declared as `let` (not `const subscribe(...)` return) and guarded with
-    // `?.()`: some suites invoke the `subscribe` callback SYNCHRONOUSLY (e.g.
-    // if all tests already finished before this call), which would otherwise
-    // try to read `unsubscribe` before its initializer has run — a TDZ
-    // `ReferenceError` that would leave this promise unsettled forever.
-    let unsubscribe: (() => void) | undefined;
-
-    const settle = (fn: (value: unknown) => void, value: unknown): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      unsubscribe?.();
-      fn(value);
-    };
-
-    Promise.resolve(runResult).then(
-      (value) => {
-        settle(resolve, value);
-        return undefined;
-      },
-      (error: unknown) => {
-        settle(reject, error);
-        return undefined;
-      },
-    );
-
-    unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
-      settle(resolve, get());
-    });
-
-    // If the callback above fired synchronously (during the `subscribe()`
-    // call itself), `settle()` ran before `unsubscribe` was assigned, so its
-    // `unsubscribe?.()` was a no-op. Clean up the now-stale subscription here
-    // instead, now that we hold a reference to it.
-    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `settled` may be flipped synchronously by the subscribe callback above; static analysis cannot model that closure write.
-    if (settled) {
-      unsubscribe();
-    }
-  });
-}
-
-/**
  * Type guard distinguishing Vest's field-scoped message list (an array) from
  * the whole-suite failure map (a keyed object). Lets callers narrow the union
  * without an unsafe cast — `Array.isArray` alone does not remove the
@@ -1055,8 +663,8 @@ export interface RunVestSuiteParams<TValue> {
 /**
  * Result of a shared, cache-aware single Vest run. `initialResult` is the
  * synchronous `SuiteResult` (or `undefined` when the suite's `run()` returns a
- * raw thenable — including a run deferred to avoid contention, see
- * {@link isSuiteContestedByOtherTree}), `runResult` is the underlying
+ * raw thenable — including a run the coordinator deferred to avoid
+ * contention, see {@link VestRunHandle}), `runResult` is the underlying
  * sync-or-async run value, and `fromCache` reports whether this run reused a
  * previously cached execution for the identical `(suite, fieldTree, value,
  * focus)` tuple.
@@ -1143,350 +751,15 @@ export function createVestAdapter(
   options: VestAdapterOptions = {},
 ): VestSuiteAdapter {
   const defaultResetOnDestroy = options.resetOnDestroy ?? true;
-  const runCache = new WeakMap<object, VestRunCache>();
+  // The run coordinator owns the cache, contention detection, FIFO queue and
+  // settlement machinery. Each adapter instance gets its own, so two adapters
+  // never share a run cache. See `./vest-run-coordinator.ts`.
+  const coordinator: VestRunCoordinator = createVestRunCoordinator();
   // Tracks how many live `resetOnDestroy`-enabled registrations currently
   // reference each suite, so a suite shared across concurrently mounted forms
   // (the README-recommended module-scope pattern) is only reset once the
   // LAST registration tears down -- see `maybeRegisterResetOnDestroy`.
   const resetOnDestroyRefCounts = new WeakMap<object, number>();
-  // Tracks, per suite, which field trees currently have a run PENDING against
-  // it -- see `isSuiteContestedByOtherTree`. A plain (non-weak) Map is
-  // required here (unlike `runCache`) because contention detection needs to
-  // enumerate/count entries, which `WeakMap` cannot do. Entries are removed
-  // as soon as their run settles (`trackPendingVestRun`), so this only ever
-  // holds field trees with a run genuinely in flight -- bounded, self-cleaning
-  // bookkeeping, not a suite-lifetime membership list.
-  const pendingTreesBySuite = new Map<
-    object,
-    Map<ReadonlyFieldTree<unknown>, VestRunCacheEntry<unknown>>
-  >();
-  // The latest queued run for each suite. The first, uncontested run still
-  // executes synchronously; its settlement is recorded here so subsequent
-  // contenders wait for it. Every queued run replaces the tail before it
-  // starts, making B and C serialize even when both were deferred behind A.
-  const runQueueBySuite = new WeakMap<object, Promise<void>>();
-
-  /**
-   * Retrieves the per-suite validation cache, creating it on first access.
-   */
-  function getVestSuiteRunCache(suite: object): VestRunCache {
-    const existingCache = runCache.get(suite);
-    if (existingCache) {
-      return existingCache;
-    }
-
-    const nextCache: VestRunCache = new WeakMap();
-    runCache.set(suite, nextCache);
-    return nextCache;
-  }
-
-  /**
-   * Reports whether `suite` currently has a PENDING, UNFOCUSED (whole-suite)
-   * run for some field tree OTHER than `fieldTree`.
-   *
-   * This is the precise condition under which Vest's shared, reconciled
-   * isolate tree is at risk: the reconciler merges/cancels pending test nodes
-   * from an in-flight run when a NEW `run()` call lands on the SAME suite
-   * before the earlier one settles (see {@link awaitVestRunSettlement}'s doc
-   * comment) -- if that overlap involves two DIFFERENT field trees, either
-   * one's final result can end up reflecting a blend of both trees' data
-   * (issue #214). When no OTHER tree is currently pending, the shared path is
-   * safe and preserves full Vest statefulness (memoization, retained `warn()`
-   * state across runs, etc.) for the common single-tree-per-suite case.
-   *
-   * Deliberately scoped to UNFOCUSED runs only (see the `focus === undefined`
-   * guards at both call sites, {@link trackPendingVestRun} and this
-   * function's caller): a suite backing several `only`-focused registrations
-   * for DIFFERENT fields of the SAME overall form (each bound to its own
-   * child `ReadonlyFieldTree`) is the documented, intentional
-   * wave-3 (#174) pattern -- Vest's `only()` mode is SUPPOSED to retain other
-   * fields' state on the one shared suite there, and that pattern already has
-   * its own settlement recovery via `awaitVestRunSettlement`'s subscribe/get
-   * race. It is indistinguishable from the issue #214 shape (same suite
-   * object, different `ReadonlyFieldTree` reference) by field-tree identity
-   * alone; `focus` is the one signal the adapter has that tells them apart --
-   * two unrelated forms sharing a suite have no reason to pass a focus field
-   * name, while the multi-field-single-form pattern always does.
-   */
-  function isSuiteContestedByOtherTree(
-    suiteKey: object,
-    fieldTree: ReadonlyFieldTree<unknown>,
-  ): boolean {
-    const pendingTrees = pendingTreesBySuite.get(suiteKey);
-    if (!pendingTrees || pendingTrees.size === 0) {
-      return false;
-    }
-
-    return pendingTrees.size > 1 || !pendingTrees.has(fieldTree);
-  }
-
-  /**
-   * Records `fieldTree` as having a pending, UNFOCUSED run for `suiteKey`
-   * when `entry`'s run has not yet settled, and removes it once the run
-   * settles. No-op for a focused run -- see
-   * {@link isSuiteContestedByOtherTree}'s doc comment for why focused runs
-   * are excluded from contention tracking entirely.
-   *
-   * The removal is guarded by identity (`pendingTrees.get(fieldTree) ===
-   * entry`) so a LATER run for the same field tree -- which replaces this
-   * entry in the run cache before this one settles -- is never accidentally
-   * un-tracked by this entry's own (possibly superseded, possibly
-   * never-firing) settlement callback.
-   */
-  function trackPendingVestRun<TValue>(
-    suiteKey: object,
-    fieldTree: ReadonlyFieldTree<unknown>,
-    entry: VestRunCacheEntry<TValue>,
-    focus: VestFieldExclusion,
-  ): void {
-    if (focus !== undefined) {
-      return;
-    }
-
-    const isPending = !entry.initialResult || entry.initialResult.isPending();
-    if (!isPending) {
-      return;
-    }
-
-    let pendingTrees = pendingTreesBySuite.get(suiteKey);
-    if (!pendingTrees) {
-      pendingTrees = new Map();
-      pendingTreesBySuite.set(suiteKey, pendingTrees);
-    }
-    pendingTrees.set(fieldTree, entry);
-
-    const untrack = (): void => {
-      const currentPendingTrees = pendingTreesBySuite.get(suiteKey);
-      if (
-        !currentPendingTrees ||
-        currentPendingTrees.get(fieldTree) !== entry
-      ) {
-        return;
-      }
-
-      currentPendingTrees.delete(fieldTree);
-      if (currentPendingTrees.size === 0) {
-        pendingTreesBySuite.delete(suiteKey);
-      }
-    };
-
-    Promise.resolve(entry.runResult).then(untrack, untrack);
-  }
-
-  /**
-   * Waits for a started run to leave the suite idle state. Vest 6's
-   * `SuiteResult` is thenable, but a later run can supersede its resolver and
-   * leave that thenable pending forever. The idle event is tied to the suite
-   * lifecycle instead, so it is the reliable queue boundary for real Vest
-   * suites. Hand-rolled suites retain the thenable-based best-effort fallback.
-   */
-  function waitForStartedVestRunTail<TValue>(
-    suite: Pick<VestRunnableSuite<TValue>, 'subscribe' | 'get'>,
-    runResult: VestResultLike | PromiseLike<VestResultLike>,
-  ): Promise<void> {
-    const settleRunResult = (): Promise<void> => {
-      return Promise.resolve(runResult).then(
-        () => undefined,
-        () => undefined,
-      );
-    };
-
-    if (
-      typeof suite.subscribe !== 'function' ||
-      typeof suite.get !== 'function'
-    ) {
-      return settleRunResult();
-    }
-
-    try {
-      return new Promise((resolve) => {
-        // A rejected run must not hold the queue forever. Successful Vest 6
-        // thenables are intentionally ignored here because they can be
-        // superseded; the suite idle event settles the normal path.
-        void Promise.resolve(runResult).then(
-          () => undefined,
-          () => {
-            resolve();
-            return undefined;
-          },
-        );
-        void Promise.resolve(waitForSuiteIdle(suite)).then(resolve, resolve);
-      });
-    } catch {
-      return settleRunResult();
-    }
-  }
-
-  /**
-   * Extends the per-suite queue boundary with a pre-built tail. This must retain
-   * an earlier reserved deferred boundary when an immediate focused run starts:
-   * later whole-suite contenders must still wait for that reserved work.
-   */
-  function recordVestRunTail(suiteKey: object, settled: Promise<void>): void {
-    const previousTail = runQueueBySuite.get(suiteKey) ?? Promise.resolve();
-    // Absorb either tail's rejection so a failed run cannot strand later
-    // contenders. `tail` represents the complete serialized boundary, not
-    // merely the most recently started run.
-    const tail = previousTail
-      .then(
-        () => settled,
-        () => settled,
-      )
-      .then(
-        () => undefined,
-        () => undefined,
-      );
-    runQueueBySuite.set(suiteKey, tail);
-    void tail.then(() => {
-      if (runQueueBySuite.get(suiteKey) === tail) {
-        runQueueBySuite.delete(suiteKey);
-      }
-      return undefined;
-    });
-  }
-
-  /**
-   * Records an immediately started run as the per-suite queue tail.
-   */
-  function recordVestRun<TValue>(
-    suiteKey: object,
-    suite: Pick<VestRunnableSuite<TValue>, 'subscribe' | 'get'>,
-    runResult: VestResultLike | PromiseLike<VestResultLike>,
-  ): void {
-    recordVestRunTail(suiteKey, waitForStartedVestRunTail(suite, runResult));
-  }
-
-  /**
-   * Adds a contested run to the per-suite exclusive queue. The prior tail is
-   * captured before this run is recorded as the new tail, so multiple callers
-   * deferred behind one pending run start in FIFO order rather than together.
-   */
-  function enqueueVestRun<TValue>(
-    suiteKey: object,
-    suite: Pick<
-      VestRunnableSuite<TValue>,
-      'run' | 'only' | 'subscribe' | 'get'
-    >,
-    value: TValue,
-    focus: VestFieldExclusion,
-  ): Promise<VestResultLike> {
-    const previousRun = runQueueBySuite.get(suiteKey) ?? Promise.resolve();
-    let resolveTail: () => void = resolveQueueTail;
-    const tail = new Promise<void>((resolve) => {
-      resolveTail = resolve;
-    });
-    // Reserve this slot before the contender begins. Its tail remains pending
-    // until this contender has actually started and the suite subsequently
-    // becomes idle, preserving FIFO ordering for every later contender.
-    recordVestRunTail(suiteKey, tail);
-    const runResult = deferVestRunUntilIdle(
-      suite,
-      value,
-      focus,
-      previousRun,
-      (startedRunResult) => {
-        void waitForStartedVestRunTail(suite, startedRunResult).then(
-          resolveTail,
-          resolveTail,
-        );
-      },
-    );
-    void runResult.then(
-      () => undefined,
-      () => {
-        resolveTail();
-        return undefined;
-      },
-    );
-    return runResult;
-  }
-
-  /**
-   * Reuses an existing Vest run for the same suite, Angular field tree, model
-   * reference, and focus key; or executes the suite once and caches the result.
-   *
-   * When `suite.run()` returns a thenable directly (rather than the documented
-   * synchronous `SuiteResult`), we capture `initialResult` as `undefined` and
-   * rely on the async branch to drive completion from the promise. This guards
-   * against consumer-wrapped suites that coerce `run()` into a Promise.
-   *
-   * Before executing a NEW run, checks whether `suite` currently has another
-   * field tree's run pending (`isSuiteContestedByOtherTree`) -- i.e. the same
-   * suite instance backs two concurrently-live field trees with overlapping
-   * in-flight validation (issue #214). When contested, the run is deferred
-   * until the suite is idle (`deferVestRunUntilIdle`) so it can never overlap
-   * with -- and thus never observe or corrupt -- the other tree's in-flight
-   * state; otherwise it runs against the suite's normal shared state
-   * immediately, exactly as before.
-   */
-  function getOrCreateVestRun<TValue>(
-    suite: Pick<
-      VestRunnableSuite<TValue>,
-      'run' | 'only' | 'subscribe' | 'get'
-    >,
-    fieldTree: ReadonlyFieldTree<TValue>,
-    value: TValue,
-    focus: VestFieldExclusion,
-  ): VestRunCacheEntry<TValue> & { readonly fromCache: boolean } {
-    const suiteKey = suite as object;
-    const suiteCache = getVestSuiteRunCache(suiteKey);
-    const cachedEntry = suiteCache.get(fieldTree);
-    const focusKey = isVestFocusNothing(focus)
-      ? VEST_FOCUS_NOTHING_SENTINEL
-      : typeof focus === 'string' || focus === undefined
-        ? focus
-        : focus.join(VEST_KEY_SEPARATOR);
-
-    if (
-      cachedEntry &&
-      Object.is(cachedEntry.value, value) &&
-      cachedEntry.focus === focusKey
-    ) {
-      return {
-        value,
-        focus: focusKey,
-        runResult: cachedEntry.runResult,
-        initialResult: cachedEntry.initialResult,
-        deferred: cachedEntry.deferred,
-        fromCache: true,
-      };
-    }
-
-    const isContested =
-      focus === undefined && isSuiteContestedByOtherTree(suiteKey, fieldTree);
-    const runResult = isContested
-      ? enqueueVestRun(suiteKey, suite, value, focus)
-      : executeVestRun(suite, value, focus);
-    if (!isContested) {
-      recordVestRun(suiteKey, suite, runResult);
-    }
-
-    const nextEntry: VestRunCacheEntry<TValue> = {
-      value,
-      focus: focusKey,
-      runResult,
-      // Vest 6's `suite.run(...)` returns a dual-shaped object that is *both*
-      // a synchronous `SuiteResult` (with `getErrors`/`isPending`) and a
-      // thenable. Previously we gated `initialResult` with `!isThenable(...)`,
-      // which would always be false for Vest 6 suites and forced every
-      // validation run through the async pipeline — hiding sync errors until
-      // the next microtask. Check the sync surface directly instead. A
-      // deferred (contested) run's `runResult` is a plain `Promise` (not
-      // Vest-result-like) until it actually starts, so it correctly falls
-      // into the "no sync result yet" branch below regardless.
-      initialResult: isVestResultLike(runResult) ? runResult : undefined,
-      deferred: isContested,
-    };
-
-    suiteCache.set(fieldTree, nextEntry);
-    trackPendingVestRun(
-      suiteKey,
-      fieldTree as ReadonlyFieldTree<unknown>,
-      nextEntry,
-      focus,
-    );
-    return { ...nextEntry, fromCache: false };
-  }
 
   function register<TValue>(
     path: VestFieldPath<TValue>,
@@ -1509,22 +782,26 @@ export function createVestAdapter(
   function runVestSuite<TValue>(
     params: RunVestSuiteParams<TValue>,
   ): RunVestSuiteResult<TValue> {
-    return getOrCreateVestRun(
-      params.suite,
-      params.fieldTree,
-      params.value,
-      params.focus,
-    );
+    const handle = coordinator.request({
+      suite: params.suite,
+      // Per-(suite, field tree) caching: the bound field tree IS the cache
+      // key on the built-in path.
+      cacheKey: params.fieldTree,
+      value: params.value,
+      ...(params.focus !== undefined && { focus: params.focus }),
+    });
+
+    return {
+      value: handle.value,
+      focus: handle.focus,
+      runResult: handle.runResult,
+      initialResult: handle.initialResult,
+      fromCache: handle.fromCache,
+    };
   }
 
   function invalidate(suite: object): void {
-    runCache.delete(suite);
-    // Also drop contention bookkeeping so a reset suite starts from a clean
-    // slate -- otherwise a stale pending marker from a run that never settled
-    // before teardown could permanently (and incorrectly) mark a
-    // subsequently-reused suite as contested.
-    pendingTreesBySuite.delete(suite);
-    runQueueBySuite.delete(suite);
+    coordinator.invalidate(suite);
   }
 
   /**
@@ -1554,7 +831,7 @@ export function createVestAdapter(
       return;
     }
 
-    const suiteKey = suite as object;
+    const suiteKey: object = suite;
     resetOnDestroyRefCounts.set(
       suiteKey,
       (resetOnDestroyRefCounts.get(suiteKey) ?? 0) + 1,
@@ -1590,14 +867,26 @@ export function createVestAdapter(
       return validationOptions.only ? validationOptions.only(ctx) : undefined;
     };
 
-    validateTree(path, (ctx) => {
-      const { fieldTree, value } = ctx;
-      const entry = getOrCreateVestRun(
+    /**
+     * Asks the run coordinator for this pass's run. The validator's bound
+     * field tree doubles as the coordinator's cache key, which is what keeps
+     * the sync (`validateTree`) and async (`validateAsync`) phases of one
+     * registration -- and every other registration bound to the same tuple --
+     * on a single `suite.run()` execution.
+     */
+    const requestRun = (ctx: FieldContext<TValue>): VestRunHandle<TValue> => {
+      const focus = resolveFocus(ctx);
+      return coordinator.request({
         suite,
-        fieldTree,
-        value(),
-        resolveFocus(ctx),
-      );
+        cacheKey: ctx.fieldTree,
+        value: ctx.value(),
+        ...(focus !== undefined && { focus }),
+      });
+    };
+
+    validateTree(path, (ctx) => {
+      const { fieldTree } = ctx;
+      const entry = requestRun(ctx);
 
       if (!entry.initialResult) {
         return [];
@@ -1622,13 +911,7 @@ export function createVestAdapter(
 
     validateAsync(path, {
       params: (ctx) => {
-        const { fieldTree, value } = ctx;
-        const entry = getOrCreateVestRun(
-          suite,
-          fieldTree,
-          value(),
-          resolveFocus(ctx),
-        );
+        const entry = requestRun(ctx);
 
         // When `run()` returned a raw Promise (no sync SuiteResult), drive the
         // async pipeline directly from the thenable. Otherwise require the sync
@@ -1639,9 +922,8 @@ export function createVestAdapter(
           }
 
           return {
-            runResult: entry.runResult,
+            settled: entry.settled,
             initialSnapshot: { errors: [], warnings: [] },
-            deferred: entry.deferred,
           } satisfies PendingVestValidationPayload;
         }
 
@@ -1665,29 +947,21 @@ export function createVestAdapter(
           : validationOptions;
 
         return {
-          runResult: entry.runResult,
+          settled: entry.settled,
           initialSnapshot: createVestValidationSnapshot(
             entry.initialResult,
             snapshotOptions,
           ),
-          deferred: entry.deferred,
         } satisfies PendingVestValidationPayload;
       },
       factory: (pendingValidation) => {
         return resource({
           params: pendingValidation,
           loader: async ({ params }) => {
-            // A deferred run's `runResult` (see `deferVestRunUntilIdle`) does
-            // not even call `suite.run()` until the suite becomes idle, so
-            // racing it against the suite-wide `ALL_RUNNING_TESTS_FINISHED`
-            // bus event here would resolve with `suite.get()`'s state from
-            // BEFORE this run started (whatever made the suite idle in the
-            // first place), not this run's own outcome. Its plain `Promise`
-            // already resolves correctly on its own once the deferred run
-            // actually completes, so await it directly.
-            const result = params.deferred
-              ? await params.runResult
-              : await awaitVestRunSettlement(params.runResult, suite);
+            // The coordinator owns the settlement strategy (bus-event race
+            // for an immediate run, direct await for a deferred one) -- this
+            // layer only awaits the handle it was given.
+            const result = await params.settled();
             if (!isVestResultLike(result)) {
               // Throw so this lands in the validator's `onError` handler below,
               // which already encodes the right policy: blocking validators

--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -1,0 +1,554 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createVestRunCoordinator,
+  type VestResultLike,
+  type VestRunnableSuite,
+} from './vest-run-coordinator';
+
+/**
+ * Coordinator-level coverage. Every test here drives the coordinator's own
+ * `request` / `invalidate` interface with a hand-rolled suite -- no `TestBed`,
+ * no rendered component, no Angular validators. That is the whole point of
+ * the seam: the FIFO ordering and single-execution guarantees the adapter
+ * documents used to be reachable only through a mounted form.
+ *
+ * The end-to-end behaviour through `validateVest` stays covered by
+ * `validate-vest.spec.ts` and `vest-adapter.spec.ts`.
+ */
+
+/**
+ * Vest's selector shape for a suite with no failures. Declared with real
+ * overloads (rather than a cast) so it satisfies {@link VestResultLike}'s
+ * whole-suite / field-scoped selector contract exactly.
+ */
+function noMessages(): Readonly<Record<string, readonly string[]>>;
+function noMessages(fieldName: string): readonly string[];
+function noMessages(
+  fieldName?: string,
+): Readonly<Record<string, readonly string[]>> | readonly string[] {
+  return fieldName === undefined ? {} : [];
+}
+
+/** A Vest 6-shaped run result: both a synchronous result AND a thenable. */
+type FakeRunResult = VestResultLike & PromiseLike<VestResultLike>;
+
+interface ControllableSuite {
+  /** The suite handed to the coordinator. */
+  readonly suite: VestRunnableSuite<string>;
+  /** Values passed to `suite.run(...)`, in the order the runs actually started. */
+  readonly started: readonly string[];
+  /** Field names passed to `suite.only(...)`, in call order. */
+  readonly focused: readonly (string | readonly string[])[];
+  /** The accumulated result a finished run settles with. */
+  readonly settledResult: VestResultLike;
+  /**
+   * Settle one in-flight run, firing the suite bus once nothing is pending.
+   * An arrow property (not a method) so tests can destructure it freely.
+   */
+  readonly finish: (label: string) => void;
+}
+
+/**
+ * A suite whose runs complete synchronously -- nothing is ever pending, so
+ * the coordinator never treats it as contested. Used by the cache-identity
+ * tests, which are about the `(suite, cacheKey, value, focus)` key alone.
+ */
+function createInstantSuite(): {
+  readonly suite: VestRunnableSuite<string>;
+  readonly started: readonly string[];
+  readonly focused: readonly (string | readonly string[])[];
+} {
+  const started: string[] = [];
+  const focused: (string | readonly string[])[] = [];
+  const run = (value: string): VestResultLike => {
+    started.push(value);
+    return {
+      isPending: () => false,
+      getErrors: noMessages,
+      getWarnings: noMessages,
+    };
+  };
+
+  return {
+    suite: {
+      run,
+      only: (field: string | string[]) => {
+        focused.push(field);
+        return { run };
+      },
+    },
+    started,
+    focused,
+  };
+}
+
+/**
+ * A hand-rolled Vest suite whose runs stay pending until explicitly finished.
+ *
+ * Mirrors the parts of a real `create()` suite the coordinator actually
+ * depends on: a dual sync-result/thenable `run()` return value, an
+ * `isPending()` that reports suite-wide (not per-run) state, an
+ * `ALL_RUNNING_TESTS_FINISHED` bus, and a `get()` accumulator.
+ *
+ * Pass `{ withEventBus: false }` to drop `subscribe`/`get` entirely -- the
+ * degraded shape the coordinator explicitly documents a fallback for.
+ */
+function createControllableSuite(
+  { withEventBus }: { withEventBus: boolean } = { withEventBus: true },
+): ControllableSuite {
+  const started: string[] = [];
+  const focused: (string | readonly string[])[] = [];
+  const listeners = new Set<() => void>();
+  const pending = new Map<string, () => void>();
+
+  const isPending = (): boolean => pending.size > 0;
+
+  // What a finished run resolves WITH. Deliberately a different object from
+  // the returned run result: a thenable that resolves with itself never
+  // settles, which is not how a real Vest run behaves.
+  const settledResult: VestResultLike = {
+    isPending: () => false,
+    getErrors: noMessages,
+    getWarnings: noMessages,
+  };
+
+  const makeResult = (label: string): FakeRunResult => {
+    let resolveRun: (result: VestResultLike) => void = () => {};
+    const settlement = new Promise<VestResultLike>((resolve) => {
+      resolveRun = resolve;
+    });
+    const result: FakeRunResult = {
+      isPending,
+      getErrors: noMessages,
+      getWarnings: noMessages,
+      // oxlint-disable-next-line unicorn/no-thenable -- Vest 6's `run()` deliberately returns a value that is BOTH a synchronous `SuiteResult` and a thenable; the coordinator's `initialResult` gating exists for exactly that shape, so the fake must reproduce it.
+      then: (onFulfilled, onRejected) =>
+        settlement.then(onFulfilled, onRejected),
+    };
+    pending.set(label, () => {
+      resolveRun(settledResult);
+    });
+    return result;
+  };
+
+  const run = (value: string): FakeRunResult => {
+    started.push(value);
+    return makeResult(value);
+  };
+
+  const eventBus = {
+    subscribe: (_event: 'ALL_RUNNING_TESTS_FINISHED', callback: () => void) => {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+      };
+    },
+    get: (): VestResultLike => ({
+      isPending,
+      getErrors: noMessages,
+      getWarnings: noMessages,
+    }),
+  };
+
+  const suite: VestRunnableSuite<string> = {
+    run,
+    only: (field: string | string[]) => {
+      focused.push(field);
+      return { run };
+    },
+    ...(withEventBus ? eventBus : {}),
+  };
+
+  return {
+    suite,
+    started,
+    focused,
+    settledResult,
+    finish: (label: string): void => {
+      const settle = pending.get(label);
+      pending.delete(label);
+      settle?.();
+      if (pending.size === 0) {
+        for (const listener of listeners) {
+          listener();
+        }
+      }
+    },
+  };
+}
+
+describe('createVestRunCoordinator', () => {
+  describe('single execution', () => {
+    it('runs the suite once for repeated requests on the same (suite, cacheKey, value, focus) tuple', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started } = createControllableSuite();
+      const cacheKey = {};
+
+      // The sync (`validateTree`) phase asks first...
+      const sync = coordinator.request({ suite, cacheKey, value: 'a' });
+      // ...and the async (`validateAsync`) phase asks for the identical tuple.
+      const async = coordinator.request({ suite, cacheKey, value: 'a' });
+
+      expect(started).toEqual(['a']);
+      expect(sync.fromCache).toBe(false);
+      expect(async.fromCache).toBe(true);
+      // Both phases observe ONE execution, not two equivalent ones.
+      expect(async.runResult).toBe(sync.runResult);
+      expect(async.initialResult).toBe(sync.initialResult);
+    });
+
+    it('re-runs when the value reference, the focus, or the cache key changes', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, focused } = createInstantSuite();
+      const cacheKey = {};
+
+      coordinator.request({ suite, cacheKey, value: 'a' });
+      expect(
+        coordinator.request({ suite, cacheKey, value: 'b' }).fromCache,
+      ).toBe(false);
+      // Same value, different focus -> different cache entry.
+      expect(
+        coordinator.request({ suite, cacheKey, value: 'b', focus: 'email' })
+          .fromCache,
+      ).toBe(false);
+      expect(
+        coordinator.request({ suite, cacheKey, value: 'b', focus: 'email' })
+          .fromCache,
+      ).toBe(true);
+      // Same tuple, different cache key -> different cache entry.
+      expect(
+        coordinator.request({ suite, cacheKey: {}, value: 'b' }).fromCache,
+      ).toBe(false);
+
+      expect(started).toEqual(['a', 'b', 'b', 'b']);
+      expect(focused).toEqual(['email']);
+    });
+
+    it('exposes the synchronous result when the suite produced one', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite } = createControllableSuite();
+
+      const handle = coordinator.request({
+        suite,
+        cacheKey: {},
+        value: 'a',
+      });
+
+      expect(handle.initialResult).toBe(handle.runResult);
+      expect(handle.initialResult?.isPending()).toBe(true);
+      expect(handle.deferred).toBe(false);
+      expect(handle.focus).toBeUndefined();
+    });
+
+    it('reports no synchronous result when the suite returns a bare promise', async () => {
+      const coordinator = createVestRunCoordinator();
+      const settledResult: VestResultLike = {
+        isPending: () => false,
+        getErrors: noMessages,
+        getWarnings: noMessages,
+      };
+      const suite: VestRunnableSuite<string> = {
+        run: () => Promise.resolve(settledResult),
+      };
+
+      const handle = coordinator.request({ suite, cacheKey: {}, value: 'a' });
+
+      expect(handle.initialResult).toBeUndefined();
+      await expect(handle.settled()).resolves.toBe(settledResult);
+    });
+  });
+
+  describe('FIFO ordering for contested runs', () => {
+    it('serialises whole-suite runs from different cache keys in request order', async () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, finish } = createControllableSuite();
+
+      // A starts immediately: nothing else is pending on this suite.
+      const first = coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      expect(first.deferred).toBe(false);
+      expect(started).toEqual(['a']);
+
+      // B and C both arrive while A is still pending on the SAME suite but a
+      // DIFFERENT cache key, so both are queued rather than overlapping A.
+      const second = coordinator.request({ suite, cacheKey: {}, value: 'b' });
+      const third = coordinator.request({ suite, cacheKey: {}, value: 'c' });
+      expect(second.deferred).toBe(true);
+      expect(third.deferred).toBe(true);
+      // A deferred run has not called `suite.run()` yet.
+      expect(second.initialResult).toBeUndefined();
+      expect(started).toEqual(['a']);
+
+      finish('a');
+      await vi.waitFor(() => {
+        expect(started).toEqual(['a', 'b']);
+      });
+      // C is still behind B -- the queue releases one contender at a time.
+      expect(started).toEqual(['a', 'b']);
+
+      finish('b');
+      await vi.waitFor(() => {
+        expect(started).toEqual(['a', 'b', 'c']);
+      });
+
+      finish('c');
+      await expect(third.settled()).resolves.toBeDefined();
+    });
+
+    it('does not queue focused runs, which are the intentional shared-suite pattern', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started } = createControllableSuite();
+
+      coordinator.request({ suite, cacheKey: {}, value: 'a', focus: 'email' });
+      const second = coordinator.request({
+        suite,
+        cacheKey: {},
+        value: 'b',
+        focus: 'password',
+      });
+
+      expect(second.deferred).toBe(false);
+      expect(started).toEqual(['a', 'b']);
+    });
+
+    it('starts a queued run immediately once the suite is no longer contested', async () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, finish } = createControllableSuite();
+
+      coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      finish('a');
+      // A macrotask boundary drains every pending microtask, including the
+      // coordinator's own "this run settled, stop tracking it" callback.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      // A settled, so a request from another cache key is uncontested.
+      const next = coordinator.request({ suite, cacheKey: {}, value: 'b' });
+      expect(next.deferred).toBe(false);
+      expect(started).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('settlement', () => {
+    it('recovers a superseded run via the suite bus event', async () => {
+      const coordinator = createVestRunCoordinator();
+      const busResult: VestResultLike = {
+        isPending: () => false,
+        getErrors: noMessages,
+        getWarnings: noMessages,
+      };
+      const listeners = new Set<() => void>();
+      // A suite whose run thenable NEVER settles -- exactly what Vest does to
+      // a run whose resolver a later run replaced.
+      const suite: VestRunnableSuite<string> = {
+        run: () => ({
+          isPending: () => true,
+          getErrors: noMessages,
+          getWarnings: noMessages,
+          // oxlint-disable-next-line unicorn/no-thenable -- see `createControllableSuite`: this fakes Vest's dual sync-result/thenable `run()` return value, here with a thenable that never settles.
+          then: () => new Promise<never>(() => {}),
+        }),
+        subscribe: (_event, callback) => {
+          listeners.add(callback);
+          return () => {
+            listeners.delete(callback);
+          };
+        },
+        get: () => busResult,
+      };
+
+      const handle = coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      const settled = handle.settled();
+      for (const listener of listeners) {
+        listener();
+      }
+
+      await expect(settled).resolves.toBe(busResult);
+      // The bus subscription is released once the race is decided.
+      expect(listeners.size).toBe(0);
+    });
+
+    it('settles from the run itself for a suite WITHOUT subscribe/get', async () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, finish, settledResult } = createControllableSuite(
+        {
+          withEventBus: false,
+        },
+      );
+
+      expect(suite.subscribe).toBeUndefined();
+      expect(suite.get).toBeUndefined();
+
+      const handle = coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      expect(started).toEqual(['a']);
+
+      // No bus event will ever fire, so settlement can only come from the
+      // run's own thenable.
+      finish('a');
+      await expect(handle.settled()).resolves.toBe(settledResult);
+    });
+
+    it('releases a queued run for a suite WITHOUT subscribe/get from the previous run thenable', async () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, finish } = createControllableSuite({
+        withEventBus: false,
+      });
+
+      coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      const second = coordinator.request({ suite, cacheKey: {}, value: 'b' });
+
+      // Contention IS still detected (a pending run on another cache key), so
+      // the run is queued -- but with no idle signal to wait for it starts as
+      // soon as the previous run's own thenable settles.
+      expect(second.deferred).toBe(true);
+      expect(started).toEqual(['a']);
+
+      finish('a');
+      await vi.waitFor(() => {
+        expect(started).toEqual(['a', 'b']);
+      });
+    });
+
+    it('propagates a rejected run through the settlement promise', async () => {
+      const coordinator = createVestRunCoordinator();
+      const failure = new Error('suite blew up');
+      const suite: VestRunnableSuite<string> = {
+        run: () => Promise.reject(failure),
+      };
+
+      const handle = coordinator.request({ suite, cacheKey: {}, value: 'a' });
+
+      await expect(handle.settled()).rejects.toBe(failure);
+    });
+  });
+
+  describe('focus', () => {
+    it('throws for a "focus nothing" request, before touching the suite', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started } = createControllableSuite();
+
+      expect(() =>
+        coordinator.request({ suite, cacheKey: {}, value: 'a', focus: false }),
+      ).toThrow(/focus nothing/i);
+      expect(() =>
+        coordinator.request({ suite, cacheKey: {}, value: 'a', focus: [] }),
+      ).toThrow(/focus nothing/i);
+      expect(started).toEqual([]);
+    });
+
+    it('composes a collision-free cache key for a field-name list', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, focused } = createControllableSuite();
+      const cacheKey = {};
+
+      const list = coordinator.request({
+        suite,
+        cacheKey,
+        value: 'a',
+        focus: ['email', 'password'],
+      });
+      expect(list.fromCache).toBe(false);
+      expect(
+        coordinator.request({
+          suite,
+          cacheKey,
+          value: 'a',
+          focus: ['email', 'password'],
+        }).fromCache,
+      ).toBe(true);
+
+      // The joined key uses a NUL separator, so it cannot collide with a
+      // single field literally named `emailpassword`.
+      expect(
+        coordinator.request({
+          suite,
+          cacheKey,
+          value: 'a',
+          focus: 'emailpassword',
+        }).fromCache,
+      ).toBe(false);
+      expect(focused).toEqual([['email', 'password'], 'emailpassword']);
+    });
+
+    it('falls back to run(value, fieldName) when the suite exposes no only()', () => {
+      const coordinator = createVestRunCoordinator();
+      const fieldNames: (string | undefined)[] = [];
+      const suite: VestRunnableSuite<string> = {
+        run: (_value: string, fieldName?: string) => {
+          fieldNames.push(fieldName);
+          return {
+            isPending: () => false,
+            getErrors: noMessages,
+            getWarnings: noMessages,
+          };
+        },
+      };
+
+      coordinator.request({ suite, cacheKey: {}, value: 'a', focus: 'email' });
+      // The legacy form takes a single name, so a list collapses to its first.
+      coordinator.request({
+        suite,
+        cacheKey: {},
+        value: 'a',
+        focus: ['email', 'password'],
+      });
+
+      expect(fieldNames).toEqual(['email', 'email']);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('drops the cached run so an identical tuple re-executes', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started } = createControllableSuite();
+      const cacheKey = {};
+
+      coordinator.request({ suite, cacheKey, value: 'a' });
+      expect(
+        coordinator.request({ suite, cacheKey, value: 'a' }).fromCache,
+      ).toBe(true);
+
+      coordinator.invalidate(suite);
+
+      expect(
+        coordinator.request({ suite, cacheKey, value: 'a' }).fromCache,
+      ).toBe(false);
+      expect(started).toEqual(['a', 'a']);
+    });
+
+    it('drops contention bookkeeping so a reused suite is not stuck "contested"', () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started } = createControllableSuite();
+
+      // A pending run that never settles would otherwise mark the suite
+      // contested forever.
+      coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      coordinator.invalidate(suite);
+
+      const next = coordinator.request({ suite, cacheKey: {}, value: 'b' });
+      expect(next.deferred).toBe(false);
+      expect(started).toEqual(['a', 'b']);
+    });
+
+    it('leaves other suites untouched', () => {
+      const coordinator = createVestRunCoordinator();
+      const first = createControllableSuite();
+      const second = createControllableSuite();
+      const cacheKey = {};
+
+      coordinator.request({ suite: first.suite, cacheKey, value: 'a' });
+      coordinator.request({ suite: second.suite, cacheKey, value: 'a' });
+
+      coordinator.invalidate(first.suite);
+
+      expect(
+        coordinator.request({ suite: first.suite, cacheKey, value: 'a' })
+          .fromCache,
+      ).toBe(false);
+      expect(
+        coordinator.request({ suite: second.suite, cacheKey, value: 'a' })
+          .fromCache,
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -329,6 +329,57 @@ describe('createVestRunCoordinator', () => {
     });
   });
 
+  describe('suite bus subscriptions', () => {
+    it('unsubscribes an idle listener whose callback fires synchronously during subscribe()', () => {
+      // Regression guard for the PR #312 review finding: a `subscribe`
+      // implementation that invokes its callback DURING the `subscribe()`
+      // call reaches the callback's `unsubscribe?.()` before `unsubscribe`
+      // has been assigned, so that cleanup was a no-op and the listener
+      // stayed registered for the suite's lifetime -- re-firing on every
+      // later idle event.
+      const coordinator = createVestRunCoordinator();
+      const listeners = new Set<() => void>();
+      let invocations = 0;
+      // Always pending, so `waitForSuiteIdle` never takes its early-return
+      // path and always reaches `subscribe()`.
+      const pendingResult: VestResultLike = {
+        isPending: () => true,
+        getErrors: noMessages,
+        getWarnings: noMessages,
+      };
+      const suite: VestRunnableSuite<string> = {
+        run: () => pendingResult,
+        subscribe: (_event, callback) => {
+          const listener = (): void => {
+            invocations += 1;
+            callback();
+          };
+          listeners.add(listener);
+          // Fire DURING `subscribe()`, before the caller can store the
+          // unsubscribe function this call is about to return.
+          listener();
+          return () => {
+            listeners.delete(listener);
+          };
+        },
+        get: () => pendingResult,
+      };
+
+      coordinator.request({ suite, cacheKey: {}, value: 'a' });
+
+      // The synchronous callback ran once, and the subscription was torn
+      // down afterwards rather than leaked.
+      expect(invocations).toBe(1);
+      expect(listeners.size).toBe(0);
+
+      // A later idle event must therefore reach nobody.
+      for (const listener of listeners) {
+        listener();
+      }
+      expect(invocations).toBe(1);
+    });
+  });
+
   describe('settlement', () => {
     it('recovers a superseded run via the suite bus event', async () => {
       const coordinator = createVestRunCoordinator();

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -458,11 +458,24 @@ function waitForSuiteIdle<TValue, F extends string = string>(
     // `subscribe`'s callback can fire synchronously; capture `unsubscribe` as
     // `let` so an immediate callback doesn't read it before assignment (same
     // TDZ hazard `awaitVestRunSettlement` guards against below).
+    let fired = false;
     let unsubscribe: (() => void) | undefined;
     unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+      fired = true;
       unsubscribe?.();
       resolve();
     });
+
+    // If the callback above fired synchronously (during the `subscribe()`
+    // call itself), its own `unsubscribe?.()` ran before `unsubscribe` had
+    // been assigned and was therefore a no-op — leaving this listener
+    // subscribed for the suite's lifetime and re-firing on every LATER idle
+    // event. Clean up here instead, now that we hold a reference to it. Same
+    // fired-synchronously guard `awaitVestRunSettlement` uses below.
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `fired` may be flipped synchronously by the subscribe callback above; static analysis cannot model that closure write.
+    if (fired) {
+      unsubscribe();
+    }
   });
 }
 

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -1,0 +1,921 @@
+import type { SuiteResult } from 'vest';
+
+/* oxlint-disable @typescript-eslint/prefer-readonly-parameter-types -- The coordinator drives real Vest suite objects and Vest's own field-exclusion arrays, neither of which the `vest` package models as readonly. */
+
+/**
+ * Vest 6.3.2's real field-exclusion argument, mirrored locally because the
+ * public `vest` package entrypoint exports the `only()` *hook function* but
+ * not the `FieldExclusion<F>` type it (and `Suite.only()`) accept — that type
+ * lives in `vest-utils`, a transitive dependency this package does not
+ * declare directly.
+ *
+ * Matches Vest's real shape: `FieldExclusion<F> = Maybe<OneOrMoreOf<F>>` (a
+ * field name, a list of field names, or `undefined` for "no exclusion —
+ * everything runs"), plus the `false` variant Vest's `only()` hook also
+ * accepts to focus on nothing. `readonly F[]` (rather than `F[]`) admits
+ * readonly arrays without a cast at the call site.
+ */
+export type VestFieldExclusion<F extends string = string> =
+  | F
+  | readonly F[]
+  | undefined
+  | false;
+
+/**
+ * Whole-suite failure map returned by Vest selector APIs such as
+ * `result.getErrors()` and `result.getWarnings()`.
+ */
+type VestFailureMessages = Readonly<Record<string, readonly string[]>>;
+
+/**
+ * Field-scoped failure list returned by Vest selector APIs such as
+ * `result.getErrors('fieldName')`.
+ */
+type VestFieldMessages = readonly string[];
+
+/**
+ * Minimal subset of Vest's public result API required by the adapter.
+ *
+ * The overloads intentionally mirror Vest's selector behavior more precisely
+ * than a plain `Pick<SuiteResult, ...>` so internal helpers can stay strict
+ * about whole-suite versus field-scoped result shapes.
+ */
+export interface VestResultLike extends Pick<SuiteResult, 'isPending'> {
+  readonly getErrors: {
+    (): VestFailureMessages;
+    (fieldName: string): VestFieldMessages;
+  };
+  readonly getWarnings: {
+    (): VestFailureMessages;
+    (fieldName: string): VestFieldMessages;
+  };
+}
+
+/**
+ * Narrow runtime contract used by the adapter. The local type preserves the
+ * documented Promise-like behavior of async `run()` results without requiring
+ * the full generic `Suite` surface in consumers.
+ */
+export interface VestRunnableSuite<TValue> {
+  /**
+   * Declared as a readonly function property (not method shorthand) so its
+   * parameter is contravariant under `strictFunctionTypes` — method
+   * parameters stay bivariant regardless of that flag, which is what
+   * previously let a suite typed for one value (e.g. the whole model) be
+   * assigned where a suite for a narrower value (e.g. a single field) was
+   * expected. See ADR-0008.
+   *
+   * `fieldName` is deliberately `string` (not `string | string[]`, and not
+   * {@link VestFieldExclusion}): a real Vest suite's own `run()` signature is
+   * derived from its callback's second parameter, which the documented
+   * idiom types as plain `field?: string` (`create((data, field?: string) =>
+   * {...})`). Contravariance means widening this beyond what real suites
+   * declare would make an ordinary `create()` suite fail assignment here —
+   * the same reasoning as {@link only}'s narrower-than-{@link
+   * VestFieldExclusion} parameter type. Multi-field and `false` focus both
+   * go through `only` instead — see {@link executeVestRun}.
+   */
+  readonly run: (
+    value: TValue,
+    fieldName?: string,
+  ) => VestResultLike | PromiseLike<VestResultLike>;
+  reset?: () => void;
+  /**
+   * Declared as a readonly function property for the same contravariance
+   * reason as {@link run}.
+   *
+   * Deliberately narrower than {@link VestFieldExclusion} (which the
+   * public-facing `VestOnlyFieldSelector` and `RunVestSuiteParams.focus` DO
+   * use): Vest 6.3.2's real `Suite.only()` method itself only accepts
+   * `FieldExclusion<F>` (a field name, a list of field names, or
+   * `undefined`) — no `false`, no readonly arrays. Widening this member's
+   * parameter type to match {@link VestFieldExclusion} would make a real,
+   * unwrapped `create()` suite (whose own `only` is that narrower type) fail
+   * structural assignment to this interface, breaking the common case this
+   * whole contract exists to describe. The coordinator narrows a wider
+   * `VestFieldExclusion` value down to this shape before ever calling
+   * `suite.only(...)` — see {@link executeVestRun}.
+   */
+  readonly only?: (
+    field: string | string[],
+  ) => Pick<VestRunnableSuite<TValue>, 'run'>;
+  /**
+   * Optional Vest bus subscription (`suite.subscribe`). Used alongside {@link
+   * get} to recover from a superseded run — see
+   * {@link awaitVestRunSettlement}. Suites created via Vest's `create()`
+   * expose this; hand-rolled suite shapes may omit it.
+   */
+  subscribe?: (
+    event: 'ALL_RUNNING_TESTS_FINISHED',
+    callback: () => void,
+  ) => () => void;
+  /**
+   * Optional synchronous accessor for the suite's current accumulated result
+   * (`suite.get`). Used alongside {@link subscribe} to recover from a
+   * superseded run — see {@link awaitVestRunSettlement}.
+   */
+  get?: () => VestResultLike;
+}
+
+/**
+ * The exact slice of {@link VestRunnableSuite} the run coordinator drives:
+ * it starts runs (`run` / `only`) and observes settlement (`subscribe` /
+ * `get`). It never resets a suite — that is the registration layer's
+ * `resetOnDestroy` concern.
+ *
+ * `subscribe` / `get` are optional on purpose. Suites created via Vest's
+ * `create()` expose them and get the full guarantees (contention avoidance,
+ * FIFO queueing, superseded-resolver recovery); a hand-rolled suite that
+ * omits them degrades to best-effort behaviour driven solely by the value
+ * `run()` returns — see {@link waitForSuiteIdle} and
+ * {@link awaitVestRunSettlement}.
+ */
+export type VestCoordinatedSuite<TValue> = Pick<
+  VestRunnableSuite<TValue>,
+  'run' | 'only' | 'subscribe' | 'get'
+>;
+
+/**
+ * Identity a coordinated run is cached under, *within* a single suite.
+ *
+ * Deliberately a bare object reference rather than
+ * `ReadonlyFieldTree<unknown>`: the coordinator never reads the key, it only
+ * compares it by identity and uses it as a `WeakMap` key. Keeping it opaque
+ * is what removes the `unknown`-typed field-tree casts the cache used to
+ * need, and it lets a spec drive the coordinator with a plain `{}` instead of
+ * a rendered Angular form.
+ *
+ * The built-in registration path passes the validator's bound
+ * `ReadonlyFieldTree`, so caching and contention detection keep exactly the
+ * per-(suite, field tree) semantics they always had.
+ */
+export type VestRunCacheKey = object;
+
+/**
+ * One request for a coordinated Vest run — the `(suite, cache key, value,
+ * focus)` tuple the cache is keyed and gated on.
+ */
+export interface VestRunRequest<TValue> {
+  readonly suite: VestCoordinatedSuite<TValue>;
+  readonly cacheKey: VestRunCacheKey;
+  readonly value: TValue;
+  readonly focus?: VestFieldExclusion;
+}
+
+/**
+ * Handle on a coordinated Vest run, returned by
+ * {@link VestRunCoordinator.request}.
+ */
+export interface VestRunHandle<TValue> {
+  readonly value: TValue;
+  /**
+   * The canonical cache key derived from the requested `focus` — a field
+   * name, a NUL-joined field-name list, or `undefined` for a whole-suite run.
+   */
+  readonly focus: string | undefined;
+  /** The raw value `suite.run(...)` returned (or the deferred run's promise). */
+  readonly runResult: VestResultLike | PromiseLike<VestResultLike>;
+  /**
+   * The synchronous `SuiteResult`, when this run produced one. `undefined`
+   * when `run()` returned a bare thenable, and always `undefined` for a
+   * {@link deferred} run (which has not called `suite.run()` yet).
+   */
+  readonly initialResult: VestResultLike | undefined;
+  /**
+   * `true` when this run was queued behind another field tree's pending run
+   * on the SAME suite instead of starting immediately — see
+   * {@link isSuiteContestedByOtherTree}.
+   */
+  readonly deferred: boolean;
+  /**
+   * `true` when this request reused a previously cached execution for an
+   * identical `(suite, cache key, value, focus)` tuple.
+   */
+  readonly fromCache: boolean;
+  /**
+   * Resolves once this run's outcome is observable, recovering from a
+   * superseded Vest resolver where the suite makes that possible — see
+   * {@link awaitVestRunSettlement}. Lazy on purpose: subscribing to the
+   * suite bus costs nothing until a caller actually needs to await.
+   */
+  readonly settled: () => PromiseLike<unknown>;
+}
+
+/**
+ * The Vest run coordinator: the cache, contention detection, FIFO queue, and
+ * settlement machinery that lets several validators (and both validation
+ * phases of one validator) share exactly one `suite.run()` execution without
+ * two field trees ever overlapping on one suite instance.
+ *
+ * Deliberately Angular-free. It knows about suites, opaque cache keys,
+ * values, and focus — nothing about field trees, validation errors, or
+ * injection contexts. That is what makes its guarantees assertable without a
+ * `TestBed` or a rendered component.
+ */
+export interface VestRunCoordinator {
+  /**
+   * Request a run for a `(suite, cache key, value, focus)` tuple. Returns the
+   * cached run when that exact tuple is already held, and otherwise starts
+   * (or, when the suite is contested, queues) a fresh one.
+   */
+  request<TValue>(request: VestRunRequest<TValue>): VestRunHandle<TValue>;
+
+  /**
+   * Drop everything held for a suite: its run cache, its contention
+   * bookkeeping, and its queue tail.
+   */
+  invalidate(suite: object): void;
+}
+
+/**
+ * Cached Vest run keyed by suite instance and {@link VestRunCacheKey} so sync
+ * and async validation can share a single suite execution.
+ */
+interface VestRunCacheEntry<TValue> {
+  readonly value: TValue;
+  readonly focus: string | undefined;
+  readonly runResult: VestResultLike | PromiseLike<VestResultLike>;
+  readonly initialResult: VestResultLike | undefined;
+  /**
+   * `true` when this run was deferred via `deferVestRunUntilIdle` because
+   * another cache key had a concurrently pending run against the SAME suite
+   * instance when this one was requested — see
+   * {@link isSuiteContestedByOtherTree}.
+   *
+   * This is NOT the same question as "is this run currently pending" —
+   * it marks HOW the run was scheduled, for the lifetime of this cache entry,
+   * so settlement knows to await `runResult` directly rather than racing it
+   * against the suite-wide `ALL_RUNNING_TESTS_FINISHED` bus event (see
+   * {@link createVestRunHandle}). That race is what
+   * {@link awaitVestRunSettlement} uses to recover a SUPERSEDED run's
+   * promise, but `runResult` here is a plain `Promise` that does not even
+   * call `suite.run()` until the suite is idle — racing it against the
+   * CURRENT bus event (fired by whichever OTHER run made the suite idle)
+   * would resolve with `suite.get()`'s state from BEFORE this run started,
+   * not this run's own outcome.
+   */
+  readonly deferred: boolean;
+}
+
+/**
+ * Strongly typed per-suite cache used to share a single Vest run between the
+ * sync and async Angular validation phases.
+ */
+type VestRunCache = WeakMap<VestRunCacheKey, VestRunCacheEntry<unknown>>;
+
+const resolveQueueTail = (): void => {};
+
+/**
+ * Internal composite-key separator. A NUL code point can never appear in a Vest
+ * field path, message, or focus name, so it composes collision-free keys for the
+ * baseline dedupe map and the focus cache key. Declared with an explicit
+ * `\u0000` escape in a named constant (rather than a literal control character
+ * embedded in template strings) so the separator stays visible and
+ * tooling/formatter/diff-safe.
+ */
+export const VEST_KEY_SEPARATOR = '\u0000';
+
+/**
+ * Internal sentinel run-cache focus key for a "focus nothing" run —
+ * {@link isVestFocusNothing}'s `true` case (the toolkit's own `false`
+ * sentinel, or an empty field-name list) — distinguishing it from a `focus
+ * === undefined` ("whole suite") run in the cache-hit comparison. Composed
+ * so it can never collide with a real, string- or array-derived focus key.
+ * Both `false` and `[]` share this ONE key (rather than each computing their
+ * own) because they are the SAME semantic request — see
+ * {@link isVestFocusNothing}'s doc comment for why a bare `focus.join(...)`
+ * on `[]` is unsafe (it collides with a field literally named `''`).
+ */
+const VEST_FOCUS_NOTHING_SENTINEL = `${VEST_KEY_SEPARATOR}nothing${VEST_KEY_SEPARATOR}`;
+
+/**
+ * Runtime guard for the subset of Vest's public result object that the adapter
+ * consumes.
+ */
+export function isVestResultLike(value: unknown): value is VestResultLike {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    typeof Reflect.get(value, 'getErrors') === 'function' &&
+    typeof Reflect.get(value, 'getWarnings') === 'function'
+  );
+}
+
+/**
+ * Reports whether `focus` is a deliberate "run nothing" selection — the
+ * toolkit's own `false` sentinel, or an empty field-name list.
+ *
+ * Vest cannot express this through either `suite.only()` or the legacy
+ * `suite.run(value, fieldName)` form. Empirically verified against
+ * `vest@6.3.2`: `suite.only([])`, `suite.only(false)`, and `suite.only('')`
+ * all run the WHOLE suite — Vest treats an empty/falsy exclusion list as "no
+ * filter", identically to calling `suite.run(value)` with no focus at all —
+ * so there is no reliable, documented way to map "focus nothing" onto
+ * `suite.only()`. (The one construction that DOES run zero tests —
+ * `suite.only(['a-field-name-that-cannot-exist'])` — depends on the adapter
+ * fabricating a name guaranteed never to collide with a real Vest field,
+ * which nothing in Vest's public contract promises stays true.) Rather than
+ * silently doing the OPPOSITE of what the caller asked for,
+ * {@link executeVestRun} throws when this is `true`.
+ */
+function isVestFocusNothing(focus: VestFieldExclusion): focus is false {
+  // Declared as `focus is false` (rather than plain `boolean`) purely so
+  // callers get a narrowed `focus` afterward — this function is used both
+  // where that matters (`executeVestRun`, which throws in the `true` branch
+  // without touching `focus` again) and where it doesn't (the cache-key
+  // ternary below). An empty array satisfying this predicate is NOT
+  // literally `false`, but every caller either throws or discards `focus`
+  // in that branch, so the imprecision is harmless.
+  return focus === false || (Array.isArray(focus) && focus.length === 0);
+}
+
+/**
+ * Derives the canonical, collision-free cache key for a requested `focus`.
+ */
+function toVestFocusKey(focus: VestFieldExclusion): string | undefined {
+  if (isVestFocusNothing(focus)) {
+    return VEST_FOCUS_NOTHING_SENTINEL;
+  }
+
+  if (typeof focus === 'string' || focus === undefined) {
+    return focus;
+  }
+
+  return focus.join(VEST_KEY_SEPARATOR);
+}
+
+/**
+ * Executes `suite.run()` using the appropriate focused-run targeting.
+ *
+ * Prefers the Vest 6 canonical `suite.only(field).run(value)` form — that
+ * matches the upgrade-guide idiom where focus logic is kept out of the suite
+ * body. Falls back to the legacy `suite.run(value, fieldName)` form only when
+ * the suite does not expose `only` (e.g. consumer-wrapped suites that
+ * surface a `run`-only adapter).
+ */
+function executeVestRun<TValue>(
+  suite: Pick<VestCoordinatedSuite<TValue>, 'run' | 'only'>,
+  value: TValue,
+  focus: VestFieldExclusion,
+): VestResultLike | PromiseLike<VestResultLike> {
+  if (focus === undefined) {
+    return suite.run(value);
+  }
+
+  if (isVestFocusNothing(focus)) {
+    throw new Error(
+      '[ngx-signal-forms] A Vest `only` selector returned `false` (or an ' +
+        'empty field-name list), requesting a "focus nothing" run. Vest has ' +
+        'no reliable way to express that through `suite.only()` or ' +
+        '`suite.run(value, fieldName)` — both treat an empty selection as ' +
+        '"run the whole suite", the opposite of what was requested. Return ' +
+        'a field name, a list of field names, or `undefined` for a ' +
+        'whole-suite run.',
+    );
+  }
+
+  if (typeof suite.only === 'function') {
+    // `suite.only` (see {@link VestRunnableSuite.only}'s doc comment) only
+    // accepts `string | string[]` — no readonly arrays. Clone a readonly
+    // array into a mutable one.
+    const focusArg: string | string[] =
+      typeof focus === 'string' ? focus : [...focus];
+    const focused = suite.only(focusArg);
+    return focused.run(value);
+  }
+
+  // No `only` shorthand: fall back to `suite.run(value, fieldName)`, whose
+  // second argument (see {@link VestRunnableSuite.run}'s doc comment) is a
+  // single `string` — this legacy path predates multi-field focus, which is
+  // expressed through `only` above and collapses to the first field name.
+  return suite.run(value, typeof focus === 'string' ? focus : focus[0]);
+}
+
+/**
+ * Resolves once `suite` has no test currently in flight.
+ *
+ * Vest suites created via `create()` are single-flight: calling ANY method
+ * that re-executes the suite's callback (`run()`, `only().run()`, and even
+ * `runStatic()` — verified empirically, since `runStatic()`'s persisted
+ * binding re-enters the ORIGINAL suite's runtime context to invoke its
+ * throwaway instance) while a PREVIOUS run on the SAME suite instance is
+ * still pending corrupts that previous run's resolver, per
+ * {@link awaitVestRunSettlement}'s doc comment. There is no supported way to
+ * safely touch a Vest suite instance while it has an in-flight run.
+ *
+ * When the suite exposes `subscribe`/`get` (true for suites created via
+ * Vest's `create()`), this checks `get().isPending()` and, if so, resolves on
+ * the next suite-wide `ALL_RUNNING_TESTS_FINISHED` bus event — a pure
+ * readiness signal, independent of which specific run's resolver ends up
+ * firing it. Suites without `subscribe`/`get` resolve immediately (best
+ * effort; contention avoidance is only guaranteed for real Vest suites).
+ */
+function waitForSuiteIdle<TValue>(
+  suite: Pick<VestCoordinatedSuite<TValue>, 'subscribe' | 'get'>,
+): PromiseLike<void> {
+  if (
+    typeof suite.subscribe !== 'function' ||
+    typeof suite.get !== 'function'
+  ) {
+    return Promise.resolve();
+  }
+
+  const subscribe = suite.subscribe;
+  if (!suite.get().isPending()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    // `subscribe`'s callback can fire synchronously; capture `unsubscribe` as
+    // `let` so an immediate callback doesn't read it before assignment (same
+    // TDZ hazard `awaitVestRunSettlement` guards against below).
+    let unsubscribe: (() => void) | undefined;
+    unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+      unsubscribe?.();
+      resolve();
+    });
+  });
+}
+
+/**
+ * Runs `suite` for `(value, focus)` after the previous queued run has settled
+ * and once the suite is idle. Calls `onRunStarted` synchronously after this
+ * contender's own `suite.run()` begins, so its queue tail cannot be released
+ * by an earlier contender's idle event.
+ *
+ * This trades a small amount of latency (the deferred run genuinely waits for
+ * the other cache key's async work to finish before its own even starts) for
+ * full correctness, using only the same `run()` / `subscribe()` / `get()`
+ * surface every other code path already relies on — no suite-internal API
+ * beyond what {@link awaitVestRunSettlement} already uses.
+ */
+async function deferVestRunUntilIdle<TValue>(
+  suite: VestCoordinatedSuite<TValue>,
+  value: TValue,
+  focus: VestFieldExclusion,
+  previousRun: PromiseLike<void>,
+  onRunStarted: (
+    runResult: VestResultLike | PromiseLike<VestResultLike>,
+  ) => void,
+): Promise<VestResultLike> {
+  await previousRun;
+  await waitForSuiteIdle(suite);
+  const runResult = executeVestRun(suite, value, focus);
+  onRunStarted(runResult);
+  return runResult;
+}
+
+/**
+ * Awaits a Vest run's settlement, recovering from a superseded resolver.
+ *
+ * Vest 6's `suite.run()` promise resolves via a single resolver tracked per
+ * suite root isolate: `ALL_RUNNING_TESTS_FINISHED` fires `root.data.resolver()`
+ * once, and any LATER `suite.run()` call on the SAME suite instance replaces
+ * that resolver before the earlier call's promise ever settles. Two
+ * registrations of the same suite with different `only` focus (e.g. two
+ * root-bound validators each focused on a different field) each call `run()`
+ * independently, so the earlier one's promise can be superseded and never
+ * settle — leaving that field `pending()` forever.
+ *
+ * When the suite exposes `subscribe`/`get` (true for suites created via
+ * Vest's `create()`), race the run's own promise against the suite-wide
+ * `ALL_RUNNING_TESTS_FINISHED` bus event, which only fires once ALL pending
+ * tests — including this run's — have finished, regardless of which `run()`
+ * call's resolver ends up firing it. On that event, `suite.get()` returns the
+ * suite's current accumulated result, which by then reflects this run's
+ * outcome. Suites without `subscribe`/`get` fall back to the original
+ * (potentially superseded) promise unchanged.
+ */
+function awaitVestRunSettlement<TValue>(
+  runResult: VestResultLike | PromiseLike<VestResultLike>,
+  suite: Pick<VestCoordinatedSuite<TValue>, 'subscribe' | 'get'>,
+): PromiseLike<unknown> {
+  if (
+    typeof suite.subscribe !== 'function' ||
+    typeof suite.get !== 'function'
+  ) {
+    return Promise.resolve(runResult);
+  }
+  const subscribe = suite.subscribe;
+  const get = suite.get;
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    // Declared as `let` (not `const subscribe(...)` return) and guarded with
+    // `?.()`: some suites invoke the `subscribe` callback SYNCHRONOUSLY (e.g.
+    // if all tests already finished before this call), which would otherwise
+    // try to read `unsubscribe` before its initializer has run — a TDZ
+    // `ReferenceError` that would leave this promise unsettled forever.
+    let unsubscribe: (() => void) | undefined;
+
+    const settle = (fn: (value: unknown) => void, value: unknown): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      unsubscribe?.();
+      fn(value);
+    };
+
+    Promise.resolve(runResult).then(
+      (value) => {
+        settle(resolve, value);
+        return undefined;
+      },
+      (error: unknown) => {
+        settle(reject, error);
+        return undefined;
+      },
+    );
+
+    unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
+      settle(resolve, get());
+    });
+
+    // If the callback above fired synchronously (during the `subscribe()`
+    // call itself), `settle()` ran before `unsubscribe` was assigned, so its
+    // `unsubscribe?.()` was a no-op. Clean up the now-stale subscription here
+    // instead, now that we hold a reference to it.
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `settled` may be flipped synchronously by the subscribe callback above; static analysis cannot model that closure write.
+    if (settled) {
+      unsubscribe();
+    }
+  });
+}
+
+/**
+ * Create a {@link VestRunCoordinator} backed by its own caches and queues.
+ *
+ * Every adapter instance owns exactly one coordinator, so two adapters never
+ * share a cache — matching the pre-extraction closure-state semantics.
+ */
+export function createVestRunCoordinator(): VestRunCoordinator {
+  const runCache = new WeakMap<object, VestRunCache>();
+  // Tracks, per suite, which cache keys currently have a run PENDING against
+  // it -- see `isSuiteContestedByOtherTree`. A plain (non-weak) Map is
+  // required here (unlike `runCache`) because contention detection needs to
+  // enumerate/count entries, which `WeakMap` cannot do. Entries are removed
+  // as soon as their run settles (`trackPendingVestRun`), so this only ever
+  // holds cache keys with a run genuinely in flight -- bounded, self-cleaning
+  // bookkeeping, not a suite-lifetime membership list.
+  const pendingKeysBySuite = new Map<
+    object,
+    Map<VestRunCacheKey, VestRunCacheEntry<unknown>>
+  >();
+  // The latest queued run for each suite. The first, uncontested run still
+  // executes synchronously; its settlement is recorded here so subsequent
+  // contenders wait for it. Every queued run replaces the tail before it
+  // starts, making B and C serialize even when both were deferred behind A.
+  const runQueueBySuite = new WeakMap<object, Promise<void>>();
+
+  /**
+   * Retrieves the per-suite validation cache, creating it on first access.
+   */
+  function getVestSuiteRunCache(suite: object): VestRunCache {
+    const existingCache = runCache.get(suite);
+    if (existingCache) {
+      return existingCache;
+    }
+
+    const nextCache: VestRunCache = new WeakMap();
+    runCache.set(suite, nextCache);
+    return nextCache;
+  }
+
+  /**
+   * Reports whether `suite` currently has a PENDING, UNFOCUSED (whole-suite)
+   * run for some cache key OTHER than `cacheKey`.
+   *
+   * This is the precise condition under which Vest's shared, reconciled
+   * isolate tree is at risk: the reconciler merges/cancels pending test nodes
+   * from an in-flight run when a NEW `run()` call lands on the SAME suite
+   * before the earlier one settles (see {@link awaitVestRunSettlement}'s doc
+   * comment) -- if that overlap involves two DIFFERENT field trees, either
+   * one's final result can end up reflecting a blend of both trees' data
+   * (issue #214). When no OTHER cache key is currently pending, the shared
+   * path is safe and preserves full Vest statefulness (memoization, retained
+   * `warn()` state across runs, etc.) for the common single-tree-per-suite
+   * case.
+   *
+   * Deliberately scoped to UNFOCUSED runs only (see the `focus === undefined`
+   * guards at both call sites, {@link trackPendingVestRun} and this
+   * function's caller): a suite backing several `only`-focused registrations
+   * for DIFFERENT fields of the SAME overall form (each bound to its own
+   * child `ReadonlyFieldTree`) is the documented, intentional
+   * wave-3 (#174) pattern -- Vest's `only()` mode is SUPPOSED to retain other
+   * fields' state on the one shared suite there, and that pattern already has
+   * its own settlement recovery via `awaitVestRunSettlement`'s subscribe/get
+   * race. It is indistinguishable from the issue #214 shape (same suite
+   * object, different cache key) by key identity alone; `focus` is the one
+   * signal the coordinator has that tells them apart -- two unrelated forms
+   * sharing a suite have no reason to pass a focus field name, while the
+   * multi-field-single-form pattern always does.
+   */
+  function isSuiteContestedByOtherKey(
+    suiteKey: object,
+    cacheKey: VestRunCacheKey,
+  ): boolean {
+    const pendingKeys = pendingKeysBySuite.get(suiteKey);
+    if (!pendingKeys || pendingKeys.size === 0) {
+      return false;
+    }
+
+    return pendingKeys.size > 1 || !pendingKeys.has(cacheKey);
+  }
+
+  /**
+   * Records `cacheKey` as having a pending, UNFOCUSED run for `suiteKey`
+   * when `entry`'s run has not yet settled, and removes it once the run
+   * settles. No-op for a focused run -- see
+   * {@link isSuiteContestedByOtherKey}'s doc comment for why focused runs
+   * are excluded from contention tracking entirely.
+   *
+   * The removal is guarded by identity (`pendingKeys.get(cacheKey) ===
+   * entry`) so a LATER run for the same cache key -- which replaces this
+   * entry in the run cache before this one settles -- is never accidentally
+   * un-tracked by this entry's own (possibly superseded, possibly
+   * never-firing) settlement callback.
+   */
+  function trackPendingVestRun(
+    suiteKey: object,
+    cacheKey: VestRunCacheKey,
+    entry: VestRunCacheEntry<unknown>,
+    focus: VestFieldExclusion,
+  ): void {
+    if (focus !== undefined) {
+      return;
+    }
+
+    const isPending = !entry.initialResult || entry.initialResult.isPending();
+    if (!isPending) {
+      return;
+    }
+
+    let pendingKeys = pendingKeysBySuite.get(suiteKey);
+    if (!pendingKeys) {
+      pendingKeys = new Map();
+      pendingKeysBySuite.set(suiteKey, pendingKeys);
+    }
+    pendingKeys.set(cacheKey, entry);
+
+    const untrack = (): void => {
+      const currentPendingKeys = pendingKeysBySuite.get(suiteKey);
+      if (!currentPendingKeys || currentPendingKeys.get(cacheKey) !== entry) {
+        return;
+      }
+
+      currentPendingKeys.delete(cacheKey);
+      if (currentPendingKeys.size === 0) {
+        pendingKeysBySuite.delete(suiteKey);
+      }
+    };
+
+    Promise.resolve(entry.runResult).then(untrack, untrack);
+  }
+
+  /**
+   * Waits for a started run to leave the suite idle state. Vest 6's
+   * `SuiteResult` is thenable, but a later run can supersede its resolver and
+   * leave that thenable pending forever. The idle event is tied to the suite
+   * lifecycle instead, so it is the reliable queue boundary for real Vest
+   * suites. Hand-rolled suites retain the thenable-based best-effort fallback.
+   */
+  function waitForStartedVestRunTail<TValue>(
+    suite: Pick<VestCoordinatedSuite<TValue>, 'subscribe' | 'get'>,
+    runResult: VestResultLike | PromiseLike<VestResultLike>,
+  ): Promise<void> {
+    const settleRunResult = (): Promise<void> => {
+      return Promise.resolve(runResult).then(
+        () => undefined,
+        () => undefined,
+      );
+    };
+
+    if (
+      typeof suite.subscribe !== 'function' ||
+      typeof suite.get !== 'function'
+    ) {
+      return settleRunResult();
+    }
+
+    try {
+      return new Promise((resolve) => {
+        // A rejected run must not hold the queue forever. Successful Vest 6
+        // thenables are intentionally ignored here because they can be
+        // superseded; the suite idle event settles the normal path.
+        void Promise.resolve(runResult).then(
+          () => undefined,
+          () => {
+            resolve();
+            return undefined;
+          },
+        );
+        void Promise.resolve(waitForSuiteIdle(suite)).then(resolve, resolve);
+      });
+    } catch {
+      return settleRunResult();
+    }
+  }
+
+  /**
+   * Extends the per-suite queue boundary with a pre-built tail. This must retain
+   * an earlier reserved deferred boundary when an immediate focused run starts:
+   * later whole-suite contenders must still wait for that reserved work.
+   */
+  function recordVestRunTail(suiteKey: object, settled: Promise<void>): void {
+    const previousTail = runQueueBySuite.get(suiteKey) ?? Promise.resolve();
+    // Absorb either tail's rejection so a failed run cannot strand later
+    // contenders. `tail` represents the complete serialized boundary, not
+    // merely the most recently started run.
+    const tail = previousTail
+      .then(
+        () => settled,
+        () => settled,
+      )
+      .then(
+        () => undefined,
+        () => undefined,
+      );
+    runQueueBySuite.set(suiteKey, tail);
+    void tail.then(() => {
+      if (runQueueBySuite.get(suiteKey) === tail) {
+        runQueueBySuite.delete(suiteKey);
+      }
+      return undefined;
+    });
+  }
+
+  /**
+   * Records an immediately started run as the per-suite queue tail.
+   */
+  function recordVestRun<TValue>(
+    suiteKey: object,
+    suite: Pick<VestCoordinatedSuite<TValue>, 'subscribe' | 'get'>,
+    runResult: VestResultLike | PromiseLike<VestResultLike>,
+  ): void {
+    recordVestRunTail(suiteKey, waitForStartedVestRunTail(suite, runResult));
+  }
+
+  /**
+   * Adds a contested run to the per-suite exclusive queue. The prior tail is
+   * captured before this run is recorded as the new tail, so multiple callers
+   * deferred behind one pending run start in FIFO order rather than together.
+   */
+  function enqueueVestRun<TValue>(
+    suiteKey: object,
+    suite: VestCoordinatedSuite<TValue>,
+    value: TValue,
+    focus: VestFieldExclusion,
+  ): Promise<VestResultLike> {
+    const previousRun = runQueueBySuite.get(suiteKey) ?? Promise.resolve();
+    let resolveTail: () => void = resolveQueueTail;
+    const tail = new Promise<void>((resolve) => {
+      resolveTail = resolve;
+    });
+    // Reserve this slot before the contender begins. Its tail remains pending
+    // until this contender has actually started and the suite subsequently
+    // becomes idle, preserving FIFO ordering for every later contender.
+    recordVestRunTail(suiteKey, tail);
+    const runResult = deferVestRunUntilIdle(
+      suite,
+      value,
+      focus,
+      previousRun,
+      (startedRunResult) => {
+        void waitForStartedVestRunTail(suite, startedRunResult).then(
+          resolveTail,
+          resolveTail,
+        );
+      },
+    );
+    void runResult.then(
+      () => undefined,
+      () => {
+        resolveTail();
+        return undefined;
+      },
+    );
+    return runResult;
+  }
+
+  /**
+   * Builds the caller-facing handle for a cache entry, binding the lazy
+   * settlement strategy to the suite that produced the run.
+   */
+  function createVestRunHandle<TValue>(
+    suite: VestCoordinatedSuite<TValue>,
+    entry: VestRunCacheEntry<TValue>,
+    fromCache: boolean,
+  ): VestRunHandle<TValue> {
+    return {
+      value: entry.value,
+      focus: entry.focus,
+      runResult: entry.runResult,
+      initialResult: entry.initialResult,
+      deferred: entry.deferred,
+      fromCache,
+      settled: () =>
+        entry.deferred
+          ? // A deferred run's `runResult` (see `deferVestRunUntilIdle`) does
+            // not even call `suite.run()` until the suite becomes idle, so
+            // racing it against the suite-wide `ALL_RUNNING_TESTS_FINISHED`
+            // bus event here would resolve with `suite.get()`'s state from
+            // BEFORE this run started (whatever made the suite idle in the
+            // first place), not this run's own outcome. Its plain `Promise`
+            // already resolves correctly on its own once the deferred run
+            // actually completes, so await it directly.
+            Promise.resolve(entry.runResult)
+          : awaitVestRunSettlement(entry.runResult, suite),
+    };
+  }
+
+  /**
+   * Reuses an existing Vest run for the same suite, cache key, model
+   * reference, and focus key; or executes the suite once and caches the result.
+   *
+   * When `suite.run()` returns a thenable directly (rather than the documented
+   * synchronous `SuiteResult`), we capture `initialResult` as `undefined` and
+   * rely on the async branch to drive completion from the promise. This guards
+   * against consumer-wrapped suites that coerce `run()` into a Promise.
+   *
+   * Before executing a NEW run, checks whether `suite` currently has another
+   * cache key's run pending (`isSuiteContestedByOtherKey`) -- i.e. the same
+   * suite instance backs two concurrently-live field trees with overlapping
+   * in-flight validation (issue #214). When contested, the run is deferred
+   * until the suite is idle (`deferVestRunUntilIdle`) so it can never overlap
+   * with -- and thus never observe or corrupt -- the other tree's in-flight
+   * state; otherwise it runs against the suite's normal shared state
+   * immediately, exactly as before.
+   */
+  function request<TValue>(
+    runRequest: VestRunRequest<TValue>,
+  ): VestRunHandle<TValue> {
+    const { suite, cacheKey, value, focus } = runRequest;
+    const suiteKey: object = suite;
+    const suiteCache = getVestSuiteRunCache(suiteKey);
+    const cachedEntry = suiteCache.get(cacheKey);
+    const focusKey = toVestFocusKey(focus);
+
+    if (
+      cachedEntry &&
+      Object.is(cachedEntry.value, value) &&
+      cachedEntry.focus === focusKey
+    ) {
+      return createVestRunHandle(
+        suite,
+        {
+          value,
+          focus: focusKey,
+          runResult: cachedEntry.runResult,
+          initialResult: cachedEntry.initialResult,
+          deferred: cachedEntry.deferred,
+        },
+        true,
+      );
+    }
+
+    const isContested =
+      focus === undefined && isSuiteContestedByOtherKey(suiteKey, cacheKey);
+    const runResult = isContested
+      ? enqueueVestRun(suiteKey, suite, value, focus)
+      : executeVestRun(suite, value, focus);
+    if (!isContested) {
+      recordVestRun(suiteKey, suite, runResult);
+    }
+
+    const nextEntry: VestRunCacheEntry<TValue> = {
+      value,
+      focus: focusKey,
+      runResult,
+      // Vest 6's `suite.run(...)` returns a dual-shaped object that is *both*
+      // a synchronous `SuiteResult` (with `getErrors`/`isPending`) and a
+      // thenable. Previously we gated `initialResult` with `!isThenable(...)`,
+      // which would always be false for Vest 6 suites and forced every
+      // validation run through the async pipeline — hiding sync errors until
+      // the next microtask. Check the sync surface directly instead. A
+      // deferred (contested) run's `runResult` is a plain `Promise` (not
+      // Vest-result-like) until it actually starts, so it correctly falls
+      // into the "no sync result yet" branch below regardless.
+      initialResult: isVestResultLike(runResult) ? runResult : undefined,
+      deferred: isContested,
+    };
+
+    suiteCache.set(cacheKey, nextEntry);
+    trackPendingVestRun(suiteKey, cacheKey, nextEntry, focus);
+    return createVestRunHandle(suite, nextEntry, false);
+  }
+
+  function invalidate(suite: object): void {
+    runCache.delete(suite);
+    // Also drop contention bookkeeping so a reset suite starts from a clean
+    // slate -- otherwise a stale pending marker from a run that never settled
+    // before teardown could permanently (and incorrectly) mark a
+    // subsequently-reused suite as contested.
+    pendingKeysBySuite.delete(suite);
+    runQueueBySuite.delete(suite);
+  }
+
+  return { request, invalidate };
+}
+
+/* oxlint-enable @typescript-eslint/prefer-readonly-parameter-types */


### PR DESCRIPTION
Closes #295

The final vest-backlog item: the run coordinator (cache, contention detection, FIFO queue, settlement) moves behind its own internal seam, per the sequencing note (after #287 and #291, both landed).

## What changed

- **New `vest-run-coordinator.ts`** (921 lines): `createVestRunCoordinator()` exposing `request<TValue, F>(request) → VestRunHandle` (sync result if any, settlement promise, deferred/fromCache flags) and `invalidate(suite)`. The cache key is an argument of the interface, so specs supply one directly. `vest-adapter.ts` shrinks 1768 → 1042 lines; registration keeps only binding, focus resolution, and result mapping, calling the coordinator instead of shared closure state.
- **17 new coordinator specs** drive it with hand-rolled suites — no TestBed, no rendering, no Angular validators: FIFO ordering for contested runs, single execution across sync + async phases, and the previously-untestable settlement path for a suite **without** `subscribe`/`get`.
- **The three `unknown`-keyed-cache casts are gone** (typed `object` keys); one documented cast remains where the run result enters the F-less cache entry (reading back out needs none — parameter contravariance).
- **Public surface unchanged**: `index.ts` untouched, moved types (`VestRunnableSuite`, `VestResultLike`, `VestFieldExclusion`) re-exported from `vest-adapter.ts`; existing specs byte-identical and passing.
- **ADR-0009** records the seam decision.
- Includes a merge of main porting #308's `F` field-name-union threading onto the extracted structure; #308's five type-level specs pass against the new layout. One deliberate extension over a literal port, flagged for review: the three result-mapping helpers take `VestResultLike<F>` instead of `VestResultLike<string>` (they only call zero-arg overloads), avoiding four new casts that would contradict this issue's casts-gone criterion.

## Verification (base = current main incl. #308)

- `CI=1 pnpm nx run toolkit:test` — 82 files, 1374 tests passed
- `CI=1 pnpm nx run toolkit:test-browser` — 17 files, 78 tests passed
- `pnpm nx run toolkit:lint` — clean
- Spec typecheck — error set identical to main baseline (zero new)
- `pnpm nx run toolkit:build` — all 7 entries built

🤖 Generated with [Claude Code](https://claude.com/claude-code)