### PR TITLE
fix(assistive): warn on unsupported character-count value with no maxLength set

### DIFF
--- a/packages/toolkit/assistive/character-count.spec.ts
+++ b/packages/toolkit/assistive/character-count.spec.ts
@@ -662,14 +662,22 @@ describe('NgxFormFieldCharacterCount', () => {
 
       expect(console.warn).toHaveBeenCalledOnce();
       const loggedArgs = vi.mocked(console.warn).mock.calls[0] ?? [];
-      const serializedArgs = loggedArgs.map(String).join(' ');
+
+      // Every logged argument must itself be a string — not the raw object.
+      // Mapping through `String()` before asserting would collapse a leaked
+      // object argument to the harmless-looking `'[object Object]'`, so this
+      // checks the *raw* mock-call arguments' types instead.
+      for (const arg of loggedArgs) {
+        expect(typeof arg).toBe('string');
+      }
 
       // The raw object's data (`{ nested: 'value' }`) must never reach the
       // console — only the type descriptor (e.g. `'Object'`). `'value'` is
       // not checked directly since the diagnostic message text legitimately
       // contains the word "value" (e.g. "unsupported value type").
-      expect(serializedArgs).not.toContain('nested');
-      expect(serializedArgs).not.toMatch(/\{.*nested.*\}/u);
+      const joinedArgs = loggedArgs.join(' ');
+      expect(joinedArgs).not.toContain('nested');
+      expect(joinedArgs).not.toMatch(/\{.*nested.*\}/u);
     });
   });
 });

--- a/packages/toolkit/assistive/character-count.spec.ts
+++ b/packages/toolkit/assistive/character-count.spec.ts
@@ -8,7 +8,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { form, maxLength as signalMaxLength } from '@angular/forms/signals';
 import { render, screen } from '@testing-library/angular';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NgxFormFieldCharacterCount } from './character-count';
 
 /**
@@ -99,6 +99,26 @@ class AutoDetectMaxLengthWrapperComponent {
       this.#model.set({ text: this.textModel() });
     });
   }
+}
+
+/**
+ * Wrapper with no `maxLength` input and no `maxLength` validator, bound to a
+ * field whose value is an unsupported type (an object). This exercises the
+ * `#charCountState() === null` fallback path in `currentLength` — no
+ * `createCharacterCount()` factory is ever created, since there is no
+ * resolved limit.
+ */
+@Component({
+  selector: 'ngx-test-unsupported-value-no-maxlength',
+  standalone: true,
+  imports: [NgxFormFieldCharacterCount],
+  template: ` <ngx-form-field-character-count [formField]="objectField" /> `,
+})
+class UnsupportedValueNoMaxLengthWrapperComponent {
+  // An object value is unsupported by the character count component.
+  readonly #model = signal({ data: { nested: 'value' } });
+  readonly objectForm = form(this.#model);
+  readonly objectField = this.objectForm.data;
 }
 
 describe('NgxFormFieldCharacterCount', () => {
@@ -597,6 +617,59 @@ describe('NgxFormFieldCharacterCount', () => {
       const host = container.querySelector('ngx-form-field-character-count');
       expect(host).toBeTruthy();
       expect(host?.textContent).toContain('0/100');
+    });
+  });
+
+  describe('unsupported value type dev warning without maxLength (regression for #269)', () => {
+    // The `currentLength` fallback used when no `maxLength` is configured
+    // (or auto-detected) duplicated the factory's string/array length logic
+    // but silently dropped its one-shot dev warning. This suite pins the
+    // warning for that fallback path specifically.
+
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('emits a console.warn once when the field value is an unsupported type and no maxLength is configured', async () => {
+      const { fixture } = await render(
+        UnsupportedValueNoMaxLengthWrapperComponent,
+      );
+      await fixture.whenStable();
+
+      // The displayed count still falls back to 0 (no crash), matching the
+      // maxLength-configured path's behavior.
+      expect(screen.getByText('0')).toBeInTheDocument();
+
+      expect(console.warn).toHaveBeenCalledOnce();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('NgxFormFieldCharacterCount'),
+        expect.anything(),
+        expect.stringContaining('0'),
+      );
+
+      // Trigger another change-detection cycle; warn must NOT fire again.
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(console.warn).toHaveBeenCalledOnce();
+    });
+
+    it('logs a type descriptor only, never the raw value', async () => {
+      await render(UnsupportedValueNoMaxLengthWrapperComponent);
+
+      expect(console.warn).toHaveBeenCalledOnce();
+      const loggedArgs = vi.mocked(console.warn).mock.calls[0] ?? [];
+      const serializedArgs = loggedArgs.map(String).join(' ');
+
+      // The raw object's data (`{ nested: 'value' }`) must never reach the
+      // console — only the type descriptor (e.g. `'Object'`). `'value'` is
+      // not checked directly since the diagnostic message text legitimately
+      // contains the word "value" (e.g. "unsupported value type").
+      expect(serializedArgs).not.toContain('nested');
+      expect(serializedArgs).not.toMatch(/\{.*nested.*\}/u);
     });
   });
 });

--- a/packages/toolkit/assistive/character-count.ts
+++ b/packages/toolkit/assistive/character-count.ts
@@ -9,6 +9,7 @@ import {
 import type { FieldTree } from '@angular/forms/signals';
 import {
   createCharacterCount,
+  createCharacterCountLength,
   type CharacterCountLimitState,
   type CharacterCountValue,
 } from '@ngx-signal-forms/toolkit/headless';
@@ -404,14 +405,28 @@ export class NgxFormFieldCharacterCount {
     });
   });
 
+  /**
+   * Length signal used when `#charCountState` is `null` (no `maxLength`
+   * configured or auto-detected), so `createCharacterCount` is never
+   * invoked. Created once as an instance field — not inline inside
+   * `currentLength` — so its one-shot unsupported-value dev warning fires at
+   * most once per directive instance rather than once per
+   * `#charCountState()` recomputation.
+   *
+   * Shares its length logic (and dev warning) with `createCharacterCount`
+   * via {@link createCharacterCountLength} so an unsupported `formField`
+   * value warns identically whether or not `maxLength` happens to be set.
+   */
+  readonly #fallbackLength = createCharacterCountLength(
+    () => this.formField()().value(),
+    'NgxFormFieldCharacterCount',
+  );
+
   protected readonly currentLength = computed(() => {
     const state = this.#charCountState();
     if (state) return state.currentLength();
 
-    const value = this.formField()().value() as unknown;
-    if (typeof value === 'string') return value.length;
-    if (Array.isArray(value)) return value.length;
-    return 0;
+    return this.#fallbackLength();
   });
 
   /**

--- a/packages/toolkit/assistive/character-count.ts
+++ b/packages/toolkit/assistive/character-count.ts
@@ -7,9 +7,9 @@ import {
   untracked,
 } from '@angular/core';
 import type { FieldTree } from '@angular/forms/signals';
+import { createCharacterCountLengthSignal } from '@ngx-signal-forms/toolkit/core';
 import {
   createCharacterCount,
-  createCharacterCountLength,
   type CharacterCountLimitState,
   type CharacterCountValue,
 } from '@ngx-signal-forms/toolkit/headless';
@@ -402,6 +402,12 @@ export class NgxFormFieldCharacterCount {
       maxLength: max,
       warningThreshold: thresholds.warning / 100,
       dangerThreshold: thresholds.danger / 100,
+      // Without this, the unsupported-value dev warning would report the
+      // factory's own default name ('createCharacterCount') instead of the
+      // component the misconfigured `formField` binding actually lives on —
+      // diverging from the `#fallbackLength` warning below for the exact
+      // same misconfiguration.
+      component: 'NgxFormFieldCharacterCount',
     });
   });
 
@@ -414,10 +420,11 @@ export class NgxFormFieldCharacterCount {
    * `#charCountState()` recomputation.
    *
    * Shares its length logic (and dev warning) with `createCharacterCount`
-   * via {@link createCharacterCountLength} so an unsupported `formField`
-   * value warns identically whether or not `maxLength` happens to be set.
+   * via {@link createCharacterCountLengthSignal} so an unsupported
+   * `formField` value warns identically whether or not `maxLength` happens
+   * to be set.
    */
-  readonly #fallbackLength = createCharacterCountLength(
+  readonly #fallbackLength = createCharacterCountLengthSignal(
     () => this.formField()().value(),
     'NgxFormFieldCharacterCount',
   );

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -55,6 +55,7 @@ export {
 } from './utilities/aria/create-hint-ids-signal';
 export { assertInjector } from './utilities/assert-injector';
 export * from './utilities/cascading-resolver';
+export { createCharacterCountLengthSignal } from './utilities/character-count-length';
 export * from './utilities/create-error-visibility';
 export {
   createFieldNameResolver,

--- a/packages/toolkit/core/utilities/character-count-length.ts
+++ b/packages/toolkit/core/utilities/character-count-length.ts
@@ -1,0 +1,62 @@
+import { computed, isDevMode, type Signal } from '@angular/core';
+import { createDevWarnOnce } from './dev-warn-once';
+
+/**
+ * Creates a `computed()` signal counting a character-count value's length:
+ * `string.length` for strings, `array.length` for arrays, `0` for
+ * `null`/`undefined` (treated as "empty"), and `0` — plus a one-shot dev-mode
+ * `console.warn` — for anything else.
+ *
+ * Shared by every caller that needs "character-count length + unsupported
+ * value diagnostic" semantics without necessarily going through the full
+ * `createCharacterCount` factory (e.g. `NgxHeadlessCharacterCount`'s
+ * `currentLength`, and `NgxFormFieldCharacterCount`'s no-`maxLength`
+ * fallback, which has no limit to hand `createCharacterCount`). Both call
+ * sites get the identical diagnostic instead of one silently re-deriving the
+ * length logic without it.
+ *
+ * @remarks Does not require an injection context (only creates a `computed()`
+ * signal internally).
+ *
+ * @param value - Reader for the field's raw value. Called reactively on
+ *   every recomputation — pass a tracked signal read (e.g. `() =>
+ *   field()().value()`).
+ * @param component - Name reported in the dev warning, e.g.
+ *   `[ngx-signal-forms] <component>: unsupported value type — …`. Required
+ *   rather than defaulted — every current caller passes its own name so the
+ *   warning always points at the component the misconfiguration lives in.
+ */
+export function createCharacterCountLengthSignal(
+  value: () => unknown,
+  component: string,
+): Signal<number> {
+  // One-shot guard so the dev warning for an unsupported value type fires at
+  // most once per returned signal (i.e. once per caller) instead of on every
+  // re-computation.
+  const warnUnsupportedValue = createDevWarnOnce();
+
+  return computed(() => {
+    const currentValue = value();
+    if (typeof currentValue === 'string') return currentValue.length;
+    if (Array.isArray(currentValue)) return currentValue.length;
+    // The type descriptor (including `constructor?.name`) is dev-diagnostic
+    // work only — gate the whole branch on `isDevMode()` so production never
+    // computes it, even though `devWarnOnce` itself would no-op the console
+    // call.
+    if (isDevMode() && currentValue !== null && currentValue !== undefined) {
+      // Log a type descriptor only — never the raw value, which may contain
+      // user-entered data and end up in dev consoles, CI logs, or screenshots.
+      const valueType =
+        typeof currentValue === 'object'
+          ? (currentValue.constructor?.name ?? 'object')
+          : typeof currentValue;
+      warnUnsupportedValue(
+        'warn',
+        `[ngx-signal-forms] ${component}: unsupported value type — expected \`string\` or \`readonly string[]\`, got`,
+        valueType,
+        '— rendering length as 0.',
+      );
+    }
+    return 0;
+  });
+}

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -105,7 +105,6 @@ export {
 // Utility functions
 export {
   createCharacterCount,
-  createCharacterCountLength,
   createErrorState,
   createFieldStateFlags,
   createUniqueId,

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -105,6 +105,7 @@ export {
 // Utility functions
 export {
   createCharacterCount,
+  createCharacterCountLength,
   createErrorState,
   createFieldStateFlags,
   createUniqueId,

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -1,10 +1,4 @@
-import {
-  computed,
-  inject,
-  isDevMode,
-  type Injector,
-  type Signal,
-} from '@angular/core';
+import { computed, inject, type Injector, type Signal } from '@angular/core';
 import type { FieldTree, ValidationError } from '@angular/forms/signals';
 import {
   createErrorVisibility,
@@ -21,7 +15,7 @@ import {
 } from '@ngx-signal-forms/toolkit';
 import {
   assertInjector,
-  createDevWarnOnce,
+  createCharacterCountLengthSignal,
   createFieldMessageIdSignals,
   humanizeFieldPath,
   stripAngularFormPrefix,
@@ -529,61 +523,6 @@ export interface CharacterCountResult {
 }
 
 /**
- * Creates a `computed()` signal counting a character-count value's length:
- * `string.length` for strings, `array.length` for arrays, `0` for
- * `null`/`undefined` (treated as "empty"), and `0` — plus a one-shot dev-mode
- * warning — for anything else.
- *
- * Extracted out of {@link createCharacterCount} so callers that count length
- * without going through the full factory (e.g. `NgxFormFieldCharacterCount`'s
- * no-`maxLength` fallback, which has no limit to hand `createCharacterCount`)
- * still get the same unsupported-value diagnostic instead of silently
- * re-deriving the length logic without it.
- *
- * @param value Reader for the field's raw value. Called reactively on every
- *   recomputation — pass a tracked signal read (e.g. `() =>
- *   field()().value()`).
- * @param component Name reported in the dev warning, e.g.
- *   `[ngx-signal-forms] <component>: unsupported value type — …`. See
- *   {@link CreateCharacterCountOptions.component}.
- * @default component 'createCharacterCount'
- */
-export function createCharacterCountLength(
-  value: () => unknown,
-  component = 'createCharacterCount',
-): Signal<number> {
-  // One-shot guard so the dev warning for an unsupported value type fires at
-  // most once per returned signal (i.e. once per caller) instead of on every
-  // re-computation.
-  const warnUnsupportedValue = createDevWarnOnce();
-
-  return computed(() => {
-    const currentValue = value();
-    if (typeof currentValue === 'string') return currentValue.length;
-    if (Array.isArray(currentValue)) return currentValue.length;
-    // The type descriptor (including `constructor?.name`) is dev-diagnostic
-    // work only — gate the whole branch on `isDevMode()` so production never
-    // computes it, even though `devWarnOnce` itself would no-op the console
-    // call.
-    if (isDevMode() && currentValue !== null && currentValue !== undefined) {
-      // Log a type descriptor only — never the raw value, which may contain
-      // user-entered data and end up in dev consoles, CI logs, or screenshots.
-      const valueType =
-        typeof currentValue === 'object'
-          ? (currentValue.constructor?.name ?? 'object')
-          : typeof currentValue;
-      warnUnsupportedValue(
-        'warn',
-        `[ngx-signal-forms] ${component}: unsupported value type — expected \`string\` or \`readonly string[]\`, got`,
-        valueType,
-        '— rendering length as 0.',
-      );
-    }
-    return 0;
-  });
-}
-
-/**
  * Creates character count signals for a form field.
  *
  * This utility provides the same state management as NgxHeadlessCharacterCount
@@ -625,7 +564,7 @@ export function createCharacterCount(
 
   const fieldState = computed(() => field());
 
-  const currentLength = createCharacterCountLength(
+  const currentLength = createCharacterCountLengthSignal(
     () => fieldState().value(),
     component,
   );

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -529,6 +529,61 @@ export interface CharacterCountResult {
 }
 
 /**
+ * Creates a `computed()` signal counting a character-count value's length:
+ * `string.length` for strings, `array.length` for arrays, `0` for
+ * `null`/`undefined` (treated as "empty"), and `0` — plus a one-shot dev-mode
+ * warning — for anything else.
+ *
+ * Extracted out of {@link createCharacterCount} so callers that count length
+ * without going through the full factory (e.g. `NgxFormFieldCharacterCount`'s
+ * no-`maxLength` fallback, which has no limit to hand `createCharacterCount`)
+ * still get the same unsupported-value diagnostic instead of silently
+ * re-deriving the length logic without it.
+ *
+ * @param value Reader for the field's raw value. Called reactively on every
+ *   recomputation — pass a tracked signal read (e.g. `() =>
+ *   field()().value()`).
+ * @param component Name reported in the dev warning, e.g.
+ *   `[ngx-signal-forms] <component>: unsupported value type — …`. See
+ *   {@link CreateCharacterCountOptions.component}.
+ * @default component 'createCharacterCount'
+ */
+export function createCharacterCountLength(
+  value: () => unknown,
+  component = 'createCharacterCount',
+): Signal<number> {
+  // One-shot guard so the dev warning for an unsupported value type fires at
+  // most once per returned signal (i.e. once per caller) instead of on every
+  // re-computation.
+  const warnUnsupportedValue = createDevWarnOnce();
+
+  return computed(() => {
+    const currentValue = value();
+    if (typeof currentValue === 'string') return currentValue.length;
+    if (Array.isArray(currentValue)) return currentValue.length;
+    // The type descriptor (including `constructor?.name`) is dev-diagnostic
+    // work only — gate the whole branch on `isDevMode()` so production never
+    // computes it, even though `devWarnOnce` itself would no-op the console
+    // call.
+    if (isDevMode() && currentValue !== null && currentValue !== undefined) {
+      // Log a type descriptor only — never the raw value, which may contain
+      // user-entered data and end up in dev consoles, CI logs, or screenshots.
+      const valueType =
+        typeof currentValue === 'object'
+          ? (currentValue.constructor?.name ?? 'object')
+          : typeof currentValue;
+      warnUnsupportedValue(
+        'warn',
+        `[ngx-signal-forms] ${component}: unsupported value type — expected \`string\` or \`readonly string[]\`, got`,
+        valueType,
+        '— rendering length as 0.',
+      );
+    }
+    return 0;
+  });
+}
+
+/**
  * Creates character count signals for a form field.
  *
  * This utility provides the same state management as NgxHeadlessCharacterCount
@@ -570,36 +625,10 @@ export function createCharacterCount(
 
   const fieldState = computed(() => field());
 
-  // One-shot guard so the dev warning for an unsupported `value()` type fires
-  // at most once per `createCharacterCount` invocation instead of on every
-  // re-computation. `null`/`undefined` are treated as "empty" and do not warn.
-  const warnUnsupportedValue = createDevWarnOnce();
-
-  const currentLength = computed(() => {
-    const state = fieldState();
-    const value = state.value();
-    if (typeof value === 'string') return value.length;
-    if (Array.isArray(value)) return value.length;
-    // The type descriptor (including `constructor?.name`) is dev-diagnostic
-    // work only — gate the whole branch on `isDevMode()` so production never
-    // computes it, even though `devWarnOnce` itself would no-op the console
-    // call.
-    if (isDevMode() && value !== null && value !== undefined) {
-      // Log a type descriptor only — never the raw value, which may contain
-      // user-entered data and end up in dev consoles, CI logs, or screenshots.
-      const valueType =
-        typeof value === 'object'
-          ? (value.constructor?.name ?? 'object')
-          : typeof value;
-      warnUnsupportedValue(
-        'warn',
-        `[ngx-signal-forms] ${component}: unsupported value type — expected \`string\` or \`readonly string[]\`, got`,
-        valueType,
-        '— rendering length as 0.',
-      );
-    }
-    return 0;
-  });
+  const currentLength = createCharacterCountLength(
+    () => fieldState().value(),
+    component,
+  );
 
   const resolvedMaxLength = computed(() => unwrapValue(maxLength));
 


### PR DESCRIPTION
## What / why

`NgxFormFieldCharacterCount.currentLength`'s no-`maxLength` fallback duplicated the headless factory's string/array length logic but dropped its one-shot dev-mode warning for unsupported `value()` types — so the same misconfiguration warned when a `maxLength` happened to be configured and was silent when it wasn't (the case with the least other diagnostic signal).

Fix: extract the shared "length + one-shot unsupported-type warning" logic into `createCharacterCountLengthSignal` in `packages/toolkit/core/utilities/character-count-length.ts` — `/core` being the documented internal cross-entry plumbing point assistive already uses — and reuse it from both `createCharacterCount` and the assistive fallback. No second copy of the warn logic; **no public API change** (`/headless` barrel untouched). The with-`maxLength` path now also passes `component: 'NgxFormFieldCharacterCount'`, so both paths report the same component name for the same misconfiguration.

Closes #269

## Acceptance criteria

- [x] Warns once per instance in dev mode, whether or not a `maxLength` is configured — fallback goes through the shared helper (created once per directive instance as a field initializer); with-`maxLength` path warns via the factory's delegation to the same helper (pre-existing spec: headless `character-count.spec.ts` "unsupported value type dev warning (regression for Bug 3 / #73)").
- [x] Type descriptor only, never the raw value — spec asserts every raw `console.warn` argument is `typeof 'string'` (catches object-argument leakage, not just interpolation) and contains no field content.
- [x] At most once per directive instance, not per CD cycle — spec re-runs change detection and asserts `toHaveBeenCalledOnce()`. (Note: on the with-`maxLength` path the guard lives per factory creation, which `#charCountState` re-creates only when `maxLength`/thresholds change — pre-existing behaviour, unchanged here.)
- [x] Spec covering no-`maxLength` + unsupported-value — `describe('unsupported value type dev warning without maxLength (regression for #269)')`, two specs.

Evidence: `pnpm nx run-many -t lint test build -p toolkit` → `1389 passed (1389)`; debugger (a `/core` consumer) `37 passed (37)`; full workspace build, 7 projects green.

## Verified against

Orchestrator re-verification at `main` @ `6cb46d48` (2026-08-11): the issue's headless coordinates had drifted — the factory and its warning moved from `headless/character-count.ts` to `headless/src/lib/utilities.ts` (~:573-604); defect re-confirmed at `assistive/character-count.ts:407`. Two-axis review before push: helper relocated from public `/headless` to internal `/core` (CONTEXT.md convention), JSDoc hardened, component-name asymmetry closed, leak spec strengthened. Out of scope by design: #262/#265's wider factory-vs-directive consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)