### PR TITLE
fix(testing)!: pin the default context and make the WCAG 2.2 AA baseline non-overridable

### DIFF
--- a/packages/toolkit/testing/README.md
+++ b/packages/toolkit/testing/README.md
@@ -52,7 +52,8 @@ Pass extra axe `RunOptions` as a second argument to merge over the WCAG 2.2
 AA defaults, e.g. to waive a rule for a fixture that intentionally renders
 unstyled controls. The WCAG 2.2 AA `runOnly` tag set is the hard-fail
 baseline and is not overridable — `runOnly` is omitted from this
-parameter's type, so passing it is a compile error:
+parameter's type, so passing it as a literal is a compile error, and the
+baseline wins at runtime regardless of what `options` carries:
 
 ```typescript
 await expectNoA11yViolations(container, {

--- a/packages/toolkit/testing/README.md
+++ b/packages/toolkit/testing/README.md
@@ -50,7 +50,9 @@ it('has no accessibility violations', async () => {
 
 Pass extra axe `RunOptions` as a second argument to merge over the WCAG 2.2
 AA defaults, e.g. to waive a rule for a fixture that intentionally renders
-unstyled controls:
+unstyled controls. The WCAG 2.2 AA `runOnly` tag set is the hard-fail
+baseline and is not overridable — `runOnly` is omitted from this
+parameter's type, so passing it is a compile error:
 
 ```typescript
 await expectNoA11yViolations(container, {

--- a/packages/toolkit/testing/README.md
+++ b/packages/toolkit/testing/README.md
@@ -50,10 +50,13 @@ it('has no accessibility violations', async () => {
 
 Pass extra axe `RunOptions` as a second argument to merge over the WCAG 2.2
 AA defaults, e.g. to waive a rule for a fixture that intentionally renders
-unstyled controls. The WCAG 2.2 AA `runOnly` tag set is the hard-fail
-baseline and is not overridable — `runOnly` is omitted from this
-parameter's type, so passing it as a literal is a compile error, and the
-baseline wins at runtime regardless of what `options` carries:
+unstyled controls. All keys are honored (`rules`, `resultTypes`, …) except
+`runOnly`: the WCAG 2.2 AA tag set is the hard-fail baseline and is not
+overridable. `runOnly` is omitted from this parameter's type, so passing it
+in an object literal is a compile error — and because TypeScript only
+enforces that omission on fresh literals, a `runOnly` smuggled in through a
+value widened to `axe.RunOptions` is overridden at runtime as well; the
+baseline always wins:
 
 ```typescript
 await expectNoA11yViolations(container, {

--- a/packages/toolkit/testing/a11y.browser.spec.ts
+++ b/packages/toolkit/testing/a11y.browser.spec.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import type axe from 'axe-core';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
 import { expectNoA11yViolations, WCAG_22_AA_TAGS } from './a11y';
 
 /**
@@ -16,21 +17,28 @@ import { expectNoA11yViolations, WCAG_22_AA_TAGS } from './a11y';
  * (e.g. color-contrast) need real rendering — matching every other
  * `expectNoA11yViolations` call site in this package.
  */
+
+// Shared mount/cleanup helper for every describe block below: creates a
+// `<div>` fixture with the given inner HTML, appends it to `document.body`,
+// and removes it after the test so specs stay isolated from one another.
+let mounted: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const el of mounted) {
+    el.remove();
+  }
+  mounted = [];
+});
+
+const mount = (innerHtml: string): HTMLElement => {
+  const host = document.createElement('div');
+  host.innerHTML = innerHtml;
+  document.body.append(host);
+  mounted.push(host);
+  return host;
+};
+
 describe('expectNoA11yViolations', () => {
-  let host: HTMLElement | undefined;
-
-  afterEach(() => {
-    host?.remove();
-    host = undefined;
-  });
-
-  const mount = (innerHtml: string): HTMLElement => {
-    host = document.createElement('div');
-    host.innerHTML = innerHtml;
-    document.body.append(host);
-    return host;
-  };
-
   it('resolves without throwing for a fixture with no accessibility violations', async () => {
     const fixture = mount(`
       <label for="ngx-a11y-self-test-name">Full name</label>
@@ -103,29 +111,18 @@ describe('expectNoA11yViolations default context', () => {
   // call scans the whole `document.body`. Every other spec in the workspace
   // passes a fixture or container explicitly, so that default path had no
   // coverage of its own — pin both directions directly against
-  // `document.body`, cleaning up whatever each test appends to it.
-  let appended: HTMLElement | undefined;
-
-  afterEach(() => {
-    appended?.remove();
-    appended = undefined;
-  });
-
+  // `document.body` (via the shared `mount` helper, which appends into it).
   it('resolves without throwing when called with no arguments against an accessible document.body', async () => {
-    appended = document.createElement('div');
-    appended.innerHTML = `
+    mount(`
       <label for="ngx-a11y-default-context-name">Full name</label>
       <input id="ngx-a11y-default-context-name" type="text" />
-    `;
-    document.body.append(appended);
+    `);
 
     await expect(expectNoA11yViolations()).resolves.toBeUndefined();
   });
 
   it('throws when called with no arguments against a document.body with a violation', async () => {
-    appended = document.createElement('img');
-    appended.setAttribute('src', 'data:,');
-    document.body.append(appended);
+    mount(`<img src="data:," />`);
 
     await expect(expectNoA11yViolations()).rejects.toThrow(
       /accessibility violation/u,
@@ -134,29 +131,50 @@ describe('expectNoA11yViolations default context', () => {
 });
 
 describe('expectNoA11yViolations WCAG 2.2 AA baseline', () => {
-  let host: HTMLElement | undefined;
-
-  afterEach(() => {
-    host?.remove();
-    host = undefined;
-  });
-
-  it('is not overridable via the options argument (runOnly is not a valid key)', async () => {
-    // `options` used to spread AFTER the WCAG 2.2 AA `runOnly` tag set, so a
-    // caller who (mis)guessed `runOnly` was accepted could silently narrow or
-    // replace the baseline. `expectNoA11yViolations`'s `options` parameter is
-    // now typed `Omit<axe.RunOptions, 'runOnly'>`, so that key does not
-    // type-check — this spec instead pins the behavioural guarantee: passing
-    // an unrelated `options` key (here, `resultTypes`) must not weaken the
-    // baseline. The fixture violates `image-alt`, which `options` does not
-    // touch, so the scan must still fail.
-    host = document.createElement('div');
-    host.innerHTML = `<img src="data:," />`;
-    document.body.append(host);
+  it('an unrelated options key does not weaken the baseline', async () => {
+    // `options` is typed `Omit<axe.RunOptions, 'runOnly'>`, so passing
+    // `runOnly` as a literal here would not compile (see the `expectTypeOf`
+    // spec below). This spec instead pins the behavioural guarantee for
+    // ordinary options: passing an unrelated key (here, `resultTypes`) must
+    // not weaken the WCAG 2.2 AA baseline. The fixture violates `image-alt`,
+    // which `resultTypes` does not touch, so the scan must still fail.
+    const fixture = mount(`<img src="data:," />`);
 
     await expect(
-      expectNoA11yViolations(host, { resultTypes: ['violations'] }),
+      expectNoA11yViolations(fixture, { resultTypes: ['violations'] }),
     ).rejects.toThrow(/image-alt/u);
+  });
+
+  it('a runOnly smuggled in through an axe.RunOptions-typed value is still overridden at runtime', async () => {
+    // The `Omit<axe.RunOptions, 'runOnly'>` parameter type only rejects
+    // fresh object literals carrying `runOnly` — TypeScript's excess-property
+    // check is literal-only. A value already typed as the wider
+    // `axe.RunOptions` (no cast needed — this is a legitimate, structurally
+    // assignable value) can still carry a `runOnly` and pass the type
+    // checker. `expectNoA11yViolations` guards against that at runtime by
+    // applying its own `runOnly` after spreading `options`, so the WCAG
+    // 2.2 AA baseline wins regardless. Prove it: point a laundered
+    // `runOnly` at a tag ('best-practice') that does not include
+    // `image-alt` (a wcag2a rule), and confirm the scan still catches the
+    // violation.
+    const laundered: axe.RunOptions = {
+      runOnly: { type: 'tag', values: ['best-practice'] },
+    };
+    const fixture = mount(`<img src="data:," />`);
+
+    await expect(expectNoA11yViolations(fixture, laundered)).rejects.toThrow(
+      /image-alt/u,
+    );
+  });
+
+  // Compile-time documentation of the `options` contract, independent of any
+  // one call site: the second parameter must never widen back to accepting
+  // `runOnly` directly, or a future refactor could silently reopen the
+  // override this file's other specs guard against at runtime.
+  it('excludes runOnly from the options parameter type', () => {
+    expectTypeOf<
+      Parameters<typeof expectNoA11yViolations>[1]
+    >().not.toHaveProperty('runOnly');
   });
 });
 

--- a/packages/toolkit/testing/a11y.browser.spec.ts
+++ b/packages/toolkit/testing/a11y.browser.spec.ts
@@ -98,6 +98,68 @@ describe('expectNoA11yViolations', () => {
   });
 });
 
+describe('expectNoA11yViolations default context', () => {
+  // The `context` parameter documents (a11y.ts) that a bare, zero-argument
+  // call scans the whole `document.body`. Every other spec in the workspace
+  // passes a fixture or container explicitly, so that default path had no
+  // coverage of its own — pin both directions directly against
+  // `document.body`, cleaning up whatever each test appends to it.
+  let appended: HTMLElement | undefined;
+
+  afterEach(() => {
+    appended?.remove();
+    appended = undefined;
+  });
+
+  it('resolves without throwing when called with no arguments against an accessible document.body', async () => {
+    appended = document.createElement('div');
+    appended.innerHTML = `
+      <label for="ngx-a11y-default-context-name">Full name</label>
+      <input id="ngx-a11y-default-context-name" type="text" />
+    `;
+    document.body.append(appended);
+
+    await expect(expectNoA11yViolations()).resolves.toBeUndefined();
+  });
+
+  it('throws when called with no arguments against a document.body with a violation', async () => {
+    appended = document.createElement('img');
+    appended.setAttribute('src', 'data:,');
+    document.body.append(appended);
+
+    await expect(expectNoA11yViolations()).rejects.toThrow(
+      /accessibility violation/u,
+    );
+  });
+});
+
+describe('expectNoA11yViolations WCAG 2.2 AA baseline', () => {
+  let host: HTMLElement | undefined;
+
+  afterEach(() => {
+    host?.remove();
+    host = undefined;
+  });
+
+  it('is not overridable via the options argument (runOnly is not a valid key)', async () => {
+    // `options` used to spread AFTER the WCAG 2.2 AA `runOnly` tag set, so a
+    // caller who (mis)guessed `runOnly` was accepted could silently narrow or
+    // replace the baseline. `expectNoA11yViolations`'s `options` parameter is
+    // now typed `Omit<axe.RunOptions, 'runOnly'>`, so that key does not
+    // type-check — this spec instead pins the behavioural guarantee: passing
+    // an unrelated `options` key (here, `resultTypes`) must not weaken the
+    // baseline. The fixture violates `image-alt`, which `options` does not
+    // touch, so the scan must still fail.
+    host = document.createElement('div');
+    host.innerHTML = `<img src="data:," />`;
+    document.body.append(host);
+
+    await expect(
+      expectNoA11yViolations(host, { resultTypes: ['violations'] }),
+    ).rejects.toThrow(/image-alt/u);
+  });
+});
+
 describe('WCAG_22_AA_TAGS', () => {
   it('covers every Level A/AA axe tag needed for WCAG 2.2 AA (additive across versions)', () => {
     expect(WCAG_22_AA_TAGS).toEqual([

--- a/packages/toolkit/testing/a11y.ts
+++ b/packages/toolkit/testing/a11y.ts
@@ -37,11 +37,13 @@ export type WCAG_22_AA_TAG = (typeof WCAG_22_AA_TAGS)[number];
  *   document body so a bare `await expectNoA11yViolations()` covers the render.
  * @param options Extra axe `RunOptions` merged over the WCAG 2.2 AA defaults —
  *   e.g. `{ rules: { 'color-contrast': { enabled: false } } }` for fixtures
- *   that intentionally render unstyled controls.
+ *   that intentionally render unstyled controls. The WCAG 2.2 AA `runOnly`
+ *   tag set is the hard-fail baseline and is not overridable: `runOnly` is
+ *   omitted from this parameter's type, so passing it is a compile error.
  */
 export async function expectNoA11yViolations(
   context: axe.ElementContext = document.body,
-  options: axe.RunOptions = {},
+  options: Omit<axe.RunOptions, 'runOnly'> = {},
 ): Promise<void> {
   const results = await axe.run(context, {
     runOnly: { type: 'tag', values: [...WCAG_22_AA_TAGS] },

--- a/packages/toolkit/testing/a11y.ts
+++ b/packages/toolkit/testing/a11y.ts
@@ -39,16 +39,26 @@ export type WCAG_22_AA_TAG = (typeof WCAG_22_AA_TAGS)[number];
  *   e.g. `{ rules: { 'color-contrast': { enabled: false } } }` for fixtures
  *   that intentionally render unstyled controls. The WCAG 2.2 AA `runOnly`
  *   tag set is the hard-fail baseline and is not overridable: `runOnly` is
- *   omitted from this parameter's type, so passing it is a compile error.
+ *   omitted from this parameter's type, so passing a literal with `runOnly`
+ *   is a compile error, and the baseline always wins at runtime even for an
+ *   `axe.RunOptions`-typed value carrying a `runOnly` (see implementation).
  */
 export async function expectNoA11yViolations(
   context: axe.ElementContext = document.body,
   options: Omit<axe.RunOptions, 'runOnly'> = {},
 ): Promise<void> {
   const results = await axe.run(context, {
-    runOnly: { type: 'tag', values: [...WCAG_22_AA_TAGS] },
+    // `resultTypes` before `...options` so callers can still override it.
     resultTypes: ['violations'],
     ...options,
+    // `runOnly` last: TypeScript's excess-property check only rejects
+    // `runOnly` on fresh object literals, so a caller could still widen a
+    // value to `axe.RunOptions` and smuggle `runOnly` through `options`
+    // (e.g. `const opts: axe.RunOptions = { runOnly: {...} }`). Applying
+    // the WCAG 2.2 AA baseline after the spread makes it win at runtime
+    // regardless, so the guarantee holds even when the type-level guard
+    // (the `Omit` above) is bypassed this way.
+    runOnly: { type: 'tag', values: [...WCAG_22_AA_TAGS] },
   });
 
   if (results.violations.length === 0) {


### PR DESCRIPTION
## What / why

Two audit-backlog findings on `packages/toolkit/testing/a11y.ts` (one 72-line file), per the fixes decided in #260:

1. **The documented default `context` had no spec.** `expectNoA11yViolations()` promises a bare call scans `document.body`; every call site in the workspace passed a container. Both directions of the zero-argument path are now pinned.
2. **`runOnly` could silently replace the WCAG 2.2 AA baseline.** The decided `Omit<axe.RunOptions, 'runOnly'>` narrowing is implemented — passing `runOnly` in a literal is now a compile error. Pre-push review additionally verified that excess-property checking is literal-only: a value pre-typed as `axe.RunOptions` still compiled and its `runOnly` won the spread. `runOnly` is therefore applied **after** `...options` so the baseline also wins at runtime (see the issue comment for why this composes with, rather than reopens, #260's rejected runtime-only alternative). `resultTypes` stays caller-overridable; the `{ rules: ... }` escape hatch is untouched.

Breaking (pre-v1, intended): the `options` parameter type narrows — no deprecation alias, no optional widening.

Closes #221

## Acceptance criteria

- [x] Spec calling `expectNoA11yViolations()` with no arguments, pass path — `resolves without throwing when called with no arguments against an accessible document.body`.
- [x] Same, fail path — `throws when called with no arguments against a document.body with a violation`.
- [x] `options` narrowed to `Omit<axe.RunOptions, 'runOnly'>` — `a11y.ts:46`; type pinned by `excludes runOnly from the options parameter type` (`expectTypeOf`, no `@ts-expect-error`).
- [x] `@param options` JSDoc states the baseline is not overridable — updated, with the literal-vs-widened nuance made explicit; README aligned.
- [x] Spec asserting the baseline survives an `options` argument — `an unrelated options key does not weaken the baseline` plus `a runOnly smuggled in through an axe.RunOptions-typed value is still overridden at runtime` (no casts; a plainly-typed `axe.RunOptions` value).
- [x] Escape hatch untouched — `{ rules: { label: { enabled: false } } }` spec unchanged at its original site.

Evidence: `pnpm nx run-many -t lint test test-browser build -p toolkit` → jsdom `1387 passed (1387)`, browser `84 passed (84)` (`testing/a11y.browser.spec.ts`: 12 tests, up from 6), build green. Workspace grep: no call site passes `runOnly`, so the type narrowing breaks nothing internally.

## Verified against

Orchestrator re-verification at `main` @ `6cb46d48` (2026-08-11): both bullets reproduced at their recorded coordinates. Two-axis review (standards + spec) before push surfaced the literal-only limit of the `Omit` guard; fixed in the second commit and re-reviewed. Rationale recorded on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accessibility checks now consistently enforce the WCAG 2.2 AA baseline, even when custom options are provided.
  * Attempts to override the required accessibility rule set are rejected both at compile time and runtime.
  * Document-body accessibility scans now work without explicitly providing a context.

* **Documentation**
  * Updated usage guidance to clarify supported options and the enforced WCAG 2.2 AA baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->