### PR TITLE
fix(vest): key kind occurrence counting on the normalized message segment

### DIFF
--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/forms/signals';
 import { TestBed } from '@angular/core/testing';
 import { render } from '@testing-library/angular';
-import { create, enforce, test as vestTest } from 'vest';
+import { create, enforce, test as vestTest, warn } from 'vest';
 import { describe, expect, it, vi } from 'vitest';
 import { validateVest } from './validate-vest';
 import { createVestAdapter, sharedVestAdapter } from './vest-adapter';
@@ -449,6 +449,69 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
       // `normalizeWarningKindSegment` / `VEST_KIND_SEGMENT_MAX_LEN`.
       expect(parts[2]).toMatch(/^a{48}-[0-9a-f]{4}$/u);
       expect(parts[3]).toBe('0');
+    });
+  });
+
+  describe('kind sanitiser: same-segment message collision', () => {
+    it('assigns distinct occurrence indices to two distinct short messages that normalize to the same kind segment', async () => {
+      // 'Too long!' and 'Too long?' both strip their trailing punctuation
+      // down to the same normalized segment ('too-long'). Neither exceeds
+      // VEST_KIND_SEGMENT_MAX_LEN, so the hash-suffix branch never engages --
+      // the occurrence index is the only thing that can keep their kinds
+      // apart. See issue #323.
+      //
+      // Both `vestTest`s use `warn()`: Vest's default (blocking) error mode
+      // only surfaces the FIRST failing test per field, so two colliding
+      // blocking messages on one field can never both appear at once --
+      // there would be nothing to collide. `warn()` mode accumulates every
+      // failing test's message per field, which is what actually exercises
+      // `createVestEntriesForField`'s occurrence counting for more than one
+      // entry.
+      const suite = create((data: { email: string }) => {
+        vestTest('email', 'Too long!', () => {
+          warn();
+          enforce(data.email).longerThan(10);
+        });
+        vestTest('email', 'Too long?', () => {
+          warn();
+          enforce(data.email).longerThan(10);
+        });
+      });
+
+      let f!: ReadonlyFieldTree<{ email: string }>;
+
+      @Component({
+        selector: 'ngx-test-adapter-kind-collision',
+        imports: [FormField],
+
+        template: `<input [formField]="f.email" />`,
+      })
+      class TestComponent {
+        readonly model = signal({ email: '' });
+        readonly f = form(this.model, (path) => {
+          validateVest(path, suite, { includeWarnings: true });
+        });
+
+        constructor() {
+          f = this.f;
+        }
+      }
+
+      await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const errors = f.email().errors();
+      expect(errors).toHaveLength(2);
+
+      const kinds = errors.map((error) => error.kind);
+      // Both share the same field + normalized-message prefix ...
+      for (const kind of kinds) {
+        expect(kind).toMatch(/^warn:vest:email:too-long:\d$/u);
+      }
+      // ... but the occurrence suffix keeps them distinct.
+      expect(new Set(kinds)).toEqual(
+        new Set(['warn:vest:email:too-long:0', 'warn:vest:email:too-long:1']),
+      );
     });
   });
 });

--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -513,5 +513,59 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
         new Set(['warn:vest:email:too-long:0', 'warn:vest:email:too-long:1']),
       );
     });
+
+    it('assigns distinct occurrence indices when one message normalizes to empty and falls back to the literal "warning" segment, colliding with an actual "warning" message', async () => {
+      // '!!!' has no alphanumeric characters, so normalizeWarningKindSegment
+      // returns '' and createVestValidationKind falls back to the literal
+      // segment 'warning'. A second message that IS literally 'warning'
+      // normalizes to that same segment directly. Both must render the
+      // 'warning' segment, so occurrence counting must key on the same
+      // fallback-applied segment kind generation uses -- keying on the raw
+      // message, or on the normalized segment WITHOUT the fallback, would
+      // give both occurrence 0. See issue #323 (Copilot review follow-up).
+      const suite = create((data: { email: string }) => {
+        vestTest('email', '!!!', () => {
+          warn();
+          enforce(data.email).longerThan(10);
+        });
+        vestTest('email', 'warning', () => {
+          warn();
+          enforce(data.email).longerThan(10);
+        });
+      });
+
+      let f!: ReadonlyFieldTree<{ email: string }>;
+
+      @Component({
+        selector: 'ngx-test-adapter-kind-collision-fallback',
+        imports: [FormField],
+
+        template: `<input [formField]="f.email" />`,
+      })
+      class TestComponent {
+        readonly model = signal({ email: '' });
+        readonly f = form(this.model, (path) => {
+          validateVest(path, suite, { includeWarnings: true });
+        });
+
+        constructor() {
+          f = this.f;
+        }
+      }
+
+      await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const errors = f.email().errors();
+      expect(errors).toHaveLength(2);
+
+      const kinds = errors.map((error) => error.kind);
+      for (const kind of kinds) {
+        expect(kind).toMatch(/^warn:vest:email:warning:\d$/u);
+      }
+      expect(new Set(kinds)).toEqual(
+        new Set(['warn:vest:email:warning:0', 'warn:vest:email:warning:1']),
+      );
+    });
   });
 });

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -449,8 +449,16 @@ function toVestValidationEntries(
 }
 
 /**
- * Annotates repeated messages with an occurrence index so duplicate kinds remain
- * deterministic and unique.
+ * Annotates repeated messages with an occurrence index so duplicate kinds
+ * remain deterministic and unique.
+ *
+ * The occurrence count is keyed on the message's normalized kind segment
+ * (see {@link normalizeWarningKindSegment}), not the raw message. Two
+ * distinct raw messages can normalize to the same segment (e.g. `'Too
+ * long!'` and `'Too long?'` both normalize to `too-long`) — keying on the
+ * raw message would give both `occurrence: 0` and let
+ * {@link createVestValidationKind} emit the same `kind` for two different
+ * `ValidationError`s.
  */
 function createVestEntriesForField(
   fieldPath: string,
@@ -459,8 +467,9 @@ function createVestEntriesForField(
   const occurrences = new Map<string, number>();
 
   return messages.map((message) => {
-    const occurrence = occurrences.get(message) ?? 0;
-    occurrences.set(message, occurrence + 1);
+    const normalizedMessage = normalizeWarningKindSegment(message);
+    const occurrence = occurrences.get(normalizedMessage) ?? 0;
+    occurrences.set(normalizedMessage, occurrence + 1);
 
     return {
       fieldPath,

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -452,11 +452,22 @@ function toVestValidationEntries(
  * Annotates repeated messages with an occurrence index so duplicate kinds
  * remain deterministic and unique.
  *
- * The occurrence count is keyed on the message's normalized kind segment
- * (see {@link normalizeWarningKindSegment}), not the raw message. Two
- * distinct raw messages can normalize to the same segment (e.g. `'Too
- * long!'` and `'Too long?'` both normalize to `too-long`) — keying on the
- * raw message would give both `occurrence: 0` and let
+ * The occurrence count is keyed on the EXACT message segment
+ * {@link createVestValidationKind} renders into the `kind` string — the
+ * normalized segment (see {@link normalizeWarningKindSegment}), falling
+ * back to the literal `'warning'` when normalization empties it out (a
+ * message like `'!!!'` has no alphanumeric characters to keep). Two
+ * distinct raw messages can render the same segment two different ways:
+ *
+ * - Both normalize to the same non-empty segment (e.g. `'Too long!'` and
+ *   `'Too long?'` both normalize to `too-long`).
+ * - One normalizes to empty and falls back to `'warning'`, while another
+ *   message is literally `'warning'` (e.g. `'!!!'` and `'warning'` both
+ *   render the `warning` segment).
+ *
+ * Keying on anything other than the rendered segment — the raw message, or
+ * the normalized segment without the fallback — would give two such
+ * messages the same `occurrence: 0` and let
  * {@link createVestValidationKind} emit the same `kind` for two different
  * `ValidationError`s.
  */
@@ -467,9 +478,9 @@ function createVestEntriesForField(
   const occurrences = new Map<string, number>();
 
   return messages.map((message) => {
-    const normalizedMessage = normalizeWarningKindSegment(message);
-    const occurrence = occurrences.get(normalizedMessage) ?? 0;
-    occurrences.set(normalizedMessage, occurrence + 1);
+    const renderedSegment = normalizeWarningKindSegment(message) || 'warning';
+    const occurrence = occurrences.get(renderedSegment) ?? 0;
+    occurrences.set(renderedSegment, occurrence + 1);
 
     return {
       fieldPath,


### PR DESCRIPTION
Closes #323

## What changed

`packages/toolkit/vest/src/vest-adapter.ts` — `createVestEntriesForField` now keys its occurrence `Map` on `normalizeWarningKindSegment(message)` instead of the raw message, matching what `createVestValidationKind` actually uses to build the kind's message segment. The kind string format, sanitisation scheme, and truncation threshold are unchanged (per the issue's out-of-scope list). `filterExistingVestEntries` deliberately still keys on the raw message — it dedups exact prior entries between sync/async passes, a different concern from kind generation.

## Audit finding

From the 2026-08-10 post-merge audit: occurrences were counted on the raw message while the kind was built from the normalized segment, so two distinct short messages normalizing identically (`'Too long!'` / `'Too long?'` → `too-long`) both got `occurrence: 0` and emitted the same supposedly-stable `kind` (`vest:email:too-long:0`). Anything keying on `kind` (custom error strategies, debugger filters) saw one error where there were two.

## Spec

New in `vest-adapter-guarantees.spec.ts`: two distinct short messages that normalize to the same segment on one field yield distinct kinds (`…:too-long:0` and `…:too-long:1`). Implementation note: Vest's blocking-error mode only surfaces the first failing test per field (verified empirically), so the spec reproduces the collision via `warn()` mode + `includeWarnings` — the exact same `createVestEntriesForField`/`createVestValidationKind` code path that errors use.

## Verification (independently re-run by the orchestrator)

- `CI=1 pnpm nx run toolkit:test` — PASS (85 files, 1405 tests)
- `CI=1 pnpm nx run toolkit:test-browser` — PASS (17 files, 79 tests)
- `pnpm nx run toolkit:lint` — PASS (exit 0; only pre-existing warnings in unrelated files)
- `pnpm exec tsc -p packages/toolkit/tsconfig.spec.json --noEmit` — 192 errors, identical to the main baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
