### PR TITLE
refactor(core): collapse form-field-renderer.provider.ts onto one generic factory pair (audit C8)

### DIFF
--- a/packages/toolkit/core/providers/form-field-renderer.provider.ts
+++ b/packages/toolkit/core/providers/form-field-renderer.provider.ts
@@ -8,6 +8,8 @@ import { inject, makeEnvironmentProviders } from '@angular/core';
 import {
   NGX_FORM_FIELD_ERROR_RENDERER,
   NGX_FORM_FIELD_HINT_RENDERER,
+  type NgxFormFieldErrorRenderer,
+  type NgxFormFieldHintRenderer,
 } from '../tokens';
 
 // Deliberately not an alias of `RendererOverride` — aliasing changes the
@@ -48,20 +50,26 @@ interface RendererOverride {
 
 /**
  * Builds the `useFactory` for a renderer token: return the override's
- * component when set, otherwise defer to a parent scope's provider (or
- * `null` if none is registered).
+ * component (run through `buildRenderer`) when set, otherwise defer to a
+ * parent scope's provider (or `null` if none is registered).
+ *
+ * `buildRenderer` — rather than a generic `{ component } as TRenderer`
+ * assertion — is what lets the compiler catch a future renderer interface
+ * growing a second required field: the object literal each caller writes in
+ * `buildRenderer` is checked structurally against the concrete
+ * `NgxFormField*Renderer` type, not merely against the loose
+ * `RendererOverride` constraint every renderer shape satisfies today.
  *
  * @internal
  */
-function createRendererFactory<
-  TRenderer extends { readonly component: Type<unknown> },
->(
+function createRendererFactory<TRenderer extends RendererOverride>(
   token: InjectionToken<TRenderer | null>,
   override: RendererOverride,
+  buildRenderer: (component: Type<unknown>) => TRenderer,
 ): () => TRenderer | null {
   return () => {
     if (override.component !== undefined) {
-      return { component: override.component } as TRenderer;
+      return buildRenderer(override.component);
     }
 
     // `skipSelf: true` is what lets a component-scoped override (registered
@@ -81,10 +89,9 @@ function createRendererFactory<
  *
  * @internal
  */
-function createRendererProviders<
-  TRenderer extends { readonly component: Type<unknown> },
->(
+function createRendererProviders<TRenderer extends RendererOverride>(
   token: InjectionToken<TRenderer | null>,
+  buildRenderer: (component: Type<unknown>) => TRenderer,
 ): {
   readonly provide: (override: RendererOverride) => EnvironmentProviders;
   readonly provideForComponent: (override: RendererOverride) => Provider[];
@@ -92,19 +99,27 @@ function createRendererProviders<
   return {
     provide: (override) =>
       makeEnvironmentProviders([
-        { provide: token, useFactory: createRendererFactory(token, override) },
+        {
+          provide: token,
+          useFactory: createRendererFactory(token, override, buildRenderer),
+        },
       ]),
     provideForComponent: (override) => [
-      { provide: token, useFactory: createRendererFactory(token, override) },
+      {
+        provide: token,
+        useFactory: createRendererFactory(token, override, buildRenderer),
+      },
     ],
   };
 }
 
 const errorRendererProviders = createRendererProviders(
   NGX_FORM_FIELD_ERROR_RENDERER,
+  (component): NgxFormFieldErrorRenderer => ({ component }),
 );
 const hintRendererProviders = createRendererProviders(
   NGX_FORM_FIELD_HINT_RENDERER,
+  (component): NgxFormFieldHintRenderer => ({ component }),
 );
 
 /**

--- a/packages/toolkit/core/providers/form-field-renderer.provider.ts
+++ b/packages/toolkit/core/providers/form-field-renderer.provider.ts
@@ -1,12 +1,17 @@
-import type { EnvironmentProviders, Provider, Type } from '@angular/core';
+import type {
+  EnvironmentProviders,
+  InjectionToken,
+  Provider,
+  Type,
+} from '@angular/core';
 import { inject, makeEnvironmentProviders } from '@angular/core';
 import {
   NGX_FORM_FIELD_ERROR_RENDERER,
   NGX_FORM_FIELD_HINT_RENDERER,
-  type NgxFormFieldErrorRenderer,
-  type NgxFormFieldHintRenderer,
 } from '../tokens';
 
+// Deliberately not an alias of `RendererOverride` — aliasing changes the
+// emitted `.d.ts` form; see `RendererOverride`'s comment.
 /**
  * Override shape for the error renderer provider. Pass `{ component }` to
  * set a renderer; pass `{}` to inherit from a parent scope's provider.
@@ -17,6 +22,8 @@ export interface NgxFormFieldErrorRendererOverride {
   readonly component?: Type<unknown>;
 }
 
+// Deliberately not an alias of `RendererOverride` — aliasing changes the
+// emitted `.d.ts` form; see `RendererOverride`'s comment.
 /**
  * Override shape for the hint renderer provider.
  *
@@ -26,39 +33,79 @@ export interface NgxFormFieldHintRendererOverride {
   readonly component?: Type<unknown>;
 }
 
-function createErrorRendererFactory(
-  override: NgxFormFieldErrorRendererOverride,
-): () => NgxFormFieldErrorRenderer | null {
+/**
+ * Structural shape shared by {@link NgxFormFieldErrorRendererOverride} and
+ * {@link NgxFormFieldHintRendererOverride}. Do not alias the public
+ * interfaces to this type — that would change them from flat interfaces to
+ * type aliases in the generated `.d.ts`, which is a visible (if harmless)
+ * shape change this refactor must not introduce.
+ *
+ * @internal
+ */
+interface RendererOverride {
+  readonly component?: Type<unknown>;
+}
+
+/**
+ * Builds the `useFactory` for a renderer token: return the override's
+ * component when set, otherwise defer to a parent scope's provider (or
+ * `null` if none is registered).
+ *
+ * @internal
+ */
+function createRendererFactory<
+  TRenderer extends { readonly component: Type<unknown> },
+>(
+  token: InjectionToken<TRenderer | null>,
+  override: RendererOverride,
+): () => TRenderer | null {
   return () => {
     if (override.component !== undefined) {
-      return { component: override.component };
+      return { component: override.component } as TRenderer;
     }
 
-    const parent = inject(NGX_FORM_FIELD_ERROR_RENDERER, {
-      optional: true,
-      skipSelf: true,
-    });
-
-    return parent;
+    // `skipSelf: true` is what lets a component-scoped override (registered
+    // on the same token) compose with an environment-level default instead
+    // of injecting its own just-registered factory and recursing.
+    return inject(token, { optional: true, skipSelf: true });
   };
 }
 
-function createHintRendererFactory(
-  override: NgxFormFieldHintRendererOverride,
-): () => NgxFormFieldHintRenderer | null {
-  return () => {
-    if (override.component !== undefined) {
-      return { component: override.component };
-    }
-
-    const parent = inject(NGX_FORM_FIELD_HINT_RENDERER, {
-      optional: true,
-      skipSelf: true,
-    });
-
-    return parent;
+/**
+ * Environment-scope + component-scope provider pair for a single renderer
+ * token. Both `provideFormFieldErrorRenderer*` and
+ * `provideFormFieldHintRenderer*` are thin wrappers around one instance of
+ * this, parameterized by token — see the audit note on
+ * `form-field-renderer.provider.ts` (C8) for why these four functions used
+ * to be ~55 duplicated lines apiece.
+ *
+ * @internal
+ */
+function createRendererProviders<
+  TRenderer extends { readonly component: Type<unknown> },
+>(
+  token: InjectionToken<TRenderer | null>,
+): {
+  readonly provide: (override: RendererOverride) => EnvironmentProviders;
+  readonly provideForComponent: (override: RendererOverride) => Provider[];
+} {
+  return {
+    provide: (override) =>
+      makeEnvironmentProviders([
+        { provide: token, useFactory: createRendererFactory(token, override) },
+      ]),
+    provideForComponent: (override) => [
+      { provide: token, useFactory: createRendererFactory(token, override) },
+    ],
   };
 }
+
+const errorRendererProviders = createRendererProviders(
+  NGX_FORM_FIELD_ERROR_RENDERER,
+);
+const hintRendererProviders = createRendererProviders(
+  NGX_FORM_FIELD_HINT_RENDERER,
+);
 
 /**
  * Provides the error renderer at environment scope.
@@ -68,12 +115,7 @@ function createHintRendererFactory(
 export function provideFormFieldErrorRenderer(
   override: NgxFormFieldErrorRendererOverride,
 ): EnvironmentProviders {
-  return makeEnvironmentProviders([
-    {
-      provide: NGX_FORM_FIELD_ERROR_RENDERER,
-      useFactory: createErrorRendererFactory(override),
-    },
-  ]);
+  return errorRendererProviders.provide(override);
 }
 
 /**
@@ -84,12 +126,7 @@ export function provideFormFieldErrorRenderer(
 export function provideFormFieldErrorRendererForComponent(
   override: NgxFormFieldErrorRendererOverride,
 ): Provider[] {
-  return [
-    {
-      provide: NGX_FORM_FIELD_ERROR_RENDERER,
-      useFactory: createErrorRendererFactory(override),
-    },
-  ];
+  return errorRendererProviders.provideForComponent(override);
 }
 
 /**
@@ -100,12 +137,7 @@ export function provideFormFieldErrorRendererForComponent(
 export function provideFormFieldHintRenderer(
   override: NgxFormFieldHintRendererOverride,
 ): EnvironmentProviders {
-  return makeEnvironmentProviders([
-    {
-      provide: NGX_FORM_FIELD_HINT_RENDERER,
-      useFactory: createHintRendererFactory(override),
-    },
-  ]);
+  return hintRendererProviders.provide(override);
 }
 
 /**
@@ -116,10 +148,5 @@ export function provideFormFieldHintRenderer(
 export function provideFormFieldHintRendererForComponent(
   override: NgxFormFieldHintRendererOverride,
 ): Provider[] {
-  return [
-    {
-      provide: NGX_FORM_FIELD_HINT_RENDERER,
-      useFactory: createHintRendererFactory(override),
-    },
-  ];
+  return hintRendererProviders.provideForComponent(override);
 }


### PR DESCRIPTION
Collapses `form-field-renderer.provider.ts`'s duplicated error/hint machinery onto one generic pair — `createRendererFactory<TRenderer>` / `createRendererProviders<TRenderer>` (both `@internal`, unexported) — with the four public `provideFormFieldErrorRenderer` / `provideFormFieldHintRenderer` (+`ForComponent`) functions now thin wrappers.

The issue's hard criterion holds: the emitted `.d.ts` is **byte-identical** to main's, verified by building both sides with `--skip-nx-cache` and diffing (empty diff, re-verified after formatting passes). That constraint drove two visible choices: the public override interfaces stay as separate flat declarations rather than aliases (aliasing changes the declared form), guarded by non-emitting `//` pointer comments so a future cleanup doesn't accidentally break the constraint; and the internal parameter type `RendererOverride` exists purely factory-side.

`skipSelf: true` semantics are preserved exactly — the generic factory keeps the same `inject(token, { optional: true, skipSelf: true })` composition (a component-scoped override composes with an environment default instead of recursing into its own provider), now with a comment explaining why, and the provider spec's 8 scope/precedence tests pass unchanged.

One honest deviation: the issue estimated "net ≈ −60 lines"; the branch nets +15 because byte-identity forbids collapsing the two public interface bodies and the new JSDoc documents the seam. The hard, checkable criterion won over the soft estimate.

Fixes #277
Refs #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
