### PR TITLE
refactor(toolkit): route the bypassing sites through createErrorVisibility (audit C1 cleanup)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,8 +79,16 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
 - **One cascade seam** — error-visibility timing is composed once, in
   `createErrorVisibility()`, and consumers call it rather than re-inlining the
   `resolveStrategyFromContext` → `resolveSubmittedStatusFromContext` →
-  `createShowErrorsComputed` chain. Several in-tree surfaces **still inline it**
-  for blocking errors; bringing them onto the seam is open work. See
+  `createShowErrorsComputed` chain. All in-tree surfaces now route through it
+  for blocking errors (`NgxHeadlessErrorState`, `NgxHeadlessFieldset`,
+  `createErrorState()`, `NgxFormFieldWrapper`, plus the pre-existing
+  `NgxSignalFormAutoAria` / `createAriaInvalidSignal` /
+  `createErrorMessageSignal()` / `NgxHeadlessErrorSummary` callers). Surfaces
+  that also expose a resolved strategy as public API (e.g.
+  `NgxFormFieldWrapper.effectiveStrategy`, `NgxHeadlessFieldset.resolvedStrategy`)
+  keep that computed separately — the seam only returns a visibility boolean —
+  and feed it into the seam alongside the raw input rather than
+  re-implementing the cascade. See
   [ADR-0006](docs/decisions/0006-one-cascade-seam.md). The **warning** channel
   is already consolidated: all surfaces resolve through
   `resolveWarningStrategyFromContext()` (input → form context

--- a/packages/toolkit/core/utilities/create-error-visibility.ts
+++ b/packages/toolkit/core/utilities/create-error-visibility.ts
@@ -35,7 +35,8 @@ export interface CreateErrorVisibilityOptions {
    */
   readonly strategy?:
     | ErrorDisplayStrategy
-    | Signal<ErrorDisplayStrategy | undefined>;
+    | Signal<ErrorDisplayStrategy | undefined>
+    | undefined;
 
   /**
    * Explicit submission status.
@@ -46,7 +47,8 @@ export interface CreateErrorVisibilityOptions {
    */
   readonly submittedStatus?:
     | SubmittedStatus
-    | Signal<SubmittedStatus | undefined>;
+    | Signal<SubmittedStatus | undefined>
+    | undefined;
 
   /**
    * Fallback strategy consulted when both `strategy` and the ambient form
@@ -79,7 +81,11 @@ export interface CreateErrorVisibilityOptions {
  *
  * Replaces the four-step manual composition of
  * `resolveStrategyFromContext` → `resolveSubmittedStatusFromContext` →
- * `createShowErrorsComputed` that every consumer used to inline.
+ * `createShowErrorsComputed` that every in-tree consumer now routes through
+ * this seam instead of inlining (ADR-0006) — `NgxHeadlessErrorState`,
+ * `NgxHeadlessFieldset`, `createErrorState()`, `NgxFormFieldWrapper`,
+ * `NgxSignalFormAutoAria`, `createAriaInvalidSignal`,
+ * `createErrorMessageSignal()`, and `NgxHeadlessErrorSummary`.
  *
  * ## What it does
  *

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -28,7 +28,7 @@ import {
   NGX_SIGNAL_FORM_CONTROL_PRESETS,
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
   NGX_SIGNAL_FORMS_CONFIG,
-  createShowErrorsComputed,
+  createErrorVisibility,
   injectFormContext,
   isBlockingError,
   isFieldStateHidden,
@@ -36,7 +36,6 @@ import {
   readDirectErrors,
   shouldShowWarnings,
   type ResolvedNgxSignalFormControlSemantics,
-  resolveErrorDisplayStrategy,
   resolveStrategyFromContext,
   resolveWarningStrategyFromContext,
 } from '@ngx-signal-forms/toolkit';
@@ -877,16 +876,19 @@ export class NgxFormFieldWrapper<TValue = unknown> {
 
   /**
    * Effective error display strategy combining component input and form context defaults.
+   *
+   * Routes through the shared `resolveStrategyFromContext` seam (ADR-0006)
+   * rather than reading `formContext.errorStrategy()` and calling
+   * `resolveErrorDisplayStrategy` directly — same cascade, one fewer
+   * hand-rolled copy of the null-context guard.
    */
-  protected readonly effectiveStrategy = computed(() => {
-    const formContext = this.#formContext;
-
-    return resolveErrorDisplayStrategy(
-      this.strategy(),
-      formContext ? formContext.errorStrategy() : undefined,
+  protected readonly effectiveStrategy = computed(() =>
+    resolveStrategyFromContext(
+      this.strategy() ?? undefined,
+      this.#formContext,
       this.#config.defaultErrorStrategy,
-    );
-  });
+    ),
+  );
 
   /**
    * Computed signal for submission status.
@@ -964,16 +966,21 @@ export class NgxFormFieldWrapper<TValue = unknown> {
   });
 
   /**
-   * Visibility-timing computed shared with `createShowErrorsComputed()`,
+   * Visibility-timing computed shared with `createErrorVisibility()`,
    * auto-aria, and the error component. Reads `invalid()` / `touched()` off
    * the field state and runs the same strategy logic — keeping every
    * surface in lockstep.
+   *
+   * `effectiveStrategy` / `submittedStatus` are already fully resolved (no
+   * `'inherit'`, no missing context) by the time they reach here, so
+   * `createErrorVisibility`'s own cascade is a no-op pass-through — this
+   * routes through the shared seam (ADR-0006) for consistency with the
+   * other four surfaces rather than for any behavior difference.
    */
-  readonly #showErrorsByStrategy = createShowErrorsComputed(
-    this.#fieldState,
-    this.effectiveStrategy,
-    this.submittedStatus,
-  );
+  readonly #showErrorsByStrategy = createErrorVisibility(this.#fieldState, {
+    strategy: this.effectiveStrategy,
+    submittedStatus: this.submittedStatus,
+  });
 
   /**
    * Whether to actually display errors based on current strategy and field state.

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -877,10 +877,11 @@ export class NgxFormFieldWrapper<TValue = unknown> {
   /**
    * Effective error display strategy combining component input and form context defaults.
    *
-   * Routes through the shared `resolveStrategyFromContext` seam (ADR-0006)
-   * rather than reading `formContext.errorStrategy()` and calling
-   * `resolveErrorDisplayStrategy` directly — same cascade, one fewer
-   * hand-rolled copy of the null-context guard.
+   * Routes through the shared `resolveStrategyFromContext` helper (the
+   * strategy-resolution half of the ADR-0006 seam; `createErrorVisibility()`
+   * is the seam itself) rather than reading `formContext.errorStrategy()`
+   * and calling `resolveErrorDisplayStrategy` directly — same cascade, one
+   * fewer hand-rolled copy of the null-context guard.
    */
   protected readonly effectiveStrategy = computed(() =>
     resolveStrategyFromContext(

--- a/packages/toolkit/headless/src/lib/error-state.ts
+++ b/packages/toolkit/headless/src/lib/error-state.ts
@@ -8,18 +8,16 @@ import {
 } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
+  createErrorVisibility,
   injectFormContext,
   NGX_SIGNAL_FORMS_CONFIG,
-  resolveStrategyFromContext,
   resolveSubmittedStatusFromContext,
   resolveWarningStrategyFromContext,
-  createShowErrorsComputed,
   shouldShowWarnings,
   unwrapValue,
   type ErrorDisplayStrategy,
   type ErrorReadableState,
   type ReactiveOrStatic,
-  type ResolvedErrorDisplayStrategy,
   type ResolvedWarningDisplayStrategy,
   type SubmittedStatus,
   type WarningDisplayStrategy,
@@ -222,21 +220,6 @@ export class NgxHeadlessErrorState<
     this.#bridgedFieldState.set(s);
   }
 
-  /**
-   * Resolution order: `strategy` input (when not `'inherit'`) → ambient
-   * form context → the global `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy`
-   * → `'on-touch'`. Mirrors `NgxHeadlessFieldset.resolvedStrategy`'s cascade
-   * so standalone usage (no `[ngxSignalForm]` host) behaves consistently
-   * regardless of which headless surface a consumer reaches for.
-   */
-  readonly #resolvedStrategy = computed<ResolvedErrorDisplayStrategy>(() =>
-    resolveStrategyFromContext(
-      this.strategy(),
-      this.#injectedContext,
-      this.#config.defaultErrorStrategy,
-    ),
-  );
-
   readonly #resolvedWarningStrategy = computed<ResolvedWarningDisplayStrategy>(
     () =>
       resolveWarningStrategyFromContext(
@@ -283,11 +266,18 @@ export class NgxHeadlessErrorState<
   readonly hasErrors = this.#core.hasErrors;
   readonly hasWarnings = this.#core.hasWarnings;
 
-  readonly #strategyBasedShowErrors = createShowErrorsComputed(
-    this.#fieldState,
-    this.#resolvedStrategy,
-    this.resolvedSubmittedStatus,
-  );
+  /**
+   * Resolution order: `strategy` input (when not `'inherit'`) → ambient
+   * form context → the global `NGX_SIGNAL_FORMS_CONFIG.defaultErrorStrategy`
+   * → `'on-touch'`. Mirrors `NgxHeadlessFieldset.resolvedStrategy`'s cascade
+   * so standalone usage (no `[ngxSignalForm]` host) behaves consistently
+   * regardless of which headless surface a consumer reaches for.
+   */
+  readonly #strategyBasedShowErrors = createErrorVisibility(this.#fieldState, {
+    strategy: this.strategy,
+    submittedStatus: this.submittedStatus,
+    configDefault: this.#config.defaultErrorStrategy,
+  });
 
   readonly #strategyBasedShowWarnings = computed(() => {
     // For warnings, we need to check hasWarnings instead of invalid

--- a/packages/toolkit/headless/src/lib/fieldset.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
+  createErrorVisibility,
   injectFormContext,
   NGX_SIGNAL_FORMS_CONFIG,
   readDirectErrors,
@@ -279,13 +280,20 @@ export class NgxHeadlessFieldset<
   );
 
   /**
-   * Show errors signal based on strategy.
+   * Show errors signal based on strategy. Routes through the shared
+   * `createErrorVisibility` seam (ADR-0006) rather than re-inlining
+   * `createShowErrorsComputed` — {@link resolvedStrategy} /
+   * {@link resolvedSubmittedStatus} stay separately computed above because
+   * they are part of this directive's public surface, but the raw
+   * `strategy`/`submittedStatus` inputs feed the seam directly so it applies
+   * the identical cascade (same function, same `configDefault`) rather than
+   * a parallel reimplementation.
    */
-  readonly #showErrorsSignal = createShowErrorsComputed(
-    this.#fieldsetState,
-    this.resolvedStrategy,
-    this.resolvedSubmittedStatus,
-  );
+  readonly #showErrorsSignal = createErrorVisibility(this.#fieldsetState, {
+    strategy: this.strategy,
+    submittedStatus: this.submittedStatus,
+    configDefault: this.#config.defaultErrorStrategy,
+  });
 
   /**
    * Show warnings signal based on {@link resolvedWarningStrategy}, timed

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -7,20 +7,16 @@ import {
 } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
+  createErrorVisibility,
   createUniqueId,
-  injectFormContext,
   isFieldStateInteractive,
   NGX_SIGNAL_FORMS_CONFIG,
   readDirectErrors,
-  resolveStrategyFromContext,
-  resolveSubmittedStatusFromContext,
   resolveValidationErrorMessage,
-  createShowErrorsComputed,
   splitByKind,
   unwrapValue,
   type ErrorDisplayStrategy,
   type ErrorReadableState,
-  type ResolvedErrorDisplayStrategy,
   type SubmittedStatus,
 } from '@ngx-signal-forms/toolkit';
 import {
@@ -442,12 +438,6 @@ function createErrorStateInternal<TValue = unknown>(
 ): ErrorStateResult {
   const { field, fieldName, strategy, submittedStatus } = options;
 
-  // Capture form context at factory call time (inside injection context).
-  // Optional: callers outside a form boundary (tests, standalone components)
-  // get undefined and fall through to the config default, matching the
-  // directive surfaces.
-  const formContext = injectFormContext();
-
   // Falls back to the global `defaultErrorStrategy` config (same cascade
   // `NgxHeadlessFieldset` applies) when neither an explicit `strategy` nor a
   // form context is present, keeping standalone usage consistent regardless
@@ -460,27 +450,27 @@ function createErrorStateInternal<TValue = unknown>(
 
   const resolvedFieldName = computed(() => unwrapValue(fieldName));
 
-  const resolvedStrategy = computed<ResolvedErrorDisplayStrategy>(() => {
-    const strategyValue =
-      strategy === undefined ? undefined : unwrapValue(strategy);
-    return resolveStrategyFromContext(
-      strategyValue,
-      formContext,
-      config?.defaultErrorStrategy,
-    );
+  // Routes strategy + submitted-status resolution and the visibility
+  // computed itself through the shared `createErrorVisibility` seam
+  // (ADR-0006) instead of re-inlining `resolveStrategyFromContext` →
+  // `resolveSubmittedStatusFromContext` → `createShowErrorsComputed`.
+  //
+  // `strategy`/`submittedStatus` are `ReactiveOrStatic<T>` (this file's own
+  // signal-or-plain-function-or-value union), which also accepts a bare
+  // `() => T` reader — a shape `createErrorVisibility`'s `Signal<T>`-typed
+  // options don't structurally accept. Normalize through `computed()` so
+  // both a real Signal and a plain reader unwrap the same way.
+  const showErrorsSignal = createErrorVisibility(fieldState, {
+    strategy:
+      strategy === undefined
+        ? undefined
+        : computed(() => unwrapValue(strategy)),
+    submittedStatus:
+      submittedStatus === undefined
+        ? undefined
+        : computed(() => unwrapValue(submittedStatus)),
+    configDefault: config?.defaultErrorStrategy,
   });
-
-  const resolvedSubmittedStatus = computed<SubmittedStatus | undefined>(() => {
-    const statusValue =
-      submittedStatus === undefined ? undefined : unwrapValue(submittedStatus);
-    return resolveSubmittedStatusFromContext(statusValue, formContext);
-  });
-
-  const showErrorsSignal = createShowErrorsComputed(
-    fieldState,
-    resolvedStrategy,
-    resolvedSubmittedStatus,
-  );
 
   const core = buildHeadlessErrorState(fieldState, resolvedFieldName);
 


### PR DESCRIPTION
> **Stacked on the #264 PR** (`feat/264-warning-cascade`, itself stacked on `refactor/279-drop-show-errors`). Review only the top commit; this retargets/rebases onto `main` as the stack merges.

Routes the error-visibility cascade's remaining bypassing sites through the one seam ADR-0006 designates, `createErrorVisibility()`: `createErrorStateInternal` (headless utilities), `NgxHeadlessErrorState`, `NgxHeadlessFieldset`, and `NgxFormFieldWrapper` — which also reconciles its `effectiveStrategy` onto `resolveStrategyFromContext`, per the issue's explicit ask. The fifth listed site, `assistive/form-field-error.ts`, needed no change: it already composes `NgxHeadlessErrorState` via `hostDirectives` with no manual resolution calls (a side effect of the warning-cascade work in #288).

Semantics are preserved site-by-site (traced in review): the wrapper feeds an already-resolved strategy so the seam's cascade is a provable pass-through, and the fieldset keeps `resolvedStrategy` as separate public API — the seam returns only the boolean, a gap ADR-0006's Costs section documents deliberately. `CreateErrorVisibilityOptions.strategy`/`submittedStatus` gain explicit `| undefined` (required under `exactOptionalPropertyTypes` for the headless `ReactiveOrStatic` inputs). CONTEXT.md's "one cascade seam" bullet now describes the completed migration.

The *warning*-cascade copies in the wrapper/fieldset are intentionally untouched — the issue scopes them out as blocked on #264, whose closing PR sits directly under this one in the stack; consolidating them through the seam is the natural follow-up once both land.

Fixes #280
Refs #265, #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
