### PR TITLE
fix(form-field): gate resolvedOrientation on bound-control resolution

### DIFF
--- a/packages/toolkit/form-field/form-field-wrapper.spec.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.spec.ts
@@ -15,6 +15,7 @@ import {
   NgxSignalFormToolkit,
   provideNgxSignalFormControlPresets,
   provideNgxSignalFormControlPresetsForComponent,
+  provideNgxSignalFormsConfig,
   requiredFromStandardSchema,
 } from '@ngx-signal-forms/toolkit';
 import { DEFAULT_NGX_SIGNAL_FORMS_CONFIG } from '@ngx-signal-forms/toolkit/core';
@@ -3702,6 +3703,38 @@ describe('NgxSignalFormWrapperComponent', () => {
       expect(formField).toHaveAttribute('data-orientation', 'vertical');
     });
 
+    it('should force vertical for radio-group control kind even when horizontal is requested', async () => {
+      const { container } = await render(
+        `<ngx-form-field-wrapper
+          [formField]="field"
+          fieldName="delivery-method"
+          orientation="horizontal"
+        >
+          <span ngxFormFieldLabel>Delivery option</span>
+          <div>
+            <label>
+              <input id="delivery-standard" type="radio" value="standard" />
+              Standard
+            </label>
+            <label>
+              <input id="delivery-express" type="radio" value="express" />
+              Express
+            </label>
+          </div>
+        </ngx-form-field-wrapper>`,
+        {
+          imports: [NgxSignalFormWrapperComponent],
+          componentProperties: { field: createMockFieldState() },
+        },
+      );
+
+      const formField = container.querySelector('ngx-form-field-wrapper');
+      expect(formField).not.toHaveClass(
+        'ngx-signal-form-field-wrapper--horizontal',
+      );
+      expect(formField).toHaveAttribute('data-orientation', 'vertical');
+    });
+
     it('should resolve inherit to global default when set to vertical (default)', async () => {
       const { container } = await render(
         `<ngx-form-field-wrapper [formField]="field" orientation="inherit">
@@ -3809,6 +3842,46 @@ describe('NgxSignalFormWrapperComponent', () => {
       );
 
       consoleErrorSpy.mockRestore();
+    });
+
+    describe('pre-resolution state (bound control not yet resolved)', () => {
+      // `resolvedOrientation` now gates its forcing logic on
+      // `#boundControlElement() === null`, the same way its siblings
+      // `isOutline` and `resolvedMarker` do (each returns its own
+      // pre-resolution value). Before the projected control is discovered,
+      // `#controlKind()` has not settled, so — without the gate — a
+      // checkbox/switch/radio-group field requesting 'horizontal' would
+      // report the raw requested orientation instead of the forced
+      // 'vertical': a `data-orientation` flash. Mirroring the sibling
+      // `resolvedMarker` spec above, this exercises the guard with no
+      // control ever projected, so `#boundControlElement()` never resolves
+      // and the pre-resolution branch is the only one that ever runs.
+      //
+      // The configured default ('horizontal', set below) is deliberately
+      // distinct from both the requested orientation ('vertical') and the
+      // forced value ('vertical') that a checkbox/switch/radio-group would
+      // otherwise produce, so this test cannot pass by coincidentally
+      // reading either of those instead of the config.
+
+      it('reports the configured default, never the requested orientation, before a control is projected (no flash)', async () => {
+        const { container } = await render(
+          `<ngx-form-field-wrapper [formField]="field" orientation="vertical">
+            <label for="agree">Agree</label>
+          </ngx-form-field-wrapper>`,
+          {
+            imports: [NgxSignalFormWrapperComponent],
+            providers: [
+              provideNgxSignalFormsConfig({
+                defaultFormFieldOrientation: 'horizontal',
+              }),
+            ],
+            componentProperties: { field: createMockFieldState() },
+          },
+        );
+
+        const formField = container.querySelector('ngx-form-field-wrapper');
+        expect(formField).toHaveAttribute('data-orientation', 'horizontal');
+      });
     });
   });
 

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -627,6 +627,8 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     return this.resolvedAppearance() === 'plain';
   });
 
+  #warnedInvalidOrientation = false;
+
   /**
    * Effective orientation for theming hooks (`data-orientation` attribute).
    *
@@ -644,8 +646,6 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * so this keeps the first frame aligned with the common case rather than
    * guessing either extreme.
    */
-  #warnedInvalidOrientation = false;
-
   protected readonly resolvedOrientation = computed<FormFieldOrientation>(
     () => {
       const orientation = this.orientation();

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -631,6 +631,18 @@ export class NgxFormFieldWrapper<TValue = unknown> {
    * Effective orientation for theming hooks (`data-orientation` attribute).
    *
    * Outline appearance and selection-control rows force vertical layout.
+   *
+   * Gated the same way as its siblings `isOutline` and `resolvedMarker`
+   * (each returns its own pre-resolution value): `#controlKind()` has not
+   * settled before the projected control is discovered, so forcing on it
+   * here would report the raw *requested* orientation for a frame before
+   * snapping to the forced `'vertical'` once a checkbox / switch /
+   * radio-group resolves — a visible `data-orientation` flash. This
+   * computed's own pre-resolution value is the *configured default* (not
+   * the requested orientation, and not the forced value): most fields
+   * already resolve to the configured default via `orientation` `'inherit'`,
+   * so this keeps the first frame aligned with the common case rather than
+   * guessing either extreme.
    */
   #warnedInvalidOrientation = false;
 
@@ -638,6 +650,11 @@ export class NgxFormFieldWrapper<TValue = unknown> {
     () => {
       const orientation = this.orientation();
       const requestedOrientation = this.#resolveOrientationInput(orientation);
+
+      if (this.#boundControlElement() === null) {
+        return this.#config.defaultFormFieldOrientation;
+      }
+
       const controlKind = this.#controlKind();
 
       if (


### PR DESCRIPTION
`resolvedOrientation` forced checkbox/switch/radio-group fields to `'vertical'` based on `#controlKind()` before the bound control had actually resolved, unlike its sibling computeds `isOutline` and `resolvedMarker`, which both gate on `#boundControlElement() === null`. The result was a first-frame orientation flash driven by a control kind that wasn't known yet.

The fix adds the same early-return gate. The chosen pre-resolution value is the **configured default orientation** (`config.defaultFormFieldOrientation`) — not the raw requested value and not a hardcoded `'vertical'` — because most fields resolve to the configured default through `orientation="inherit"`, making it the least-surprising first-frame value. The docblock states this decision explicitly; each sibling gate deliberately returns its own domain's pre-resolution value (`false` / `null` / configured default).

Tests follow the file's established `render()` pattern and mirror the sibling `resolvedMarker` approach of a permanently-unresolved control (no projected control at all): with `defaultFormFieldOrientation: 'horizontal'` provided, the pre-resolution value is asserted as `'horizontal'` — distinct from both the requested and the forced value, so the test can only pass if the code genuinely reads the configured default. A previously missing settled-state test proving radio-group forces vertical is added as well.

One note for reviewers: a same-render "before vs. after `whenStable()`" assertion for a *really projected* control is not observable in the jsdom/Vitest harness — `afterEveryRender`'s write phase settles synchronously there — so the unresolved-control fixture is the accurate way to cover the gate, matching how the `resolvedMarker` pre-resolution test already works.

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
