### PR TITLE
feat(vest): expose settled() and deferred on runVestSuite's public result

### DIFF
--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -201,11 +201,11 @@ const adapter: VestSuiteAdapter = createVestAdapter();
 const shared = sharedVestAdapter;
 ```
 
-| Member                 | Description                                                                                                                                                            |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `register(path, …)`    | Wire the suite into Signal Forms (the `validateTree` + `validateAsync` pipeline). `validateVest`/`validateVestWarnings` delegate here.                                 |
-| `runVestSuite(params)` | Run the suite once through the shared cache. Returns the cached run for an identical `(suite, fieldTree, value, focus)` tuple, or a fresh run when any of them change. |
-| `invalidate(suite)`    | Drop the shared run cache for a suite (the `resetOnDestroy` teardown hook calls this).                                                                                 |
+| Member                 | Description                                                                                                                                                                                                                                                |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `register(path, …)`    | Wire the suite into Signal Forms (the `validateTree` + `validateAsync` pipeline). `validateVest`/`validateVestWarnings` delegate here.                                                                                                                     |
+| `runVestSuite(params)` | Run the suite once through the shared cache. Returns the cached run for an identical `(suite, fieldTree, value, focus)` tuple, or a fresh run when any of them change. The result's `settled()` — not `runResult` — is the safe thing to await; see below. |
+| `invalidate(suite)`    | Drop the shared run cache for a suite (the `resetOnDestroy` teardown hook calls this).                                                                                                                                                                     |
 
 The companion option/shape types are also exported for typing your own
 integrations: `VestAdapterOptions` (for `createVestAdapter()`),
@@ -275,6 +275,32 @@ Because `runVestSuite` reads the shared cache keyed on
 `(suite, fieldTree, value, focus)`, a custom validator and a regular
 `validateVest(path, checkoutSuite)` on the same path execute `checkoutSuite.run()`
 exactly once per value.
+
+#### Awaiting a manual run's outcome
+
+Outside a `validateTree`/`validateAsync` pair — a one-off manual check, a test,
+a script — await `run.settled()`, not `run.runResult`:
+
+```typescript
+const run = sharedVestAdapter.runVestSuite({ suite, fieldTree, value });
+const result = await run.settled(); // correct
+```
+
+`run.runResult` is the raw value `suite.run()` returned. Vest 6 tracks a
+single resolver per suite instance, so a LATER `suite.run()` call on the SAME
+suite — a second `runVestSuite` call, or a second focused `validateVest`
+registration — replaces that resolver before an earlier, still-pending call's
+`runResult` promise ever settles (empirically verified against `vest@6.3.2`).
+Awaiting `runResult` directly then hangs forever:
+
+```typescript
+// UNSAFE: hangs forever if another run lands on the same suite first.
+const result = await Promise.resolve(run.runResult);
+```
+
+`run.settled()` recovers from that supersession by racing the run against the
+suite's own `ALL_RUNNING_TESTS_FINISHED` bus event — the same mechanism the
+built-in `validateVest`/`validateVestWarnings` pipeline relies on internally.
 
 ## When to use Vest
 

--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -281,10 +281,94 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
       });
       expect(repeat.fromCache).toBe(true);
 
+      // `settled()` is the safe thing to await for a manual flow (see
+      // `RunVestSuiteResult`'s doc comment), but it returns `PromiseLike<unknown>`
+      // -- deliberately decoupled from the suite's own result type, see
+      // `VestRunHandle.settled`. Await it for the safety guarantee, then read
+      // through `runResult` (already known Vest-result-shaped here -- this
+      // suite is synchronous, so there is no supersession risk) for a typed
+      // result.
+      await multiFocus.settled();
       const result = await Promise.resolve(multiFocus.runResult);
       expect(Object.keys(result.getErrors())).toEqual(
         expect.arrayContaining(['email', 'username']),
       );
+    });
+  });
+
+  describe('settled()', () => {
+    it('resolves even when a later focused run on the same suite supersedes the earlier run’s own runResult promise', async () => {
+      const adapter = createVestAdapter();
+      const gates: Array<() => void> = [];
+
+      // A focused run bypasses contention/FIFO gating entirely (see
+      // `isSuiteContestedByOtherKey`'s doc comment) -- two focused
+      // `runVestSuite` calls on the SAME suite both call `suite.only(...).run()`
+      // immediately, back to back. Per Vest 6.3.2's single-resolver-per-suite
+      // behaviour (documented on `awaitVestRunSettlement`), the SECOND call
+      // replaces the suite's resolver before the FIRST call's own promise ever
+      // settles -- so `first.runResult` is permanently pending, and only
+      // `first.settled()` (which races the run against the suite-wide
+      // `ALL_RUNNING_TESTS_FINISHED` bus event) recovers its outcome.
+      const suite = create((data: { email: string; username: string }) => {
+        vestTest('email', 'Email is required', async () => {
+          await new Promise<void>((resolve) => gates.push(resolve));
+          enforce(data.email).isNotBlank();
+        });
+        vestTest('username', 'Username is required', async () => {
+          await new Promise<void>((resolve) => gates.push(resolve));
+          enforce(data.username).isNotBlank();
+        });
+      });
+
+      const fieldTree = TestBed.runInInjectionContext(() =>
+        form(signal({ email: '', username: '' })),
+      );
+      const value = { email: '', username: '' };
+
+      const first = adapter.runVestSuite({
+        suite,
+        fieldTree,
+        value,
+        focus: 'email',
+      });
+      expect(first.deferred).toBe(false);
+
+      const second = adapter.runVestSuite({
+        suite,
+        fieldTree,
+        value,
+        focus: 'username',
+      });
+      expect(second.deferred).toBe(false);
+
+      let firstRunResultSettled = false;
+      void Promise.resolve(first.runResult).then(() => {
+        firstRunResultSettled = true;
+        return undefined;
+      });
+
+      let firstSettled = false;
+      void Promise.resolve(first.settled()).then(() => {
+        firstSettled = true;
+        return undefined;
+      });
+
+      await vi.waitFor(() => {
+        expect(gates.length).toBe(2);
+      });
+      gates[0]();
+      gates[1]();
+
+      await vi.waitFor(() => {
+        expect(firstSettled).toBe(true);
+      });
+
+      // Give the microtask/macrotask queue a real chance to flush before
+      // asserting the negative -- this is what distinguishes "genuinely never
+      // settles" from "just hasn't settled yet".
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(firstRunResultSettled).toBe(false);
     });
   });
 
@@ -377,7 +461,7 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
       // Let A's async test settle -> the suite goes idle -> B's deferred run
       // starts automatically. C must NOT start yet -- it is queued behind B.
       await releaseGate(gates, 0);
-      await Promise.resolve(resultA.runResult);
+      await resultA.settled();
 
       await vi.waitFor(() => {
         expect(runCallOrder).toEqual(['run:a', 'run:b']);
@@ -386,7 +470,7 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
       // Let B's async test settle -> the suite goes idle again -> C's
       // deferred run starts only now, strictly after B.
       await releaseGate(gates, 1);
-      await Promise.resolve(resultB.runResult);
+      await resultB.settled();
 
       await vi.waitFor(() => {
         expect(runCallOrder).toEqual(['run:a', 'run:b', 'run:c']);
@@ -394,7 +478,7 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
 
       // Clean up C's now-started async test so nothing dangles past the test.
       await releaseGate(gates, 2);
-      await Promise.resolve(resultC.runResult);
+      await resultC.settled();
 
       // FIFO + single-execution: each tree's suite.run() fired exactly once,
       // strictly in request order -- A, then B (only after A settled), then

--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -342,16 +342,17 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
       });
       expect(second.deferred).toBe(false);
 
+      // `.finally()` (not `.then()`) so a REJECTED runResult still marks
+      // itself settled -- the point being tested is whether the promise
+      // settles at all, not whether it resolves successfully.
       let firstRunResultSettled = false;
-      void Promise.resolve(first.runResult).then(() => {
+      void Promise.resolve(first.runResult).finally(() => {
         firstRunResultSettled = true;
-        return undefined;
       });
 
       let firstSettled = false;
-      void Promise.resolve(first.settled()).then(() => {
+      void Promise.resolve(first.settled()).finally(() => {
         firstSettled = true;
-        return undefined;
       });
 
       await vi.waitFor(() => {

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -701,13 +701,41 @@ export interface RunVestSuiteParams<TValue, F extends string = string> {
  * sync-or-async run value, and `fromCache` reports whether this run reused a
  * previously cached execution for the identical `(suite, fieldTree, value,
  * focus)` tuple.
+ *
+ * **Do not `await runResult` directly.** Vest 6's `suite.run()` promise
+ * resolves through a single resolver tracked per suite instance: a LATER
+ * `suite.run()` call on the SAME suite (e.g. a second `runVestSuite` call, or
+ * a second focused `validateVest` registration on the same suite) replaces
+ * that resolver before an earlier, still-pending call's promise ever settles
+ * — empirically verified against `vest@6.3.2`. Await {@link settled} instead;
+ * it recovers from that supersession the same way the built-in
+ * `validateVest`/`validateVestWarnings` pipeline does. See
+ * {@link VestRunHandle.settled}.
  */
 export interface RunVestSuiteResult<TValue, F extends string = string> {
   readonly value: TValue;
-  readonly focus: string | undefined;
+  /**
+   * The `focus` exactly as requested in {@link RunVestSuiteParams.focus} — a
+   * field name, a list of field names, `false`, or `undefined` for a
+   * whole-suite run. Not the coordinator's internal, NUL-joined cache key.
+   */
+  readonly focus: VestFieldExclusion<F>;
   readonly runResult: VestResultLike<F> | PromiseLike<VestResultLike<F>>;
   readonly initialResult: VestResultLike<F> | undefined;
   readonly fromCache: boolean;
+  /**
+   * `true` when this run was queued behind another field tree's pending run
+   * on the SAME suite instead of starting immediately. Forwarded from
+   * {@link VestRunHandle.deferred}.
+   */
+  readonly deferred: boolean;
+  /**
+   * Resolves once this run's outcome is observable, recovering from a
+   * superseded Vest resolver where the suite makes that possible. The safe
+   * thing to await for a manual flow — see this interface's doc comment.
+   * Forwarded from {@link VestRunHandle.settled}.
+   */
+  readonly settled: () => PromiseLike<unknown>;
 }
 
 /**
@@ -826,10 +854,14 @@ export function createVestAdapter(
 
     return {
       value: handle.value,
-      focus: handle.focus,
+      // The original requested shape, not `handle.focus` (the coordinator's
+      // internal, NUL-joined cache key) — see this interface's doc comment.
+      focus: params.focus,
       runResult: handle.runResult,
       initialResult: handle.initialResult,
       fromCache: handle.fromCache,
+      deferred: handle.deferred,
+      settled: handle.settled,
     };
   }
 


### PR DESCRIPTION
Closes #324

## What changed

**`packages/toolkit/vest/src/vest-adapter.ts`**

- `RunVestSuiteResult<TValue, F>` gains `readonly deferred: boolean` and `readonly settled: () => PromiseLike<unknown>`, forwarded from the coordinator's `VestRunHandle`.
- `focus` no longer leaks the coordinator's internal NUL-joined cache key: it now returns the original `VestFieldExclusion<F>` the caller passed via `RunVestSuiteParams.focus` (the issue's preferred option; pre-v1, no alias kept).
- Doc comment on `runResult` warns against awaiting it directly: Vest 6.3.2 tracks one resolver per suite instance, so a later `run()` supersedes an earlier still-pending promise.

**`packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts`**

- All `await Promise.resolve(x.runResult)` uses switched to `await x.settled()`.
- New `settled()` spec: two focused runs on one suite prove `first.settled()` resolves while `first.runResult` genuinely never settles (real 20ms flush window; ran 3x for flake check).

**`packages/toolkit/vest/README.md`**

- `runVestSuite` table flags `settled()` as the safe thing to await.
- New "Awaiting a manual run's outcome" subsection shows `await run.settled()` and marks awaiting `runResult` as unsafe, with the resolver-supersession explanation. (The README had no section literally awaiting `runResult`; the unsafe pattern lived in the guarantees spec, so the safe pattern is documented as a new subsection.)

## Audit finding

From the 2026-08-10 post-merge audit: the coordinator's `VestRunHandle` carries `settled()`/`deferred`, but the public `RunVestSuiteResult` dropped both and exposed only the supersedable raw `runResult` promise — a consumer awaiting it hangs forever the moment a second run lands on the suite. `focus` also read back as the internal separator-joined cache key for multi-name focuses.

## Verification (independently re-run by the orchestrator)

- `CI=1 pnpm nx run toolkit:test` — PASS (85 files, 1405 tests)
- `CI=1 pnpm nx run toolkit:test-browser` — PASS (17 files, 79 tests)
- `pnpm nx run toolkit:lint` — PASS (exit 0; only pre-existing warnings in unrelated files)
- `pnpm exec tsc -p packages/toolkit/tsconfig.spec.json --noEmit` — 192 errors, identical to the main baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
