### PR TITLE
build(toolkit): enforce @internal in published types via post-build member stripping

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -464,9 +464,13 @@ names:
 
 The `set*` writer methods are tagged `@internal`: the surrounding
 `ngx-form-field-wrapper` **drives** the identity, and consumers **read** the
-resolved signals — they do not drive them. The tag is a convention, not a
-compile-time barrier — `stripInternal` is not enabled, so the writers do appear
-in the published `.d.ts`. Treat them as unsupported and subject to change.
+resolved signals — they do not drive them. A post-build step
+(`scripts/strip-internal-members.mjs`) removes `@internal`-tagged class
+members from the published `.d.ts`, so the writers do not appear there — this
+is a compile-time barrier, not just a naming convention. (`tsconfig.lib.json`
+does not enable TypeScript's own `stripInternal`: that flag breaks
+ng-packagr's multi-entry-point `.d.ts` bundling for this package, dropping
+unrelated public symbols along with the tagged ones — see #289.)
 
 Building a wrapper of your own? Don't reach for the writers — compose the pure
 ARIA factories (`createAriaDescribedBySignal`, `createAriaInvalidSignal`, …)

--- a/packages/toolkit/project.json
+++ b/packages/toolkit/project.json
@@ -35,6 +35,7 @@
           "mkdir -p dist/packages/toolkit",
           "cp README.md dist/packages/toolkit/README.md",
           "cp LICENSE dist/packages/toolkit/LICENSE",
+          "node packages/toolkit/scripts/strip-internal-members.mjs",
           "node packages/toolkit/scripts/strip-internal-exports.mjs"
         ],
         "parallel": false,

--- a/packages/toolkit/scripts/strip-internal-members.mjs
+++ b/packages/toolkit/scripts/strip-internal-members.mjs
@@ -22,190 +22,207 @@
 //    cross-entry/cross-project use case (see AGENTS.md note on
 //    `libs/debugger` consuming `/core` internals), so this script leaves
 //    them alone.
-// 2. `@internal`-tagged *members* on an otherwise-public class (e.g.
-//    `NgxFieldIdentity.setFieldName`) — the class itself is re-exported to
-//    real consumers (the root barrel re-exports `NgxFieldIdentity` from
-//    `/core` via a relative specifier that bypasses the `exports` map), so
-//    every member TypeScript considers public — regardless of the
-//    `@internal` tag — ships in the published `.d.ts` and is callable.
-//    This is the actual "advisory, not enforced" gap #289 reports.
+// 2. `@internal`-tagged *members* on an otherwise-public class, interface,
+//    or namespace (e.g. `NgxFieldIdentity.setFieldName`) — the container
+//    itself is re-exported to real consumers (the root barrel re-exports
+//    `NgxFieldIdentity` from `/core` via a relative specifier that bypasses
+//    the `exports` map), so every member TypeScript considers public —
+//    regardless of the `@internal` tag — ships in the published `.d.ts` and
+//    is callable. This is the actual "advisory, not enforced" gap #289
+//    reports.
 //
-// This script removes case (2): any `@internal`-tagged declaration nested
-// inside a class or interface body (bracket depth > 0) is deleted from the
-// published `.d.ts`, verbatim comment and signature. Top-level (depth 0)
-// `@internal` declarations are left untouched.
+// This script removes exactly case (2): declarations whose JSDoc carries a
+// real `@internal` tag AND that are direct members of a class, interface,
+// or namespace (module) body are deleted — comment and signature — from the
+// published `.d.ts`. Top-level statements (depth 0: not nested inside any
+// such body) keep their `@internal` tag untouched, whatever form it takes.
 //
-// Detecting "the real tag" vs. prose that merely *mentions* `@internal`
-// inside a sentence (several doc comments in this codebase read like
-// "...tagged `@internal`...") requires matching the tag on its own line,
-// not just the substring.
+// Uses the TypeScript compiler API (already a repo devDependency, pulled in
+// for the structural-integrity guard below) rather than a line-based/regex
+// scan: `ts.getJSDocTags` is TypeScript's own JSDoc parser, so it correctly
+// recognizes every tag form (`/** @internal */` on one line, prose that only
+// *mentions* `@internal` inside a sentence is never parsed as a tag, etc.)
+// and AST membership — not brace counting — decides what counts as
+// "nested", so a brace inside a string-literal type (e.g. `const x: '{';`)
+// can't miscount a declaration's boundary the way a character scan could.
 
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import ts from 'typescript';
 
-// A real `@internal` JSDoc tag stands alone on its comment line (optionally
-// followed by trailing whitespace only). Prose that references `@internal`
-// inside a sentence always has more text after it on the same line.
-const INTERNAL_TAG_LINE = /^\s*\*\s*@internal\s*$/u;
-
 /**
- * Net bracket delta for a line of TypeScript declaration source. Counts
- * `{`/`(` as +1 and `}`/`)` as -1. Declaration files in this package don't
- * contain string or template literals with unbalanced brackets, so a naive
- * character scan is sufficient — no tokenizer needed.
- *
- * @param {string} line
- * @returns {number}
+ * @param {ts.Node} node
+ * @returns {boolean}
  */
-function bracketDelta(line) {
-  let delta = 0;
-  for (const ch of line) {
-    if (ch === '{' || ch === '(') delta++;
-    else if (ch === '}' || ch === ')') delta--;
-  }
-  return delta;
+function hasInternalTag(node) {
+  const tags = ts.getJSDocTags(node);
+  return tags.some((tag) => tag.tagName.text === 'internal');
 }
 
 /**
- * Reads a full `/** ... *\/` comment block starting at `lines[start]`.
- * Returns the block's lines, whether it contains a real `@internal` tag, and
- * the index of the first line after the block.
+ * The direct member/statement list of `node`'s body, if `node` is a
+ * class, interface, or namespace (module-with-a-block) declaration —
+ * i.e. exactly the container kinds whose members are "nested" for the
+ * purpose of this script. `undefined` for every other node kind, including
+ * the source file itself (whose top-level statements are `/core`'s
+ * intentionally-untouched build-time plumbing — see the file header).
  *
- * @param {readonly string[]} lines
- * @param {number} start
- * @returns {{ commentLines: string[], sawInternal: boolean, next: number }}
+ * @param {ts.Node} node
+ * @returns {readonly ts.Node[] | undefined}
  */
-function readCommentBlock(lines, start) {
-  /** @type {string[]} */
-  const commentLines = [];
-  let sawInternal = false;
-  let index = start;
-  for (; index < lines.length; index++) {
-    const commentLine = lines[index] ?? '';
-    commentLines.push(commentLine);
-    if (INTERNAL_TAG_LINE.test(commentLine)) sawInternal = true;
-    if (commentLine.trim().endsWith('*/')) {
-      index++;
-      break;
+function containerMembers(node) {
+  if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) {
+    return node.members;
+  }
+  if (
+    ts.isModuleDeclaration(node) &&
+    node.body !== undefined &&
+    ts.isModuleBlock(node.body)
+  ) {
+    return node.body.statements;
+  }
+  return undefined;
+}
+
+/**
+ * @typedef {{ start: number, end: number }} RemovalSpan
+ */
+
+/**
+ * Walks `sourceFile`'s AST and collects the character spans of every
+ * `@internal`-tagged declaration that is a direct member of a class,
+ * interface, or namespace body. Each span covers the declaration's leading
+ * JSDoc comment (if any) through its own end, plus one trailing line break
+ * so removal doesn't leave a blank line behind.
+ *
+ * @param {ts.SourceFile} sourceFile
+ * @returns {RemovalSpan[]}
+ */
+function collectInternalMemberSpans(sourceFile) {
+  /** @type {RemovalSpan[]} */
+  const spans = [];
+
+  /**
+   * @param {ts.Node} node
+   * @returns {void}
+   */
+  function visit(node) {
+    const members = containerMembers(node);
+    if (members !== undefined) {
+      for (const member of members) {
+        if (hasInternalTag(member)) spans.push(removalSpanFor(member));
+      }
     }
+    ts.forEachChild(node, visit);
   }
-  return { commentLines, sawInternal, next: index };
+
+  /**
+   * @param {ts.Node} node
+   * @returns {RemovalSpan}
+   */
+  function removalSpanFor(node) {
+    const fullStart = node.getFullStart();
+    const leadingComments =
+      ts.getLeadingCommentRanges(sourceFile.text, fullStart) ?? [];
+    let start =
+      leadingComments.length > 0
+        ? leadingComments[0].pos
+        : node.getStart(sourceFile);
+    // Also remove the declaration's own indentation — walk `start` back
+    // over horizontal whitespace to the start of its line, so the removal
+    // doesn't leave a blank, whitespace-only line behind.
+    while (start > 0 && /[ \t]/u.test(sourceFile.text[start - 1])) start--;
+
+    let end = node.getEnd();
+    // Consume trailing horizontal whitespace and a single line break so the
+    // removal doesn't leave a blank line where the declaration used to be.
+    while (end < sourceFile.text.length && /[ \t]/u.test(sourceFile.text[end]))
+      end++;
+    if (sourceFile.text[end] === '\r') end++;
+    if (sourceFile.text[end] === '\n') end++;
+
+    return { start, end };
+  }
+
+  visit(sourceFile);
+  return spans;
 }
 
 /**
- * Finds the end of the declaration that starts at `lines[start]`, given the
- * bracket depth immediately before it (`baseDepth`). The declaration ends on
- * the first line where the running depth returns to `baseDepth` and the line
- * terminates a statement (`;`) or closes a body (bare `}` or `};`).
+ * Removes `@internal`-tagged declarations that are direct members of a
+ * class, interface, or namespace body from `content`. Returns the
+ * rewritten text and the count of declarations removed.
  *
- * @param {readonly string[]} lines
- * @param {number} start
- * @param {number} baseDepth
- * @returns {number} Index of the first line after the declaration.
- */
-function findDeclarationEnd(lines, start, baseDepth) {
-  let depth = baseDepth;
-  for (let index = start; index < lines.length; index++) {
-    const declLine = lines[index] ?? '';
-    depth += bracketDelta(declLine);
-    const trimmed = declLine.trim();
-    const terminates =
-      trimmed.endsWith(';') || trimmed === '}' || trimmed.endsWith('};');
-    if (depth === baseDepth && terminates) return index + 1;
-  }
-  throw new Error(
-    `Could not find the end of the @internal declaration starting at line ` +
-      `${start + 1} — bracket depth never returned to ${baseDepth}. ` +
-      `Refusing to guess; fix the parser or the declaration shape.`,
-  );
-}
-
-/**
- * Removes `@internal`-tagged declarations that are nested inside a class or
- * interface body (i.e. appear at bracket depth > 0) from `content`. Returns
- * the rewritten text and the count of declarations removed.
- *
- * Top-level (depth 0) `@internal` declarations are left untouched — see the
- * file header for why.
+ * Top-level (not-nested) `@internal` declarations are left untouched — see
+ * the file header for why.
  *
  * @param {string} content
+ * @param {string} [fileName]
  * @returns {{ text: string, removedCount: number }}
  */
-export function stripNestedInternalMembers(content) {
-  const lines = content.split('\n');
-  /** @type {string[]} */
-  const out = [];
-  let depth = 0;
-  let removedCount = 0;
-  let i = 0;
+export function stripNestedInternalMembers(content, fileName = 'input.d.ts') {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  const spans = collectInternalMemberSpans(sourceFile).toSorted(
+    (a, b) => a.start - b.start,
+  );
 
-  while (i < lines.length) {
-    const line = lines[i] ?? '';
-    if (!line.trim().startsWith('/**')) {
-      out.push(line);
-      depth += bracketDelta(line);
-      i++;
-      continue;
-    }
-
-    const { commentLines, sawInternal, next } = readCommentBlock(lines, i);
-    if (!sawInternal || depth <= 0) {
-      // Top-level `@internal` (or non-internal) comment — keep verbatim.
-      out.push(...commentLines);
-      i = next;
-      continue;
-    }
-
-    // Nested `@internal` declaration — drop the comment and the declaration
-    // it documents, then resume scanning from what follows.
-    const baseDepth = depth;
-    const declEnd = findDeclarationEnd(lines, next, baseDepth);
-    for (let k = next; k < declEnd; k++) depth += bracketDelta(lines[k] ?? '');
-    removedCount++;
-    i = declEnd;
+  let text = content;
+  // Remove from the end backwards so earlier spans' offsets stay valid.
+  for (let i = spans.length - 1; i >= 0; i--) {
+    const span = spans[i];
+    text = text.slice(0, span.start) + text.slice(span.end);
   }
 
-  return { text: out.join('\n'), removedCount };
+  return { text, removedCount: spans.length };
 }
 
 /**
- * Fails loudly if any `@internal`-tagged declaration remains nested inside a
- * class/interface body after stripping — a silent parser miss would leave
- * an "enforced" symbol reachable, defeating the point of this script.
+ * Belt-and-braces check: re-parses `content` and re-runs the same AST walk
+ * `stripNestedInternalMembers` uses. If it finds any remaining nested
+ * `@internal` declaration, stripping missed it — fail loudly rather than
+ * publish a symbol #289 says must be enforced. Run unconditionally on every
+ * file, not just ones `stripNestedInternalMembers` touched, so a bug that
+ * makes the stripper under-count (`removedCount` wrongly 0) can't hide
+ * behind that early exit.
  *
  * @param {string} content
  * @param {string} filePath
  * @returns {void}
  */
 function assertNoNestedInternalTagsRemain(content, filePath) {
-  const lines = content.split('\n');
-  let depth = 0;
-  for (const [index, line] of lines.entries()) {
-    if (INTERNAL_TAG_LINE.test(line) && depth > 0) {
-      throw new Error(
-        `${filePath}:${index + 1} still has a nested @internal tag at ` +
-          `depth ${depth} after stripping. The parser missed a declaration ` +
-          `shape — fix it before publishing.`,
-      );
-    }
-    depth += bracketDelta(line);
-  }
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  const leftover = collectInternalMemberSpans(sourceFile);
+  if (leftover.length === 0) return;
+  throw new Error(
+    `${filePath} still has ${leftover.length} nested @internal ` +
+      `declaration(s) after stripping. The stripper missed a declaration ` +
+      `shape — fix it before publishing.`,
+  );
 }
 
 /**
- * Structural-integrity guard: `stripNestedInternalMembers`'s bracket-depth
- * scan is a naive character count, not a real parser. Given the wrong input
- * shape it could mis-bound a declaration — swallowing part of an untagged
- * sibling, or leaving a dangling brace behind — and produce output that
- * *looks* plausible (no leftover `@internal` tag, so
- * `assertNoNestedInternalTagsRemain` would miss it) but is not valid
- * TypeScript.
+ * Structural-integrity guard: even though spans are now derived from a real
+ * parse of the *original* text (not a character-counting heuristic),
+ * splicing those spans out of the raw string is still a textual edit that
+ * could — given a bug in `removalSpanFor`'s boundary math — cut through a
+ * token instead of between declarations.
  *
- * Parses the post-strip text with the real TypeScript parser and fails
- * loudly on any syntax error, so a bracket-counting bug is a hard build
- * failure instead of a silently corrupted published `.d.ts`.
+ * Parses the post-strip text and fails loudly on any syntax error, so such
+ * a bug is a hard build failure instead of a silently corrupted published
+ * `.d.ts`.
  *
  * @param {string} content
  * @param {string} filePath
@@ -239,8 +256,8 @@ function assertValidSyntax(content, filePath) {
   });
   throw new Error(
     `${filePath} is not valid TypeScript after stripping @internal ` +
-      `members — the structural-integrity guard tripped (a bracket-depth ` +
-      `miscount likely swallowed or mis-bounded a declaration):\n` +
+      `members — the structural-integrity guard tripped (a span-removal ` +
+      `bug likely cut through a token):\n` +
       messages.join('\n'),
   );
 }
@@ -257,10 +274,13 @@ function main() {
   for (const name of dtsFiles) {
     const filePath = join(typesDir, name);
     const content = readFileSync(filePath, 'utf8');
-    const { text, removedCount } = stripNestedInternalMembers(content);
+    const { text, removedCount } = stripNestedInternalMembers(content, name);
+
+    // Unconditional: a bug that makes `removedCount` wrongly 0 must not be
+    // able to skip this check by short-circuiting before it runs.
+    assertNoNestedInternalTagsRemain(text, name);
     if (removedCount === 0) continue;
 
-    assertNoNestedInternalTagsRemain(text, name);
     assertValidSyntax(text, name);
     writeFileSync(filePath, text);
     totalRemoved += removedCount;
@@ -269,8 +289,8 @@ function main() {
 
   console.log(
     totalRemoved === 0
-      ? '[toolkit] no nested @internal class/interface members found to strip'
-      : `[toolkit] stripped ${totalRemoved} @internal class/interface member(s): ${touchedFiles.join(', ')}`,
+      ? '[toolkit] no nested @internal class/interface/namespace members found to strip'
+      : `[toolkit] stripped ${totalRemoved} @internal class/interface/namespace member(s): ${touchedFiles.join(', ')}`,
   );
 }
 

--- a/packages/toolkit/scripts/strip-internal-members.mjs
+++ b/packages/toolkit/scripts/strip-internal-members.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// Post-build hardening for the `@ngx-signal-forms/toolkit` package.
+//
+// `@internal` is a JSDoc convention, not a TypeScript compiler barrier —
+// `tsconfig.lib.json` deliberately does NOT set `stripInternal`, because
+// enabling it breaks ng-packagr's declaration bundling for this package (see
+// the `stripInternal` investigation linked from issue #289: the flag's
+// interaction with ng-packagr's multi-entry-point `.d.ts` rollup drops
+// unrelated, non-tagged public symbols from the bundle wholesale — a
+// tooling defect, not something fixable by re-tagging individual symbols).
+//
+// Two different things carry the `@internal` tag in this package, and only
+// one of them is a real external leak:
+//
+// 1. Top-level declarations inside the `/core` secondary entry (tokens,
+//    factories, helper types) that sibling entries (`form-field`,
+//    `assistive`, `headless`) and `libs/debugger` legitimately import at
+//    build time. `/core` is already hidden from external consumers by
+//    `strip-internal-exports.mjs`, which deletes `"./core"` from the
+//    published `exports` map — so these are *already* unreachable from
+//    outside the package. Stripping them here would break the legitimate
+//    cross-entry/cross-project use case (see AGENTS.md note on
+//    `libs/debugger` consuming `/core` internals), so this script leaves
+//    them alone.
+// 2. `@internal`-tagged *members* on an otherwise-public class (e.g.
+//    `NgxFieldIdentity.setFieldName`) — the class itself is re-exported to
+//    real consumers (the root barrel re-exports `NgxFieldIdentity` from
+//    `/core` via a relative specifier that bypasses the `exports` map), so
+//    every member TypeScript considers public — regardless of the
+//    `@internal` tag — ships in the published `.d.ts` and is callable.
+//    This is the actual "advisory, not enforced" gap #289 reports.
+//
+// This script removes case (2): any `@internal`-tagged declaration nested
+// inside a class or interface body (bracket depth > 0) is deleted from the
+// published `.d.ts`, verbatim comment and signature. Top-level (depth 0)
+// `@internal` declarations are left untouched.
+//
+// Detecting "the real tag" vs. prose that merely *mentions* `@internal`
+// inside a sentence (several doc comments in this codebase read like
+// "...tagged `@internal`...") requires matching the tag on its own line,
+// not just the substring.
+
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+// A real `@internal` JSDoc tag stands alone on its comment line (optionally
+// followed by trailing whitespace only). Prose that references `@internal`
+// inside a sentence always has more text after it on the same line.
+const INTERNAL_TAG_LINE = /^\s*\*\s*@internal\s*$/u;
+
+/**
+ * Net bracket delta for a line of TypeScript declaration source. Counts
+ * `{`/`(` as +1 and `}`/`)` as -1. Declaration files in this package don't
+ * contain string or template literals with unbalanced brackets, so a naive
+ * character scan is sufficient — no tokenizer needed.
+ *
+ * @param {string} line
+ * @returns {number}
+ */
+function bracketDelta(line) {
+  let delta = 0;
+  for (const ch of line) {
+    if (ch === '{' || ch === '(') delta++;
+    else if (ch === '}' || ch === ')') delta--;
+  }
+  return delta;
+}
+
+/**
+ * Reads a full `/** ... *\/` comment block starting at `lines[start]`.
+ * Returns the block's lines, whether it contains a real `@internal` tag, and
+ * the index of the first line after the block.
+ *
+ * @param {readonly string[]} lines
+ * @param {number} start
+ * @returns {{ commentLines: string[], sawInternal: boolean, next: number }}
+ */
+function readCommentBlock(lines, start) {
+  /** @type {string[]} */
+  const commentLines = [];
+  let sawInternal = false;
+  let index = start;
+  for (; index < lines.length; index++) {
+    const commentLine = lines[index] ?? '';
+    commentLines.push(commentLine);
+    if (INTERNAL_TAG_LINE.test(commentLine)) sawInternal = true;
+    if (commentLine.trim().endsWith('*/')) {
+      index++;
+      break;
+    }
+  }
+  return { commentLines, sawInternal, next: index };
+}
+
+/**
+ * Finds the end of the declaration that starts at `lines[start]`, given the
+ * bracket depth immediately before it (`baseDepth`). The declaration ends on
+ * the first line where the running depth returns to `baseDepth` and the line
+ * terminates a statement (`;`) or closes a body (bare `}` or `};`).
+ *
+ * @param {readonly string[]} lines
+ * @param {number} start
+ * @param {number} baseDepth
+ * @returns {number} Index of the first line after the declaration.
+ */
+function findDeclarationEnd(lines, start, baseDepth) {
+  let depth = baseDepth;
+  for (let index = start; index < lines.length; index++) {
+    const declLine = lines[index] ?? '';
+    depth += bracketDelta(declLine);
+    const trimmed = declLine.trim();
+    const terminates =
+      trimmed.endsWith(';') || trimmed === '}' || trimmed.endsWith('};');
+    if (depth === baseDepth && terminates) return index + 1;
+  }
+  throw new Error(
+    `Could not find the end of the @internal declaration starting at line ` +
+      `${start + 1} — bracket depth never returned to ${baseDepth}. ` +
+      `Refusing to guess; fix the parser or the declaration shape.`,
+  );
+}
+
+/**
+ * Removes `@internal`-tagged declarations that are nested inside a class or
+ * interface body (i.e. appear at bracket depth > 0) from `content`. Returns
+ * the rewritten text and the count of declarations removed.
+ *
+ * Top-level (depth 0) `@internal` declarations are left untouched — see the
+ * file header for why.
+ *
+ * @param {string} content
+ * @returns {{ text: string, removedCount: number }}
+ */
+export function stripNestedInternalMembers(content) {
+  const lines = content.split('\n');
+  /** @type {string[]} */
+  const out = [];
+  let depth = 0;
+  let removedCount = 0;
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i] ?? '';
+    if (!line.trim().startsWith('/**')) {
+      out.push(line);
+      depth += bracketDelta(line);
+      i++;
+      continue;
+    }
+
+    const { commentLines, sawInternal, next } = readCommentBlock(lines, i);
+    if (!sawInternal || depth <= 0) {
+      // Top-level `@internal` (or non-internal) comment — keep verbatim.
+      out.push(...commentLines);
+      i = next;
+      continue;
+    }
+
+    // Nested `@internal` declaration — drop the comment and the declaration
+    // it documents, then resume scanning from what follows.
+    const baseDepth = depth;
+    const declEnd = findDeclarationEnd(lines, next, baseDepth);
+    for (let k = next; k < declEnd; k++) depth += bracketDelta(lines[k] ?? '');
+    removedCount++;
+    i = declEnd;
+  }
+
+  return { text: out.join('\n'), removedCount };
+}
+
+/**
+ * Fails loudly if any `@internal`-tagged declaration remains nested inside a
+ * class/interface body after stripping — a silent parser miss would leave
+ * an "enforced" symbol reachable, defeating the point of this script.
+ *
+ * @param {string} content
+ * @param {string} filePath
+ * @returns {void}
+ */
+function assertNoNestedInternalTagsRemain(content, filePath) {
+  const lines = content.split('\n');
+  let depth = 0;
+  for (const [index, line] of lines.entries()) {
+    if (INTERNAL_TAG_LINE.test(line) && depth > 0) {
+      throw new Error(
+        `${filePath}:${index + 1} still has a nested @internal tag at ` +
+          `depth ${depth} after stripping. The parser missed a declaration ` +
+          `shape — fix it before publishing.`,
+      );
+    }
+    depth += bracketDelta(line);
+  }
+}
+
+/**
+ * Structural-integrity guard: `stripNestedInternalMembers`'s bracket-depth
+ * scan is a naive character count, not a real parser. Given the wrong input
+ * shape it could mis-bound a declaration — swallowing part of an untagged
+ * sibling, or leaving a dangling brace behind — and produce output that
+ * *looks* plausible (no leftover `@internal` tag, so
+ * `assertNoNestedInternalTagsRemain` would miss it) but is not valid
+ * TypeScript.
+ *
+ * Parses the post-strip text with the real TypeScript parser and fails
+ * loudly on any syntax error, so a bracket-counting bug is a hard build
+ * failure instead of a silently corrupted published `.d.ts`.
+ *
+ * @param {string} content
+ * @param {string} filePath
+ * @returns {void}
+ */
+function assertValidSyntax(content, filePath) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  // `parseDiagnostics` isn't part of the public `ts.SourceFile` type, but is
+  // populated by `createSourceFile` and is the standard way declaration
+  // tooling (e.g. dts bundlers) gets syntax-only diagnostics without
+  // building a full `ts.Program`.
+  const diagnostics =
+    /** @type {{ parseDiagnostics?: readonly import('typescript').Diagnostic[] }} */ (
+      sourceFile
+    ).parseDiagnostics ?? [];
+  if (diagnostics.length === 0) return;
+
+  const messages = diagnostics.map((diagnostic) => {
+    const position =
+      diagnostic.file && diagnostic.start !== undefined
+        ? ts.getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start)
+        : { line: 0, character: 0 };
+    const text = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+    return `  ${filePath}:${position.line + 1}:${position.character + 1} ${text}`;
+  });
+  throw new Error(
+    `${filePath} is not valid TypeScript after stripping @internal ` +
+      `members — the structural-integrity guard tripped (a bracket-depth ` +
+      `miscount likely swallowed or mis-bounded a declaration):\n` +
+      messages.join('\n'),
+  );
+}
+
+function main() {
+  const typesDir = resolve('dist/packages/toolkit/types');
+  const dtsFiles = readdirSync(typesDir).filter((/** @type {string} */ name) =>
+    name.endsWith('.d.ts'),
+  );
+  let totalRemoved = 0;
+  /** @type {string[]} */
+  const touchedFiles = [];
+
+  for (const name of dtsFiles) {
+    const filePath = join(typesDir, name);
+    const content = readFileSync(filePath, 'utf8');
+    const { text, removedCount } = stripNestedInternalMembers(content);
+    if (removedCount === 0) continue;
+
+    assertNoNestedInternalTagsRemain(text, name);
+    assertValidSyntax(text, name);
+    writeFileSync(filePath, text);
+    totalRemoved += removedCount;
+    touchedFiles.push(`${name} (${removedCount})`);
+  }
+
+  console.log(
+    totalRemoved === 0
+      ? '[toolkit] no nested @internal class/interface members found to strip'
+      : `[toolkit] stripped ${totalRemoved} @internal class/interface member(s): ${touchedFiles.join(', ')}`,
+  );
+}
+
+// Only run as a CLI — importing this module (e.g. from the unit tests for
+// `stripNestedInternalMembers`) must not have the side effect of scanning
+// `dist/`, which may not exist yet in the importing process's cwd. Errors
+// are converted to `console.error` + a non-zero exit here, matching
+// `strip-internal-exports.mjs`'s convention (its spec asserts on stderr
+// text, not a stack trace) — the pure functions above still throw raw
+// `Error`s, which is what the unit tests below assert on directly.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[toolkit] ERROR: ${message}`);
+    process.exit(1);
+  }
+}

--- a/packages/toolkit/scripts/strip-internal-members.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-members.spec.ts
@@ -7,17 +7,23 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { stripNestedInternalMembers } from './strip-internal-members.mjs';
 
 // Regression tests for the post-build hardening script that removes
-// `@internal`-tagged class/interface members from the published `.d.ts`
-// bundles — the part of #289 that `stripInternal` cannot safely do (see the
-// script's own header comment for why the compiler flag is not viable here).
+// `@internal`-tagged class/interface/namespace members from the published
+// `.d.ts` bundles — the part of #289 that `stripInternal` cannot safely do
+// (see the script's own header comment for why the compiler flag is not
+// viable here).
 //
 // Deliberately does NOT strip top-level `@internal` declarations: `/core`'s
 // build-time-only plumbing (tokens, factories) is legitimately imported by
 // sibling entries and `libs/debugger` at build time, and is already hidden
 // from external consumers by `strip-internal-exports.mjs` deleting `"./core"`
 // from the published `exports` map. Only members nested inside an otherwise
-// public class/interface — reachable because the *class* is re-exported to
-// real consumers — are an actual enforcement gap.
+// public class/interface/namespace — reachable because the *container* is
+// re-exported to real consumers — are an actual enforcement gap.
+//
+// The scan is TS-AST-based (`ts.getJSDocTags` + real container membership),
+// not a line/regex/bracket-counting scan, so it correctly handles every
+// `@internal` tag form and can't be confused by braces inside string or
+// template-literal types.
 
 const scriptPath = resolve(import.meta.dirname, './strip-internal-members.mjs');
 
@@ -48,7 +54,27 @@ describe('stripNestedInternalMembers (unit)', () => {
     expect(text).toContain('static ɵfac: unknown;');
   });
 
-  it('leaves a top-level (depth 0) @internal declaration untouched', () => {
+  it('recognizes a one-line `/** @internal */` tag, not just the multi-line form', () => {
+    // A regex/line scan anchored on `@internal` standing alone on its own
+    // comment line misses this — `ts.getJSDocTags` (real JSDoc parsing)
+    // handles it natively regardless of comment layout.
+    const input = [
+      'declare class Foo {',
+      '    readonly value: number;',
+      '    /** @internal */',
+      '    setValue(v: number): void;',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(1);
+    expect(text).not.toContain('setValue');
+    expect(text).toContain('readonly value: number;');
+  });
+
+  it('leaves a top-level (not-nested) @internal declaration untouched', () => {
     const input = [
       '/**',
       ' * Build-time-only plumbing for sibling entries.',
@@ -84,7 +110,7 @@ describe('stripNestedInternalMembers (unit)', () => {
     expect(text).toBe(input);
   });
 
-  it('removes a multi-line @internal interface nested inside another body', () => {
+  it('removes a multi-line @internal interface nested inside a namespace body', () => {
     const input = [
       'declare namespace Ns {',
       '    /**',
@@ -94,7 +120,7 @@ describe('stripNestedInternalMembers (unit)', () => {
       '        readonly a: string;',
       '        readonly b: number;',
       '    }',
-      '    declare const kept: string;',
+      '    const kept: string;',
       '}',
       '',
     ].join('\n');
@@ -103,27 +129,57 @@ describe('stripNestedInternalMembers (unit)', () => {
 
     expect(removedCount).toBe(1);
     expect(text).not.toContain('interface Options');
-    expect(text).toContain('declare const kept: string;');
+    expect(text).toContain('const kept: string;');
   });
 
-  it('throws instead of silently corrupting output when a declaration never terminates', () => {
+  it('produces a syntactically valid empty class body when the only member is @internal', () => {
+    // Regression guard for the removal-span boundary: it must delete
+    // exactly the member (comment + declaration), never the container's own
+    // opening/closing braces, even when nothing else is left inside.
     const input = [
-      'declare class Foo {',
+      'declare class OnlyInternal {',
       '    /**',
       '     * @internal',
       '     */',
-      '    setValue(v: number)', // no trailing `;` or `}` — malformed on purpose
+      '    setValue(v: number): void;',
       '}',
       '',
     ].join('\n');
 
-    expect(() => stripNestedInternalMembers(input)).toThrow(/never returned/u);
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(1);
+    expect(text).toContain('declare class OnlyInternal {\n}');
+  });
+
+  it('does not miscount a brace inside a string-literal type', () => {
+    // `weird(): '{' | void;` contains an unbalanced `{` as far as a naive
+    // character scan is concerned — real AST parsing sees it correctly as
+    // part of a string-literal type, not a body brace, so it can never
+    // mis-bound the declaration above or below it.
+    const input = [
+      'declare class Foo {',
+      '    readonly ok: string;',
+      '    /**',
+      '     * @internal',
+      '     */',
+      "    weird(): '{' | void;",
+      '    static x: number;',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(1);
+    expect(text).not.toContain('weird');
+    expect(text).toContain('readonly ok: string;');
+    expect(text).toContain('static x: number;');
+    expect(text).toContain('declare class Foo {');
+    expect(text.trim().endsWith('}')).toBe(true);
   });
 
   it('does not miscount a balanced brace pair from a template-literal type', () => {
-    // `${number}` contributes one balanced `{`/`}` pair. A naive bracket
-    // counter that got this wrong would either mis-bound the @internal
-    // declaration above it or swallow the untagged sibling below it.
     const input = [
       'declare class Foo {',
       '    /**',
@@ -197,57 +253,41 @@ describe('strip-internal-members.mjs (CLI)', () => {
     expect(core).toContain('static ɵprov: unknown;');
   });
 
-  it('fails loudly instead of publishing corrupted output when the structural-integrity guard trips', async () => {
+  it('strips a member whose signature contains a brace inside a string-literal type without tripping the guard', async () => {
+    // Regression test for the bracket-counting bug the AST rewrite fixes:
+    // this exact shape used to make the old character-scanning
+    // implementation swallow the untagged sibling and the class's own
+    // closing brace, which the structural-integrity guard correctly caught
+    // as invalid output. With real AST parsing this now just works —
+    // assert the correct output, not a thrown error.
     workDir = mkdtempSync(join(tmpdir(), 'strip-internal-members-'));
     const typesDir = join(workDir, 'dist/packages/toolkit/types');
     await mkdir(typesDir, { recursive: true });
 
-    // An unbalanced brace inside a string literal (`'{'`) inside the
-    // @internal member's own return type throws off the bracket-depth
-    // counter: it "terminates" one line into the following sibling instead
-    // of at the real declaration boundary, swallowing `static x` and the
-    // class's own closing `}` — the bracket-count parser produces no
-    // leftover `@internal` tag (so the older leftover-tag check would miss
-    // this), but the result is not valid TypeScript. The structural-integrity
-    // guard must catch it and fail the build instead of writing it.
-    const original = [
-      'declare class Foo {',
-      '    readonly ok: string;',
-      '    /**',
-      '     * @internal',
-      '     */',
-      "    weird(): '{' | void;",
-      '    static x: number;',
-      '}',
-      '',
-    ].join('\n');
     writeFileSync(
       join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
-      original,
+      [
+        'declare class Foo {',
+        '    readonly ok: string;',
+        '    /**',
+        '     * @internal',
+        '     */',
+        "    weird(): '{' | void;",
+        '    static x: number;',
+        '}',
+        '',
+      ].join('\n'),
     );
 
-    let failure: { status: number | null; stderr: string } | undefined;
-    try {
-      execFileSync(process.execPath, [scriptPath], {
-        cwd: workDir,
-        stdio: 'pipe',
-        encoding: 'utf8',
-      });
-    } catch (error) {
-      const execError = error as { status: number | null; stderr: string };
-      failure = { status: execError.status, stderr: execError.stderr };
-    }
+    execFileSync(process.execPath, [scriptPath], { cwd: workDir });
 
-    expect(failure).toBeDefined();
-    expect(failure?.status).not.toBe(0);
-    expect(failure?.stderr).toContain('[toolkit] ERROR');
-
-    // The corrupted output must never be written — the source file on disk
-    // is untouched.
-    const onDisk = readFileSync(
+    const core = readFileSync(
       join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
       'utf8',
     );
-    expect(onDisk).toBe(original);
+    expect(core).not.toContain('weird');
+    expect(core).toContain('readonly ok: string;');
+    expect(core).toContain('static x: number;');
+    expect(core.trim().endsWith('}')).toBe(true);
   });
 });

--- a/packages/toolkit/scripts/strip-internal-members.spec.ts
+++ b/packages/toolkit/scripts/strip-internal-members.spec.ts
@@ -1,0 +1,253 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { stripNestedInternalMembers } from './strip-internal-members.mjs';
+
+// Regression tests for the post-build hardening script that removes
+// `@internal`-tagged class/interface members from the published `.d.ts`
+// bundles — the part of #289 that `stripInternal` cannot safely do (see the
+// script's own header comment for why the compiler flag is not viable here).
+//
+// Deliberately does NOT strip top-level `@internal` declarations: `/core`'s
+// build-time-only plumbing (tokens, factories) is legitimately imported by
+// sibling entries and `libs/debugger` at build time, and is already hidden
+// from external consumers by `strip-internal-exports.mjs` deleting `"./core"`
+// from the published `exports` map. Only members nested inside an otherwise
+// public class/interface — reachable because the *class* is re-exported to
+// real consumers — are an actual enforcement gap.
+
+const scriptPath = resolve(import.meta.dirname, './strip-internal-members.mjs');
+
+describe('stripNestedInternalMembers (unit)', () => {
+  it('removes a single-line @internal method from a class body', () => {
+    const input = [
+      'declare class Foo {',
+      '    /**',
+      '     * Reads a value.',
+      '     */',
+      '    readonly value: number;',
+      '    /**',
+      '     * Writes a value. Package-internal.',
+      '     * @internal',
+      '     */',
+      '    setValue(v: number): void;',
+      '    static ɵfac: unknown;',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(1);
+    expect(text).not.toContain('setValue');
+    expect(text).not.toContain('@internal');
+    expect(text).toContain('readonly value: number;');
+    expect(text).toContain('static ɵfac: unknown;');
+  });
+
+  it('leaves a top-level (depth 0) @internal declaration untouched', () => {
+    const input = [
+      '/**',
+      ' * Build-time-only plumbing for sibling entries.',
+      ' * @internal',
+      ' */',
+      'declare const INTERNAL_TOKEN: unknown;',
+      'declare class Foo {',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(0);
+    expect(text).toBe(input);
+  });
+
+  it('does not strip a comment that merely mentions `@internal` in prose', () => {
+    const input = [
+      'declare class Foo {',
+      '    /**',
+      '     * The `set*` writers are tagged `@internal` and must not be called',
+      '     * from outside this package.',
+      '     */',
+      '    readonly value: number;',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(0);
+    expect(text).toBe(input);
+  });
+
+  it('removes a multi-line @internal interface nested inside another body', () => {
+    const input = [
+      'declare namespace Ns {',
+      '    /**',
+      '     * @internal',
+      '     */',
+      '    interface Options {',
+      '        readonly a: string;',
+      '        readonly b: number;',
+      '    }',
+      '    declare const kept: string;',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(1);
+    expect(text).not.toContain('interface Options');
+    expect(text).toContain('declare const kept: string;');
+  });
+
+  it('throws instead of silently corrupting output when a declaration never terminates', () => {
+    const input = [
+      'declare class Foo {',
+      '    /**',
+      '     * @internal',
+      '     */',
+      '    setValue(v: number)', // no trailing `;` or `}` — malformed on purpose
+      '}',
+      '',
+    ].join('\n');
+
+    expect(() => stripNestedInternalMembers(input)).toThrow(/never returned/u);
+  });
+
+  it('does not miscount a balanced brace pair from a template-literal type', () => {
+    // `${number}` contributes one balanced `{`/`}` pair. A naive bracket
+    // counter that got this wrong would either mis-bound the @internal
+    // declaration above it or swallow the untagged sibling below it.
+    const input = [
+      'declare class Foo {',
+      '    /**',
+      '     * @internal',
+      '     */',
+      '    setValue(v: number): void;',
+      '    readonly kind: `Point<${number}>`;',
+      '    readonly sibling: string;',
+      '}',
+      '',
+    ].join('\n');
+
+    const { text, removedCount } = stripNestedInternalMembers(input);
+
+    expect(removedCount).toBe(1);
+    expect(text).not.toContain('setValue');
+    expect(text).toContain('readonly kind: `Point<${number}>`;');
+    expect(text).toContain('readonly sibling: string;');
+  });
+});
+
+describe('strip-internal-members.mjs (CLI)', () => {
+  let workDir: string | undefined;
+
+  afterEach(() => {
+    if (workDir !== undefined)
+      rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('strips nested @internal members across every .d.ts in dist/packages/toolkit/types', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'strip-internal-members-'));
+    const typesDir = join(workDir, 'dist/packages/toolkit/types');
+    await mkdir(typesDir, { recursive: true });
+
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      [
+        'declare class NgxFieldIdentity {',
+        '    readonly fieldName: unknown;',
+        '    /**',
+        '     * @internal',
+        '     */',
+        '    setFieldName(name: string | null): void;',
+        '    static ɵprov: unknown;',
+        '}',
+        '/**',
+        ' * @internal',
+        ' */',
+        'declare const NGX_ERROR_MESSAGES: unknown;',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-assistive.d.ts'),
+      'export declare class NgxFormFieldError {\n}\n',
+    );
+
+    execFileSync(process.execPath, [scriptPath], { cwd: workDir });
+
+    const core = readFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      'utf8',
+    );
+    // The class member is gone (the actual enforcement gap).
+    expect(core).not.toContain('setFieldName');
+    // The top-level `/core`-only token survives — sibling entries and
+    // `libs/debugger` legitimately import it at build time, and it is
+    // already unreachable externally via the stripped `"./core"` export.
+    expect(core).toContain('NGX_ERROR_MESSAGES');
+    expect(core).toContain('readonly fieldName: unknown;');
+    expect(core).toContain('static ɵprov: unknown;');
+  });
+
+  it('fails loudly instead of publishing corrupted output when the structural-integrity guard trips', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'strip-internal-members-'));
+    const typesDir = join(workDir, 'dist/packages/toolkit/types');
+    await mkdir(typesDir, { recursive: true });
+
+    // An unbalanced brace inside a string literal (`'{'`) inside the
+    // @internal member's own return type throws off the bracket-depth
+    // counter: it "terminates" one line into the following sibling instead
+    // of at the real declaration boundary, swallowing `static x` and the
+    // class's own closing `}` — the bracket-count parser produces no
+    // leftover `@internal` tag (so the older leftover-tag check would miss
+    // this), but the result is not valid TypeScript. The structural-integrity
+    // guard must catch it and fail the build instead of writing it.
+    const original = [
+      'declare class Foo {',
+      '    readonly ok: string;',
+      '    /**',
+      '     * @internal',
+      '     */',
+      "    weird(): '{' | void;",
+      '    static x: number;',
+      '}',
+      '',
+    ].join('\n');
+    writeFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      original,
+    );
+
+    let failure: { status: number | null; stderr: string } | undefined;
+    try {
+      execFileSync(process.execPath, [scriptPath], {
+        cwd: workDir,
+        stdio: 'pipe',
+        encoding: 'utf8',
+      });
+    } catch (error) {
+      const execError = error as { status: number | null; stderr: string };
+      failure = { status: execError.status, stderr: execError.stderr };
+    }
+
+    expect(failure).toBeDefined();
+    expect(failure?.status).not.toBe(0);
+    expect(failure?.stderr).toContain('[toolkit] ERROR');
+
+    // The corrupted output must never be written — the source file on disk
+    // is untouched.
+    const onDisk = readFileSync(
+      join(typesDir, 'ngx-signal-forms-toolkit-core.d.ts'),
+      'utf8',
+    );
+    expect(onDisk).toBe(original);
+  });
+});


### PR DESCRIPTION
Makes `@internal` enforced in the published types instead of advisory — but not via the compiler flag the issue title suggests, because that flag demonstrably cannot work here.

**Why not `stripInternal`:** enabling it breaks ng-packagr's multi-entry-point `.d.ts` rollup outright. Reproduced twice independently (implementation and review): with the flag on, untagged public symbols (`NGX_SIGNAL_FORMS_CONFIG`, `NgxFieldIdentity`, `NGX_SIGNAL_FORM_CONTEXT`, ...) vanish from the bundled declarations even after removing every `@internal` tag in the package; toggling the flag off restores them immediately. The failure is the flag × rollup interaction, not tag placement — no amount of per-symbol untagging fixes it. `tsconfig.lib.json` stays untouched, and the README documents why.

**What enforces it instead:** a new post-build script, `strip-internal-members.mjs`, running before the existing `strip-internal-exports.mjs`. It deletes `@internal`-tagged declarations nested inside class/interface bodies from the emitted `.d.ts` bundles — the actual leak: `NgxFieldIdentity`'s five `set*` writers (core), `hintChildren`/`hintDescriptors` (form-field), and `connectFieldState` (headless); the build log reports exactly which. Top-level `@internal` declarations in `/core` are deliberately left alone: they are build-time plumbing for sibling entries and `libs/debugger`, and are already unreachable externally because `strip-internal-exports.mjs` removes `"./core"` from the published exports map.

**Safety net:** the scan is a line-based bracket counter, so after stripping, every rewritten file is re-parsed with the TypeScript compiler API (`ts.createSourceFile` parse diagnostics) and the build fails loudly — original file untouched — on any syntax error. One test constructs an input that genuinely fools the counter (unbalanced brace inside a string-literal type) and proves the guard trips instead of publishing corrupted output. Eight tests total, including a template-literal-type false-positive guard; error reporting follows the sibling script's `[toolkit] ERROR` + non-zero-exit convention.

Fixes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published TypeScript declarations now exclude internal members nested within classes, interfaces, and namespaces.
  * Public APIs and top-level declarations remain preserved and valid.
  * Added safeguards to detect malformed declarations and prevent publishing corrupted output.

* **Documentation**
  * Clarified how internal members are removed from published declarations and why existing TypeScript declaration settings remain unchanged.

* **Tests**
  * Added coverage for nested member removal, declaration preservation, edge cases, and publishing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->