### PR TITLE
refactor(vest): delete the validate-vest re-export shim (S2 carve-out from #275)

### DIFF
--- a/packages/toolkit/vest/src/validate-vest.spec.ts
+++ b/packages/toolkit/vest/src/validate-vest.spec.ts
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { create, enforce, group, only, test, warn } from 'vest';
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { validateVest, validateVestWarnings } from './validate-vest';
 import {
   type VestFieldExclusion,
   type VestOnlyFieldSelector,
@@ -12,10 +13,8 @@ import {
   type VestRunnableSuite,
   VEST_ERROR_KIND_PREFIX,
   VEST_WARNING_KIND_PREFIX,
-  validateVest,
-  validateVestWarnings,
-} from './validate-vest';
-import { createVestAdapter } from './vest-adapter';
+  createVestAdapter,
+} from './vest-adapter';
 
 describe('validateVest', () => {
   it('maps blocking Vest failures onto a signal form field after blur', async () => {

--- a/packages/toolkit/vest/src/validate-vest.ts
+++ b/packages/toolkit/vest/src/validate-vest.ts
@@ -10,19 +10,6 @@ import {
   type VestRunnableSuite,
 } from './vest-adapter';
 
-// Re-export the moved public contracts and constants so existing import sites
-// that targeted `./validate-vest` keep resolving unchanged. The canonical home
-// for these symbols is now `./vest-adapter`.
-export {
-  VEST_ERROR_KIND_PREFIX,
-  VEST_WARNING_KIND_PREFIX,
-  type VestFieldExclusion,
-  type VestOnlyFieldSelector,
-  type VestResultLike,
-  type VestRunnableSuite,
-  type VestFieldPath,
-} from './vest-adapter';
-
 /**
  * Options accepted by {@link validateVest} (and the focus/reset subset by
  * {@link validateVestWarnings}). Controls warning surfacing, suite-state reset


### PR DESCRIPTION
## What / why

Deletes the back-compat re-export block in `packages/toolkit/vest/src/validate-vest.ts` (audit item S2 from #275, carved out to #338 because the vest lane owned this package at the time). The canonical home for `VEST_ERROR_KIND_PREFIX`, `VEST_WARNING_KIND_PREFIX`, and the `Vest*` contract types is `./vest-adapter`; the shim only existed so old import sites kept resolving. Pre-v1 (`1.0.0-rc.11`) carries no back-compat shims.

The file itself stays: since #275 was filed it became the canonical home of `validateVest` / `validateVestWarnings` / `ValidateVestOptions`, so only the re-export block (13 lines) is deleted, not the file.

Closes #338

## Acceptance criteria

- [x] Delete the re-export shim in `validate-vest.ts` — the `export { ... } from './vest-adapter'` block and its comment are gone (diff: −13 lines; grep confirms no re-export of the moved symbols remains).
- [x] Repoint the corresponding spec at `./vest-adapter` — `validate-vest.spec.ts` now imports the moved constants/types (+`createVestAdapter`) from `./vest-adapter`, keeping `validateVest`/`validateVestWarnings` at their canonical `./validate-vest` home.
- [x] Zero-consumer sweep before deleting — re-run across `packages/`, `libs/`, `apps/`, `docs/`: the only consumer of the shimmed symbols was `validate-vest.spec.ts` (repointed); `index.ts`, `vest-adapter-guarantees.spec.ts`, `validate-vest.browser.spec.ts` already imported from the correct modules.
- [x] Verify — `pnpm nx run-many -t lint test build -p toolkit`: lint clean, tests `1387 passed (1387)` (jsdom, 83 files), build green. Targeted vest specs: `validate-vest.spec.ts` (42), `vest-adapter-guarantees.spec.ts` (9), `vest-adapter.spec.ts` (15), `vest-run-coordinator.spec.ts` (21) — all green before and after.

## Verified against

Orchestrator re-verification at `main` @ `6cb46d48` (2026-08-11): the issue's `validate-vest.ts:11-18` coordinates had drifted — the shim now sits at lines 13–25 and the file also holds the canonical `validateVest` implementations, so the fix is a block deletion, not a file deletion. `src/index.ts` already sources the moved symbols from `./vest-adapter`, leaving one spec as the sole shim consumer. Two-axis review (standards + spec) ran clean before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined validation module exports by consolidating shared Vest adapter contracts and constants in a dedicated adapter module.
  * Validation options and registration functionality remain unchanged.
  * Updated internal validation tests to use the consolidated imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->