### PR TITLE
refactor(vest): code-hygiene sweep for seams left by the backlog PRs

### DIFF
--- a/packages/toolkit/vest/src/index.ts
+++ b/packages/toolkit/vest/src/index.ts
@@ -24,6 +24,7 @@ export {
   type RunVestSuiteParams,
   type RunVestSuiteResult,
   type VestAdapterOptions,
+  type VestCoordinatedSuite,
   type VestFieldExclusion,
   type VestFieldPath,
   type VestOnlyFieldSelector,

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -1,5 +1,9 @@
 import {
   sharedVestAdapter,
+  // `VestFieldExclusion` has no real type-position use in this file — it is
+  // imported so the local binding exists for `{@link VestFieldExclusion}` in
+  // `ValidateVestOptions.only`'s doc comment below to resolve. Kept
+  // deliberately, not dead: removing it would silently break that doc link.
   type VestFieldExclusion,
   type VestFieldPath,
   type VestOnlyFieldSelector,

--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -24,14 +24,15 @@ import { createVestAdapter, sharedVestAdapter } from './vest-adapter';
  * contention/FIFO run queue, and the `kind` sanitiser's truncation-plus-hash
  * branch. See issue #294.
  *
- * Every test builds its own Vest suite instance. The adapter's internal
- * caches (`runCache`, `pendingTreesBySuite`, `runQueueBySuite`) are all keyed
- * by suite object identity, so a fresh suite per test -- including the tests
- * that exercise the module-scope {@link sharedVestAdapter} singleton --
- * cannot leak state into another spec file sharing that same singleton
- * within one test run. The `sharedVestAdapter` test additionally calls
- * `invalidate()` on its own suite once done, as an extra belt-and-braces
- * reset.
+ * Every test builds its own Vest suite instance. The run coordinator's
+ * internal caches (`runCache`, `pendingKeysBySuite`, `runQueueBySuite` -- see
+ * `./vest-run-coordinator.ts`, not the adapter itself, which only owns
+ * `resetOnDestroyRefCounts`) are all keyed by suite object identity, so a
+ * fresh suite per test -- including the tests that exercise the module-scope
+ * {@link sharedVestAdapter} singleton -- cannot leak state into another spec
+ * file sharing that same singleton within one test run. The
+ * `sharedVestAdapter` test additionally calls `invalidate()` on its own suite
+ * once done, as an extra belt-and-braces reset.
  *
  * Tests that only need a `ReadonlyFieldTree` identity (not a rendered,
  * bound-to-the-DOM form) build one via `TestBed.runInInjectionContext(() =>
@@ -272,7 +273,8 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
 
       // A different array INSTANCE with the same names hits the cache: the
       // focus cache key is content-derived (the joined names), not the array
-      // reference -- see the `focusKey` computation in `getOrCreateVestRun`.
+      // reference -- see `toVestFocusKey` and its use in the run
+      // coordinator's `request` (`./vest-run-coordinator.ts`).
       const repeat = adapter.runVestSuite({
         suite,
         fieldTree,

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -12,6 +12,8 @@ import {
   createVestRunCoordinator,
   isVestResultLike,
   VEST_KEY_SEPARATOR,
+  type VestCoordinatedSuite,
+  type VestFailureMessages,
   type VestFieldExclusion,
   type VestResultLike,
   type VestRunCoordinator,
@@ -26,6 +28,7 @@ import {
 // queue, and settlement machinery. They are re-exported here because
 // `./vest-adapter` is their documented public home (see `./index.ts`).
 export type {
+  VestCoordinatedSuite,
   VestFieldExclusion,
   VestResultLike,
   VestRunnableSuite,
@@ -69,18 +72,6 @@ export type VestOnlyFieldSelector<TValue, F extends string = string> = (
  * `validateVest`/`validateVestWarnings` entry points.
  */
 export type VestFieldPath<TValue> = SchemaPath<TValue> & SchemaPathTree<TValue>;
-
-/**
- * Whole-suite failure map returned by Vest selector APIs such as
- * `result.getErrors()` and `result.getWarnings()`.
- */
-type VestFailureMessages = Readonly<Record<string, readonly string[]>>;
-
-/**
- * Field-scoped failure list returned by Vest selector APIs such as
- * `result.getErrors('fieldName')`.
- */
-type VestFieldMessages = readonly string[];
 
 /**
  * Adapter-local severity mapping used to generate Angular validation error
@@ -137,18 +128,6 @@ interface ResolvedVestValidationPayload {
 
 const VEST_PATH_SEGMENT = /[^.[\]]+/gu;
 const VEST_KIND_SEGMENT_MAX_LEN = 48;
-/**
- * Internal sentinel `fieldPath` meaning "attach directly to the validator's
- * own bound field tree" rather than resolving a child field by name.
- *
- * Composed from the same NUL-based separator as {@link VEST_KEY_SEPARATOR} so
- * it can never collide with a REAL Vest field name -- including a field
- * literally named `root`. Using the bare string `'root'` as this sentinel
- * previously meant that a suite with a test registered against a field named
- * `root` (e.g. model shape `{ root: ... }`) had its failures mis-attached to
- * the validator-bound field instead of resolved to the `root` child field.
- */
-const VEST_ROOT_FIELD_SENTINEL = `${VEST_KEY_SEPARATOR}root${VEST_KEY_SEPARATOR}`;
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
   return (
@@ -158,11 +137,18 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
-// Field tree nodes are callable proxies, so callability is a necessary (not
-// sufficient) proxy for "is a tree node". The sole caller
-// (`resolveVestFieldName`) only uses this to decide whether a fully walked
-// path landed on a tree-shaped node, so a false positive still yields a
-// tree-shaped value — the loose predicate is intentional and contained.
+/**
+ * Runtime guard used to confirm that a walked field-tree path landed on a
+ * field tree node rather than a plain data leaf.
+ *
+ * Deliberately loose: it accepts ANY callable value, not just a genuine
+ * `ReadonlyFieldTree`. Field tree nodes are callable proxies, so callability
+ * is a necessary (not sufficient) condition for "is a tree node" — but the
+ * sole caller ({@link resolveVestFieldName}) only uses this to decide whether
+ * a fully walked path landed on a tree-shaped node, so a false positive still
+ * yields a tree-shaped value. Tightening this further would need a
+ * `ReadonlyFieldTree`-specific brand Angular Signal Forms does not expose.
+ */
 function isFieldTree(value: unknown): value is ReadonlyFieldTree<unknown> {
   return typeof value === 'function';
 }
@@ -186,6 +172,13 @@ function fnv1a4Hex(value: string): string {
  * Sanitizes arbitrary Vest field/message fragments so generated validation
  * kinds remain stable and CSS/DOM-friendly.
  *
+ * Despite the name, this is mode-agnostic: {@link createVestValidationKind}
+ * calls it for BOTH blocking-error and warning kinds, not just warnings — the
+ * name predates the toolkit surfacing Vest `test()` failures as `vest:*`
+ * kinds alongside `warn()` results as `warn:vest:*`. Kept as-is (see the
+ * caller's fallback-literal note below) rather than renamed, to avoid
+ * unrelated churn across every call site.
+ *
  * When the sanitized value exceeds {@link VEST_KIND_SEGMENT_MAX_LEN}, a short
  * FNV-1a hash suffix of the *original* value is appended to guarantee that
  * two long, otherwise-identical prefixes do not collide.
@@ -206,6 +199,17 @@ function normalizeWarningKindSegment(value: string): string {
 /**
  * Creates a deterministic Angular validation error kind for a mapped Vest
  * error or warning.
+ *
+ * The `'field'`/`'warning'` fallback literals below are generic placeholders
+ * for "the sanitized segment came out empty" (e.g. a message that is only
+ * punctuation) — they are NOT a mode indicator. In particular, the
+ * `'warning'` fallback also applies when `mode === 'error'`, so a blocking
+ * error whose message sanitizes to empty can produce a kind that literally
+ * contains the substring `warning` (e.g. `vest:field:warning:0`). This is a
+ * cosmetic quirk of the placeholder text, not a mode misclassification: the
+ * kind's PREFIX (`vest:` vs `warn:vest:`, from {@link VEST_ERROR_KIND_PREFIX}
+ * / {@link VEST_WARNING_KIND_PREFIX}) is what callers actually match on to
+ * tell errors and warnings apart.
  */
 function createVestValidationKind(
   mode: VestValidationMode,
@@ -412,35 +416,23 @@ function resolveVestValidationFieldTree(
 }
 
 /**
- * Type guard distinguishing Vest's field-scoped message list (an array) from
- * the whole-suite failure map (a keyed object). Lets callers narrow the union
- * without an unsafe cast — `Array.isArray` alone does not remove the
- * `readonly string[]` branch.
- */
-function isVestFieldMessages(
-  messages: VestFailureMessages | VestFieldMessages,
-): messages is VestFieldMessages {
-  return Array.isArray(messages);
-}
-
-/**
  * Normalizes Vest selector output into a flat list of field-targeted messages.
+ *
+ * Only takes the whole-suite {@link VestFailureMessages} map, not Vest's
+ * field-scoped `getErrors('fieldName')`/`getWarnings('fieldName')` array
+ * shape: every internal call site (`createVestValidationSnapshot`,
+ * `mapVestValidationResult`) calls `getErrors()`/`getWarnings()` with zero
+ * arguments only, so the array shape never reaches this function — verified
+ * against vest@6.3.2. A prior version of this helper also accepted and
+ * branched on the array shape; that branch was dead code and has been
+ * removed. See {@link VestResultLike}'s doc comment for why the array-typed
+ * overload still exists on the result type itself.
  */
 function toVestValidationEntries(
-  messages: VestFailureMessages,
-): readonly VestValidationEntry[];
-function toVestValidationEntries(
-  messages: VestFieldMessages,
-): readonly VestValidationEntry[];
-function toVestValidationEntries(
-  messages: VestFailureMessages | VestFieldMessages | undefined,
+  messages: VestFailureMessages | undefined,
 ): readonly VestValidationEntry[] {
   if (!messages) {
     return [];
-  }
-
-  if (isVestFieldMessages(messages)) {
-    return createVestEntriesForField(VEST_ROOT_FIELD_SENTINEL, messages);
   }
 
   return Object.entries(messages).flatMap(([fieldPath, fieldMessages]) =>
@@ -512,10 +504,10 @@ function toVestValidationErrors(
   mode: VestValidationMode,
 ): readonly ValidationError.WithFieldTree[] {
   return entries.map(({ fieldPath, message, occurrence }) => {
-    const targetFieldTree =
-      fieldPath === VEST_ROOT_FIELD_SENTINEL
-        ? fieldTree
-        : resolveVestValidationFieldTree(fieldTree, fieldPath);
+    const targetFieldTree = resolveVestValidationFieldTree(
+      fieldTree,
+      fieldPath,
+    );
 
     return {
       kind: createVestValidationKind(mode, fieldPath, message, occurrence),
@@ -700,10 +692,14 @@ export interface VestRegisterOptions<
  * {@link VestSuiteAdapter.runVestSuite}.
  */
 export interface RunVestSuiteParams<TValue, F extends string = string> {
-  readonly suite: Pick<
-    VestRunnableSuite<TValue, F>,
-    'run' | 'only' | 'subscribe' | 'get'
-  >;
+  /**
+   * The exact slice of {@link VestRunnableSuite} the run coordinator drives —
+   * see {@link VestCoordinatedSuite}'s doc comment. Using that one named type
+   * here (rather than re-spelling the identical `Pick` inline) keeps this
+   * public parameter and the coordinator's own internal request shape
+   * structurally and nominally the same type.
+   */
+  readonly suite: VestCoordinatedSuite<TValue, F>;
   readonly fieldTree: ReadonlyFieldTree<TValue>;
   readonly value: TValue;
   readonly focus?: VestFieldExclusion<F>;

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -24,21 +24,33 @@ export type VestFieldExclusion<F extends string = string> =
 /**
  * Whole-suite failure map returned by Vest selector APIs such as
  * `result.getErrors()` and `result.getWarnings()`.
+ *
+ * Exported so `./vest-adapter` — the other module that talks about Vest
+ * selector shapes — imports this one definition instead of re-declaring an
+ * identical local copy.
  */
-type VestFailureMessages = Readonly<Record<string, readonly string[]>>;
+export type VestFailureMessages = Readonly<Record<string, readonly string[]>>;
 
 /**
  * Field-scoped failure list returned by Vest selector APIs such as
  * `result.getErrors('fieldName')`.
+ *
+ * Exported for the same reason as {@link VestFailureMessages}.
  */
-type VestFieldMessages = readonly string[];
+export type VestFieldMessages = readonly string[];
 
 /**
  * Minimal subset of Vest's public result API required by the adapter.
  *
- * The overloads intentionally mirror Vest's selector behavior more precisely
- * than a plain `Pick<SuiteResult, ...>` so internal helpers can stay strict
- * about whole-suite versus field-scoped result shapes.
+ * The overloads intentionally mirror Vest's real `getErrors`/`getWarnings`
+ * selector signatures more precisely than a plain `Pick<SuiteResult, ...>`.
+ * The adapter's OWN internal helpers only ever call the zero-argument,
+ * whole-suite overload — every internal call site passes no field name (see
+ * `toVestValidationEntries` in `./vest-adapter`, verified against
+ * vest@6.3.2). The field-scoped `(fieldName: F)` overload exists so that
+ * `RunVestSuiteResult.runResult`/`initialResult`, which this type also backs,
+ * stay a faithful, typed mirror of Vest's public result object for consumers
+ * calling `runVestSuite(...)` directly.
  *
  * `F` mirrors {@link VestOnlyFieldSelector}'s field-name union and defaults
  * to `string`, so the field-scoped overloads narrow to a typed suite's
@@ -300,8 +312,6 @@ interface VestRunCacheEntry<TValue> {
  */
 type VestRunCache = WeakMap<VestRunCacheKey, VestRunCacheEntry<unknown>>;
 
-const resolveQueueTail = (): void => {};
-
 /**
  * Internal composite-key separator. A NUL code point can never appear in a Vest
  * field path, message, or focus name, so it composes collision-free keys for the
@@ -462,9 +472,12 @@ function waitForSuiteIdle<TValue, F extends string = string>(
   }
 
   return new Promise((resolve) => {
-    // `subscribe`'s callback can fire synchronously; capture `unsubscribe` as
-    // `let` so an immediate callback doesn't read it before assignment (same
-    // TDZ hazard `awaitVestRunSettlement` guards against below).
+    // Defensive only: real Vest 6.3.2 suites never invoke the `subscribe`
+    // callback synchronously (empirically verified), so this branch does not
+    // protect against documented Vest behavior. It guards a hand-rolled
+    // suite shape that DOES fire synchronously — capture `unsubscribe` as
+    // `let` so such a callback doesn't read it before assignment (same TDZ
+    // hazard `awaitVestRunSettlement` guards against below).
     let fired = false;
     let unsubscribe: (() => void) | undefined;
     unsubscribe = subscribe('ALL_RUNNING_TESTS_FINISHED', () => {
@@ -474,8 +487,9 @@ function waitForSuiteIdle<TValue, F extends string = string>(
     });
 
     // If the callback above fired synchronously (during the `subscribe()`
-    // call itself), its own `unsubscribe?.()` ran before `unsubscribe` had
-    // been assigned and was therefore a no-op — leaving this listener
+    // call itself — not possible with a real Vest 6.3.2 suite, only with a
+    // hand-rolled one), its own `unsubscribe?.()` ran before `unsubscribe`
+    // had been assigned and was therefore a no-op — leaving this listener
     // subscribed for the suite's lifetime and re-firing on every LATER idle
     // event. Clean up here instead, now that we hold a reference to it. Same
     // fired-synchronously guard `awaitVestRunSettlement` uses below.
@@ -551,10 +565,12 @@ function awaitVestRunSettlement<TValue, F extends string = string>(
   return new Promise((resolve, reject) => {
     let settled = false;
     // Declared as `let` (not `const subscribe(...)` return) and guarded with
-    // `?.()`: some suites invoke the `subscribe` callback SYNCHRONOUSLY (e.g.
-    // if all tests already finished before this call), which would otherwise
-    // try to read `unsubscribe` before its initializer has run — a TDZ
-    // `ReferenceError` that would leave this promise unsettled forever.
+    // `?.()`: defensive only, since real Vest 6.3.2 suites never invoke the
+    // `subscribe` callback synchronously (empirically verified) — but a
+    // hand-rolled suite that DOES (e.g. because it reports all tests already
+    // finished before this call) would otherwise try to read `unsubscribe`
+    // before its initializer has run — a TDZ `ReferenceError` that would
+    // leave this promise unsettled forever.
     let unsubscribe: (() => void) | undefined;
 
     const settle = (fn: (value: unknown) => void, value: unknown): void => {
@@ -582,9 +598,10 @@ function awaitVestRunSettlement<TValue, F extends string = string>(
     });
 
     // If the callback above fired synchronously (during the `subscribe()`
-    // call itself), `settle()` ran before `unsubscribe` was assigned, so its
-    // `unsubscribe?.()` was a no-op. Clean up the now-stale subscription here
-    // instead, now that we hold a reference to it.
+    // call itself — not possible with a real Vest 6.3.2 suite, only with a
+    // hand-rolled one), `settle()` ran before `unsubscribe` was assigned, so
+    // its `unsubscribe?.()` was a no-op. Clean up the now-stale subscription
+    // here instead, now that we hold a reference to it.
     // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `settled` may be flipped synchronously by the subscribe callback above; static analysis cannot model that closure write.
     if (settled) {
       unsubscribe();
@@ -788,23 +805,19 @@ export function createVestRunCoordinator(): VestRunCoordinator {
       return settleRunResult();
     }
 
-    try {
-      return new Promise((resolve) => {
-        // A rejected run must not hold the queue forever. Successful Vest 6
-        // thenables are intentionally ignored here because they can be
-        // superseded; the suite idle event settles the normal path.
-        void Promise.resolve(runResult).then(
-          () => undefined,
-          () => {
-            resolve();
-            return undefined;
-          },
-        );
-        void Promise.resolve(waitForSuiteIdle(suite)).then(resolve, resolve);
-      });
-    } catch {
-      return settleRunResult();
-    }
+    return new Promise((resolve) => {
+      // A rejected run must not hold the queue forever. Successful Vest 6
+      // thenables are intentionally ignored here because they can be
+      // superseded; the suite idle event settles the normal path.
+      void Promise.resolve(runResult).then(
+        () => undefined,
+        () => {
+          resolve();
+          return undefined;
+        },
+      );
+      void Promise.resolve(waitForSuiteIdle(suite)).then(resolve, resolve);
+    });
   }
 
   /**
@@ -858,7 +871,10 @@ export function createVestRunCoordinator(): VestRunCoordinator {
     focus: VestFieldExclusion<F>,
   ): Promise<VestResultLike<F>> {
     const previousRun = runQueueBySuite.get(suiteKey) ?? Promise.resolve();
-    let resolveTail: () => void = resolveQueueTail;
+    // The `Promise` executor below runs synchronously, so `resolveTail` is
+    // always assigned before this function returns — the definite-assignment
+    // assertion documents that rather than working around a real gap.
+    let resolveTail!: () => void;
     const tail = new Promise<void>((resolve) => {
       resolveTail = resolve;
     });


### PR DESCRIPTION
Closes #327

Code-hygiene sweep for the seams the vest backlog PRs left behind. Zero behavior changes; every existing spec passes untouched. Per the issue's acceptance criteria, each item is recorded below as addressed or explicitly documented-not-changed with a reason.

## Per-item record

1. **Duplicate types — addressed.** `VestFailureMessages`/`VestFieldMessages` are now exported from `vest-run-coordinator.ts` (previously module-private there); the identical local declarations in `vest-adapter.ts` are removed and imported instead (`VestFieldMessages` is no longer needed in the adapter after item 3).
2. **Three names for one suite shape — addressed.** `RunVestSuiteParams.suite` uses `VestCoordinatedSuite<TValue, F>` instead of re-spelling the same `Pick` inline. `VestCoordinatedSuite` is re-exported from the adapter and added to `index.ts` — the only public-surface change, and it is additive.
3. **Unreachable field-scoped result branch — deleted.** `isVestFieldMessages`, the array overload of `toVestValidationEntries`, and the `VEST_ROOT_FIELD_SENTINEL` comparison are removed: every internal `getErrors()`/`getWarnings()` call site passes zero arguments (always the keyed map; verified against vest@6.3.2). Rationale documented on `toVestValidationEntries` and `VestResultLike`.
4. **Stale identifiers in comments — addressed, one part documented-not-renamed.** Spec-file comments updated (`getOrCreateVestRun` → `request`/`toVestFocusKey`, `pendingTreesBySuite` → `pendingKeysBySuite`, caches attributed to the coordinator). `normalizeWarningKindSegment` keeps its name: PR #332 added another call site to the same function mid-flight, and a rename would have created avoidable merge friction. Instead its doc comment now states the helper is mode-agnostic and that the `'warning'` fallback literal can appear in an error-mode kind as a cosmetic quirk (callers match on the prefix, not the fallback text).
5. **Vestigial defensive code — addressed.** Unreachable try/catch around the `new Promise` in `waitForStartedVestRunTail` removed; `resolveQueueTail` no-op initializer replaced with a documented definite-assignment `let resolveTail!`; both "subscribe fired synchronously" guard comments now say the guards protect hand-rolled suite shapes only (vest@6.3.2 never fires synchronously) — guards kept, per the issue.
6. **Nits — addressed, one part documented-not-removed.** The `VestFieldExclusion` import in `validate-vest.ts` stays with an inline comment: it exists solely so the `{@link}` doc tag resolves, and removing it silently breaks that link. `VestResultLike<F>` overload comment fixed (see item 3). `isFieldTree` doc comment now states the guard is intentionally loose (accepts any callable).

## Verification (independently re-run by the orchestrator after merging current main, which includes all four Wave-1 PRs)

- `CI=1 pnpm nx run toolkit:test` — PASS (85 files, 1411 tests)
- `CI=1 pnpm nx run toolkit:test-browser` — PASS (17 files, 79 tests)
- `pnpm nx run toolkit:lint` — PASS (exit 0; only pre-existing warnings in unrelated files)
- `pnpm exec tsc -p packages/toolkit/tsconfig.spec.json --noEmit` — 192 errors, identical to the main baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
