### PR TITLE
docs(testing): form-component unit-testing guide + runnable example spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ screen-reader testing) before claiming conformance.
 **Guides**
 
 - [Use-case FAQ](./docs/FAQ.md) — "how do I build X?" answers linking the right API, doc, and demo
+- [Unit-testing a form component](./docs/TESTING.md) — TestBed/Vitest setup, native-event driving, and asserting rendered errors/ARIA, with a runnable example spec
 - [Best practices](./docs/BEST_PRACTICES.md) — the five practices, with do/don't examples and a review checklist
 - [Angular vs toolkit](./docs/ANGULAR_VS_TOOLKIT.md) — what the toolkit adds, with a before/after example
 - [Validation strategies](./docs/VALIDATION_STRATEGY.md) — when to use Angular validators, Zod, or Vest

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts
@@ -1,0 +1,142 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
+import { render, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { YourFirstFormComponent } from './your-first-form.form';
+
+/**
+ * Runnable example for `docs/TESTING.md`.
+ *
+ * This is what a *consumer* writes to unit-test a component built with
+ * `form()` plus the toolkit's wrapper-free `NgxFormFieldError`. It imports
+ * only from the published entry points (`@ngx-signal-forms/toolkit`,
+ * `@testing-library/angular`) and drives the DOM through native events —
+ * typing, tabbing, clicking — never by writing to the form's signals
+ * directly, because that is what exercises the touched/dirty/submitted
+ * path a real user triggers.
+ *
+ * See `docs/TESTING.md` for the walkthrough this spec backs.
+ */
+describe('YourFirstFormComponent (unit-testing guide example)', () => {
+  async function setup() {
+    return render(YourFirstFormComponent, {
+      providers: [
+        provideZonelessChangeDetection(),
+        // Matches apps/demo/src/main.ts: 'on-touch' errors become visible
+        // once a field is blurred, not on every keystroke.
+        provideNgxSignalFormsConfig({
+          defaultErrorStrategy: 'on-touch',
+          autoAria: true,
+        }),
+      ],
+    });
+  }
+
+  it('shows no error before the field is touched', async () => {
+    await setup();
+
+    const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+
+    // Blocking-error live region stays mounted (WCAG 4.1.3) but empty, so
+    // assert on the visible text rather than the container's presence.
+    expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
+    expect(nameInput.getAttribute('aria-invalid')).not.toBe('true');
+  });
+
+  it('reveals the rendered error and wires aria-invalid/aria-describedby after a native blur', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+
+    // Drive the control the way a real user does: focus in, tab out. This
+    // is what flips the field's `touched` signal — writing `model.set(...)`
+    // directly would change the value but never touch `touched`, so the
+    // 'on-touch' strategy would never reveal the error.
+    await user.click(nameInput);
+    await user.tab();
+
+    // Flushes zoneless change detection + effects so the assertions below
+    // see settled state rather than racing the write.
+    const errorText = await screen.findByText(/name is required/i);
+    expect(errorText).toBeInTheDocument();
+
+    // Stable id/attribute contract documented in docs/FAQ.md §"How do I
+    // unit-test a form component…": error containers use
+    // `{fieldName}-error`, the control carries aria-invalid="true" and an
+    // aria-describedby that chains to that id.
+    await waitFor(() => {
+      expect(nameInput.getAttribute('aria-invalid')).toBe('true');
+    });
+    expect(nameInput.getAttribute('aria-describedby')).toBe(
+      'contact-name-error',
+    );
+
+    // The message renders inside the toolkit's role="alert" live region.
+    const errorContainer = document.querySelector('#contact-name-error');
+    expect(errorContainer).not.toBeNull();
+    expect(errorContainer).toHaveAttribute('role', 'alert');
+    expect(errorContainer).toContainElement(errorText);
+  });
+
+  it('clears the error and aria-invalid once the field becomes valid', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+
+    await user.click(nameInput);
+    await user.tab();
+    await screen.findByText(/name is required/i);
+
+    await user.type(nameInput, 'Ada Lovelace');
+
+    await waitFor(() => {
+      expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(nameInput.getAttribute('aria-invalid')).not.toBe('true');
+    });
+  });
+
+  it('marks every field touched and shows all errors on submit', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    // Submitting an untouched, empty form must reveal every field's error
+    // at once, matching the toolkit's `createOnInvalidHandler()` wiring.
+    const submitButton = screen.getByRole('button', { name: /send message/i });
+    await user.click(submitButton);
+
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+    expect(await screen.findByText(/email is required/i)).toBeInTheDocument();
+    expect(await screen.findByText(/message is required/i)).toBeInTheDocument();
+  });
+
+  it('starts the declarative submission action once every field is valid', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+    const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+    const messageInput = screen.getByLabelText(/message/i) as HTMLInputElement;
+
+    await user.type(nameInput, 'Ada Lovelace');
+    await user.type(emailInput, 'ada@example.com');
+    await user.type(messageInput, 'Hello from a unit test!');
+
+    const submitButton = screen.getByRole('button', { name: /send message/i });
+    await user.click(submitButton);
+
+    // A valid submit must not surface any field error…
+    expect(screen.queryByText(/is required/i)).not.toBeInTheDocument();
+
+    // …and the form's submission.action (an async fn with a real delay) must
+    // have actually started — the button's pending label is the observable
+    // proof, without this spec waiting out the delay itself.
+    expect(
+      await screen.findByRole('button', { name: /sending/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts
@@ -69,9 +69,12 @@ describe('YourFirstFormComponent (unit-testing guide example)', () => {
     await waitFor(() => {
       expect(nameInput.getAttribute('aria-invalid')).toBe('true');
     });
-    expect(nameInput.getAttribute('aria-describedby')).toBe(
-      'contact-name-error',
-    );
+    // aria-describedby is a space-separated id list — the toolkit may
+    // compose it from preserved ids, hints, and the error/warning ids
+    // together, so assert membership rather than an exact string match.
+    const describedBy = nameInput.getAttribute('aria-describedby');
+    expect(describedBy).not.toBeNull();
+    expect(describedBy?.split(/\s+/)).toContain('contact-name-error');
 
     // The message renders inside the toolkit's role="alert" live region.
     const errorContainer = document.querySelector('#contact-name-error');

--- a/apps/demo/test-setup.ts
+++ b/apps/demo/test-setup.ts
@@ -2,5 +2,6 @@ import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-snapshots';
 import '@analogjs/vitest-angular/setup-serializers';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import '@testing-library/jest-dom/vitest';
 
 setupTestBed();

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -520,35 +520,40 @@ the summary.
 
 ### How do I unit-test a form component (set value, touch, assert rendered error + `aria-invalid`) in Vitest/TestBed?
 
-Render the component with TestBed, drive state through the model signal and the field's own methods,
-then assert on the toolkit's documented, stable id/attribute contract: error containers use
+Render the component and drive it through native DOM events — type into the control, then tab or
+click away — rather than writing the model signal or calling a field's `markAsTouched()` directly.
+A direct signal write changes the value but never marks the field touched, so an `'on-touch'` (the
+toolkit default) or `'on-submit'` strategy would never reveal the error you're asserting on. Then
+assert on the toolkit's documented, stable id/attribute contract: error containers use
 `{fieldName}-error`, and the bound input carries `aria-invalid="true"` and an `aria-describedby`
 that chains to that id. Blocking errors render inside a `role="alert"` element.
 
 ```ts
-const fixture = TestBed.createComponent(LoginForm);
-const cmp = fixture.componentInstance;
+const user = userEvent.setup();
+const { container } = await render(LoginForm);
 
-cmp.model.update((m) => ({ ...m, email: 'not-an-email' })); // set value
-cmp.form.email().markAsTouched(); // trigger 'on-touch' visibility
-fixture.detectChanges();
-await fixture.whenStable();
+const emailInput = screen.getByLabelText(/email/i) as HTMLInputElement;
+await user.type(emailInput, 'not-an-email'); // set value
+await user.tab(); // blur → marks the field touched, triggering 'on-touch' visibility
 
-const input = fixture.nativeElement.querySelector('#email');
-expect(input.getAttribute('aria-invalid')).toBe('true');
-expect(fixture.nativeElement.querySelector('#email-error')).toHaveTextContent(
-  /valid email/i,
-);
+expect(await screen.findByText(/valid email/i)).toBeInTheDocument();
+await waitFor(() => {
+  expect(emailInput.getAttribute('aria-invalid')).toBe('true');
+});
+expect(container.querySelector('#email-error')).not.toBeNull();
 ```
 
-To assert a submit-time path, call Angular's `submit(cmp.form, { action })` (it marks every field
-touched). For accessibility, the toolkit ships `expectNoA11yViolations()` from
+To assert a submit-time path, click the submit button through `userEvent` — Angular's own
+`submit()`, invoked internally by the form's `submission` config, marks every field touched. For
+accessibility, the toolkit ships `expectNoA11yViolations()` from
 `@ngx-signal-forms/toolkit/testing` (axe-core WCAG 2.2 AA) for use in a Vitest browser-mode spec
-after rendering a fixture. Honest gap: no dedicated component-testing guide or example spec exists
-yet — the mechanics above are assembled from the id/ARIA contract plus Angular's own testing
-conventions.
+after rendering a fixture.
 
-**See:** [packages/toolkit/README.md](../packages/toolkit/README.md) ·
+**See:** [docs/TESTING.md](./TESTING.md) — the full walkthrough, including driving controls
+through native events with `@testing-library/angular` and flushing effects before asserting ·
+[apps/demo/.../your-first-form.spec.ts](../apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts) —
+the runnable example this FAQ entry and the guide are both backed by ·
+[packages/toolkit/README.md](../packages/toolkit/README.md) ·
 [packages/toolkit/headless/README.md](../packages/toolkit/headless/README.md) ·
 [docs/decisions/0004-wcag22-testing-strategy.md](./decisions/0004-wcag22-testing-strategy.md)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,178 @@
+# Unit-testing a form component
+
+This guide shows how to unit-test a component built with Angular Signal
+Forms' `form()` and the toolkit's error-rendering components — set a field
+value, mark it touched, and assert the rendered error text, `aria-invalid`,
+`aria-describedby`, and live-region markup. It also covers triggering submit
+and asserting `on-submit`-strategy behavior.
+
+The condensed version of this pattern lives in the [use-case FAQ, "How do I
+unit-test a form component…"](./FAQ.md#how-do-i-unit-test-a-form-component-set-value-touch-assert-rendered-error--aria-invalid-in-vitesttestbed).
+This guide is the full walkthrough that answer links to.
+
+## When to read this guide
+
+Read this if your project uses Vitest (this repo's test runner) and you want
+to unit-test a component that renders a Signal Forms field — asserting that
+an invalid field shows the right error message, carries the right ARIA
+attributes, and that submitting the form behaves correctly.
+
+This guide does not cover:
+
+- **Accessibility conformance scans.** For an automated WCAG 2.2 AA audit of
+  a rendered fixture, use `expectNoA11yViolations()` from
+  [`@ngx-signal-forms/toolkit/testing`](../packages/toolkit/testing/README.md)
+  in a Vitest **browser-mode** spec (`*.a11y.browser.spec.ts` in this repo).
+  This guide's specs run in jsdom instead — assertions target specific
+  attributes and text, not a full accessibility tree scan. See
+  [ADR-0004](./decisions/0004-wcag22-testing-strategy.md) for why the two run
+  in different modes.
+- **End-to-end tests.** Playwright specs (`*.e2e.spec.ts`) drive a real
+  browser and are out of scope here.
+
+## The runnable example
+
+The example below is not inlined from a copy — it is the real spec, kept
+runnable so it cannot drift from what the guide describes:
+
+**[`apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts`](../apps/demo/src/app/01-getting-started/your-first-form/your-first-form.spec.ts)**
+
+It tests
+[`YourFirstFormComponent`](../apps/demo/src/app/01-getting-started/your-first-form/your-first-form.form.ts),
+the toolkit's own "hello world" contact form, and runs as part of the demo
+app's normal test target:
+
+```bash
+pnpm nx test demo
+```
+
+## Setup: TestBed + a component using `form()` and the wrapper
+
+Render the component the same way `@testing-library/angular`'s `render()`
+does under the hood — through `TestBed` — and provide the same toolkit
+configuration your app bootstraps with (`main.ts`), so strategy defaults
+match:
+
+```typescript
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
+import { render, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+async function setup() {
+  return render(YourFirstFormComponent, {
+    providers: [
+      provideZonelessChangeDetection(),
+      provideNgxSignalFormsConfig({
+        defaultErrorStrategy: 'on-touch',
+        autoAria: true,
+      }),
+    ],
+  });
+}
+```
+
+`@testing-library/angular`, `@testing-library/dom`, and
+`@testing-library/user-event` are already workspace dependencies (see
+`package.json`'s `testing-library` catalog group) — no extra install is
+needed inside this repo. In your own project, install them as dev
+dependencies alongside Vitest.
+
+## Drive controls through native events, not signal writes
+
+Write to the field through the DOM — click, type, tab — not by writing
+`model.set(...)` or calling the field's signals directly. A direct signal
+write changes the value but never marks the field `touched`, so an
+`'on-touch'` (the toolkit default) or `'on-submit'` strategy would never
+reveal the error your test is trying to observe:
+
+```typescript
+const user = userEvent.setup();
+await setup();
+
+const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+
+// Focus in, then tab out — this is what flips the field's `touched` signal.
+await user.click(nameInput);
+await user.tab();
+```
+
+## Flush effects before asserting
+
+The toolkit's ARIA attributes and error visibility are written from
+`afterEveryRender` and `effect()` callbacks, not synchronously on the event
+that triggered them. Under zoneless change detection (the default in this
+repo's demos), a `userEvent` interaction schedules that work but does not
+wait for it. Use `screen.findByText(...)` (which polls) for text, and wrap
+attribute reads in `waitFor(...)`:
+
+```typescript
+const errorText = await screen.findByText(/name is required/i);
+expect(errorText).toBeInTheDocument();
+
+await waitFor(() => {
+  expect(nameInput.getAttribute('aria-invalid')).toBe('true');
+});
+```
+
+## Asserting the id/ARIA contract
+
+The toolkit's error id, `aria-invalid`, and `aria-describedby` wiring is a
+stable, documented contract:
+
+- Error containers use the id `{fieldName}-error` (warnings use
+  `{fieldName}-warning`).
+- The bound control carries `aria-invalid="true"` and an `aria-describedby`
+  that includes that id, once the error should be visible under the active
+  strategy.
+- Blocking errors render inside a `role="alert"` element (see
+  [`NgxFormFieldError`](../packages/toolkit/assistive/form-field-error.ts)) —
+  an implicit assertive live region, so no error is missed even on its first
+  appearance.
+
+```typescript
+expect(nameInput.getAttribute('aria-describedby')).toBe('contact-name-error');
+
+const errorContainer = document.querySelector('#contact-name-error');
+expect(errorContainer).toHaveAttribute('role', 'alert');
+expect(errorContainer).toContainElement(errorText);
+```
+
+`{fieldName}` is whichever field name resolves for the control — the
+element's own `id` when using `NgxFormFieldError` directly (as in the
+example spec), or the wrapper's resolved field name when using
+`ngx-form-field-wrapper`. See
+[`docs/CUSTOM_WRAPPERS.md`](./CUSTOM_WRAPPERS.md) if you're testing a custom
+wrapper instead of the built-in one.
+
+## Triggering submit and asserting `on-submit`-strategy behavior
+
+Click the submit button through `userEvent`, the same as any other control —
+Angular's own `submit()` (invoked internally by the form's `submission`
+config) marks every field touched, which is what reveals every field's
+error at once under any of the toolkit's strategies:
+
+```typescript
+const submitButton = screen.getByRole('button', { name: /send message/i });
+await user.click(submitButton);
+
+expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+expect(await screen.findByText(/email is required/i)).toBeInTheDocument();
+```
+
+To assert a form's declarative `submission.action` actually ran (rather than
+being blocked by validation), fill every field with valid data first, submit,
+and assert on the resulting state change. A pending label the component
+renders while its action is in flight (`contactForm().submitting()`, in the
+example) is a reliable, fast signal that the action started — prefer it over
+awaiting the action's own delay in the test, which only makes the spec slower
+without proving anything more. The example spec's last test does this against
+`YourFirstFormComponent`'s async `submission.action`.
+
+## Related documentation
+
+- [Use-case FAQ — unit-testing a form component](./FAQ.md#how-do-i-unit-test-a-form-component-set-value-touch-assert-rendered-error--aria-invalid-in-vitesttestbed) — the condensed version of this guide
+- [`packages/toolkit/testing/README.md`](../packages/toolkit/testing/README.md) — `expectNoA11yViolations()` for WCAG 2.2 AA conformance scans (browser-mode specs)
+- [ADR-0004](./decisions/0004-wcag22-testing-strategy.md) — why conformance scans run in browser mode and everything else in jsdom
+- [`docs/BEST_PRACTICES.md`](./BEST_PRACTICES.md) — the toolkit's five best practices
+- [`docs/CUSTOM_WRAPPERS.md`](./CUSTOM_WRAPPERS.md) — testing considerations when the id/ARIA contract is produced by a custom wrapper instead of the built-in one

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -124,14 +124,18 @@ stable, documented contract:
   `{fieldName}-warning`).
 - The bound control carries `aria-invalid="true"` and an `aria-describedby`
   that includes that id, once the error should be visible under the active
-  strategy.
+  strategy. `aria-describedby` is a space-separated id list — the toolkit may
+  compose it from preserved ids, hints, and the error/warning ids together —
+  so assert membership rather than an exact string match.
 - Blocking errors render inside a `role="alert"` element (see
   [`NgxFormFieldError`](../packages/toolkit/assistive/form-field-error.ts)) —
   an implicit assertive live region, so no error is missed even on its first
   appearance.
 
 ```typescript
-expect(nameInput.getAttribute('aria-describedby')).toBe('contact-name-error');
+const describedBy = nameInput.getAttribute('aria-describedby');
+expect(describedBy).not.toBeNull();
+expect(describedBy?.split(/\s+/)).toContain('contact-name-error');
 
 const errorContainer = document.querySelector('#contact-name-error');
 expect(errorContainer).toHaveAttribute('role', 'alert');

--- a/packages/toolkit/testing/README.md
+++ b/packages/toolkit/testing/README.md
@@ -82,6 +82,7 @@ root README for what the toolkit's own automation does and does not cover.
 
 ## Related documentation
 
+- [Unit-testing a form component](../../../docs/TESTING.md) — TestBed/Vitest setup for the rest of a form component's behavior: rendered errors, `aria-invalid`/`aria-describedby`, and submit handling. This entry point covers only the WCAG conformance scan.
 - [Toolkit core](../README.md) — error strategies, ARIA, configuration
 - [Root README — Accessibility](../../../README.md#accessibility) — what the toolkit verifies in CI and what remains your responsibility
 


### PR DESCRIPTION
Adds the form-component unit-testing guide (`docs/TESTING.md`) plus the runnable example it teaches from: a real spec for the getting-started demo form (`your-first-form.spec.ts`, 5 tests), living in `apps/demo`'s existing Vitest target so it runs in CI and cannot drift from the guide.

The guide covers TestBed/Vitest setup, driving fields through the DOM (`userEvent` type/tab/click) rather than direct signal writes — a direct write changes the value but never marks the field touched — flushing effects before asserting, the toolkit's `{fieldName}-error` / `aria-invalid` / `aria-describedby` / `role="alert"` contract (each claim verified against the toolkit source), and asserting `on-submit`-strategy behavior by checking the pending state instead of waiting out real async delays. The FAQ's testing answer now links the guide and its code sample was rewritten to the same DOM-driving pattern so the two docs agree; `packages/toolkit/testing/README.md` links back.

Two incidental notes: the issue's stated blocker ("apps/demo has no vitest target") turned out to be stale — the target exists and runs, so the spec lives there per the issue's intent without new infrastructure. And `apps/demo/test-setup.ts` was missing the `@testing-library/jest-dom/vitest` import every sibling app already has; added, since the new spec's matchers need it.

Fixes #230
Refs #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
