### PR TITLE
fix(vest): gate warning deferral on includeErrors; inject DestroyRef before ref count

### DIFF
--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -351,12 +351,17 @@ a sibling mount is still using the same suite leaves that sibling's retained
 - **Warnings vs. pending async tests.** Angular's `validateAsync` only
   schedules its resource when the bound subtree has zero sync errors, and a
   toolkit `warn:vest:*` result is an ordinary `ValidationError`. To avoid a
-  sync warning silently suppressing a blocking async check on the same field,
-  the adapter defers surfacing a warning while the suite still has pending
-  async tests, and re-surfaces it together with the settled result once they
-  finish. In practice this means a warning can appear one tick later than a
-  blocking sync error while async validation is in flight — it does not
-  change what surfaces once the field settles.
+  sync warning silently suppressing a blocking async check from the SAME
+  registration, the adapter defers surfacing a warning while the suite still
+  has pending async tests and this registration also maps errors
+  (`includeErrors: true`), re-surfacing the warning together with the settled
+  result once they finish. In practice this means a warning can appear one
+  tick later than a blocking sync error while async validation is in flight —
+  it does not change what surfaces once the field settles. A warning-only
+  registration (`validateVestWarnings`, or `includeErrors: false`) has no
+  blocking error of its own to protect, so it never defers: its warnings
+  surface immediately, even while the suite is pending or a separate
+  validator on the same subtree is blocking.
 
 ### Focused `only()` runs
 

--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef, Component, signal } from '@angular/core';
-import { form, FormField } from '@angular/forms/signals';
+import { form, FormField, required } from '@angular/forms/signals';
 import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
@@ -1603,6 +1603,60 @@ describe('validateVest', () => {
     expect(emailErrors).toHaveLength(1);
     expect(emailErrors[0]?.message).toBe('Email availability check failed');
 
+    const bioErrors = fixture.componentInstance.f.bio().errors();
+    expect(bioErrors).toHaveLength(1);
+    expect(bioErrors[0]?.message).toBe('Consider adding more detail');
+    expect(bioErrors[0]?.kind).toMatch(/^warn:vest:/);
+  });
+
+  it('surfaces a warn-only Vest warning even when a sibling blocking Angular validator keeps async from ever scheduling', async () => {
+    // Issue #325: `shouldDeferVestWarnings` used to gate purely on
+    // `initialResult.isPending()`. That protects a registration's OWN
+    // blocking async Vest error from being masked by its OWN sync warning --
+    // but `validateVestWarnings` maps no errors at all (`includeErrors:
+    // false`), so it has nothing to protect. Deferring anyway is unsafe:
+    // Angular's `validateAsync` only schedules once the WHOLE bound subtree
+    // is sync-valid, so a completely unrelated blocking validator on a
+    // sibling field (here, `required()` on `username`) can keep async from
+    // ever running -- starving a deferred warning forever. Gating deferral on
+    // `includeErrors` means a warning-only registration never defers in the
+    // first place, so it cannot be starved this way.
+    const suite = create((data: { email: string; bio: string }) => {
+      test('email', 'Email availability check failed', async () => {
+        // Never resolves: keeps the suite's own `isPending()` true for the
+        // lifetime of the test, so a pre-fix adapter would defer forever.
+        await new Promise<void>(() => {});
+      });
+      test('bio', 'Consider adding more detail', () => {
+        warn();
+        enforce(data.bio.length >= 20).isTruthy();
+      });
+    });
+
+    @Component({
+      selector: 'ngx-test-vest-warning-only-not-starved',
+      imports: [FormField],
+
+      template: `
+        <input id="username" [formField]="f.username" />
+        <input id="bio" [formField]="f.bio" />
+      `,
+    })
+    class TestComponent {
+      // `username` is blank, so `required()` keeps the WHOLE bound subtree
+      // (the form root) sync-invalid forever -- `validateAsync` for the Vest
+      // registration below never schedules.
+      readonly model = signal({ username: '', email: '', bio: 'short' });
+      readonly f = form(this.model, (path) => {
+        required(path.username);
+        validateVestWarnings(path, suite);
+      });
+    }
+
+    const { fixture } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(fixture.componentInstance.f().valid()).toBe(false);
     const bioErrors = fixture.componentInstance.f.bio().errors();
     expect(bioErrors).toHaveLength(1);
     expect(bioErrors[0]?.message).toBe('Consider adding more detail');

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -35,9 +35,13 @@ export interface ValidateVestOptions<
    * objects with a `kind` prefixed by `warn:` so existing toolkit components
    * render them as non-blocking guidance.
    *
-   * While the suite has pending async tests, a sync warning is deferred (not
-   * yet surfaced) and re-emitted together with the settled result once they
-   * finish — see the vest README's "Async caveats" section for why.
+   * While the suite has pending async tests AND this registration also maps
+   * blocking errors (`includeErrors: true`, `validateVest`'s default), a sync
+   * warning is deferred (not yet surfaced) and re-emitted together with the
+   * settled result once they finish — see the vest README's "Async caveats"
+   * section for why. A warning-only registration (`validateVestWarnings`, or
+   * `includeErrors: false`) has no blocking error of its own to protect and
+   * never defers: its warnings surface immediately.
    *
    * @default false
    */

--- a/packages/toolkit/vest/src/vest-adapter.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter.spec.ts
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { create, enforce, test as vestTest, warn } from 'vest';
 import { describe, expect, it, vi } from 'vitest';
-import { createVestAdapter } from './vest-adapter';
+import { createVestAdapter, type VestFieldPath } from './vest-adapter';
 
 // Vitest hoists `vi.mock` above every import in this file (including its own
 // `@angular/core` import elsewhere), registering the mock before any other
@@ -691,6 +691,56 @@ describe('createVestAdapter', () => {
 
     second.destroy();
     // Only the LAST surviving registration's teardown actually resets.
+    expect(resetCount).toBe(1);
+  });
+
+  it('leaves the resetOnDestroy ref count unchanged when inject(DestroyRef) throws outside an injection context', () => {
+    // Issue #325: `maybeRegisterResetOnDestroy` used to increment the
+    // per-suite ref count and only THEN call `inject(DestroyRef)`. If that
+    // injection throws -- e.g. `register` called outside an injection
+    // context -- the count stayed permanently one too high, so no surviving
+    // registration's teardown could ever bring it back to zero and the suite
+    // was never reset. The fix injects first, increments second.
+    const adapter = createVestAdapter();
+
+    let resetCount = 0;
+    const baseSuite = create((data: { email: string }) => {
+      vestTest('email', 'Email is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+    const suite = {
+      ...baseSuite,
+      reset: () => {
+        resetCount += 1;
+        baseSuite.reset();
+      },
+    };
+
+    // `register`'s path argument is never dereferenced before the throw:
+    // `maybeRegisterResetOnDestroy` runs before any path-dependent work, so a
+    // placeholder is safe here. Called straight from the test body -- no
+    // `TestBed.runInInjectionContext`, no component construction -- so
+    // `inject(DestroyRef)` throws NG0203.
+    const placeholderPath = {} as VestFieldPath<{ email: string }>;
+    expect(() => {
+      adapter.register(placeholderPath, suite, { resetOnDestroy: true });
+    }).toThrow(/injection context/iu);
+
+    // A later, properly-scoped registration on the SAME suite must still
+    // reset on destroy -- proving the failed attempt above left the
+    // per-suite ref count at zero, not stuck at one.
+    @Component({ template: '' })
+    class TestComponent {
+      readonly model = signal({ email: '' });
+      readonly f = form(this.model, (path) => {
+        adapter.register(path, suite, { resetOnDestroy: true });
+      });
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.destroy();
+
     expect(resetCount).toBe(1);
   });
 });

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -619,12 +619,28 @@ function mapVestValidationResult<F extends string = string>(
  * errors — from ever running. Defer warnings only while pending; once the
  * suite settles, {@link mapVestValidationResult}'s async `onSuccess` mapping
  * surfaces them together with the final result.
+ *
+ * Deferral is gated on `includeErrors`: it exists solely to protect THIS
+ * registration's own blocking async Vest errors from being masked by its own
+ * sync warning. A warning-only registration (`includeErrors: false`, e.g.
+ * `validateVestWarnings`) has no blocking error of its own to protect, so
+ * deferring buys nothing — and costs a real risk. `validateAsync` needs the
+ * WHOLE bound subtree sync-valid before it schedules, so a separate,
+ * unrelated blocking validator on the same subtree (an Angular `required()`,
+ * a Zod issue) can keep the async phase from ever running. A warning deferred
+ * on the strength of `isPending()` alone would then never resurface. Skipping
+ * deferral when there are no errors to protect keeps the warning-only path
+ * safe from that starvation.
  */
 function shouldDeferVestWarnings<F extends string = string>(
   options: VestValidationFlags,
   initialResult: VestResultLike<F>,
 ): boolean {
-  return options.includeWarnings && initialResult.isPending();
+  return (
+    options.includeErrors &&
+    options.includeWarnings &&
+    initialResult.isPending()
+  );
 }
 
 /**
@@ -870,12 +886,18 @@ export function createVestAdapter(
     }
 
     const suiteKey: object = suite;
+    // `inject(DestroyRef)` first, ref count second: if the injection throws
+    // (this `register` call happened outside an injection context), the
+    // count must stay untouched -- otherwise it is permanently one too high
+    // and no surviving registration's teardown ever brings it back to zero,
+    // so the suite is never reset.
+    const destroyRef = inject(DestroyRef);
     resetOnDestroyRefCounts.set(
       suiteKey,
       (resetOnDestroyRefCounts.get(suiteKey) ?? 0) + 1,
     );
 
-    inject(DestroyRef).onDestroy(() => {
+    destroyRef.onDestroy(() => {
       const remaining = (resetOnDestroyRefCounts.get(suiteKey) ?? 1) - 1;
       if (remaining > 0) {
         // Another registration is still relying on this suite -- leave its


### PR DESCRIPTION
Closes #325

## What changed

Two small, independent behavioral fixes in `packages/toolkit/vest/src/vest-adapter.ts` (both module-private; no public surface changes):

1. **Warning starvation** — `shouldDeferVestWarnings` now requires `options.includeErrors && options.includeWarnings && initialResult.isPending()` (previously it did not check `includeErrors`). A warning-only registration (`validateVestWarnings`) has no blocking async error of its own to protect, so it no longer defers its sync warnings. This removes the starvation path where a sibling blocking validator (Angular `required`, Zod issue) on the same subtree keeps `validateAsync` from ever scheduling, which made a deferred warning never surface at all — contradicting the README's "one tick later" promise.
2. **resetOnDestroy ref-count order** — `maybeRegisterResetOnDestroy` now calls `inject(DestroyRef)` *before* incrementing the ref count. If the injection throws (registration outside an injection context), the count stays untouched, so a later normal registration still resets the suite on destroy.

Docs: README "Async caveats" and the `includeWarnings` doc comment in `validate-vest.ts` now state the deferral is conditional on `includeErrors` and that a warning-only registration surfaces immediately.

## Audit finding

From the 2026-08-10 post-merge audit: the `validateVestWarnings` + Angular-validators pattern the README itself teaches starved deferred warnings indefinitely, and a throwing `inject(DestroyRef)` permanently leaked a ref count, disabling suite reset for every surviving registration.

## Specs

- `validate-vest.spec.ts`: warning-only vest registration + a sibling blocking `required()` on the same subtree, with a never-resolving async suite test — the sync warning surfaces immediately instead of starving.
- `vest-adapter.spec.ts`: a registration outside an injection context throws and leaves the ref count unchanged; a later in-context registration on the same suite still triggers exactly one `reset()` on destroy.

## Verification (independently re-run by the orchestrator)

- `CI=1 pnpm nx run toolkit:test` — PASS (85 files, 1406 tests)
- `CI=1 pnpm nx run toolkit:test-browser` — PASS (17 files, 79 tests)
- `pnpm nx run toolkit:lint` — PASS (exit 0; only pre-existing warnings in unrelated files)
- `pnpm exec tsc -p packages/toolkit/tsconfig.spec.json --noEmit` — 192 errors, identical to the main baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Warning messages now appear immediately when they are not accompanied by blocking validation errors, including while async validation is pending.
  * Fixed form reset behavior after an invalid registration attempt outside the required Angular injection context.
  * Ensured later valid registrations can still reset validation state correctly when destroyed.

* **Documentation**
  * Clarified when synchronous warnings are deferred during asynchronous validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->