### PR TITLE
feat(demo): autosave example — debounced field-level save with accessible status

### DIFF
--- a/apps/demo/src/app/05-advanced/README.md
+++ b/apps/demo/src/app/05-advanced/README.md
@@ -28,6 +28,8 @@ This is the production frontier of the demo app. Each demo here stands on its ow
   - What you'll learn: `resource()`-driven prefill · form-level vs. field-level server errors · the auto-clear semantics of submission errors · `reset(value)` after a successful save.
 - **[store-binding](./store-binding/README.md)** — honest two-way binding between a Signal Form and an `@ngrx/signals` store via `linkedSignal`, contrasted with the wizard's draft/commit buffer.
   - What you'll learn: `linkedSignal({ source, computation })` read seam · overriding `set`/`update` to write straight through to `patchState` · when live binding beats draft/commit.
+- **[autosave](./autosave/README.md)** — debounced, field-level save via `debounce(path, 500)` + `httpResource`, with no submit button.
+  - What you'll learn: the native `debounce()` schema rule · gating a save on `dirty()` **and** `valid()` · pausing `httpResource` with an `undefined` request · accessible save-status live regions.
 
 ## 🧠 Core concepts
 

--- a/apps/demo/src/app/05-advanced/advanced-wizard/README.md
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/README.md
@@ -81,3 +81,4 @@ The most complex demo in the app: a three-step travel-booking wizard built on a 
 - [Cross-Field Validation](../cross-field-validation/README.md) — the simpler cross-field primer.
 - [Submission Patterns](../submission-patterns/README.md) — declarative submission in a single-screen form.
 - [Global Configuration](../global-configuration/README.md) — app-level defaults the wizard also consumes.
+- [Autosave](../autosave/README.md) — the native `debounce()` schema rule replacing this wizard's own RxJS-based auto-save draft, for simple field-level cases.

--- a/apps/demo/src/app/05-advanced/autosave/README.md
+++ b/apps/demo/src/app/05-advanced/autosave/README.md
@@ -1,0 +1,209 @@
+# Autosave
+
+## Intent
+
+`05-advanced/` had three form↔backend patterns and no runnable example of the
+one developers ask for most: persist valid, dirty changes as the user types,
+with no submit button. This demo fills that gap — debounced field-level save
+via the native `debounce()` schema rule, a "save only dirty+valid" gate, and
+an accessible save-status announcement.
+
+Prompted by [Auto-Saving Signal Forms](https://tech.trellis.org/blog/2026-07-08-Auto-Saving-Signal-Forms)
+(Trellis) — this demo takes the use case, not that post's mechanism. See
+"What this demo deliberately does not do" below.
+
+## Toolkit features showcased
+
+- `debounce(path, 500)` (`@angular/forms/signals`, `@publicApi 22.0`) — delays
+  writing a UI edit into a field's own value signal until 500ms after the
+  user stops typing it. Applied per field (`displayName`, `bio`), so each
+  debounces independently.
+- A computed patch gate: a field is included only when it is both `dirty()`
+  **and** `valid()`.
+- `httpResource` (`@angular/common/http`, `@publicApi 22.0`) — the request
+  function returns `undefined` whenever nothing dirty+valid is waiting,
+  pausing the resource. No separate "should I save?" flag.
+- `reset(value)` on a successful save — the same call
+  [Server Integration](../server-integration/README.md) makes after a
+  successful submit — re-baselines `dirty()`/`touched()` without touching
+  what the user typed.
+- `NgxFormField` wrapper for the two fields; no other toolkit-specific
+  save-status API — the status region is hand-rolled (see below).
+
+## Form model
+
+- Signal model: `signal<AutosaveProfileModel>({ displayName, bio })`
+  (`autosave.model.ts`).
+- Schema: `schema<AutosaveProfileModel>` with `debounce()` + validators per
+  field (`autosave.validations.ts`). No `form(..., { submission })` — there
+  is nothing to submit.
+- Backend: a real MSW handler, `PATCH /api/autosave/profile`
+  (`apps/demo/src/mocks/handlers.ts`) — unlike
+  [Server Integration](../server-integration/README.md)'s in-memory fake
+  service, `httpResource`'s loading/error states here come from an actual
+  (mocked) HTTP round trip.
+
+## Validation rules
+
+### Errors
+
+- Display name — required; min length 2.
+- Bio — max length 280.
+
+### Warnings
+
+- None.
+
+## Save-only-dirty-and-valid gate
+
+```ts
+protected readonly dirtyValidPatch = computed(() => {
+  const displayName = this.profileForm.displayName();
+  const bio = this.profileForm.bio();
+  const patch: Partial<AutosaveProfileModel> = {};
+  if (displayName.dirty() && displayName.valid()) patch.displayName = displayName.value();
+  if (bio.dirty() && bio.valid()) patch.bio = bio.value();
+  return Object.keys(patch).length > 0 ? patch : undefined;
+});
+```
+
+Both conditions matter independently:
+
+- `dirty()` alone would resend an already-saved value on any unrelated
+  re-render.
+- `valid()` alone would happily PATCH a value the user hasn't finished
+  typing (e.g. a required field mid-edit, before `debounce` even lets the
+  invalid intermediate value settle — though in practice `debounce` means
+  validators only ever see the settled value).
+
+Each field is gated independently, so one invalid field never blocks the
+other from autosaving.
+
+### Why not `extractValue()`
+
+`@angular/forms/signals/compat` exports `extractValue(field, { dirty: true })`,
+which would collect the whole dirty subtree in one call instead of two
+explicit per-field checks. It was considered and not used here, for two
+reasons:
+
+1. It lives in the **compat** entry point, whose stated purpose is Reactive
+   Forms interop — importing it into a pure Signal Forms demo would be
+   off-label, even though nothing about `extractValue` itself is
+   compat-specific.
+2. With only two fields, two explicit `if` checks are more legible than a
+   loop plus a compat import, and they keep the same `keyof`-precision style
+   as `server-integration.form.ts`'s `PROFILE_FIELD_KEYS`.
+
+If a real form had a dozen+ autosaved fields, `extractValue` would very
+likely be the better trade — this demo's teaching point is the gate, not
+"never use extractValue."
+
+## Accessible save status
+
+Idle / saving / saved / failed is surfaced through **two fixed-role live
+regions**, always present in the DOM:
+
+- `role="status"` (polite) for "Saving…" and "All changes saved."
+- `role="alert"` (assertive) for a failed save, paired with a **Retry save**
+  button.
+
+Only the content _inside_ each region is conditionally rendered via `@if`;
+the container and its `role` never toggle. That is deliberate: toggling
+`role` in the same tick content is inserted is the exact bug
+`packages/toolkit/assistive/form-field-notification.ts` documents (NVDA +
+Chrome miss the first announcement when role and content arrive together).
+A save-status region has the same failure mode, so it gets the same fix.
+
+Announcements are naturally coalesced without extra debounce logic: the
+status only changes on a genuine state-machine transition
+(`idle → saving → saved`), not on every keystroke, so there's nothing to
+separately throttle.
+
+**A companion issue, [#267](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/267),
+proposes a toolkit primitive for this exact save-status announcement shape.**
+This demo does not block on it and hand-rolls the live regions instead — see
+the `TODO(#267)` comment in `autosave.form.ts`. If the primitive lands, this
+demo should adopt it.
+
+## Retry and reset
+
+- **Retry:** a failed save leaves its field(s) `dirty()`; **Retry save**
+  calls `saveResource.reload()`, which re-issues the same patch.
+- **Reset demo:** `profileForm().reset(createInitialAutosaveProfile())` — one
+  call sets the model back to its initial value _and_ clears
+  `dirty()`/`touched()`.
+
+## What this demo deliberately does not do
+
+The source post builds a Proxy-based path builder with a dual `from`/`to`
+schema and RxJS (`share`, `distinctUntilChanged`, `takeUntilDestroyed`). This
+demo does not adopt that:
+
+- its hardest part — debouncing — is now the native `debounce()` schema
+  rule, so hand-rolling it would be outdated;
+- the post's own published version is "simplified" and leaves nested arrays,
+  reset-state tracking, and pristine-vs-debounce discrimination unsolved;
+- a Proxy path-builder is a state/persistence framework, and this toolkit
+  deliberately stays out of state management.
+
+Contrast with [Advanced Wizard](../advanced-wizard/README.md): its
+`wizard.store.ts` already has an auto-save-with-debounce feature (`rxMethod`
+with RxJS `debounceTime(2000)` over the whole draft), predating the native
+`debounce()` rule. This demo is the idiomatic Signal Forms alternative for
+that same "save as you go" need, at the field level instead of the whole
+form.
+
+## Out of scope
+
+- **Conflict resolution / optimistic concurrency.** A successful save calls
+  `reset(this.profileForm().value())` — the form's _current_ value at
+  resolve time, not a snapshot of exactly what was sent. If the user edits a
+  different field while a PATCH is in flight, that edit gets marked clean
+  too once the in-flight request resolves, even though the server hasn't
+  seen it yet (it will be picked up by the next debounce/valid cycle,
+  because `httpResource` re-issues on any change to the computed patch).
+  Last-write-wins is fine for this demo; a production autosave with real
+  conflict risk needs more than this.
+- **Offline queueing / `localStorage` persistence.** Not implemented.
+
+## Key files
+
+- [autosave.model.ts](autosave.model.ts) — `AutosaveProfileModel`.
+- [autosave.validations.ts](autosave.validations.ts) — `debounce()` +
+  validators.
+- [autosave.api.ts](autosave.api.ts) — endpoint + failure-marker constants.
+- [autosave.form.ts](autosave.form.ts) — the dirty+valid gate, `httpResource`,
+  save-status live regions.
+- [autosave.page.ts](autosave.page.ts) — page wrapper and debugger.
+- `apps/demo/src/mocks/handlers.ts` — the `PATCH /api/autosave/profile` MSW
+  handler.
+
+## How to test
+
+1. Run the demo and navigate to `/advanced-scenarios/autosave`.
+2. Edit **Display name** and stop typing — after ~500ms the status region
+   reads _Saving…_, then _All changes saved._ after the ~400ms mocked PATCH
+   resolves. Confirm `dirty()` in the state panel returns to `false`.
+3. Type `FAIL_SAVE` anywhere in **Bio** and stop typing — confirm the
+   assertive region shows a failure message and a **Retry save** button, and
+   that `dirty()` for `bio` stays `true`.
+4. Click **Retry save** without changing anything — confirm it fails again
+   (the marker is still present).
+5. Remove `FAIL_SAVE` from **Bio** and stop typing — confirm it autosaves
+   successfully this time.
+6. Clear **Display name** entirely — confirm it shows a required error and
+   the state panel's pending PATCH body omits `displayName` (invalid fields
+   are never sent).
+7. Click **Reset demo** — confirm both fields return to their initial values
+   and `dirty()` is `false` for both.
+
+## Related
+
+- [Server Integration](../server-integration/README.md) — explicit submit +
+  server-error mapping; contrast with this demo's no-submit-button autosave.
+- [Advanced Wizard](../advanced-wizard/README.md) — draft/commit buffer with
+  an explicit commit step, plus the pre-existing RxJS-based auto-save this
+  demo's native `debounce()` supersedes for simple field-level cases.
+- [Store Binding](../store-binding/README.md) — live two-way form ↔
+  `@ngrx/signals` store, the third existing form↔backend pattern this demo
+  completes the set against.

--- a/apps/demo/src/app/05-advanced/autosave/README.md
+++ b/apps/demo/src/app/05-advanced/autosave/README.md
@@ -23,10 +23,10 @@ Prompted by [Auto-Saving Signal Forms](https://tech.trellis.org/blog/2026-07-08-
 - `httpResource` (`@angular/common/http`, `@publicApi 22.0`) — the request
   function returns `undefined` whenever nothing dirty+valid is waiting,
   pausing the resource. No separate "should I save?" flag.
-- `reset(value)` on a successful save — the same call
-  [Server Integration](../server-integration/README.md) makes after a
-  successful submit — re-baselines `dirty()`/`touched()` without touching
-  what the user typed.
+- Per-field, no-argument `reset()` on a successful save — clears
+  `dirty()`/`touched()` for exactly the fields the resolved request covered,
+  leaving any field edited again mid-flight dirty so it autosaves for real
+  on the next debounce cycle (see "Lost-update guard" below).
 - `NgxFormField` wrapper for the two fields; no other toolkit-specific
   save-status API — the status region is hand-rolled (see below).
 
@@ -69,12 +69,17 @@ protected readonly dirtyValidPatch = computed(() => {
 
 Both conditions matter independently:
 
-- `dirty()` alone would resend an already-saved value on any unrelated
-  re-render.
-- `valid()` alone would happily PATCH a value the user hasn't finished
-  typing (e.g. a required field mid-edit, before `debounce` even lets the
-  invalid intermediate value settle — though in practice `debounce` means
-  validators only ever see the settled value).
+- `dirty()` excludes a pristine value — one that hasn't changed since the
+  field's last reset baseline, including immediately after this demo's own
+  post-save `reset()` (see "Lost-update guard" below). Without it, `valid()`
+  alone would keep re-including an already-saved value forever, since
+  validity doesn't change just because a request resolved.
+- `valid()` excludes a settled invalid value. Without it, `dirty()` alone
+  would happily PATCH a value that currently fails validation. Neither
+  signal is affected by unrelated re-renders, and — because `debounce()`
+  delays what `dirty()`/`valid()` ever observe until the value has
+  settled — there is no "still typing" intermediate value to worry about
+  either; the gate only ever sees settled values.
 
 Each field is gated independently, so one invalid field never blocks the
 other from autosaving.
@@ -97,6 +102,48 @@ reasons:
 If a real form had a dozen+ autosaved fields, `extractValue` would very
 likely be the better trade — this demo's teaching point is the gate, not
 "never use extractValue."
+
+## Lost-update guard
+
+`httpResource` is last-write-wins **for requests**: if the computed patch
+changes while a PATCH is in flight, the resource cancels it and issues a new
+one with the current patch — so an edit that lands _before_ the request is
+dispatched is never lost, it just gets folded into the request that actually
+goes out.
+
+What is not automatically safe is an edit that lands _after_ a request is
+already dispatched and _before_ it resolves. A naive "reset the whole form on
+success" (`this.profileForm().reset(this.profileForm().value())`, this
+demo's first draft) would mark that concurrently-edited field pristine too,
+even though the server never saw the newer value — a **lost update**, not
+"last write wins" (nothing was ever un-sent; the fact it changed after being
+sent was just forgotten).
+
+The fix, in `autosave.form.ts`:
+
+1. The `httpResource` request builder captures the exact patch it sends into
+   a plain instance field, `#lastRequestedPatch` — not a signal, so reading
+   it back later can't itself trigger reactivity, and it can never drift
+   from what was truly sent (unlike re-reading `dirtyValidPatch()` from an
+   effect, which could already reflect a newer edit by the time that effect
+   runs).
+2. On a resolved save, `fieldsSafeToMarkSaved()` (`autosave.save-reconciliation.ts`,
+   a pure function with its own spec) compares `#lastRequestedPatch` against
+   each field's **current** value. A field is safe to mark saved only if it
+   was part of the request that resolved **and** its value hasn't moved on
+   since.
+3. Each safe field gets its own no-argument `reset()` —
+   `this.profileForm[key]().reset()` — which clears that field's
+   `dirty()`/`touched()` alone, without touching its value or any sibling
+   field. A field that fails either check in step 2 is left dirty, so the
+   next debounce cycle autosaves it for real instead of silently dropping
+   it.
+
+This works because Signal Forms' `FieldState.reset()` takes an optional
+value but doesn't require one: called on a single field with no argument, it
+resets only that field's touched/dirty state, "per-field markAsPristine" —
+there is no separately-named method for it, but the no-argument form of
+`reset()` on a leaf field _is_ that mechanism.
 
 ## Accessible save status
 
@@ -128,10 +175,13 @@ demo should adopt it.
 ## Retry and reset
 
 - **Retry:** a failed save leaves its field(s) `dirty()`; **Retry save**
-  calls `saveResource.reload()`, which re-issues the same patch.
+  calls `saveResource.reload()`, which re-issues the current patch (picking
+  up any edits made since the failure).
 - **Reset demo:** `profileForm().reset(createInitialAutosaveProfile())` — one
   call sets the model back to its initial value _and_ clears
-  `dirty()`/`touched()`.
+  `dirty()`/`touched()` for the whole form. This one is a deliberate
+  whole-form reset (there is nothing to preserve — the demo is starting
+  over), unlike the per-field reconciliation after a successful save.
 
 ## What this demo deliberately does not do
 
@@ -155,15 +205,26 @@ form.
 
 ## Out of scope
 
-- **Conflict resolution / optimistic concurrency.** A successful save calls
-  `reset(this.profileForm().value())` — the form's _current_ value at
-  resolve time, not a snapshot of exactly what was sent. If the user edits a
-  different field while a PATCH is in flight, that edit gets marked clean
-  too once the in-flight request resolves, even though the server hasn't
-  seen it yet (it will be picked up by the next debounce/valid cycle,
-  because `httpResource` re-issues on any change to the computed patch).
-  Last-write-wins is fine for this demo; a production autosave with real
-  conflict risk needs more than this.
+- **Conflict resolution / optimistic concurrency.** The client-side
+  lost-update guard above (only marking a field saved if it still matches
+  what was sent) is not the same thing as server-side conflict detection —
+  there's no ETag/version check, and two different clients autosaving the
+  same record concurrently can still silently overwrite each other on the
+  server. Last-write-wins at the server is fine for this demo; a production
+  autosave with real multi-client conflict risk needs more than this
+  (optimistic concurrency tokens, CRDTs, or similar).
+- **`httpResource`'s request-level cancellation is coarser than the
+  save.** `httpResource` cancels the entire in-flight HTTP request when its
+  computed request changes — it has no concept of "this PATCH's body
+  changed, but keep the connection." That's the right trade for this demo
+  (it's exactly what folds a pre-dispatch edit into the next request, see
+  "Lost-update guard" above) but it does mean a request that was almost
+  done can still be aborted and re-sent from scratch. A production autosave
+  with stricter delivery guarantees (e.g. "never re-send a request that's
+  already X% through," or serialized-queue semantics) would need to drop to
+  `HttpClient` directly and manage that queue explicitly — out of scope for
+  what is meant to stay an idiomatic `httpResource` example matching this
+  repo's other `resource()`/`httpResource` demos.
 - **Offline queueing / `localStorage` persistence.** Not implemented.
 
 ## Key files
@@ -172,8 +233,11 @@ form.
 - [autosave.validations.ts](autosave.validations.ts) — `debounce()` +
   validators.
 - [autosave.api.ts](autosave.api.ts) — endpoint + failure-marker constants.
+- [autosave.save-reconciliation.ts](autosave.save-reconciliation.ts) — the
+  pure lost-update guard (`fieldsSafeToMarkSaved()`), with its own
+  [spec](autosave.save-reconciliation.spec.ts).
 - [autosave.form.ts](autosave.form.ts) — the dirty+valid gate, `httpResource`,
-  save-status live regions.
+  the post-save reconciliation, save-status live regions.
 - [autosave.page.ts](autosave.page.ts) — page wrapper and debugger.
 - `apps/demo/src/mocks/handlers.ts` — the `PATCH /api/autosave/profile` MSW
   handler.
@@ -196,6 +260,14 @@ form.
    are never sent).
 7. Click **Reset demo** — confirm both fields return to their initial values
    and `dirty()` is `false` for both.
+8. **Lost-update guard**, covered automatically by
+   `autosave.save-reconciliation.spec.ts` at the unit level; to see it live:
+   edit **Display name** and, within the ~400ms the mocked PATCH is in
+   flight (right after the 500ms debounce fires — watch for _Saving…_), also
+   edit **Bio**. Confirm both eventually read _All changes saved._ and both
+   `dirty()` flags return to `false` — no edit is ever lost, regardless of
+   which request happens to be in flight when the other field's debounce
+   fires.
 
 ## Related
 

--- a/apps/demo/src/app/05-advanced/autosave/autosave.api.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.api.ts
@@ -1,0 +1,18 @@
+/**
+ * Autosave API constants
+ *
+ * The autosave demo routes through a **real** MSW handler (see
+ * `apps/demo/src/mocks/handlers.ts`) via `httpResource`, unlike
+ * `server-integration`'s in-memory fake service — this file only holds the
+ * endpoint and the magic value that makes the fake backend reject a save, so
+ * the client and the handler agree on both without duplicating literals.
+ */
+
+/** Endpoint the autosave `httpResource` PATCHes dirty, valid changes to. */
+export const AUTOSAVE_ENDPOINT = '/api/autosave/profile';
+
+/**
+ * Substring that makes the fake backend reject the save with a 500, so the
+ * demo's failure + retry path is reachable without waiting on a real error.
+ */
+export const AUTOSAVE_FAILURE_MARKER = 'FAIL_SAVE';

--- a/apps/demo/src/app/05-advanced/autosave/autosave.content.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.content.ts
@@ -24,8 +24,8 @@ export const AUTOSAVE_CONTENT = {
           '• <strong><code>httpResource</code>:</strong> the request function returns <code>undefined</code> whenever nothing dirty+valid is waiting, which pauses the resource — no polling flag to keep in sync',
           "• <strong>Real MSW handler:</strong> the PATCH hits <code>/api/autosave/profile</code> in <code>apps/demo/src/mocks/handlers.ts</code>, not an in-memory fake — <code>httpResource</code>'s loading/error states are the real thing",
           "• <strong>Status surfaced:</strong> idle / saving / saved / failed, mapped from the resource's own <code>status()</code> signal",
-          '• <strong>Retry:</strong> a failed save leaves its field(s) dirty; <code>resource.reload()</code> re-issues the same patch',
-          '• <strong>Re-baseline on success:</strong> <code>reset(value)</code> clears <code>dirty()</code> without touching what the user typed — the same call <a href="/advanced-scenarios/server-integration">Server Integration</a> makes after a successful submit',
+          '• <strong>Retry:</strong> a failed save leaves its field(s) dirty; <code>resource.reload()</code> re-issues the current patch',
+          "• <strong>Lost-update guard on success:</strong> only fields whose value still matches what was actually sent get marked saved, via each field's own no-argument <code>reset()</code> — a field edited again while the request was in flight stays dirty, so nothing silently drops",
         ],
       },
       {
@@ -45,7 +45,7 @@ export const AUTOSAVE_CONTENT = {
         title: '🧪 Try This',
         items: [
           '1. Edit <strong>Display name</strong> and stop typing — after ~500ms the status region reads <em>Saving…</em>, then <em>All changes saved.</em> after the fake ~400ms PATCH resolves.',
-          '2. Watch the state panel: <code>dirty()</code> flips back to <code>false</code> the instant the save resolves, via <code>reset(value)</code>.',
+          "2. Watch the state panel: <code>dirty()</code> flips back to <code>false</code> the instant the save resolves, via that field's own <code>reset()</code>.",
           '3. Type <code>FAIL_SAVE</code> anywhere in <strong>Bio</strong> and stop typing → the assertive region announces a failure and shows a <strong>Retry save</strong> button; the field stays dirty until a save actually succeeds.',
           '4. Remove <code>FAIL_SAVE</code> from Bio and stop typing again → the corrected value autosaves normally.',
           '5. Clear <strong>Display name</strong> entirely → it becomes invalid (required), so the debounce still settles the value but the patch omits it — nothing is PATCHed for an invalid field.',
@@ -62,7 +62,7 @@ export const AUTOSAVE_CONTENT = {
       {
         title: 'Dirty + Valid Gate',
         items: [
-          "• <strong>Both conditions, not one:</strong> <code>dirty()</code> alone would resend an already-saved value after every unrelated re-render trigger; <code>valid()</code> alone would happily PATCH a value the user hasn't finished editing.",
+          "• <strong>Both conditions, not one:</strong> without <code>dirty()</code>, <code>valid()</code> alone would keep re-including an already-saved value, since validity doesn't change just because a request resolved; without <code>valid()</code>, <code>dirty()</code> alone would happily PATCH a value that currently fails validation.",
           '• <strong>Per field, not per form:</strong> gating each field independently means one invalid field never blocks the other from autosaving.',
         ],
       },

--- a/apps/demo/src/app/05-advanced/autosave/autosave.content.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.content.ts
@@ -1,0 +1,76 @@
+/**
+ * Autosave Content
+ *
+ * Educational content for the autosave example
+ */
+
+export const AUTOSAVE_CONTENT = {
+  demonstrated: {
+    icon: '💾',
+    title: 'Autosave',
+    sections: [
+      {
+        title: 'Debounced field-level save',
+        items: [
+          "• <strong>Native debounce:</strong> <code>debounce(path, 500)</code> — the Angular 22 schema rule — delays writing a UI edit into that field's value signal until 500ms after the user stops typing it",
+          "• <strong>Per field, not per form:</strong> <code>displayName</code> and <code>bio</code> debounce independently; editing one does not reset or extend the other's timer",
+          '• <strong>Save only what should be saved:</strong> a computed patch includes a field only when it is both <code>dirty()</code> and <code>valid()</code> — never an untouched or invalid value',
+          '• <strong>No submit button:</strong> saving is the interaction, not a separate step',
+        ],
+      },
+      {
+        title: 'The save itself',
+        items: [
+          '• <strong><code>httpResource</code>:</strong> the request function returns <code>undefined</code> whenever nothing dirty+valid is waiting, which pauses the resource — no polling flag to keep in sync',
+          "• <strong>Real MSW handler:</strong> the PATCH hits <code>/api/autosave/profile</code> in <code>apps/demo/src/mocks/handlers.ts</code>, not an in-memory fake — <code>httpResource</code>'s loading/error states are the real thing",
+          "• <strong>Status surfaced:</strong> idle / saving / saved / failed, mapped from the resource's own <code>status()</code> signal",
+          '• <strong>Retry:</strong> a failed save leaves its field(s) dirty; <code>resource.reload()</code> re-issues the same patch',
+          '• <strong>Re-baseline on success:</strong> <code>reset(value)</code> clears <code>dirty()</code> without touching what the user typed — the same call <a href="/advanced-scenarios/server-integration">Server Integration</a> makes after a successful submit',
+        ],
+      },
+      {
+        title: 'Accessible save status',
+        items: [
+          '• <strong>Two fixed-role live regions:</strong> a <code>role="status"</code> container for "Saving…"/"All changes saved" (polite) and a separate <code>role="alert"</code> container for failure (assertive) — never one region whose role is swapped at runtime',
+          '• <strong>Role never toggles:</strong> only the content inside each region is conditionally rendered; the container and its role are always present, which is what keeps screen readers from missing the first announcement',
+          '• <strong>Naturally coalesced:</strong> the status only changes on a genuine transition (idle→saving→saved), so there is nothing to separately debounce for the announcement itself',
+        ],
+      },
+    ],
+  },
+  learning: {
+    title: 'Best Practices & Patterns',
+    sections: [
+      {
+        title: '🧪 Try This',
+        items: [
+          '1. Edit <strong>Display name</strong> and stop typing — after ~500ms the status region reads <em>Saving…</em>, then <em>All changes saved.</em> after the fake ~400ms PATCH resolves.',
+          '2. Watch the state panel: <code>dirty()</code> flips back to <code>false</code> the instant the save resolves, via <code>reset(value)</code>.',
+          '3. Type <code>FAIL_SAVE</code> anywhere in <strong>Bio</strong> and stop typing → the assertive region announces a failure and shows a <strong>Retry save</strong> button; the field stays dirty until a save actually succeeds.',
+          '4. Remove <code>FAIL_SAVE</code> from Bio and stop typing again → the corrected value autosaves normally.',
+          '5. Clear <strong>Display name</strong> entirely → it becomes invalid (required), so the debounce still settles the value but the patch omits it — nothing is PATCHed for an invalid field.',
+          '6. Click <strong>Reset demo</strong> → the form returns to its initial value and <code>dirty()</code> clears, in one <code>reset(value)</code> call.',
+        ],
+      },
+      {
+        title: 'Debounce Pattern',
+        items: [
+          "• <strong>Schema rule over RxJS:</strong> <code>debounce(path, 500)</code> replaces a hand-rolled <code>debounceTime</code> pipeline — the value signal itself is what's delayed, so every downstream read (<code>dirty()</code>, <code>valid()</code>, validators) already sees the settled value.",
+          '• <strong>Contrast with <a href="/advanced-scenarios/advanced-wizard">Advanced Wizard</a>:</strong> that demo\'s auto-save uses an <code>@ngrx/signals</code> <code>rxMethod</code> with RxJS <code>debounceTime</code> at the store level, predating this native rule — this demo is the idiomatic Signal Forms alternative for the same use case.',
+        ],
+      },
+      {
+        title: 'Dirty + Valid Gate',
+        items: [
+          "• <strong>Both conditions, not one:</strong> <code>dirty()</code> alone would resend an already-saved value after every unrelated re-render trigger; <code>valid()</code> alone would happily PATCH a value the user hasn't finished editing.",
+          '• <strong>Per field, not per form:</strong> gating each field independently means one invalid field never blocks the other from autosaving.',
+        ],
+      },
+    ],
+    nextStep: {
+      text: 'Compare with the draft/commit buffer pattern (explicit commit step)',
+      link: '/advanced-scenarios/advanced-wizard',
+      linkText: 'Advanced Wizard →',
+    },
+  },
+} as const;

--- a/apps/demo/src/app/05-advanced/autosave/autosave.form.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.form.ts
@@ -1,0 +1,293 @@
+import { JsonPipe } from '@angular/common';
+import { httpResource } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  input,
+  signal,
+  untracked,
+} from '@angular/core';
+import { form, FormField } from '@angular/forms/signals';
+import {
+  type ResolvedErrorDisplayStrategy,
+  type FormFieldAppearance,
+  type FormFieldOrientation,
+  NgxSignalFormToolkit,
+} from '@ngx-signal-forms/toolkit';
+import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
+
+import { AUTOSAVE_ENDPOINT, AUTOSAVE_FAILURE_MARKER } from './autosave.api';
+import {
+  createInitialAutosaveProfile,
+  type AutosaveProfileModel,
+} from './autosave.model';
+import { autosaveProfileSchema } from './autosave.validations';
+
+/**
+ * Idle/saving/saved/error status surfaced to the user. Not exported — this is
+ * a small state machine local to this demo, not a general-purpose
+ * announcement abstraction (that question belongs to the toolkit primitive
+ * proposed in issue #267).
+ */
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+interface AutosavePatchResponse {
+  savedAt: string;
+}
+
+/**
+ * Autosave Component
+ *
+ * Debounced, field-level autosave: `debounce(path, 500)` settles each field
+ * independently, a computed patch collects only the fields that are both
+ * `dirty()` and `valid()`, and `httpResource` PATCHes that patch — paused
+ * (no request) whenever nothing qualifies. There is no submit button; saving
+ * *is* the interaction.
+ */
+@Component({
+  selector: 'ngx-autosave',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+
+  imports: [FormField, NgxSignalFormToolkit, NgxFormField, JsonPipe],
+  template: `
+    <div class="px-6 pt-0 pb-6">
+      <h2 class="mb-4 text-2xl font-bold">Autosave Demo</h2>
+      <p class="mb-6 text-gray-600 dark:text-gray-400">
+        Edit a field and stop typing — there is no submit button. Each field
+        debounces independently, then a changed, valid value is saved
+        automatically.
+      </p>
+
+      <div
+        class="mb-6 rounded-lg border border-sky-200 bg-sky-50 p-4 text-sm text-sky-950 dark:border-sky-900/60 dark:bg-sky-950/30 dark:text-sky-100"
+      >
+        <p class="font-semibold">Angular 22 pattern in use</p>
+        <ul class="mt-2 list-disc space-y-1 pl-5">
+          <li>
+            <code>debounce(path, 500)</code> delays writing a UI edit into the
+            field's value signal until 500ms after typing stops — the delay
+            autosave wants, with no hand-rolled RxJS.
+          </li>
+          <li>
+            A computed patch includes a field only when it is both
+            <code>dirty()</code> <strong>and</strong> <code>valid()</code> —
+            never an untouched or invalid value.
+          </li>
+          <li>
+            <code>httpResource(() =&gt; patch ? &#123; url, method:
+            'PATCH', body: patch &#125; : undefined)</code> — returning
+            <code>undefined</code> pauses the resource, so there is no
+            request while nothing qualifies.
+          </li>
+          <li>
+            On a successful save, <code>reset(value)</code> re-baselines the
+            form: <code>dirty()</code> clears without touching what the user
+            typed, matching <a
+              href="/advanced-scenarios/server-integration"
+              class="underline"
+              >Server Integration</a
+            >'s post-submit reset.
+          </li>
+        </ul>
+      </div>
+
+      <form
+        [formRoot]="profileForm"
+        ngxSignalForm
+        [errorStrategy]="errorDisplayMode()"
+        class="max-w-md space-y-6"
+      >
+        <ngx-form-field-wrapper
+          [formField]="profileForm.displayName"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="autosave-display-name">Display name</label>
+          <input
+            id="autosave-display-name"
+            type="text"
+            [formField]="profileForm.displayName"
+          />
+          <ngx-form-field-hint>
+            Saved automatically 500ms after you stop typing.
+          </ngx-form-field-hint>
+        </ngx-form-field-wrapper>
+
+        <ngx-form-field-wrapper
+          [formField]="profileForm.bio"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="autosave-bio">Bio</label>
+          <textarea
+            id="autosave-bio"
+            rows="3"
+            [formField]="profileForm.bio"
+          ></textarea>
+          <ngx-form-field-hint>
+            Type <code>{{ failureMarker }}</code> anywhere in this field to
+            see the failure + retry path.
+          </ngx-form-field-hint>
+        </ngx-form-field-wrapper>
+
+        <!--
+          Save status: two fixed-role live regions, always present in the DOM.
+          Only the content inside each is toggled via @if — the role itself
+          never flips, which is what keeps NVDA + Chrome from missing the
+          first announcement (same workaround NgxFormFieldNotification
+          documents in packages/toolkit/assistive/form-field-notification.ts).
+          Polite ("Saving…"/"All changes saved") vs assertive (failure) is a
+          deliberate split, not an accident: a save failure must interrupt,
+          a save succeeding must not.
+          TODO(#267): adopt the toolkit's save-status announcement primitive
+          here once it lands, instead of this hand-rolled pair.
+        -->
+        <div
+          role="status"
+          class="min-h-6 text-sm text-gray-600 dark:text-gray-400"
+        >
+          @if (saveStatus() === 'saving') {
+            <span>Saving…</span>
+          } @else if (saveStatus() === 'saved') {
+            <span>All changes saved.</span>
+          }
+        </div>
+
+        <div role="alert" class="min-h-6">
+          @if (saveStatus() === 'error') {
+            <div
+              class="flex flex-wrap items-center gap-3 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100"
+            >
+              <span>Could not save your changes.</span>
+              <button
+                type="button"
+                class="btn-secondary"
+                (click)="retrySave()"
+              >
+                Retry save
+              </button>
+            </div>
+          }
+        </div>
+
+        <div class="flex flex-wrap gap-4">
+          <button type="button" class="btn-secondary" (click)="resetDemo()">
+            Reset demo
+          </button>
+        </div>
+
+        <div
+          class="rounded-lg border border-gray-200 bg-gray-50 p-4 font-mono text-xs dark:border-gray-700 dark:bg-gray-900"
+        >
+          <div>
+            displayName: dirty()={{ profileForm.displayName().dirty() }}
+            valid()={{ profileForm.displayName().valid() }}
+          </div>
+          <div>
+            bio: dirty()={{ profileForm.bio().dirty() }} valid()={{
+              profileForm.bio().valid()
+            }}
+          </div>
+          <div>saveStatus(): {{ saveStatus() }}</div>
+          <div>pending PATCH body: {{ dirtyValidPatch() | json }}</div>
+        </div>
+      </form>
+    </div>
+  `,
+})
+export class AutosaveComponent {
+  readonly errorDisplayMode = input<ResolvedErrorDisplayStrategy>('on-touch');
+  readonly appearance = input<FormFieldAppearance>('outline');
+  readonly orientation = input<FormFieldOrientation>('vertical');
+
+  protected readonly failureMarker = AUTOSAVE_FAILURE_MARKER;
+
+  readonly #model = signal<AutosaveProfileModel>(
+    createInitialAutosaveProfile(),
+  );
+  readonly profileForm = form(this.#model, autosaveProfileSchema);
+
+  /**
+   * Save only what should be saved: a field qualifies only when it is both
+   * `dirty()` (changed since the last successful save or initial load) and
+   * `valid()`. Written as two explicit checks rather than a loop over
+   * `Object.keys` for the same `keyof` precision reason as
+   * `server-integration.form.ts`'s `PROFILE_FIELD_KEYS` — there are only two
+   * fields here, so the loop would cost more clarity than it saves.
+   */
+  protected readonly dirtyValidPatch = computed<
+    Partial<AutosaveProfileModel> | undefined
+  >(() => {
+    const displayName = this.profileForm.displayName();
+    const bio = this.profileForm.bio();
+    const patch: Partial<AutosaveProfileModel> = {};
+
+    if (displayName.dirty() && displayName.valid()) {
+      patch.displayName = displayName.value();
+    }
+    if (bio.dirty() && bio.valid()) {
+      patch.bio = bio.value();
+    }
+
+    return Object.keys(patch).length > 0 ? patch : undefined;
+  });
+
+  /**
+   * PATCHes `dirtyValidPatch()` whenever it holds a value. Returning
+   * `undefined` from the request function pauses `httpResource` — there is
+   * no request while nothing dirty+valid is waiting to be saved, and no
+   * separate "should I save?" flag to keep in sync.
+   */
+  protected readonly saveResource = httpResource<AutosavePatchResponse>(() => {
+    const patch = this.dirtyValidPatch();
+    return patch
+      ? { url: AUTOSAVE_ENDPOINT, method: 'PATCH', body: patch }
+      : undefined;
+  });
+
+  /**
+   * Maps the resource's `ResourceStatus` onto the four states this demo
+   * shows the user. `'reloading'` (the state during a manual retry) reads as
+   * `'saving'` too — the user doesn't need a fifth word for that.
+   */
+  protected readonly saveStatus = computed<SaveStatus>(() => {
+    switch (this.saveResource.status()) {
+      case 'loading':
+      case 'reloading':
+        return 'saving';
+      case 'resolved':
+      case 'local':
+        return 'saved';
+      case 'error':
+        return 'error';
+      default:
+        return 'idle';
+    }
+  });
+
+  constructor() {
+    /// Re-baseline on a successful save: `reset(value)` clears dirty/touched
+    /// without changing what the user typed — see the same call in
+    /// server-integration.form.ts. `untracked` keeps the reset's own value
+    /// write from re-triggering this effect.
+    effect(() => {
+      if (this.saveResource.status() === 'resolved') {
+        untracked(() => {
+          this.profileForm().reset(this.profileForm().value());
+        });
+      }
+    });
+  }
+
+  /** Re-issues the last PATCH after a failure — the fields stay dirty until it succeeds. */
+  protected retrySave(): void {
+    this.saveResource.reload();
+  }
+
+  /** Restores the initial value and clears dirty/touched in one `reset(value)` call. */
+  protected resetDemo(): void {
+    this.profileForm().reset(createInitialAutosaveProfile());
+  }
+}

--- a/apps/demo/src/app/05-advanced/autosave/autosave.form.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.form.ts
@@ -23,6 +23,7 @@ import {
   createInitialAutosaveProfile,
   type AutosaveProfileModel,
 } from './autosave.model';
+import { fieldsSafeToMarkSaved } from './autosave.save-reconciliation';
 import { autosaveProfileSchema } from './autosave.validations';
 
 /**
@@ -82,13 +83,11 @@ interface AutosavePatchResponse {
             request while nothing qualifies.
           </li>
           <li>
-            On a successful save, <code>reset(value)</code> re-baselines the
-            form: <code>dirty()</code> clears without touching what the user
-            typed, matching <a
-              href="/advanced-scenarios/server-integration"
-              class="underline"
-              >Server Integration</a
-            >'s post-submit reset.
+            On a successful save, only the fields that are still unchanged
+            since the request was sent are marked pristine, via each field's
+            own no-argument <code>reset()</code> — a field edited again while
+            the request was in flight stays dirty, so the next debounce
+            cycle saves it instead of silently dropping it.
           </li>
         </ul>
       </div>
@@ -111,7 +110,7 @@ interface AutosavePatchResponse {
             [formField]="profileForm.displayName"
           />
           <ngx-form-field-hint>
-            Saved automatically 500ms after you stop typing.
+            Valid changes save automatically 500ms after you stop typing.
           </ngx-form-field-hint>
         </ngx-form-field-wrapper>
 
@@ -235,6 +234,17 @@ export class AutosaveComponent {
   });
 
   /**
+   * The patch actually included in the most recently issued PATCH — a plain
+   * field, not a signal, written synchronously inside the `httpResource`
+   * request builder below. It can never drift from what was truly sent,
+   * unlike re-reading `dirtyValidPatch()` later from an effect (which could
+   * already reflect a newer edit by the time that effect runs). Read back in
+   * `#reconcileAfterSave()` to decide which fields a resolved save may mark
+   * pristine.
+   */
+  #lastRequestedPatch: Partial<AutosaveProfileModel> | undefined;
+
+  /**
    * PATCHes `dirtyValidPatch()` whenever it holds a value. Returning
    * `undefined` from the request function pauses `httpResource` — there is
    * no request while nothing dirty+valid is waiting to be saved, and no
@@ -242,9 +252,10 @@ export class AutosaveComponent {
    */
   protected readonly saveResource = httpResource<AutosavePatchResponse>(() => {
     const patch = this.dirtyValidPatch();
-    return patch
-      ? { url: AUTOSAVE_ENDPOINT, method: 'PATCH', body: patch }
-      : undefined;
+    if (!patch) return undefined;
+
+    this.#lastRequestedPatch = patch;
+    return { url: AUTOSAVE_ENDPOINT, method: 'PATCH', body: patch };
   });
 
   /**
@@ -268,17 +279,37 @@ export class AutosaveComponent {
   });
 
   constructor() {
-    /// Re-baseline on a successful save: `reset(value)` clears dirty/touched
-    /// without changing what the user typed — see the same call in
-    /// server-integration.form.ts. `untracked` keeps the reset's own value
-    /// write from re-triggering this effect.
+    /// Re-baseline on a successful save, but only for fields the save
+    /// actually covered: `httpResource` is last-write-wins for *requests*
+    /// (a new patch cancels an in-flight one), but a field can still change
+    /// again *after* its request was already dispatched and before it
+    /// resolves. Blindly resetting the whole form at that point would mark
+    /// that field pristine even though the server never saw the newer
+    /// value — a lost update. `fieldsSafeToMarkSaved` excludes exactly that
+    /// field, leaving it dirty so the next debounce cycle saves it for real.
+    /// `untracked` keeps each field's own `reset()` from re-triggering this
+    /// effect.
     effect(() => {
       if (this.saveResource.status() === 'resolved') {
         untracked(() => {
-          this.profileForm().reset(this.profileForm().value());
+          this.#reconcileAfterSave();
         });
       }
     });
+  }
+
+  #reconcileAfterSave(): void {
+    const safeFields = fieldsSafeToMarkSaved(
+      this.#lastRequestedPatch,
+      this.profileForm().value(),
+    );
+
+    for (const key of safeFields) {
+      // No-argument `reset()` clears touched/dirty for this field alone,
+      // without touching its value or any sibling field — see
+      // `FieldState.reset()` in `@angular/forms/signals`.
+      this.profileForm[key]().reset();
+    }
   }
 
   /** Re-issues the last PATCH after a failure — the fields stay dirty until it succeeds. */

--- a/apps/demo/src/app/05-advanced/autosave/autosave.model.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.model.ts
@@ -1,0 +1,18 @@
+/**
+ * Autosave Model
+ *
+ * Model for the autosave example: a small profile form that persists valid,
+ * dirty changes to the server as the user types — no submit button.
+ */
+
+export interface AutosaveProfileModel {
+  displayName: string;
+  bio: string;
+}
+
+export function createInitialAutosaveProfile(): AutosaveProfileModel {
+  return {
+    displayName: 'Ada Lovelace',
+    bio: 'Mathematician and writer, first to publish an algorithm for a computing machine.',
+  };
+}

--- a/apps/demo/src/app/05-advanced/autosave/autosave.page.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.page.ts
@@ -1,0 +1,142 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  type ResolvedErrorDisplayStrategy,
+  type FormFieldAppearance,
+} from '@ngx-signal-forms/toolkit';
+import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
+import {
+  AppearanceToggleComponent,
+  DisplayControlsCardComponent,
+  DisplayControlsSectionComponent,
+  ExampleCardsComponent,
+  NgxPageControlsDirective,
+  OrientationToggleComponent,
+  PageHeaderComponent,
+  SplitLayoutComponent,
+} from '../../ui';
+import { APPEARANCE_LABELS } from '../../ui/appearance-toggle';
+import {
+  createOrientationSelection,
+  getOrientationLabel,
+} from '../../ui/orientation-toggle';
+import {
+  ERROR_DISPLAY_MODE_LABELS,
+  ErrorDisplayModeSelectorComponent,
+} from '../../ui/error-display-mode-selector/error-display-mode-selector';
+import { AUTOSAVE_CONTENT } from './autosave.content';
+import { AutosaveComponent } from './autosave.form';
+
+@Component({
+  selector: 'ngx-autosave-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+  `,
+  imports: [
+    AutosaveComponent,
+    ExampleCardsComponent,
+    ErrorDisplayModeSelectorComponent,
+    AppearanceToggleComponent,
+    OrientationToggleComponent,
+    DisplayControlsCardComponent,
+    DisplayControlsSectionComponent,
+    NgxPageControlsDirective,
+    PageHeaderComponent,
+    SplitLayoutComponent,
+    NgxSignalFormDebugger,
+  ],
+  template: `
+    <ng-template ngxPageControls>
+      <ngx-display-controls-card
+        title="Autosave controls"
+        description="Compare error timing and wrapper treatments while watching debounced, field-level saves."
+        [chips]="currentControlChips()"
+        layout="split"
+      >
+        <ngx-error-display-mode-selector
+          [(selectedMode)]="errorDisplayMode"
+          [embedded]="true"
+          display-controls-primary
+          class="block min-w-0"
+        />
+        <ngx-display-controls-section
+          title="🎨 Wrapper appearance"
+          description="Confirm the save-status regions stay legible across wrapper treatments."
+        >
+          <ngx-appearance-toggle [(value)]="selectedAppearance" />
+        </ngx-display-controls-section>
+        <ngx-display-controls-section
+          title="↔️ Label orientation"
+          description="Check the same states with horizontal label columns. Outline remains vertical only."
+        >
+          <ngx-orientation-toggle
+            [(value)]="selectedOrientation"
+            [appearance]="selectedAppearance()"
+          />
+        </ngx-display-controls-section>
+      </ngx-display-controls-card>
+    </ng-template>
+
+    <ngx-page-header
+      title="Autosave"
+      subtitle="Debounced field-level save with accessible save status — no submit button"
+    />
+
+    <ngx-example-cards
+      [demonstrated]="content.demonstrated"
+      [learning]="content.learning"
+    >
+      <ngx-split-layout>
+        <ngx-autosave
+          [errorDisplayMode]="errorDisplayMode()"
+          [appearance]="selectedAppearance()"
+          [orientation]="selectedOrientation()"
+          left
+        />
+
+        @if (formRef(); as form) {
+          <div right>
+            <ngx-signal-form-debugger [formTree]="form.profileForm" />
+          </div>
+        }
+      </ngx-split-layout>
+    </ngx-example-cards>
+  `,
+})
+export class AutosavePage {
+  protected readonly errorDisplayMode =
+    signal<ResolvedErrorDisplayStrategy>('on-touch');
+  protected readonly selectedAppearance =
+    signal<FormFieldAppearance>('outline');
+  protected readonly selectedOrientation = createOrientationSelection(
+    this.selectedAppearance,
+  );
+
+  protected readonly currentControlChips = computed(() => [
+    {
+      label: 'Mode',
+      value: ERROR_DISPLAY_MODE_LABELS[this.errorDisplayMode()],
+    },
+    {
+      label: 'Appearance',
+      value: APPEARANCE_LABELS[this.selectedAppearance()],
+    },
+    {
+      label: 'Orientation',
+      value: getOrientationLabel(this.selectedOrientation()),
+    },
+  ]);
+  protected readonly content = AUTOSAVE_CONTENT;
+  protected readonly formRef = viewChild(AutosaveComponent);
+}

--- a/apps/demo/src/app/05-advanced/autosave/autosave.save-reconciliation.spec.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.save-reconciliation.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AutosaveProfileModel } from './autosave.model';
+import { fieldsSafeToMarkSaved } from './autosave.save-reconciliation';
+
+describe('fieldsSafeToMarkSaved', () => {
+  it('marks nothing saved when there is no snapshot (nothing was ever sent)', () => {
+    const current: AutosaveProfileModel = { displayName: 'Ada', bio: 'Bio' };
+
+    expect(fieldsSafeToMarkSaved(undefined, current)).toEqual([]);
+  });
+
+  it('marks a field saved when its current value still matches what was sent', () => {
+    const current: AutosaveProfileModel = { displayName: 'Ada', bio: 'Bio' };
+
+    expect(fieldsSafeToMarkSaved({ displayName: 'Ada' }, current)).toEqual([
+      'displayName',
+    ]);
+  });
+
+  it('does not mark a field saved when it changed again while the request was in flight (lost-update guard)', () => {
+    // Snapshot reflects what was actually PATCHed; the user kept typing
+    // after the request was already sent, so the current value has moved on.
+    const current: AutosaveProfileModel = {
+      displayName: 'Ada Lovelace',
+      bio: 'Bio',
+    };
+
+    expect(fieldsSafeToMarkSaved({ displayName: 'Ada' }, current)).toEqual([]);
+  });
+
+  it('only reports fields that were actually part of the resolved request', () => {
+    // bio changed concurrently and was never included in this snapshot/PATCH.
+    const current: AutosaveProfileModel = {
+      displayName: 'Ada',
+      bio: 'Updated bio',
+    };
+
+    expect(fieldsSafeToMarkSaved({ displayName: 'Ada' }, current)).toEqual([
+      'displayName',
+    ]);
+  });
+
+  it('marks multiple fields saved when both still match the snapshot', () => {
+    const current: AutosaveProfileModel = { displayName: 'Ada', bio: 'Bio' };
+
+    expect(
+      fieldsSafeToMarkSaved({ displayName: 'Ada', bio: 'Bio' }, current),
+    ).toEqual(['displayName', 'bio']);
+  });
+});

--- a/apps/demo/src/app/05-advanced/autosave/autosave.save-reconciliation.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.save-reconciliation.ts
@@ -1,0 +1,43 @@
+import type { AutosaveProfileModel } from './autosave.model';
+
+/**
+ * Decides which fields a just-resolved save may mark pristine.
+ *
+ * `httpResource` is last-write-wins: a new PATCH cancels an in-flight one, so
+ * two nearly-simultaneous saves can never both land. What can still happen
+ * without this check is a **lost update**: if the user edits `bio` while a
+ * `displayName`-only PATCH is in flight, a naive "reset the whole form on
+ * success" would mark `bio` pristine too — even though the value the server
+ * just confirmed never included that edit. The next keystroke wouldn't
+ * re-trigger a save for it, because nothing would look dirty anymore.
+ *
+ * A field is safe to mark saved only when both hold:
+ * 1. it was actually part of the resolved request (`snapshot`, captured at
+ *    the moment the request was built — see `saveResource` in
+ *    `autosave.form.ts`), and
+ * 2. its value right now still equals what was sent — i.e. no further edit
+ *    raced the in-flight request.
+ *
+ * A field that fails either check is left dirty, so the next debounce cycle
+ * autosaves it for real instead of silently dropping it.
+ */
+export function fieldsSafeToMarkSaved(
+  snapshot: Partial<AutosaveProfileModel> | undefined,
+  current: AutosaveProfileModel,
+): (keyof AutosaveProfileModel)[] {
+  if (!snapshot) return [];
+
+  const safe: (keyof AutosaveProfileModel)[] = [];
+
+  if (
+    snapshot.displayName !== undefined &&
+    snapshot.displayName === current.displayName
+  ) {
+    safe.push('displayName');
+  }
+  if (snapshot.bio !== undefined && snapshot.bio === current.bio) {
+    safe.push('bio');
+  }
+
+  return safe;
+}

--- a/apps/demo/src/app/05-advanced/autosave/autosave.validations.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.validations.ts
@@ -1,0 +1,30 @@
+import {
+  debounce,
+  maxLength,
+  minLength,
+  required,
+  schema,
+} from '@angular/forms/signals';
+import type { AutosaveProfileModel } from './autosave.model';
+
+/**
+ * `debounce(path, 500)` — the native Angular 22 schema rule — delays writing
+ * a UI edit into the field's own value signal until 500ms after the user
+ * stops typing that field. Everything downstream (`dirty()`, `valid()`, and
+ * the autosave `httpResource` request built from them) only ever sees the
+ * settled value, so no hand-rolled RxJS `debounceTime` is needed to get a
+ * debounced autosave.
+ *
+ * Each field debounces independently — typing in `bio` does not reset or
+ * extend `displayName`'s timer, and vice versa.
+ */
+export const autosaveProfileSchema = schema<AutosaveProfileModel>((path) => {
+  debounce(path.displayName, 500);
+  required(path.displayName, { message: 'Display name is required' });
+  minLength(path.displayName, 2, {
+    message: 'Display name must be at least 2 characters',
+  });
+
+  debounce(path.bio, 500);
+  maxLength(path.bio, 280, { message: 'Bio must be 280 characters or fewer' });
+});

--- a/apps/demo/src/app/05-advanced/server-integration/README.md
+++ b/apps/demo/src/app/05-advanced/server-integration/README.md
@@ -105,3 +105,4 @@ Try step 5 in "Try This" below to see this asymmetry directly.
 - [Submission Patterns](../submission-patterns/README.md) — declarative submission and the GOV.UK-style error summary; contrast its checkbox-triggered server error with this demo's real `TreeValidationResult` mapping.
 - [Field State Patterns](../field-state-patterns/README.md) — the `reset()` semantics used here also drive its Reset button.
 - [Async Validation](../async-validation/README.md) — the one demo in this section that _does_ route through MSW/real HTTP, for contrast with this demo's in-memory fake API.
+- [Autosave](../autosave/README.md) — reuses this demo's `reset(value)`-after-success pattern, but with no submit button and a real MSW-backed `httpResource` PATCH.

--- a/apps/demo/src/app/05-advanced/store-binding/README.md
+++ b/apps/demo/src/app/05-advanced/store-binding/README.md
@@ -68,3 +68,5 @@ Demo only. The `@ngx-signal-forms/toolkit` source is **not** touched, and the
 
 - [Advanced Wizard](../advanced-wizard/README.md) — the contrasting draft/commit
   buffer pattern.
+- [Autosave](../autosave/README.md) — the contrasting "persist valid, dirty
+  changes as the user types" pattern, with no submit button.

--- a/apps/demo/src/app/app.routes.ts
+++ b/apps/demo/src/app/app.routes.ts
@@ -244,6 +244,14 @@ export const appRoutes: Routes = [
           ),
         title: getRouteTitle('/advanced-scenarios/server-integration'),
       },
+      {
+        path: 'autosave',
+        loadComponent: () =>
+          import('./05-advanced/autosave/autosave.page').then(
+            (m) => m.AutosavePage,
+          ),
+        title: getRouteTitle('/advanced-scenarios/autosave'),
+      },
     ],
   },
 

--- a/apps/demo/src/mocks/handlers.ts
+++ b/apps/demo/src/mocks/handlers.ts
@@ -1,5 +1,9 @@
 import { delay, http, HttpResponse } from 'msw';
 
+import {
+  AUTOSAVE_ENDPOINT,
+  AUTOSAVE_FAILURE_MARKER,
+} from '../app/05-advanced/autosave/autosave.api';
 import type {
   Destination,
   Traveler,
@@ -74,14 +78,15 @@ interface AutosaveProfilePatch {
 }
 
 export const autosaveHandlers = [
-  http.patch('/api/autosave/profile', async ({ request }) => {
+  http.patch(AUTOSAVE_ENDPOINT, async ({ request }) => {
     await delay(400);
 
     const patch = (await request.json()) as AutosaveProfilePatch;
 
-    // Demo-only failure trigger: a bio containing FAIL_SAVE always rejects,
-    // so the failure + retry path is reachable without waiting on a real error.
-    if (patch.bio?.includes('FAIL_SAVE')) {
+    // Demo-only failure trigger: a bio containing the failure marker always
+    // rejects, so the failure + retry path is reachable without waiting on a
+    // real error.
+    if (patch.bio?.includes(AUTOSAVE_FAILURE_MARKER)) {
       return HttpResponse.json(
         { error: 'Could not persist this change.' },
         { status: 500 },

--- a/apps/demo/src/mocks/handlers.ts
+++ b/apps/demo/src/mocks/handlers.ts
@@ -65,6 +65,34 @@ export const asyncValidationHandlers = [
 ];
 
 // ══════════════════════════════════════════════════════════════════════════════
+// AUTOSAVE DEMO HANDLERS
+// ══════════════════════════════════════════════════════════════════════════════
+
+interface AutosaveProfilePatch {
+  displayName?: string;
+  bio?: string;
+}
+
+export const autosaveHandlers = [
+  http.patch('/api/autosave/profile', async ({ request }) => {
+    await delay(400);
+
+    const patch = (await request.json()) as AutosaveProfilePatch;
+
+    // Demo-only failure trigger: a bio containing FAIL_SAVE always rejects,
+    // so the failure + retry path is reachable without waiting on a real error.
+    if (patch.bio?.includes('FAIL_SAVE')) {
+      return HttpResponse.json(
+        { error: 'Could not persist this change.' },
+        { status: 500 },
+      );
+    }
+
+    return HttpResponse.json({ savedAt: new Date().toISOString() });
+  }),
+];
+
+// ══════════════════════════════════════════════════════════════════════════════
 // WIZARD API HANDLERS
 // ══════════════════════════════════════════════════════════════════════════════
 
@@ -228,4 +256,8 @@ export const wizardHandlers = [
 // EXPORT ALL HANDLERS
 // ══════════════════════════════════════════════════════════════════════════════
 
-export const handlers = [...asyncValidationHandlers, ...wizardHandlers];
+export const handlers = [
+  ...asyncValidationHandlers,
+  ...autosaveHandlers,
+  ...wizardHandlers,
+];

--- a/packages/demo-shared/src/lib/routes.metadata.ts
+++ b/packages/demo-shared/src/lib/routes.metadata.ts
@@ -20,6 +20,7 @@ export const DEMO_PATHS = {
   crossFieldValidation: '/advanced-scenarios/cross-field-validation',
   storeBinding: '/advanced-scenarios/store-binding',
   serverIntegration: '/advanced-scenarios/server-integration',
+  autosave: '/advanced-scenarios/autosave',
 } as const;
 
 export const DEMO_CATEGORIES = [
@@ -165,6 +166,11 @@ export const DEMO_CATEGORIES = [
       {
         path: '/advanced-scenarios/server-integration',
         label: 'Server Integration',
+        hasControls: true,
+      },
+      {
+        path: '/advanced-scenarios/autosave',
+        label: 'Autosave',
         hasControls: true,
       },
     ],


### PR DESCRIPTION
Adds the autosave demo (`advanced-scenarios/autosave`): debounced field-level saving with an accessible save status, filling the gap the 05-advanced README row promised.

What it shows, per the issue's acceptance list: Angular's native `debounce(path, 500)` schema rule (no RxJS), a computed patch that includes a field only when it is `dirty() && valid()`, the save itself through `httpResource` against a new MSW handler (`PATCH /api/autosave/profile`, with a `FAIL_SAVE` marker driving the failure path), `reset(value)` re-baselining on success (same pattern as server-integration's post-submit reset), an idle/saving/saved/failed status with retry, and a README that contrasts the approach with server-integration, advanced-wizard, and store-binding.

The save status announces through two always-present live regions — `role="status"` (polite) for saving/saved, `role="alert"` (assertive) for failure — with only inner content toggling, the same fixed-role pattern `NgxFormFieldNotification` documents for the NVDA/Chrome first-announcement bug. A toolkit-level save-status primitive is deliberately not invented here; that's issue #267, marked with a `TODO(#267)`.

One knowing correction of the issue text: it says to reuse MSW "like server-integration does", but server-integration deliberately uses an in-memory fake with no MSW or HttpClient — and `httpResource` (which the same criterion mandates) needs a real request. The demo therefore adds a genuine handler to the `handlers.ts` file the issue points at. `extractValue()` from the compat entry point was evaluated per the issue comment and not adopted; the README documents why.

Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced Scenarios autosave demo for saving profile fields as users type.
  * Added independent debouncing, validation, dirty-field detection, and accessible save-status updates.
  * Added retry and reset flows, including simulated save failures for demonstration.
  * Added controls for error display, field appearance, and label orientation.
  * Added navigation, related links, and comprehensive usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->