### PR TITLE
docs(vest): post-backlog documentation sweep — overclaims, missing rules, drift

### DIFF
--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -748,11 +748,20 @@ full composition examples and the exported option types.
 import {
   VEST_ERROR_KIND_PREFIX, // 'vest:'
   VEST_WARNING_KIND_PREFIX, // 'warn:vest:'
+  createVestAdapter,
+  sharedVestAdapter,
   validateVest,
   validateVestWarnings,
+  type RunVestSuiteParams,
+  type RunVestSuiteResult,
   type ValidateVestOptions,
+  type VestAdapterOptions,
+  type VestCoordinatedSuite,
   type VestFieldExclusion,
   type VestOnlyFieldSelector,
+  type VestRegisterOptions,
+  type VestRunnableSuite,
+  type VestSuiteAdapter,
 } from '@ngx-signal-forms/toolkit/vest';
 
 interface ValidateVestOptions<TValue = unknown, F extends string = string> {
@@ -797,18 +806,35 @@ interface VestRegisterOptions<TValue = unknown, F extends string = string> {
   readonly resetOnDestroy?: boolean;
   readonly only?: VestOnlyFieldSelector<TValue, F>;
 }
+// The exact slice of `VestRunnableSuite` the run coordinator drives (`run`,
+// `only`, `subscribe`, `get`) — NOT the full suite contract. `reset` is
+// registration-layer-only (`resetOnDestroy`), never passed to a run.
+type VestCoordinatedSuite<TValue, F extends string = string> = Pick<
+  VestRunnableSuite<TValue, F>,
+  'run' | 'only' | 'subscribe' | 'get'
+>;
+
 interface RunVestSuiteParams<TValue, F extends string = string> {
-  readonly suite: VestRunnableSuite<TValue, F>;
+  readonly suite: VestCoordinatedSuite<TValue, F>;
   readonly fieldTree: ReadonlyFieldTree<TValue>;
   readonly value: TValue;
   readonly focus?: VestFieldExclusion<F>;
 }
 interface RunVestSuiteResult<TValue, F extends string = string> {
   readonly value: TValue;
-  readonly focus: string | undefined;
+  // The `focus` exactly as requested — a field name, a list of field names,
+  // `false`, or `undefined` — NOT the coordinator's internal cache key.
+  readonly focus: VestFieldExclusion<F>;
   readonly runResult: VestResultLike<F> | PromiseLike<VestResultLike<F>>;
   readonly initialResult: VestResultLike<F> | undefined;
   readonly fromCache: boolean;
+  // `true` when this run was queued behind another field tree's pending run
+  // on the SAME suite instead of starting immediately.
+  readonly deferred: boolean;
+  // Resolves once this run's outcome is observable, recovering from a
+  // superseded Vest resolver. Await THIS, not `runResult` — see
+  // "Awaiting a manual run's outcome" in the vest package README.
+  readonly settled: () => PromiseLike<unknown>;
 }
 interface VestSuiteAdapter {
   register<TValue, F extends string = string>(path, suite, options?): void;

--- a/.agents/skills/ngx-signal-forms/references/pitfalls.md
+++ b/.agents/skills/ngx-signal-forms/references/pitfalls.md
@@ -340,6 +340,34 @@ pitfall only applies to standalone callers of `showErrors()` or
 hand-rolled components, services). Either pass the status, or move the work
 inside the form context so inheritance can do it for you.
 
+## Vest — An Invalid Field Name Throws in Dev Mode
+
+```typescript
+// Wrong — `address.cityy` is a typo: `address` resolves on the bound field
+// tree, but `cityy` does not. Throws synchronously in dev mode.
+const suite = create((data: { address: { city: string } }) => {
+  test('address.cityy', 'City is required', () => {
+    /* ... */
+  });
+});
+
+// Correct — name a real child of the bound path
+const suite = create((data: { address: { city: string } }) => {
+  test('address.city', 'City is required', () => {
+    /* ... */
+  });
+});
+```
+
+A Vest field name whose FIRST segment does not resolve (e.g.
+`test('passwordMatch', …)` on a model with no `passwordMatch` field) is a
+legitimate **virtual** field name — a deliberate, form-level error — and
+never throws. Only a valid prefix followed by an unresolvable tail, or a
+resolution probe that throws, is treated as an authoring bug: a hard throw in
+dev mode, `console.error()` in production (still attaching the failure to
+the bound field either way). See [Vest field-name resolution](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/packages/toolkit/vest/README.md#vest-field-name-resolution)
+and [ADR-0008](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/decisions/0008-vest-suite-input-is-the-bound-path.md).
+
 ## Vest — Sharing One Suite Across Concurrent Forms Is Safe by Default
 
 A module-scope Vest suite mounted in two forms at once (list/detail, wizard step

--- a/.agents/skills/ngx-signal-forms/vest/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/vest/SKILL.md
@@ -133,8 +133,24 @@ reference-counted, so mounting a module-scope suite in two forms at once (a
 list/detail view, a wizard step beside a summary, two open tabs) does not reset
 one mount out from under the other — the suite only resets when the **last**
 surviving registration tears down. Concurrently-pending field trees that share
-one suite are isolated per run, so an in-flight async run or retained `only()`
-state on a sibling mount stays untouched.
+one suite are isolated per run **for unfocused (whole-suite) runs only** — the
+coordinator detects two different field trees with an overlapping pending run
+against the same suite and defers the later one until the suite is idle. A
+**focused** (`only`) registration is never deferred: several `only`-focused
+registrations for different fields of the SAME form are the documented,
+intentional shared-suite pattern, but a focused registration racing an
+UNRELATED form's concurrently-mounted registration on the SAME suite is
+**unsupported** — give each independently-mounted form its own suite instance
+in that case.
+
+**SSR: do not share a suite (or `sharedVestAdapter`) across requests.** A
+Node SSR process serves several concurrent requests from ONE process, so a
+module-scope suite and the module-scope `sharedVestAdapter` singleton become
+one suite instance / one run cache shared across those requests — a
+per-request `resetOnDestroy` teardown then resets a suite another request is
+still mid-render on. Under SSR, create the suite (and, for isolation, an
+adapter via `createVestAdapter()`) per request instead, e.g. from a
+request-scoped provider.
 
 ### Focused runs with `only`
 
@@ -143,6 +159,15 @@ pass a selector so the adapter threads the changed field through:
 
 ```typescript
 import { create, enforce, only, test } from 'vest';
+
+interface Model {
+  email: string;
+  username: string;
+  // Declared as the exact field-name union so `ctx.value().lastTouched`
+  // below already returns `'email' | 'username' | undefined` — proving the
+  // `only` selector's narrowing, not just its shape.
+  lastTouched?: 'email' | 'username';
+}
 
 const suite = create((data: Model, field?: string) => {
   only(field);
@@ -162,8 +187,27 @@ correct but wasteful for large suites.
 
 Declare the suite with `create<{ fields: 'email' | 'username' }>(…)` (Vest
 ≥6.3.2, or a schema-typed suite) to get a field-name union instead of a bare
-`string`. `validateVest` infers that union from `suite` — no type argument to
-write — and narrows the `only` selector's accepted return value to it, so
+`string`:
+
+```typescript
+const typedSuite = create<{ fields: 'email' | 'username' }>(
+  (data: Model, field?: string) => {
+    only(field);
+    test('email', 'Email is required', () => enforce(data.email).isNotBlank());
+    test('username', 'Username is required', () =>
+      enforce(data.username).isNotBlank(),
+    );
+  },
+);
+
+validateVest(path, typedSuite, {
+  // Return type narrows to `VestFieldExclusion<'email' | 'username'>`.
+  only: (ctx) => ctx.value().lastTouched,
+});
+```
+
+`validateVest` infers that union from `suite` — no type argument to write —
+and narrows the `only` selector's accepted return value to it, so
 `only: () => 'emial'` (a typo) is a compile error instead of a focused run
 that silently executes zero tests and reports the field valid. A suite
 declared with plain `create(…)` (no `fields`, no schema) is unaffected and
@@ -223,7 +267,7 @@ await submitWithWarnings(signupForm, async () => {
 });
 ```
 
-For Angular 21.2 `submit()` with Vest warnings, pass `{ ignoreValidators: 'all' }` and gate with `hasOnlyWarnings(form().errorSummary())`.
+For Angular's `submit()` with Vest warnings, pass `{ ignoreValidators: 'all' }` and gate with `hasOnlyWarnings(form().errorSummary())`.
 
 ## Error Handling
 
@@ -232,3 +276,4 @@ For Angular 21.2 `submit()` with Vest warnings, pass `{ ignoreValidators: 'all' 
 - If Vest v5 is installed: upgrade to `vest@^6.0.0` — v6+ implements the Standard Schema interface required by this adapter.
 - If stale errors appear on a second mount of a form using a module-scope suite: the adapter clears suite state on teardown by default — confirm `resetOnDestroy` has not been set to `false`. (Conversely, if you _want_ suite state to persist across mounts, pass `{ resetOnDestroy: false }`.)
 - If detecting Vest-origin errors in a custom strategy or test: import `VEST_ERROR_KIND_PREFIX` / `VEST_WARNING_KIND_PREFIX` and match against `error.kind` instead of hard-coding the string.
+- If a form throws in dev mode ("Vest field name ... does not resolve"): a Vest `test`/`warn` field name has a valid prefix but an invalid tail (e.g. `test('address.cityy', …)` when the bound path only has `address.city`) — fix the field name so it names a real child of the bound path. A field name whose FIRST segment doesn't resolve (e.g. `test('passwordMatch', …)`) is a legitimate **virtual** Vest field name and does not throw. See [Vest field-name resolution](../../../../packages/toolkit/vest/README.md#vest-field-name-resolution) and [`references/pitfalls.md`](../references/pitfalls.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,5 +138,6 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   [ADR-0008](docs/decisions/0008-vest-suite-input-is-the-bound-path.md).
   Implemented in
   [#287](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/287);
-  the unresolvable-Vest-field-name rule remains open, tracked in
-  [#291](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/291).
+  the unresolvable-Vest-field-name rule
+  ([#291](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/291))
+  shipped in [#307](https://github.com/ngx-signal-forms/ngx-signal-forms/pull/307).

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -833,6 +833,29 @@ true })` with `validateVest(path, suite, { only: () => activeField })`,
   authored for that subtree's value (e.g. `validateVest(path.address,
 addressSuite)` where `addressSuite` takes `{ city: string, … }`).
 
+- **BREAKING — a typed suite's field-name union now flows through `only`
+  (#292, PR #308).** Vest ≥6.3.2 propagates a field-name union `F` through
+  `only`, `getErrors`, and `getWarnings` for a suite declared with
+  `create<{ fields: 'email' | 'password' }>(…)` (or a schema-typed suite).
+  `VestRunnableSuite`, `VestOnlyFieldSelector`, `VestResultLike`,
+  `VestRegisterOptions`, `RunVestSuiteParams`/`RunVestSuiteResult`,
+  `ValidateVestOptions`, `validateVest`, `validateVestWarnings`, and
+  `VestSuiteAdapter.register`/`runVestSuite` all gained a field-name type
+  parameter `F extends string = string`, inferred from the `suite` argument —
+  no call site writes it explicitly. Previously, every `only` selector's
+  return type was erased to plain `string`, so a mistyped focus name
+  (`only: () => 'emial'`) compiled, ran zero tests, and reported the field
+  valid.
+
+  **Action:** an `only` selector for a `create<{ fields: … }>(…)` suite that
+  previously returned a wider `string` (including via a helper function typed
+  `() => string`, or a value read from an untyped source) can now fail to
+  typecheck — narrow the selector's return type (or the helper's) to the
+  suite's field-name union, or to `string` explicitly if the selector
+  genuinely needs to accept any field name. A suite declared with plain
+  `create(…)` (no `fields`, no schema) is unaffected: `F` defaults to
+  `string`, exactly as before.
+
 See [`packages/toolkit/vest/README.md`](../packages/toolkit/vest/README.md#suite-lifecycle)
 for the full suite-lifecycle discussion.
 

--- a/docs/PACKAGE_ARCHITECTURE.md
+++ b/docs/PACKAGE_ARCHITECTURE.md
@@ -98,7 +98,8 @@ packages/toolkit/
 │   ├── src/
 │   │   ├── index.ts
 │   │   ├── validate-vest.ts
-│   │   └── vest-adapter.ts             # createVestAdapter() + VestSuiteAdapter contract
+│   │   ├── vest-adapter.ts             # createVestAdapter() + VestSuiteAdapter contract
+│   │   └── vest-run-coordinator.ts     # cache, contention detection, FIFO queue, settlement (ADR-0009)
 │   ├── ng-package.json
 │   └── README.md
 ├── scripts/

--- a/docs/decisions/0008-vest-suite-input-is-the-bound-path.md
+++ b/docs/decisions/0008-vest-suite-input-is-the-bound-path.md
@@ -118,15 +118,16 @@ Automatic per-field focus — the capability `focusCurrentField` was reaching fo
 
 ### Neutral
 
-- The run coordinator (cache, contention detection, FIFO queue, settlement — roughly 500 of `vest-adapter.ts`'s 1614 lines) is **not** retired by this decision. Contention is a two-mount concern: one module-scope suite, two field trees. Giving it its own interface is tracked in #295.
+- The run coordinator (cache, contention detection, FIFO queue, settlement — roughly 500 of `vest-adapter.ts`'s 1614 lines) is **not** retired by this decision. Contention is a two-mount concern: one module-scope suite, two field trees. Giving it its own interface was tracked in #295 — see [ADR-0009](0009-vest-run-coordination-is-its-own-seam.md), which implements it.
 
 ## Related
 
 - [ADR-0006](0006-one-cascade-seam.md) — the same "one contract, one place" reasoning applied to error-visibility timing.
+- [ADR-0009](0009-vest-run-coordination-is-its-own-seam.md) — gives the run coordinator noted under "Neutral" above its own interface, implementing #295.
 - [#287](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/287) — re-scoped around this decision: suite input rule, `focusCurrentField` deletion, enforceable suite contract.
 - [#291](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/291) — the unresolvable-name rule from decision point 4.
 - [#292](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/292) — threading Vest's typed field-name union through the focus selector.
 - [#293](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/293) — research: automatic per-field focus at the root, the deliberate replacement for `focusCurrentField`.
 - [#294](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/294) — coverage of the exported interface, including the untested shared adapter singleton.
-- [#295](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/295) — giving the run coordinator its own interface.
+- [#295](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/295) — giving the run coordinator its own interface, implemented by ADR-0009.
 - [#286](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/286) — spec typecheck target; nine of its errors are resolved by #287.

--- a/packages/toolkit/vest/README.md
+++ b/packages/toolkit/vest/README.md
@@ -362,6 +362,27 @@ injection context tears down, not the first one. Destroying one mount while
 a sibling mount is still using the same suite leaves that sibling's retained
 `only()`-run state and any in-flight async run untouched.
 
+Two concurrently-mounted field trees sharing one suite are also isolated
+against each other's **unfocused** (whole-suite) runs: the adapter defers the
+later-arriving tree's run until the suite is idle, so the two never overlap
+(#214). This does not cover **focused** (`only`) registrations: several
+`only`-focused registrations for different fields of the SAME form are the
+documented, intentional shared-suite pattern and are never deferred, but a
+focused registration racing an unrelated, concurrently-mounted form's
+registration on the same suite is unsupported — give each independently
+mounted form its own suite instance in that case.
+
+### Server-side rendering (SSR)
+
+Do not share a suite — or the module-scope `sharedVestAdapter` — across
+concurrent SSR requests. A Node SSR process serves several requests from ONE
+process, so a module-scope suite instance and `sharedVestAdapter`'s run cache
+are shared across those requests: a per-request `resetOnDestroy` teardown
+resets a suite (and drops the run cache) that another request is still
+mid-render on. Create the suite, and ideally an adapter via
+`createVestAdapter()`, **per request** instead — for example, provided by a
+request-scoped provider — rather than at module scope.
+
 ### Async caveats
 
 - `suite.run(data)` returns a synchronous `SuiteResult` that is _also_ a
@@ -397,6 +418,15 @@ pass an `only` selector so the adapter threads the changed field through:
 ```typescript
 import { create, enforce, only, test } from 'vest';
 
+interface Model {
+  email: string;
+  username: string;
+  // Declared as the exact field-name union so `ctx.value().lastTouched`
+  // below already returns `'email' | 'username' | undefined` — proving the
+  // `only` selector's narrowing, not just its shape.
+  lastTouched?: 'email' | 'username';
+}
+
 const suite = create((data: Model, field?: string) => {
   only(field);
   test('email', 'Email is required', () => {
@@ -419,10 +449,12 @@ suites where per-field isolation matters.
 #### Typed focus names
 
 Declare the suite with `create<{ fields: … }>(…)` (Vest ≥6.3.2) to get a
-field-name union instead of a bare `string`:
+field-name union instead of a bare `string`. Reusing the same `Model` from
+above (whose `lastTouched` is already typed as `'email' | 'username'`) shows
+the union propagating end to end:
 
 ```typescript
-const suite = create<{ fields: 'email' | 'username' }>(
+const typedSuite = create<{ fields: 'email' | 'username' }>(
   (data: Model, field?: string) => {
     only(field);
     test('email', 'Email is required', () => {
@@ -434,7 +466,7 @@ const suite = create<{ fields: 'email' | 'username' }>(
   },
 );
 
-validateVest(path, suite, {
+validateVest(path, typedSuite, {
   // Return type narrows to `VestFieldExclusion<'email' | 'username'>`: a
   // single field name, a `('email' | 'username')[]` for multi-field focus,
   // `undefined` for a whole-suite run, or `false` to focus nothing (throws —
@@ -475,6 +507,52 @@ call runs the whole suite when `field` is `undefined`, and just that field's
 tests otherwise. There is no separate auto-focus option: the suite always
 runs on the bound path's value, so the field to focus is information only
 your form knows and must supply.
+
+## Vest field-name resolution
+
+Per [ADR-0008](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/decisions/0008-vest-suite-input-is-the-bound-path.md), a Vest field name (the string a `test()`/`warn()` is
+registered under) is resolved **relative to the bound path** by walking the
+Angular field tree the validator is attached to. A name that does not resolve
+is classified by shape:
+
+- **Virtual Vest field name** — the name's FIRST segment does not resolve
+  against the bound field tree, e.g. `test('passwordMatch', 'Passwords must
+match', …)` on a model with no `passwordMatch` field. This is a deliberate,
+  form-level error and is indistinguishable from an authoring mistake at that
+  point, so it is treated as legitimate: the failure attaches to the bound
+  field silently, with no warning or error logged.
+- **Invalid Vest field name** — a valid prefix resolves but a LATER segment
+  does not (`test('address.cityy', …)` when the bound field tree has
+  `address.city` but no `address.cityy`), or the resolution probe itself
+  throws. Nothing but a typo or a field-tree/suite shape mismatch explains
+  this shape, so it is treated as an authoring bug:
+  - **Development mode:** the adapter **throws** synchronously, inside the
+    validator's computed — the form's render fails loudly rather than
+    silently misattaching the error.
+  - **Production builds:** the adapter logs a `console.error()` instead of
+    throwing, and still attaches the failure to the bound field so it is
+    never silently lost.
+
+```typescript
+const suite = create((data: SignupModel) => {
+  // Virtual: `passwordMatch` names no field on `SignupModel` — legitimate,
+  // attaches to the bound field silently.
+  test('passwordMatch', 'Passwords must match', () => {
+    /* ... */
+  });
+
+  // Invalid, IF the bound field tree has `address.city` but not
+  // `address.cityy` — a valid prefix (`address`) followed by a typo'd tail.
+  // Throws in dev mode; logs and attaches to the bound field in production.
+  test('address.cityy', 'City is required', () => {
+    /* ... */
+  });
+});
+```
+
+This only applies to a Vest field name's own shape — it is unrelated to
+`validateVest`'s `only` selector, which focuses which Vest tests RUN, not how
+a result's field name is resolved.
 
 ## Using Angular `submit()` with warnings
 

--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -281,6 +281,31 @@ describe('createVestRunCoordinator', () => {
       expect(async.initialResult).toBe(sync.initialResult);
     });
 
+    it('is idempotent for a repeated tuple across many redundant calls', () => {
+      // Regression guard for the invariant `request()`'s doc comment states:
+      // a reactive computed re-running for a reason unrelated to this
+      // request (see `registerVestValidation`'s `validateTree`/
+      // `validateAsync` callbacks, which call `request()` on every
+      // re-evaluation) must never start a second `suite.run()` for the same
+      // tuple. Five calls stand in for "however many times change detection
+      // happens to re-run the computed".
+      const coordinator = createVestRunCoordinator();
+      const { suite, started } = createControllableSuite();
+      const cacheKey = {};
+
+      const results = Array.from({ length: 5 }, () =>
+        coordinator.request({ suite, cacheKey, value: 'a' }),
+      );
+
+      expect(started).toEqual(['a']);
+      expect(results[0]?.fromCache).toBe(false);
+      expect(results.slice(1).every((result) => result.fromCache)).toBe(true);
+      for (const result of results.slice(1)) {
+        expect(result.runResult).toBe(results[0]?.runResult);
+        expect(result.initialResult).toBe(results[0]?.initialResult);
+      }
+    });
+
     it('re-runs when the value reference, the focus, or the cache key changes', () => {
       const coordinator = createVestRunCoordinator();
       const { suite, started, focused } = createInstantSuite();

--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -293,16 +293,21 @@ describe('createVestRunCoordinator', () => {
       const { suite, started } = createControllableSuite();
       const cacheKey = {};
 
-      const results = Array.from({ length: 5 }, () =>
+      const [first, ...rest] = Array.from({ length: 5 }, () =>
         coordinator.request({ suite, cacheKey, value: 'a' }),
       );
+      // Fail loudly (not via an untyped `undefined`) if `Array.from({ length: 5 }, ...)`
+      // ever stopped producing at least one result.
+      if (first === undefined) {
+        throw new Error('expected at least one coordinator.request() result');
+      }
 
       expect(started).toEqual(['a']);
-      expect(results[0]?.fromCache).toBe(false);
-      expect(results.slice(1).every((result) => result.fromCache)).toBe(true);
-      for (const result of results.slice(1)) {
-        expect(result.runResult).toBe(results[0]?.runResult);
-        expect(result.initialResult).toBe(results[0]?.initialResult);
+      expect(first.fromCache).toBe(false);
+      expect(rest.every((result) => result.fromCache)).toBe(true);
+      for (const result of rest) {
+        expect(result.runResult).toBe(first.runResult);
+        expect(result.initialResult).toBe(first.initialResult);
       }
     });
 

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -255,7 +255,7 @@ export interface VestRunCoordinator {
    * calls `request()` from INSIDE the reactive computeds `validateTree` and
    * `validateAsync` register, which Angular's change-detection machinery can
    * re-run for reasons unrelated to this request (an unrelated signal read in
-   * the same computed changing, a `markCheck`/re-evaluation pass, …) without
+   * the same computed changing, a `markForCheck()`/re-evaluation pass, …) without
    * the tuple itself changing. A non-idempotent `request()` would re-execute
    * `suite.run()` — and the coordinator's other side effects (contention
    * bookkeeping, the FIFO queue) — on every such re-run, not just on a real

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -247,6 +247,19 @@ export interface VestRunCoordinator {
    * Request a run for a `(suite, cache key, value, focus)` tuple. Returns the
    * cached run when that exact tuple is already held, and otherwise starts
    * (or, when the suite is contested, queues) a fresh one.
+   *
+   * **Must be idempotent for a repeated tuple** — calling `request()` twice
+   * with the identical `(suite, cache key, value, focus)` tuple must never
+   * start a second `suite.run()`. This is not just a caching nicety: the
+   * built-in registration path (`vest-adapter.ts`'s `registerVestValidation`)
+   * calls `request()` from INSIDE the reactive computeds `validateTree` and
+   * `validateAsync` register, which Angular's change-detection machinery can
+   * re-run for reasons unrelated to this request (an unrelated signal read in
+   * the same computed changing, a `markCheck`/re-evaluation pass, …) without
+   * the tuple itself changing. A non-idempotent `request()` would re-execute
+   * `suite.run()` — and the coordinator's other side effects (contention
+   * bookkeeping, the FIFO queue) — on every such re-run, not just on a real
+   * value/focus change.
    */
   request<TValue, F extends string = string>(
     request: VestRunRequest<TValue, F>,


### PR DESCRIPTION
Closes #326

Documentation-only sweep closing the last issue from the 2026-08-10 post-merge vest audit, written against the tree with all five campaign code PRs merged (#329, #330, #331, #332, #334). Per the acceptance criteria, every numbered item's disposition is recorded below; none was rejected as wrong.

## Per-item disposition

1. **Focused-run isolation overclaim — fixed.** SKILL.md and the package README now qualify the isolation guarantee to unfocused (whole-suite) runs and state that a focused registration on a suite shared across concurrently-mounted forms is unsupported (verified against the coordinator source).
2. **SSR state-scoping — fixed.** New "Server-side rendering (SSR)" README subsection + SKILL.md caveat: create the suite and an adapter (`createVestAdapter()`) per request; module-scope suites / `sharedVestAdapter` share one suite instance and run cache across concurrent requests, and per-request `resetOnDestroy` teardown resets a suite another request is mid-render on.
3. **Dev-mode throw for dotted virtual names — fixed.** New "Vest field-name resolution" README section and a pitfalls entry documenting the virtual-vs-invalid split, the dev throw inside the validator computed, and the prod `console.error`.
4. **Reactive-context side effects — addressed.** The idempotency invariant is documented on `VestRunCoordinator.request` (doc comment only), plus a small additive coordinator spec: five repeated `request()` calls with an identical tuple produce exactly one `suite.run()` and identical `runResult`/`initialResult` references.
5. **PACKAGE_ARCHITECTURE.md — fixed.** `vest-run-coordinator.ts` added to the vest/src tree.
6. **CONTEXT.md — fixed.** The unresolvable-field-name rule is no longer "open, tracked in #291"; it points at the shipped #307.
7. **MIGRATING_BETA_TO_V1.md — fixed.** Breaking-change entry added for the typed field-name union `F` (#308).
8. **api.md suite type — fixed against the post-#334 tree.** `RunVestSuiteParams.suite` now documented as `VestCoordinatedSuite<TValue, F>` (the type #334 converged on, publicly exported), and `RunVestSuiteResult` corrected to match #330 (`focus: VestFieldExclusion<F>`, `deferred`, `settled()`).
9. **"Angular 21.2" claim — fixed.** Reworded to avoid a version-specific claim.
10. **ADR-0008 — fixed.** Forward pointers to ADR-0009 added where it said the coordinator interface "is tracked in #295".
11. **Typed-focus examples — fixed.** README and SKILL.md examples now declare `Model` with `lastTouched?: 'email' | 'username'` so the snippets compile and demonstrate the narrowing. One four-line options-summary teaser (README ~L136) was deliberately left: it has no `suite`/`Model` in scope, so there is no real type to mismatch, and grafting a model onto a non-compiling teaser line would add noise, not proof.

## Verification (independently re-run by the orchestrator)

- `CI=1 pnpm nx run toolkit:test` — PASS (85 files, 1412 tests, including the new coordinator spec)
- `CI=1 pnpm nx run toolkit:test-browser` — PASS (17 files, 79 tests)
- `pnpm nx run toolkit:lint` — PASS (exit 0; only pre-existing warnings in unrelated files)
- `pnpm exec tsc -p packages/toolkit/tsconfig.spec.json --noEmit` — 192 errors, identical to the main baseline (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated Vest suite execution with deferred and settlement status for queued or superseded runs.
  - Added type-safe field selectors and improved propagation of suite field names across validation APIs.
  - Added Vest adapter creation and shared-adapter options.

- **Bug Fixes**
  - Repeated identical validation requests now reuse a single suite execution and consistent results.
  - Invalid nested field paths now report errors appropriately while supporting virtual field names.

- **Documentation**
  - Expanded guidance for concurrency, SSR isolation, typed selectors, migration, and field-name troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->