### PR TITLE
docs(i18n): make the provideErrorMessages/provideFieldLabels examples switch language at runtime

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -482,22 +482,37 @@ toward `invalid()`, submit warning-only forms via `canSubmitWithWarnings`/`submi
 Both go through provider factories that you can wire to your translation service.
 `provideErrorMessages(factory)` registers a message registry (keys are camelCase error kinds, values
 are a string or `(params) => string`); `provideFieldLabels(factory)` does the same for field
-labels/paths. Use the factory form so you can `inject()` your translation service:
+labels/paths. The factory itself runs once, at injection — so the contract for a runtime language
+switch is:
+
+- A **string** entry is captured once, at injection time, and frozen for the injector's lifetime.
+  It never changes afterward.
+- A **function** entry is invoked on every render, and re-renders on a language change only if it
+  reads a reactive signal during that call. Calling `translate.instant(...)` alone reads nothing
+  reactive — you must also read a language signal, e.g. `toSignal(translate.onLangChange)`.
+
+Make every entry a function that reads that signal:
 
 ```ts
+import { toSignal } from '@angular/core/rxjs-interop';
+
 provideFieldLabels(() => {
   const t = inject(TranslateService);
-  return (path) => t.instant(`fields.${path}`) || humanizeFieldPath(path);
+  const lang = toSignal(t.onLangChange, { initialValue: null });
+  return (path) => {
+    lang(); // reactive dependency — re-renders on language switch
+    return t.instant(`fields.${path}`) || humanizeFieldPath(path);
+  };
 });
 ```
 
 Validators keep emitting plain `{ kind, message }`; the toolkit resolves display text via a 3-tier
 cascade (validator `message` → registry → built-in fallback), exposed declaratively
 (`ngx-form-field-error`, wrapper) and programmatically (`createErrorMessageSignal`,
-`resolveValidationErrorMessage`). Honest gaps: the worked i18n example in the docs is written for
-`provideFieldLabels` (apply the same shape to `provideErrorMessages`), there is no i18n demo, and
-whether an already-rendered message re-renders on a runtime language switch is not documented as a
-guarantee.
+`resolveValidationErrorMessage`). `$localize` cannot do any of this — it's build-time only (one
+build per locale via `ng build --localize`), with no runtime language switching. Honest gap: there
+is still no end-to-end i18n demo proving a runtime language switch (tracked in
+[#231](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/231)).
 
 **See:** [docs/WARNINGS_SUPPORT.md](./WARNINGS_SUPPORT.md) ·
 [packages/toolkit/README.md](../packages/toolkit/README.md) ·

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -494,7 +494,11 @@ switch is:
 Make every entry a function that reads that signal:
 
 ```ts
+import { inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
+import { provideFieldLabels } from '@ngx-signal-forms/toolkit';
+import { humanizeFieldPath } from '@ngx-signal-forms/toolkit/headless';
 
 provideFieldLabels(() => {
   const t = inject(TranslateService);

--- a/docs/WARNINGS_SUPPORT.md
+++ b/docs/WARNINGS_SUPPORT.md
@@ -909,6 +909,12 @@ applies: read a reactive language signal inside the resolver, or a language
 switch won't schedule a re-render:
 
 ```typescript
+import { inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
+import { provideFieldLabels } from '@ngx-signal-forms/toolkit';
+import { humanizeFieldPath } from '@ngx-signal-forms/toolkit/headless';
+
 provideFieldLabels(() => {
   const translate = inject(TranslateService);
   const lang = toSignal(translate.onLangChange, { initialValue: null });

--- a/docs/WARNINGS_SUPPORT.md
+++ b/docs/WARNINGS_SUPPORT.md
@@ -820,22 +820,65 @@ provideErrorMessages({
 });
 ```
 
-For i18n, pass a factory instead of a static object. It runs in an injection
-context, so you can `inject()` a translation service and build the registry
-from it:
+### The i18n contract: string vs. function entries
+
+`NGX_ERROR_MESSAGES` holds a plain object. The factory passed to
+`provideErrorMessages()` runs **once**, at injection — not on every render. So
+the two entry kinds behave differently on a runtime language switch:
+
+- A **string** value is captured once, at injection time, and frozen into the
+  registry for the life of the injector. It can never change afterward — not
+  even if you switch language.
+- A **function** value is invoked each time the toolkit resolves a message.
+  It re-renders with a new string on a language change **only if it reads a
+  signal** during that call. Calling `translate.instant(...)` alone reads
+  nothing reactive, so a function that only calls `instant()` still won't
+  re-render on its own — nothing tells Angular to re-run it.
+
+The fix: make **every** entry a function, and have each one read a reactive
+language signal. The mechanism is library-agnostic — it works the same with
+Transloco, ngx-translate, or a bare `signal<Lang>`:
 
 ```typescript
+import { inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
+import { provideErrorMessages } from '@ngx-signal-forms/toolkit';
+
 provideErrorMessages(() => {
   const translate = inject(TranslateService);
+  // A reactive language source. `onLangChange` fires whenever
+  // `translate.use(...)` switches language; `toSignal` turns that into a
+  // signal each entry below can read.
+  const lang = toSignal(translate.onLangChange, { initialValue: null });
 
   return {
-    required: translate.instant('validation.required'),
-    email: translate.instant('validation.email'),
-    minLength: ({ minLength }) =>
-      translate.instant('validation.minLength', { minLength }),
+    // Reading `lang()` is what matters here — it registers the signal as a
+    // dependency of the caller's render, so a language switch schedules a
+    // re-render. `translate.instant()` itself is not reactive.
+    required: () => {
+      lang();
+      return translate.instant('validation.required');
+    },
+    email: () => {
+      lang();
+      return translate.instant('validation.email');
+    },
+    minLength: ({ minLength }) => {
+      lang();
+      return translate.instant('validation.minLength', { minLength });
+    },
   };
 });
 ```
+
+Angular's own i18n cannot do this at all. `$localize` is build-time: per
+[angular.dev](https://angular.dev/guide/i18n), tagged messages are processed
+once, when the tagged string is first encountered, and do not support dynamic
+language changes without a browser refresh. The supported Angular model is
+one build per locale (`ng build --localize`). Runtime language switching is
+third-party or hand-rolled territory — Transloco, ngx-translate, or your own
+signal — not something `$localize` provides.
 
 ### Field label resolution
 
@@ -859,13 +902,21 @@ provideFieldLabels({
 });
 ```
 
-For dynamic i18n or a fully custom resolver, pass a factory:
+For dynamic i18n or a fully custom resolver, pass a factory. The factory
+returns a resolver function, and the toolkit calls that resolver each time it
+renders a field label — so the same contract as `provideErrorMessages`
+applies: read a reactive language signal inside the resolver, or a language
+switch won't schedule a re-render:
 
 ```typescript
 provideFieldLabels(() => {
   const translate = inject(TranslateService);
-  return (path) =>
-    translate.instant(`fields.${path}`) || humanizeFieldPath(path);
+  const lang = toSignal(translate.onLangChange, { initialValue: null });
+
+  return (path) => {
+    lang(); // registers the language signal as a render dependency
+    return translate.instant(`fields.${path}`) || humanizeFieldPath(path);
+  };
 });
 ```
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -340,13 +340,23 @@ provideFieldLabels({
 });
 ```
 
-Use a factory for dynamic resolvers (ngx-translate, `$localize`, etc.):
+Use a factory for dynamic resolvers (ngx-translate, Transloco, etc.). The
+resolver it returns runs on every render, so a runtime language switch works
+only if the resolver reads a reactive language signal — `$localize` is
+build-time only and can't do this; see
+[`WARNINGS_SUPPORT.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/WARNINGS_SUPPORT.md#the-i18n-contract-string-vs-function-entries)
+for the full contract:
 
 ```typescript
 provideFieldLabels(() => {
   const translate = inject(TranslateService);
-  return (fieldPath) =>
-    translate.instant(`fields.${fieldPath}`) || humanizeFieldPath(fieldPath);
+  const lang = toSignal(translate.onLangChange, { initialValue: null });
+  return (fieldPath) => {
+    lang(); // reactive dependency — re-renders on language switch
+    return (
+      translate.instant(`fields.${fieldPath}`) || humanizeFieldPath(fieldPath)
+    );
+  };
 });
 ```
 

--- a/packages/toolkit/core/providers/error-messages.provider.ts
+++ b/packages/toolkit/core/providers/error-messages.provider.ts
@@ -124,17 +124,35 @@ type ErrorMessageRegistryFactory = () => ErrorMessageRegistryInput;
  * ```
  *
  * @example With ngx-translate (alternative pattern)
+ *
+ * The factory runs once, at injection — so a **string** entry is captured
+ * once and frozen for the injector's lifetime; it never changes, even on a
+ * language switch. A **function** entry is invoked per render, and re-renders
+ * on a language change only if it reads a signal during that call —
+ * `translate.instant()` alone reads nothing reactive. Make every entry a
+ * function that reads a reactive language source, such as
+ * `toSignal(translate.onLangChange)`:
  * ```typescript
+ * import { toSignal } from '@angular/core/rxjs-interop';
  * import { TranslateService } from '@ngx-translate/core';
  *
  * provideErrorMessages(() => {
  *   const translate = inject(TranslateService);
+ *   const lang = toSignal(translate.onLangChange, { initialValue: null });
  *
  *   return {
- *     required: translate.instant('validation.required'),
- *     email: translate.instant('validation.email'),
- *     minLength: ({ minLength }) =>
- *       translate.instant('validation.minLength', { minLength }),
+ *     required: () => {
+ *       lang(); // reactive dependency — re-renders on language switch
+ *       return translate.instant('validation.required');
+ *     },
+ *     email: () => {
+ *       lang();
+ *       return translate.instant('validation.email');
+ *     },
+ *     minLength: ({ minLength }) => {
+ *       lang();
+ *       return translate.instant('validation.minLength', { minLength });
+ *     },
  *   };
  * })
  * ```
@@ -285,18 +303,36 @@ export const NGX_ERROR_MESSAGES = new InjectionToken<ErrorMessageRegistry>(
  * ```
  *
  * @example With ngx-translate
+ *
+ * Every entry must be a function that reads a reactive language signal —
+ * `translate.instant()` alone is not reactive, and a string entry is frozen
+ * at injection and can never change. See the `ErrorMessageRegistry` doc above
+ * for the full string-vs-function contract.
  * ```typescript
+ * import { toSignal } from '@angular/core/rxjs-interop';
+ *
  * provideErrorMessages(() => {
  *   const translate = inject(TranslateService);
+ *   const lang = toSignal(translate.onLangChange, { initialValue: null });
  *
  *   return {
- *     required: translate.instant('validation.required'),
- *     email: translate.instant('validation.email'),
+ *     required: () => {
+ *       lang();
+ *       return translate.instant('validation.required');
+ *     },
+ *     email: () => {
+ *       lang();
+ *       return translate.instant('validation.email');
+ *     },
  *   };
  * })
  * ```
  *
  * @example With @angular/localize
+ *
+ * `$localize` is build-time, not runtime: one build per locale
+ * (`ng build --localize`). It cannot switch language without a page reload,
+ * so use it only with the static (non-factory) form:
  * ```typescript
  * provideErrorMessages({
  *   required: $localize`:@@validation.required:This field is required`,

--- a/packages/toolkit/core/providers/field-labels.provider.ts
+++ b/packages/toolkit/core/providers/field-labels.provider.ts
@@ -66,16 +66,30 @@ export const NGX_FIELD_LABEL_RESOLVER = new InjectionToken<FieldLabelResolver>(
  *
  * For dynamic resolution (i18n libraries, locale-aware logic), pass a
  * factory function. The factory runs in an injection context so you can
- * call `inject()`.
+ * call `inject()`. The factory itself runs once, at injection — but the
+ * *resolver it returns* is called on every render, so a runtime language
+ * switch works only if the resolver reads a reactive language signal.
+ * Calling `translate.instant()` alone reads nothing reactive:
  *
  * ```typescript
+ * import { toSignal } from '@angular/core/rxjs-interop';
+ *
  * provideFieldLabels(() => {
  *   const translate = inject(TranslateService);
- *   return (fieldPath) => translate.instant(`fields.${fieldPath}`) || humanizeFieldPath(fieldPath);
+ *   const lang = toSignal(translate.onLangChange, { initialValue: null });
+ *
+ *   return (fieldPath) => {
+ *     lang(); // reactive dependency — re-renders on language switch
+ *     return translate.instant(`fields.${fieldPath}`) || humanizeFieldPath(fieldPath);
+ *   };
  * })
  * ```
  *
  * ### With `@angular/localize`
+ *
+ * `$localize` is build-time, not runtime — one build per locale
+ * (`ng build --localize`), no in-page language switching. Use it only with
+ * the static (non-factory) form:
  *
  * ```typescript
  * provideFieldLabels({

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
@@ -15,6 +15,7 @@ import {
 import { NGX_SIGNAL_FORMS_CONFIG } from '@ngx-signal-forms/toolkit';
 import {
   NGX_ERROR_MESSAGES,
+  provideErrorMessages,
   type ErrorMessageRegistry,
 } from '@ngx-signal-forms/toolkit/core';
 import { describe, expect, it } from 'vitest';
@@ -462,6 +463,58 @@ describe('createErrorMessageSignal — reactive registry', () => {
     field.errors.set([{ kind: 'minLength', minLength: 8 } as ValidationError]);
     expect(result()[0]?.kind).toBe('minLength');
     expect(result()[0]?.message).toBe('Minimum 8 characters required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// i18n contract — string entries frozen at injection, function entries
+// re-render only when they read a signal (docs/WARNINGS_SUPPORT.md
+// "The i18n contract: string vs. function entries")
+// ---------------------------------------------------------------------------
+
+describe('createErrorMessageSignal — i18n contract (provideErrorMessages)', () => {
+  it('freezes a string entry at injection and re-renders a function entry that reads a signal', () => {
+    const lang = signal<'en' | 'ja'>('en');
+    const translations = {
+      en: { required: 'Required (en)' },
+      ja: { required: 'Required (ja)' },
+    };
+
+    const injector = Injector.create({
+      providers: [
+        provideErrorMessages(() => ({
+          // String entry: evaluated once, right now, while the factory runs
+          // at injection. Never re-evaluated afterward.
+          email: translations[lang()].required,
+          // Function entry: invoked every time the resolving computed
+          // re-runs. Reading `lang()` inside it registers the signal as a
+          // dependency of that computed, so a language flip retriggers it.
+          required: () => translations[lang()].required,
+        })),
+      ],
+    });
+
+    const field = mockFieldState({
+      errors: [{ kind: 'email' }, { kind: 'required' }],
+    });
+
+    const result = runInInjectionContext(injector, () =>
+      createErrorMessageSignal(() => field, { fieldName: 'contact' }),
+    );
+
+    const messageFor = (kind: string) =>
+      result().find((entry) => entry.kind === kind)?.message;
+
+    expect(messageFor('email')).toBe('Required (en)');
+    expect(messageFor('required')).toBe('Required (en)');
+
+    lang.set('ja');
+
+    // Function entry: re-renders because it read the signal.
+    expect(messageFor('required')).toBe('Required (ja)');
+    // String entry: frozen at the value captured when the factory ran once,
+    // at injection — the language flip never touches it.
+    expect(messageFor('email')).toBe('Required (en)');
   });
 });
 

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.spec.ts
@@ -476,8 +476,8 @@ describe('createErrorMessageSignal — i18n contract (provideErrorMessages)', ()
   it('freezes a string entry at injection and re-renders a function entry that reads a signal', () => {
     const lang = signal<'en' | 'ja'>('en');
     const translations = {
-      en: { required: 'Required (en)' },
-      ja: { required: 'Required (ja)' },
+      en: { email: 'Invalid email (en)', required: 'Required (en)' },
+      ja: { email: 'Invalid email (ja)', required: 'Required (ja)' },
     };
 
     const injector = Injector.create({
@@ -485,7 +485,7 @@ describe('createErrorMessageSignal — i18n contract (provideErrorMessages)', ()
         provideErrorMessages(() => ({
           // String entry: evaluated once, right now, while the factory runs
           // at injection. Never re-evaluated afterward.
-          email: translations[lang()].required,
+          email: translations[lang()].email,
           // Function entry: invoked every time the resolving computed
           // re-runs. Reading `lang()` inside it registers the signal as a
           // dependency of that computed, so a language flip retriggers it.
@@ -505,7 +505,7 @@ describe('createErrorMessageSignal — i18n contract (provideErrorMessages)', ()
     const messageFor = (kind: string) =>
       result().find((entry) => entry.kind === kind)?.message;
 
-    expect(messageFor('email')).toBe('Required (en)');
+    expect(messageFor('email')).toBe('Invalid email (en)');
     expect(messageFor('required')).toBe('Required (en)');
 
     lang.set('ja');
@@ -514,7 +514,7 @@ describe('createErrorMessageSignal — i18n contract (provideErrorMessages)', ()
     expect(messageFor('required')).toBe('Required (ja)');
     // String entry: frozen at the value captured when the factory ran once,
     // at injection — the language flip never touches it.
-    expect(messageFor('email')).toBe('Required (en)');
+    expect(messageFor('email')).toBe('Invalid email (en)');
   });
 });
 


### PR DESCRIPTION
The documented i18n examples for `provideErrorMessages`/`provideFieldLabels` could never switch language at runtime: string entries are captured once when the DI factory runs, so a `translate.instant(...)` string is frozen at injection. Function entries are re-invoked inside the resolving `computed()` on every recompute — but only react to a language flip if they read a signal during that call, which `translate.instant()` alone does not.

This is a docs-only defect (traced through `error-messages.provider.ts` → `create-error-message-signal.ts`; no toolkit change needed). Every documented i18n site now uses function entries reading a `toSignal(translate.onLangChange, ...)`-backed signal, and the string-vs-function contract is stated explicitly:

- `docs/WARNINGS_SUPPORT.md` (canonical contract section + both rewritten examples)
- `docs/FAQ.md` §"How do I translate error messages" (plus corrected `$localize` build-time-only framing)
- `packages/toolkit/README.md` (`provideFieldLabels` resolver example, links to the canonical section)
- JSDoc `@example` blocks in `error-messages.provider.ts` (×2) and `field-labels.provider.ts`

The two JSDoc examples keyed off `LOCALE_ID` are deliberately untouched — locale is fixed at bootstrap there, so the frozen-string defect does not apply.

A new regression spec in `create-error-message-signal.spec.ts` pins the contract: flip a language signal, the function entry re-renders, the string entry stays frozen at its injection-time value. The test fails if the toolkit ever stops re-invoking function entries.

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
