### PR TITLE
fix(vest): untrack a pending run off its settlement, not its raw promise

### DIFF
--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -177,6 +177,90 @@ function createControllableSuite(
   };
 }
 
+/**
+ * A suite that reproduces Vest 6's SUPERSEDED-RESOLVER behaviour.
+ *
+ * Vest tracks one resolver per suite root isolate, so every `run()` replaces
+ * the previous call's resolver: the earlier call's returned thenable then
+ * stays pending forever. Only the suite-wide `ALL_RUNNING_TESTS_FINISHED`
+ * event still reports that the earlier run finished.
+ */
+function createSupersedingSuite(): {
+  readonly suite: VestRunnableSuite<string>;
+  readonly started: readonly string[];
+  /** Finish every in-flight run and fire the suite bus once. */
+  readonly finishAll: () => void;
+} {
+  const started: string[] = [];
+  const listeners = new Set<() => void>();
+  let pendingCount = 0;
+  // The single resolver Vest keeps per suite. A new run overwrites it, which
+  // is what strands the previous run's promise.
+  let resolveLatest: ((result: VestResultLike) => void) | undefined;
+
+  const isPending = (): boolean => pendingCount > 0;
+  const settledResult: VestResultLike = {
+    isPending: () => false,
+    getErrors: noMessages,
+    getWarnings: noMessages,
+  };
+
+  const run = (value: string): FakeRunResult => {
+    started.push(value);
+    pendingCount += 1;
+    let resolveRun: (result: VestResultLike) => void = () => {};
+    const settlement = new Promise<VestResultLike>((resolve) => {
+      resolveRun = resolve;
+    });
+    resolveLatest = resolveRun;
+    return {
+      isPending,
+      getErrors: noMessages,
+      getWarnings: noMessages,
+      // oxlint-disable-next-line unicorn/no-thenable -- see `createControllableSuite`: this fakes Vest's dual sync-result/thenable `run()` return value.
+      then: (onFulfilled, onRejected) =>
+        settlement.then(onFulfilled, onRejected),
+    };
+  };
+
+  return {
+    suite: {
+      run,
+      only: (_field: string | string[]) => ({ run }),
+      subscribe: (
+        _event: 'ALL_RUNNING_TESTS_FINISHED',
+        callback: () => void,
+      ) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+      get: (): VestResultLike => ({
+        isPending,
+        getErrors: noMessages,
+        getWarnings: noMessages,
+      }),
+    },
+    started,
+    finishAll: (): void => {
+      pendingCount = 0;
+      resolveLatest?.(settledResult);
+      resolveLatest = undefined;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+}
+
+/** Drains every pending microtask, including the coordinator's own callbacks. */
+function drainMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 describe('createVestRunCoordinator', () => {
   describe('single execution', () => {
     it('runs the suite once for repeated requests on the same (suite, cacheKey, value, focus) tuple', () => {
@@ -318,14 +402,42 @@ describe('createVestRunCoordinator', () => {
       finish('a');
       // A macrotask boundary drains every pending microtask, including the
       // coordinator's own "this run settled, stop tracking it" callback.
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
+      await drainMicrotasks();
 
       // A settled, so a request from another cache key is uncontested.
       const next = coordinator.request({ suite, cacheKey: {}, value: 'b' });
       expect(next.deferred).toBe(false);
       expect(started).toEqual(['a', 'b']);
+    });
+
+    it('stops tracking an unfocused run a focused run superseded, once the suite settles', async () => {
+      // Regression guard for issue #322. A focused run is never deferred, so
+      // it starts while an unfocused run is still pending on the same suite
+      // and replaces that suite's single resolver -- the unfocused run's own
+      // thenable can then never settle. Untracking off that thenable leaked
+      // the pending marker (and the strongly held cache key and result) for
+      // the suite's lifetime, and pinned the suite as contested for every
+      // other cache key.
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, finishAll } = createSupersedingSuite();
+
+      const unfocused = coordinator.request({
+        suite,
+        cacheKey: {},
+        value: 'a',
+      });
+      expect(unfocused.deferred).toBe(false);
+
+      coordinator.request({ suite, cacheKey: {}, value: 'b', focus: 'email' });
+      expect(started).toEqual(['a', 'b']);
+
+      // The bus event is the ONLY signal that the superseded run finished.
+      finishAll();
+      await drainMicrotasks();
+
+      const next = coordinator.request({ suite, cacheKey: {}, value: 'c' });
+      expect(next.deferred).toBe(false);
+      expect(started).toEqual(['a', 'b', 'c']);
     });
   });
 
@@ -367,16 +479,20 @@ describe('createVestRunCoordinator', () => {
 
       coordinator.request({ suite, cacheKey: {}, value: 'a' });
 
-      // The synchronous callback ran once, and the subscription was torn
-      // down afterwards rather than leaked.
-      expect(invocations).toBe(1);
+      // One request makes more than one subscription (the queue tail waits for
+      // the suite to go idle, and the pending marker waits for the run to
+      // settle), so assert the property that matters rather than a count: each
+      // callback fired, and every subscription was torn down rather than
+      // leaked.
+      const synchronousInvocations = invocations;
+      expect(synchronousInvocations).toBeGreaterThan(0);
       expect(listeners.size).toBe(0);
 
       // A later idle event must therefore reach nobody.
       for (const listener of listeners) {
         listener();
       }
-      expect(invocations).toBe(1);
+      expect(invocations).toBe(synchronousInvocations);
     });
   });
 
@@ -567,14 +683,31 @@ describe('createVestRunCoordinator', () => {
       expect(started).toEqual(['a', 'a']);
     });
 
-    it('drops contention bookkeeping so a reused suite is not stuck "contested"', () => {
+    it('does not un-defer a run that is genuinely still in flight', () => {
+      // Regression guard for issue #322. `invalidate` used to drop the
+      // contention bookkeeping as well, which it cannot do safely: it has no
+      // way to tell a stale marker from a live one, so it un-deferred runs
+      // that were still executing and let the next request overlap them.
       const coordinator = createVestRunCoordinator();
       const { suite, started } = createControllableSuite();
 
-      // A pending run that never settles would otherwise mark the suite
-      // contested forever.
       coordinator.request({ suite, cacheKey: {}, value: 'a' });
       coordinator.invalidate(suite);
+
+      const next = coordinator.request({ suite, cacheKey: {}, value: 'b' });
+      expect(next.deferred).toBe(true);
+      expect(started).toEqual(['a']);
+    });
+
+    it('lets a pending run retire on its own, so a reused suite is not stuck "contested"', async () => {
+      const coordinator = createVestRunCoordinator();
+      const { suite, started, finish } = createControllableSuite();
+
+      coordinator.request({ suite, cacheKey: {}, value: 'a' });
+      coordinator.invalidate(suite);
+
+      finish('a');
+      await drainMicrotasks();
 
       const next = coordinator.request({ suite, cacheKey: {}, value: 'b' });
       expect(next.deferred).toBe(false);

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -241,8 +241,15 @@ export interface VestRunCoordinator {
   ): VestRunHandle<TValue, F>;
 
   /**
-   * Drop everything held for a suite: its run cache, its contention
-   * bookkeeping, and its queue tail.
+   * Drop the run cache held for a suite, so the next identical
+   * `(suite, cache key, value, focus)` tuple executes a fresh run.
+   *
+   * Deliberately leaves the contention bookkeeping and the queue tail alone.
+   * A pending marker is not garbage the caller can identify as stale: the run
+   * behind it can still be in flight, and dropping the marker would let the
+   * next request overlap that run — the exact hazard the bookkeeping exists to
+   * prevent. Markers retire on their own when their run settles (see
+   * `trackPendingVestRun`), and the queue tail deletes itself once it drains.
    */
   invalidate(suite: object): void;
 }
@@ -586,6 +593,35 @@ function awaitVestRunSettlement<TValue, F extends string = string>(
 }
 
 /**
+ * Resolves once a cached run's outcome is observable — the ONE settlement
+ * strategy both the caller-facing handle and the internal pending-marker
+ * bookkeeping use.
+ *
+ * A run that has already started gets {@link awaitVestRunSettlement}, which
+ * races the run's own promise against the suite bus and therefore survives a
+ * superseded resolver. Awaiting the raw promise instead is unsafe: a LATER
+ * `run()` on the same suite — a focused run, for example, which is never
+ * deferred — replaces the resolver, and the earlier promise then stays pending
+ * forever.
+ *
+ * A DEFERRED run (see {@link deferVestRunUntilIdle}) is the one exception. It
+ * has not called `suite.run()` yet, so racing it against the suite-wide
+ * `ALL_RUNNING_TESTS_FINISHED` event would resolve with `suite.get()`'s state
+ * from BEFORE this run started (whatever made the suite idle in the first
+ * place), not this run's own outcome. Its plain `Promise` already resolves
+ * correctly on its own once the deferred run completes, so await it directly.
+ */
+function awaitVestRunOutcome<TValue, F extends string = string>(
+  suite: Pick<VestCoordinatedSuite<TValue, F>, 'subscribe' | 'get'>,
+  runResult: VestResultLike<F> | PromiseLike<VestResultLike<F>>,
+  deferred: boolean,
+): PromiseLike<unknown> {
+  return deferred
+    ? Promise.resolve(runResult)
+    : awaitVestRunSettlement(runResult, suite);
+}
+
+/**
  * Create a {@link VestRunCoordinator} backed by its own caches and queues.
  *
  * Every adapter instance owns exactly one coordinator, so two adapters never
@@ -675,11 +711,20 @@ export function createVestRunCoordinator(): VestRunCoordinator {
    * The removal is guarded by identity (`pendingKeys.get(cacheKey) ===
    * entry`) so a LATER run for the same cache key -- which replaces this
    * entry in the run cache before this one settles -- is never accidentally
-   * un-tracked by this entry's own (possibly superseded, possibly
-   * never-firing) settlement callback.
+   * un-tracked by this entry's own settlement callback.
+   *
+   * The removal hangs off {@link awaitVestRunOutcome}, NOT off the raw
+   * `entry.runResult`. That raw promise is precisely the one a later
+   * `suite.run()` can supersede so that it never settles at all -- and a
+   * focused run is never deferred, so it can start (and supersede) while an
+   * unfocused run is pending on the same suite. Untracking off it therefore
+   * leaked the marker, the cache key and the cached result for the lifetime of
+   * the suite, and pinned the suite as permanently contested for every other
+   * cache key.
    */
-  function trackPendingVestRun(
+  function trackPendingVestRun<TValue, F extends string = string>(
     suiteKey: object,
+    suite: Pick<VestCoordinatedSuite<TValue, F>, 'subscribe' | 'get'>,
     cacheKey: VestRunCacheKey,
     entry: VestRunCacheEntry<unknown>,
     focus: VestFieldExclusion,
@@ -712,7 +757,10 @@ export function createVestRunCoordinator(): VestRunCoordinator {
       }
     };
 
-    Promise.resolve(entry.runResult).then(untrack, untrack);
+    void awaitVestRunOutcome(suite, entry.runResult, entry.deferred).then(
+      untrack,
+      untrack,
+    );
   }
 
   /**
@@ -857,17 +905,7 @@ export function createVestRunCoordinator(): VestRunCoordinator {
       deferred: entry.deferred,
       fromCache,
       settled: () =>
-        entry.deferred
-          ? // A deferred run's `runResult` (see `deferVestRunUntilIdle`) does
-            // not even call `suite.run()` until the suite becomes idle, so
-            // racing it against the suite-wide `ALL_RUNNING_TESTS_FINISHED`
-            // bus event here would resolve with `suite.get()`'s state from
-            // BEFORE this run started (whatever made the suite idle in the
-            // first place), not this run's own outcome. Its plain `Promise`
-            // already resolves correctly on its own once the deferred run
-            // actually completes, so await it directly.
-            Promise.resolve(entry.runResult)
-          : awaitVestRunSettlement(entry.runResult, suite),
+        awaitVestRunOutcome(suite, entry.runResult, entry.deferred),
     };
   }
 
@@ -953,18 +991,18 @@ export function createVestRunCoordinator(): VestRunCoordinator {
     };
 
     suiteCache.set(cacheKey, nextEntry);
-    trackPendingVestRun(suiteKey, cacheKey, nextEntry, focus);
+    trackPendingVestRun(suiteKey, suite, cacheKey, nextEntry, focus);
     return createVestRunHandle(suite, nextEntry, false);
   }
 
   function invalidate(suite: object): void {
+    // The run cache only. Contention bookkeeping and the queue tail stay:
+    // `invalidate` cannot tell a stale marker from a live one, and dropping a
+    // LIVE marker would let the next request overlap a run that is genuinely
+    // still in flight. Markers now retire on their own once their run settles
+    // (see `trackPendingVestRun`), so there is no stale marker left to clean
+    // up here.
     runCache.delete(suite);
-    // Also drop contention bookkeeping so a reset suite starts from a clean
-    // slate -- otherwise a stale pending marker from a run that never settled
-    // before teardown could permanently (and incorrectly) mark a
-    // subsequently-reused suite as contested.
-    pendingKeysBySuite.delete(suite);
-    runQueueBySuite.delete(suite);
   }
 
   return { request, invalidate };


### PR DESCRIPTION
Closes #322

## What changed

`packages/toolkit/vest/src/vest-run-coordinator.ts`:

- New module-level `awaitVestRunOutcome(suite, runResult, deferred)` — the single settlement strategy, lifted from the inline logic in `createVestRunHandle.settled`: `awaitVestRunSettlement` (suite-bus race, survives a superseded resolver) for a started run, `Promise.resolve(runResult)` for a deferred one.
- `trackPendingVestRun` now takes the `suite` and untracks off `awaitVestRunOutcome(...)` instead of the raw `entry.runResult`. This is the leak fix: a focused run that supersedes a pending unfocused run no longer strands the pending entry in the strong `pendingKeysBySuite` map.
- `createVestRunHandle.settled` delegates to `awaitVestRunOutcome`; behavior identical.
- `invalidate` drops the run cache only. It no longer clears `pendingKeysBySuite` / `runQueueBySuite`, so it cannot un-defer a genuinely in-flight run; pending entries retire through settlement-driven untrack.

## Audit finding

From the 2026-08-10 post-merge audit: `trackPendingVestRun` untracked off the raw `runResult` promise — exactly the promise a later `run()` on the same suite supersedes and leaves forever pending. Consequences: a permanent pending-entry leak (suite, cache key, cached `SuiteResult` retained in a deliberately strong `Map`) and `isSuiteContestedByOtherKey` pinned `true`, needlessly deferring every later unfocused run from other keys. Related: `invalidate()` unconditionally cleared contention bookkeeping for runs still in flight.

## Specs

New in `vest-run-coordinator.spec.ts` (both confirmed red on unmodified source):

- `stops tracking an unfocused run a focused run superseded, once the suite settles` — plus asserts a subsequent unfocused run from another key is NOT deferred.
- `does not un-defer a run that is genuinely still in flight` (invalidate).
- `lets a pending run retire on its own, so a reused suite is not stuck "contested"` — replaces the old `drops contention bookkeeping…` spec, which asserted the exact semantics this fix removes.

Backed by a new `createSupersedingSuite()` fake reproducing Vest 6's one-resolver-per-suite behavior. One other existing spec (`unsubscribes an idle listener whose callback fires synchronously`) hard-coded a subscription count that legitimately changed from 1 to 2; rewritten to assert the load-bearing properties instead.

## Verification (independently re-run by the orchestrator)

- `CI=1 pnpm nx run toolkit:test` — PASS (85 files, 1406 tests)
- `CI=1 pnpm nx run toolkit:test-browser` — PASS (17 files, 79 tests)
- `pnpm nx run toolkit:lint` — PASS (exit 0; only pre-existing warnings in unrelated files)
- `pnpm exec tsc -p packages/toolkit/tsconfig.spec.json --noEmit` — 192 errors, identical to the main baseline (zero new)

## Noted follow-up (not in scope)

A smaller residual leak remains for *deferred* entries superseded after they start; closing it needs a "deferred run has started" hook through the queue plumbing, beyond this issue's remedy. Can be filed separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
