### PR TITLE
fix(a11y): relocate required-ness for role=group multi-control clusters

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -163,6 +163,7 @@ provideNgxSignalFormsConfig({
   optionalMarker: ' (optional)', // marker for optional fields ('optional' mode)
   requiredLegendText: '{marker} indicates a required field',
   optionalLegendText: 'All fields are required unless marked {marker}',
+  requiredHintText: 'required', // visually-hidden required hint for role="group" clusters
 });
 ```
 

--- a/packages/toolkit/core/directives/auto-aria.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.spec.ts
@@ -86,6 +86,7 @@ describe('NgxSignalFormAutoAria', () => {
     invalid = false,
     touched = false,
     errors: unknown[] = [],
+    required = false,
   ) => {
     const fieldState = {
       invalid: signal(invalid),
@@ -94,7 +95,7 @@ describe('NgxSignalFormAutoAria', () => {
       valid: signal(!invalid),
       dirty: signal(touched),
       value: signal(''),
-      required: signal(false),
+      required: signal(required),
       focusBoundControl: vi.fn(),
     };
     // Control signal returns a function (signal) that returns the field state object
@@ -417,6 +418,80 @@ describe('NgxSignalFormAutoAria', () => {
 
       const input = container.querySelector('input');
       expect(input?.hasAttribute('aria-invalid')).toBe(false);
+    });
+  });
+
+  describe('ARIA Required role gating (issue #300)', () => {
+    /**
+     * `NgxSignalFormAutoAria`'s generic selector also matches
+     * `NgxFormFieldWrapper`'s host when a multi-control cluster binds
+     * `[formField]` directly on the wrapper — the real-world path that
+     * surfaced issue #300. These fixtures use a bare `<div>` instead of the
+     * full wrapper component to keep this a directive-level unit test.
+     */
+    it('does NOT set aria-required on a host with role="group"', async () => {
+      @Component({
+        template:
+          '<div role="group" id="cluster" [formField]="clusterControl()"></div>',
+        imports: [MockFormFieldDirective, NgxSignalFormAutoAria],
+      })
+      class TestComponent {
+        clusterControl = createMockControl(
+          true,
+          true,
+          [{ kind: 'required', message: 'Field is required' }],
+          true,
+        );
+      }
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const group = container.querySelector('[role="group"]');
+      expect(group?.hasAttribute('aria-required')).toBe(false);
+    });
+
+    it('still sets aria-required="true" on a host with role="radiogroup"', async () => {
+      @Component({
+        template:
+          '<div role="radiogroup" id="cluster" [formField]="clusterControl()"></div>',
+        imports: [MockFormFieldDirective, NgxSignalFormAutoAria],
+      })
+      class TestComponent {
+        clusterControl = createMockControl(
+          true,
+          true,
+          [{ kind: 'required', message: 'Field is required' }],
+          true,
+        );
+      }
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const group = container.querySelector('[role="radiogroup"]');
+      expect(group?.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('still sets aria-required="true" on a host with no role attribute', async () => {
+      @Component({
+        template: '<div id="cluster" [formField]="clusterControl()"></div>',
+        imports: [MockFormFieldDirective, NgxSignalFormAutoAria],
+      })
+      class TestComponent {
+        clusterControl = createMockControl(
+          true,
+          true,
+          [{ kind: 'required', message: 'Field is required' }],
+          true,
+        );
+      }
+
+      const { container } = await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const group = container.querySelector('#cluster');
+      expect(group?.getAttribute('aria-required')).toBe('true');
     });
   });
 

--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -39,6 +39,7 @@ interface AutoAriaDomSnapshot {
   readonly describedBy: string | null;
   readonly ariaInvalid: string | null;
   readonly ariaRequired: string | null;
+  readonly role: string | null;
 }
 
 const INITIAL_DOM_SNAPSHOT: AutoAriaDomSnapshot = {
@@ -46,6 +47,7 @@ const INITIAL_DOM_SNAPSHOT: AutoAriaDomSnapshot = {
   describedBy: null,
   ariaInvalid: null,
   ariaRequired: null,
+  role: null,
 };
 
 /**
@@ -365,12 +367,30 @@ export class NgxSignalFormAutoAria {
    * Returns 'true' | null based on the field's `required()` signal.
    *
    * Delegates to {@link createAriaRequiredSignal} for the actual resolution.
-   * The directive shell only owns the manual-mode opt-out branch — when
-   * `ngxSignalFormControlAria='manual'`, the consumer's DOM value wins.
+   * The directive shell owns two branches on top of that unconditional
+   * factory:
+   *
+   * - manual-mode opt-out — when `ngxSignalFormControlAria='manual'`, the
+   *   consumer's DOM value wins.
+   * - role-aware suppression — `aria-required` is only valid ARIA on a
+   *   handful of roles (`radiogroup`, `combobox`, `textbox`, …) plus native
+   *   form controls with no explicit role. This directive also matches
+   *   `NgxFormFieldWrapper`'s host when a multi-control cluster binds
+   *   `[formField]` directly on the wrapper, and that host can carry
+   *   `role="group"` for a checkbox cluster — a role ARIA does NOT allow
+   *   `aria-required` on. Rather than enumerate every allowed role, this
+   *   blocks the one role this directive can attach to that forbids it;
+   *   `radiogroup` (the wrapper's other cluster role) and plain controls
+   *   (no `role` attribute) are unaffected. See
+   *   https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300.
    */
   protected readonly ariaRequired = computed(() => {
     if (this.#isManualAriaMode()) {
       return this.#domSnapshot().ariaRequired;
+    }
+
+    if (this.#domSnapshot().role === 'group') {
+      return null;
     }
 
     return this.#ariaRequiredFromFactory();
@@ -487,6 +507,13 @@ export class NgxSignalFormAutoAria {
       describedBy: this.#readPreservedDescribedBy(fieldName),
       ariaInvalid: this.#element.nativeElement.getAttribute('aria-invalid'),
       ariaRequired: this.#element.nativeElement.getAttribute('aria-required'),
+      // Read fresh every tick (rather than cached) so the `group` gate in
+      // `ariaRequired` above reacts the same render cycle a host's `role`
+      // changes — e.g. `NgxFormFieldWrapper` switching cluster kind. Host
+      // `[attr.*]` bindings on the same element are already flushed to the
+      // DOM by the time `afterEveryRender` runs, so this reflects the
+      // current render's role, not a stale one.
+      role: this.#element.nativeElement.getAttribute('role'),
     };
   }
 
@@ -527,7 +554,8 @@ export class NgxSignalFormAutoAria {
             current.fieldName !== snapshot.fieldName ||
             current.describedBy !== snapshot.describedBy ||
             current.ariaInvalid !== snapshot.ariaInvalid ||
-            current.ariaRequired !== snapshot.ariaRequired
+            current.ariaRequired !== snapshot.ariaRequired ||
+            current.role !== snapshot.role
           ) {
             this.#domSnapshot.set(snapshot);
           }

--- a/packages/toolkit/core/providers/config.provider.spec.ts
+++ b/packages/toolkit/core/providers/config.provider.spec.ts
@@ -165,4 +165,20 @@ describe('provideNgxSignalFormsConfigForComponent', () => {
     expect(resolved.requiredLegendText).toBe('');
     expect(resolved.optionalLegendText).toBe('');
   });
+
+  it('flows a custom requiredHintText override through to the resolved config (issue #300 localization)', () => {
+    // `requiredHintText` drives the visually-hidden required-state hint
+    // NgxFormFieldWrapper renders for a `role="group"` selection cluster
+    // (see form-field-wrapper.ts `resolvedRequiredHintText`) — it must be
+    // config-driven, not a hardcoded English word, so a non-English app can
+    // localize it through the same provider seam as `requiredLegendText`.
+    const providers = provideNgxSignalFormsConfig({
+      requiredHintText: 'obligatoire',
+    });
+    const injector = createInjectorFromEnvProviders([providers]);
+
+    expect(injector.get(NGX_SIGNAL_FORMS_CONFIG).requiredHintText).toBe(
+      'obligatoire',
+    );
+  });
 });

--- a/packages/toolkit/core/providers/config.provider.ts
+++ b/packages/toolkit/core/providers/config.provider.ts
@@ -84,6 +84,11 @@ function createConfigFactory(
         configDefault: parentOrNull?.optionalLegendText,
         fallback: DEFAULT_NGX_SIGNAL_FORMS_CONFIG.optionalLegendText,
       }),
+      requiredHintText: createCascadingResolver({
+        input: userConfig.requiredHintText,
+        configDefault: parentOrNull?.requiredHintText,
+        fallback: DEFAULT_NGX_SIGNAL_FORMS_CONFIG.requiredHintText,
+      }),
     };
   };
 }

--- a/packages/toolkit/core/tokens.ts
+++ b/packages/toolkit/core/tokens.ts
@@ -40,6 +40,7 @@ export const DEFAULT_NGX_SIGNAL_FORMS_CONFIG = {
   optionalMarker: ' (optional)',
   requiredLegendText: '{marker} indicates a required field',
   optionalLegendText: 'All fields are required unless marked {marker}',
+  requiredHintText: 'required',
 } as const satisfies NgxSignalFormsConfig;
 
 /**

--- a/packages/toolkit/core/types.ts
+++ b/packages/toolkit/core/types.ts
@@ -412,7 +412,9 @@ export interface NgxSignalFormsUserConfig {
   optionalLegendText?: string;
   /**
    * Override the visually-hidden required-hint text for `role="group"`
-   * selection clusters. Pass `''` to clear an inherited hint.
+   * selection clusters. Pass `''` to suppress the hint entirely — the
+   * wrapper renders no hint node and omits its id from `aria-describedby`,
+   * rather than pointing the description at an empty element.
    */
   requiredHintText?: string;
 }

--- a/packages/toolkit/core/types.ts
+++ b/packages/toolkit/core/types.ts
@@ -365,6 +365,18 @@ export interface NgxSignalFormsConfig {
    * @default 'All fields are required unless marked {marker}'
    */
   optionalLegendText: string;
+
+  /**
+   * Text for the visually-hidden required-state hint on a `role="group"`
+   * multi-control selection cluster (e.g. a required checkbox cluster).
+   *
+   * `group` does not support `aria-required` (only `radiogroup` does), so
+   * `NgxFormFieldWrapper` relocates required-ness into this text, exposed
+   * via `aria-describedby` instead of an ARIA state — see
+   * https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300.
+   * @default 'required'
+   */
+  requiredHintText: string;
 }
 
 /**
@@ -398,4 +410,9 @@ export interface NgxSignalFormsUserConfig {
   requiredLegendText?: string;
   /** Override the `'optional'` legend text. `{marker}` is substituted. */
   optionalLegendText?: string;
+  /**
+   * Override the visually-hidden required-hint text for `role="group"`
+   * selection clusters. Pass `''` to clear an inherited hint.
+   */
+  requiredHintText?: string;
 }

--- a/packages/toolkit/core/utilities/field-resolution.ts
+++ b/packages/toolkit/core/utilities/field-resolution.ts
@@ -213,3 +213,24 @@ export function buildAriaDescribedBy(
 export function generateWarningId(fieldName: string): string {
   return `${fieldName}-warning`;
 }
+
+/**
+ * Generates the ID for a selection cluster's visually-hidden required hint.
+ *
+ * `role="group"` does not support `aria-required` (only `radiogroup` does),
+ * so `NgxFormFieldWrapper` relocates required-ness for `group` clusters into
+ * a visually-hidden node referenced by `aria-describedby` instead of an ARIA
+ * state — see
+ * https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300.
+ *
+ * @param fieldName - The field name
+ * @returns The required-hint ID in format: `{fieldName}-required-hint`
+ *
+ * @example
+ * ```typescript
+ * generateRequiredHintId('consent'); // Returns: 'consent-required-hint'
+ * ```
+ */
+export function generateRequiredHintId(fieldName: string): string {
+  return `${fieldName}-required-hint`;
+}

--- a/packages/toolkit/core/utilities/normalize-config.spec.ts
+++ b/packages/toolkit/core/utilities/normalize-config.spec.ts
@@ -41,6 +41,7 @@ describe('normalizeSignalFormsConfig', () => {
       optionalMarker: undefined,
       requiredLegendText: undefined,
       optionalLegendText: undefined,
+      requiredHintText: undefined,
     });
 
     expect(result).toEqual(DEFAULT_NGX_SIGNAL_FORMS_CONFIG);

--- a/packages/toolkit/core/utilities/normalize-config.ts
+++ b/packages/toolkit/core/utilities/normalize-config.ts
@@ -50,5 +50,8 @@ export function normalizeSignalFormsConfig(
     optionalLegendText:
       config.optionalLegendText ??
       DEFAULT_NGX_SIGNAL_FORMS_CONFIG.optionalLegendText,
+    requiredHintText:
+      config.requiredHintText ??
+      DEFAULT_NGX_SIGNAL_FORMS_CONFIG.requiredHintText,
   };
 }

--- a/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
@@ -8,7 +8,10 @@ import {
   schema,
   validate,
 } from '@angular/forms/signals';
-import { NgxSignalFormToolkit } from '@ngx-signal-forms/toolkit';
+import {
+  NgxSignalFormToolkit,
+  provideNgxSignalFormsConfig,
+} from '@ngx-signal-forms/toolkit';
 import { render } from '@testing-library/angular';
 import { page, userEvent } from 'vitest/browser';
 import { describe, expect, it } from 'vitest';
@@ -355,6 +358,38 @@ describe('form-field wrapper — WCAG 2.2 AA conformance', () => {
       // The hint must actually be exposed to the accessibility tree — unlike
       // the visual `*` marker, it is NOT `aria-hidden`.
       expect(requiredHint).not.toHaveAttribute('aria-hidden');
+
+      await expectNoA11yViolations(container);
+    });
+
+    it('suppresses the required hint entirely when requiredHintText is empty, instead of describedby-ing an empty node', async () => {
+      // Regression guard: `requiredHintText: ''` is documented as
+      // "suppress the hint" (mirrors `requiredMarker`'s empty-string-clears
+      // convention), but the wrapper used to keep rendering the hint span
+      // and referencing its id in `aria-describedby` even when the text was
+      // empty — an empty accessible-description target.
+      const TestComponent = defineFixtureComponent(
+        'ngx-test-a11y-checkbox-cluster-empty-hint-text',
+        CHECKBOX_CLUSTER_TEMPLATE,
+        () =>
+          form(
+            signal({ consentRead: false, consentAgree: false }),
+            schema((path) => {
+              required(path.consentRead, { message: 'Consent is required' });
+              required(path.consentAgree, { message: 'Consent is required' });
+            }),
+          ),
+      );
+
+      const { container } = await render(TestComponent, {
+        providers: [provideNgxSignalFormsConfig({ requiredHintText: '' })],
+      });
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('role', 'group');
+      expect(container.querySelector('#consent-required-hint')).toBeNull();
+      expect(wrapper).not.toHaveAttribute('aria-describedby');
 
       await expectNoA11yViolations(container);
     });

--- a/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts
@@ -329,20 +329,34 @@ describe('form-field wrapper — WCAG 2.2 AA conformance', () => {
         .element(page.getByRole('alert'))
         .toHaveTextContent('Consent is required');
 
-      // KNOWN VIOLATION, filed as
-      // https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300 (not
-      // fixed here — see the module doc comment above this `describe` block
-      // on the toolkit's scope guard for newly discovered defects): a
-      // required checkbox cluster puts `aria-required="true"` on the wrapper
-      // host alongside `role="group"`. `group` does not support
-      // `aria-required` in the ARIA spec (only `radiogroup` does among the
-      // roles this wrapper emits), so axe's `aria-allowed-attr` rule fires
-      // here — confirmed via the rendered wrapper: `role="group"
-      // aria-required="true"`. Scoped out here so the rest of the WCAG 2.2 AA
-      // gate stays a hard failure; remove this exclusion once #300 lands.
-      await expectNoA11yViolations(container, {
-        rules: { 'aria-allowed-attr': { enabled: false } },
-      });
+      // Regression coverage for
+      // https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300: a
+      // required checkbox cluster used to put `aria-required="true"` on the
+      // wrapper host alongside `role="group"`, which axe's
+      // `aria-allowed-attr` rule flags as critical (`group` does not support
+      // `aria-required` — only `radiogroup` does among the roles this
+      // wrapper emits). `NgxSignalFormAutoAria` is now role-aware and drops
+      // `aria-required` whenever the host's resolved role is `group`, so the
+      // full rule set runs here with no exclusions. Required-ness isn't
+      // simply dropped, though — the issue asked for it to be relocated, so
+      // it stays perceivable via a visually-hidden node wired into
+      // `aria-describedby` (see `groupRequiredHintId` in
+      // form-field-wrapper.ts) instead of the disallowed ARIA state.
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('role', 'group');
+      expect(wrapper).not.toHaveAttribute('aria-required');
+
+      const requiredHintId = 'consent-required-hint';
+      const describedBy = wrapper?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy.split(' ')).toContain(requiredHintId);
+
+      const requiredHint = container.querySelector(`#${requiredHintId}`);
+      expect(requiredHint).toHaveTextContent('required');
+      // The hint must actually be exposed to the accessibility tree — unlike
+      // the visual `*` marker, it is NOT `aria-hidden`.
+      expect(requiredHint).not.toHaveAttribute('aria-hidden');
+
+      await expectNoA11yViolations(container);
     });
 
     it('two unnamed clusters skip label wiring instead of colliding on the same fallback id, and still have no violations', async () => {

--- a/packages/toolkit/form-field/form-field-wrapper.css
+++ b/packages/toolkit/form-field/form-field-wrapper.css
@@ -878,6 +878,25 @@
   opacity: var(--ngx-form-field-optional-marker-opacity, 0.7);
 }
 
+/* Relocated required-state text for a `group`-role selection cluster (see
+   `groupRequiredHintId` in form-field-wrapper.ts) — perceivable to
+   assistive tech via `aria-describedby`, hidden from sighted users. Standard
+   clip-rect technique (not `display: none` / `visibility: hidden`, which
+   screen readers also skip); matches the pattern already used by
+   `ngx-form-field-character-count`. */
+.ngx-signal-form-field-wrapper__visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Remove input default styling (container provides all visual feedback) */
 :host(.ngx-signal-forms-outline):not(.ngx-signal-form-field-wrapper--switch)
   ::ng-deep

--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -1502,6 +1502,138 @@ describe('NgxSignalFormWrapperComponent', () => {
       ).toBeTruthy();
     });
 
+    it('relocates required-ness for a required checkbox cluster (role="group") into a visually-hidden aria-describedby hint', async () => {
+      // Regression coverage for
+      // https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300:
+      // `role="group"` does not support `aria-required` (only `radiogroup`
+      // does), so `NgxSignalFormAutoAria` never writes it here. Required-ness
+      // must still be perceivable, though, so the wrapper relocates it into a
+      // visually-hidden node wired into `aria-describedby` — independent of
+      // whether an error is currently visible.
+      const validField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" fieldName="consent">
+          <span ngxFormFieldLabel>Consent</span>
+          <div>
+            <label>
+              <input id="consent-read" type="checkbox" required />
+              I have read the terms
+            </label>
+            <label>
+              <input id="consent-agree" type="checkbox" required />
+              I agree to the terms
+            </label>
+          </div>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: validField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('role', 'group');
+      expect(wrapper).not.toHaveAttribute('aria-required');
+      expect(wrapper).toHaveAttribute(
+        'aria-describedby',
+        'consent-required-hint',
+      );
+
+      const requiredHint = container.querySelector('#consent-required-hint');
+      expect(requiredHint).toBeTruthy();
+      expect(requiredHint).not.toHaveAttribute('aria-hidden');
+      expect(requiredHint?.textContent).toBe('required');
+    });
+
+    it('does NOT relocate a required hint for a non-required checkbox cluster', async () => {
+      const validField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" fieldName="consent">
+          <span ngxFormFieldLabel>Consent</span>
+          <div>
+            <label>
+              <input id="consent-read" type="checkbox" />
+              I have read the terms
+            </label>
+            <label>
+              <input id="consent-agree" type="checkbox" />
+              I agree to the terms
+            </label>
+          </div>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: {
+            field: validField,
+          },
+        },
+      );
+
+      const wrapper = container.querySelector('ngx-form-field-wrapper');
+      expect(wrapper).toHaveAttribute('role', 'group');
+      expect(wrapper).not.toHaveAttribute('aria-describedby');
+      expect(
+        container.querySelector('#consent-required-hint'),
+      ).not.toBeTruthy();
+    });
+
+    it('renders a config-provided requiredHintText instead of the English default (issue #300 localization)', async () => {
+      // `requiredHintText` must flow from `NGX_SIGNAL_FORMS_CONFIG` — same
+      // seam as `requiredLegendText` — so a non-English app isn't stuck
+      // announcing a hardcoded English word in the cluster's description.
+      const validField = signal({
+        invalid: () => false,
+        touched: () => false,
+        errors: () => [],
+      });
+
+      const { container } = await render(
+        `<ngx-form-field-wrapper [formField]="field" fieldName="consent">
+          <span ngxFormFieldLabel>Consent</span>
+          <div>
+            <label>
+              <input id="consent-read" type="checkbox" required />
+              I have read the terms
+            </label>
+            <label>
+              <input id="consent-agree" type="checkbox" required />
+              I agree to the terms
+            </label>
+          </div>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          providers: [
+            {
+              provide: NGX_SIGNAL_FORMS_CONFIG,
+              useValue: {
+                ...DEFAULT_NGX_SIGNAL_FORMS_CONFIG,
+                requiredHintText: 'obligatoire',
+              },
+            },
+          ],
+          componentProperties: {
+            field: validField,
+          },
+        },
+      );
+
+      const requiredHint = container.querySelector('#consent-required-hint');
+      expect(requiredHint?.textContent).toBe('obligatoire');
+    });
+
     it('merges an author-supplied aria-describedby with the cluster-managed error id instead of clobbering it', async () => {
       // Regression guard: `[attr.aria-describedby]` on the host is always
       // active (Angular host bindings can't be conditionally applied at

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -1096,12 +1096,22 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * required-ness signal that already drives the visible `*` marker in the
    * label, so both indicators agree.
    *
+   * `null` also whenever {@link resolvedRequiredHintText} resolves to `''`
+   * (an explicit `requiredHintText: ''` override, clearing the hint —
+   * mirrors `requiredMarker`'s / `requiredLegendText`'s empty-string-clears
+   * convention). Rendering an empty visually-hidden node would still leave
+   * its id in `aria-describedby`, pointing at a text-less element — an
+   * empty accessible-description target, not a missing one, but pointless
+   * either way, so the id is withheld here rather than in the describedby
+   * composer.
+   *
    * See https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300.
    */
   protected readonly groupRequiredHintId = computed<string | null>(() => {
     if (
       this.selectionClusterRole() !== 'group' ||
-      !this.#boundControlIsRequired()
+      !this.#boundControlIsRequired() ||
+      this.resolvedRequiredHintText() === ''
     ) {
       return null;
     }

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -46,6 +46,7 @@ import {
 import {
   NGX_SIGNAL_FORM_HINT_REGISTRY,
   NgxFieldIdentity,
+  generateRequiredHintId,
   isElementCssVisible,
   resolveBoundControlFromBindings,
   toHintDescriptors,
@@ -260,6 +261,20 @@ import {
           "
           aria-hidden="true"
           >{{ marker.text }}</span
+        >
+      }
+      @if (groupRequiredHintId(); as requiredHintId) {
+        <!--
+          Relocated required-state announcement for a \`group\`-role selection
+          cluster (see \`groupRequiredHintId\` doc comment): \`aria-required\`
+          isn't valid ARIA on \`group\`, so this visually-hidden (NOT
+          aria-hidden) node carries the text instead, wired into
+          \`aria-describedby\` on the host. WCAG 1.3.1 / 4.1.2.
+        -->
+        <span
+          [id]="requiredHintId"
+          class="ngx-signal-form-field-wrapper__visually-hidden"
+          >{{ resolvedRequiredHintText() }}</span
         >
       }
     </div>
@@ -1062,6 +1077,51 @@ export class NgxFormFieldWrapper<TValue = unknown> {
   });
 
   /**
+   * ID of the visually-hidden required hint for a `group`-role cluster, or
+   * `null` when it doesn't apply.
+   *
+   * `aria-required` is only valid ARIA on `radiogroup` among the roles this
+   * wrapper emits — `group` does not support it, and writing it anyway trips
+   * axe's `aria-allowed-attr` rule (critical impact). Rather than silently
+   * dropping required-ness for a `group` cluster, it is relocated here: a
+   * visually-hidden node (rendered in the template below, not `aria-hidden`)
+   * carries the text and is wired into {@link selectionClusterDescribedBy},
+   * so required-ness stays perceivable to assistive tech via the group's
+   * accessible description instead of an ARIA state.
+   * `radiogroup` is unaffected — it keeps `aria-required` from
+   * `NgxSignalFormAutoAria` exactly as before, so this hint only exists for
+   * `group`.
+   *
+   * Reuses {@link #boundControlIsRequired} — the same DOM-observed
+   * required-ness signal that already drives the visible `*` marker in the
+   * label, so both indicators agree.
+   *
+   * See https://github.com/ngx-signal-forms/ngx-signal-forms/issues/300.
+   */
+  protected readonly groupRequiredHintId = computed<string | null>(() => {
+    if (
+      this.selectionClusterRole() !== 'group' ||
+      !this.#boundControlIsRequired()
+    ) {
+      return null;
+    }
+
+    const fieldName = this.resolvedFieldName();
+    return fieldName === null ? null : generateRequiredHintId(fieldName);
+  });
+
+  /**
+   * Resolved text for {@link groupRequiredHintId}'s visually-hidden node.
+   * Sourced from `NgxSignalFormsConfig.requiredHintText` — the same
+   * config-driven text seam as {@link resolvedRequiredMarker} and
+   * `NgxFormMarkingLegend`'s `requiredLegendText` — so a non-English app can
+   * localize it instead of announcing a hardcoded English word.
+   */
+  protected readonly resolvedRequiredHintText = computed(() => {
+    return this.#config.requiredHintText;
+  });
+
+  /**
    * Falls back to (never replaces) `#initialAriaLabelledby` for non-cluster
    * wrappers — see the field doc comment on `#initialAriaLabelledby` for why
    * the host binding can't simply be left unbound instead.
@@ -1078,41 +1138,43 @@ export class NgxFormFieldWrapper<TValue = unknown> {
 
   /**
    * Merges the author-supplied `#initialAriaDescribedby` with the
-   * cluster-managed error/warning id rather than replacing it — same
-   * preservation rule auto-aria already applies to the bound control itself.
+   * cluster-managed required-hint/error/warning ids rather than replacing
+   * it — same preservation rule auto-aria already applies to the bound
+   * control itself. The required hint (see {@link groupRequiredHintId}) is
+   * independent of error/warning visibility, so it can combine with either.
    */
   protected readonly selectionClusterDescribedBy = computed<string | null>(
     () => {
-      const managedId = ((): string | null => {
-        if (!this.isSelectionCluster()) {
-          return null;
+      const managedIds: string[] = [];
+
+      if (this.isSelectionCluster()) {
+        const requiredHintId = this.groupRequiredHintId();
+        if (requiredHintId !== null) {
+          managedIds.push(requiredHintId);
         }
 
         const fieldName = this.resolvedFieldName();
-        if (fieldName === null) {
-          return null;
+        if (fieldName !== null) {
+          if (this.showInvalidState()) {
+            managedIds.push(`${fieldName}-error`);
+          } else if (this.showWarningState() && this.shouldShowWarnings()) {
+            // `shouldShowWarnings()` gates whether the projected error
+            // renderer's warning live region is in the DOM (see
+            // `shouldRenderErrorSlot` /
+            // `NgxFormFieldError.warningContainerVisible`). Guard
+            // `aria-describedby` on the same signal to avoid dangling
+            // references for warning-only clusters gated by a
+            // non-'immediate' `warningStrategy`.
+            managedIds.push(`${fieldName}-warning`);
+          }
         }
+      }
 
-        if (this.showInvalidState()) {
-          return `${fieldName}-error`;
-        }
-
-        // `shouldShowWarnings()` gates whether the projected error renderer's
-        // warning live region is in the DOM (see `shouldRenderErrorSlot` /
-        // `NgxFormFieldError.warningContainerVisible`). Guard
-        // `aria-describedby` on the same signal to avoid dangling references
-        // for warning-only clusters gated by a non-'immediate'
-        // `warningStrategy`.
-        if (this.showWarningState() && this.shouldShowWarnings()) {
-          return `${fieldName}-warning`;
-        }
-
-        return null;
-      })();
-
-      if (managedId === null) {
+      if (managedIds.length === 0) {
         return this.#initialAriaDescribedby;
       }
+
+      const managedId = managedIds.join(' ');
 
       return this.#initialAriaDescribedby
         ? `${this.#initialAriaDescribedby} ${managedId}`


### PR DESCRIPTION
Required multi-control clusters rendered `aria-required="true"` on a `role="group"` host — invalid per ARIA (`group` does not support `aria-required`; only `radiogroup` does), reported by axe as a critical `aria-allowed-attr` violation.

Two halves to the fix:

- **Suppress the invalid attribute.** `NgxSignalFormAutoAria` now captures the host's `role` in its per-render DOM snapshot (same `earlyRead`/`write` cycle as the existing `aria-invalid`/`aria-required` handling) and returns no `aria-required` when the role is `group`. `radiogroup` hosts and plain controls are untouched — unit tests cover all three role cases.
- **Relocate required-ness instead of losing it.** The wrapper's visual required marker is `aria-hidden`, so dropping the attribute alone would leave screen-reader users with no indication the cluster is required. Group clusters now render a visually-hidden hint (clip-rect technique, mirroring the character-count component) wired into the cluster's managed `aria-describedby` alongside the existing error/warning ids. The hint text is configurable as `requiredHintText` (default `'required'`) through the same three-tier config cascade as `requiredMarker`/`requiredLegendText`, so it is i18n-able like every other toolkit string. The hint is driven by the same DOM-observed required signal as the visual marker, so the two can never disagree.

The a11y browser spec's `aria-allowed-attr` scope-out (which referenced this issue) is removed — the cluster fixtures now pass the full axe rule set, and assertions pin the hint's id, text, and presence in `aria-describedby`. Issue #300 explicitly offered "drop or relocate"; this takes the relocate path.

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
