### PR TITLE
fix(vest): harden isVestResultLike guard and close the lossy-normalizer collision class

### DIFF
--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -542,11 +542,11 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
   describe('kind sanitiser: same-segment message collision', () => {
     it('gives two distinct messages that fold to the same normalized segment distinct kinds via the lossy-normalization hash suffix', async () => {
       // 'Too long!' and 'Too long?' both strip their case/punctuation down to
-      // the same normalized segment ('too-long') -- but normalization is
+      // the same normalized segment ('too-long') — but normalization is
       // LOSSY for both (the sanitized string differs from the original), so
       // `normalizeWarningKindSegment` now appends an `fnv1a4Hex` suffix of
       // each ORIGINAL message. The two originals differ, so their hashes
-      // differ, so the two kinds are already distinct at occurrence 0 --
+      // differ, so the two kinds are already distinct at occurrence 0 —
       // no fold-collision reaches the occurrence counter at all. See issue
       // #219 / #260 (character-folding collision hardening).
       //
@@ -598,7 +598,7 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
         expect(kind).toMatch(/^warn:vest:email:too-long-[0-9a-f]{4}:\d$/u);
       }
       // ... and both land at occurrence 0, because the hash suffix alone
-      // already keeps the two kinds apart -- no fold-collision reaches the
+      // already keeps the two kinds apart — no fold-collision reaches the
       // occurrence counter.
       expect(new Set(kinds).size).toBe(2);
       expect(kinds[0]).toMatch(/:0$/u);
@@ -661,19 +661,64 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
     // literal message `'warning'` to exercise `createVestValidationKind`'s
     // `|| 'warning'` fallback colliding with a genuine `'warning'` message.
     // That scenario no longer applies: `normalizeWarningKindSegment` now
-    // hashes ANY lossily-normalized input -- including one that folds to
-    // nothing -- so `'!!!'` now gets its own hash-suffixed segment instead of
-    // falling back to the bare `'warning'` literal (see the fold-collision
-    // test above/below for the replacement coverage of that code path). The
-    // `'field'`/`'warning'` fallback literals in `createVestValidationKind`
-    // are only reachable by a truly empty (`''`) raw fieldPath/message now,
-    // and Vest itself silently drops a `test(fieldName, '', ...)` call (it
-    // registers no error/warning at all -- verified empirically against
-    // vest@6.3.2), so that fallback is defensive-only and not exercisable
-    // through the public `validateVest` surface. It remains covered
-    // structurally: `normalizeWarningKindSegment('')` returns `''` unchanged
-    // (non-lossy, since `''` sanitizes to itself), which is exactly the
-    // input the `|| 'field'`/`|| 'warning'` fallback exists to catch.
+    // hashes ANY lossily-normalized input — including one that folds to
+    // nothing — so `'!!!'` now gets its own hash-suffixed segment instead of
+    // falling back to the bare `'warning'` literal (see the fold-to-empty
+    // test right below, and the fold-collision test further down, for the
+    // replacement coverage of that code path). The `'field'`/`'warning'`
+    // fallback literals in `createVestValidationKind` are only reachable by
+    // a truly empty (`''`) raw fieldPath/message now, and Vest itself
+    // silently drops a `test(fieldName, '', ...)` call (it registers no
+    // error/warning at all — verified empirically against vest@6.3.2), so
+    // that fallback is defensive-only and not exercisable through the
+    // public `validateVest` surface. It remains covered structurally:
+    // `normalizeWarningKindSegment('')` returns `''` unchanged (non-lossy,
+    // since `''` sanitizes to itself), which is exactly the input the
+    // `|| 'field'`/`|| 'warning'` fallback exists to catch.
+
+    it('gives a punctuation-only message a bare hash segment, with no leading hyphen', async () => {
+      // '!!!' folds to '' (every character is stripped by the sanitize
+      // regex), which is lossy (`'' !== '!!!'`), so `normalizeWarningKindSegment`
+      // appends a hash suffix. The folded segment being EMPTY is the edge
+      // case a naive `${truncated}-${hash}` join gets wrong: it would
+      // reintroduce a leading hyphen (`-a1b2`) that the trim step earlier in
+      // the same function just stripped, producing an invalid CSS-identifier
+      // start and an ugly kind (`warn:vest:email:-a1b2:0`). The fix returns
+      // the bare hash instead, so the segment is exactly 4 hex digits with
+      // no leading hyphen.
+      const suite = create((data: { email: string }) => {
+        vestTest('email', '!!!', () => {
+          warn();
+          enforce(data.email).longerThan(10);
+        });
+      });
+
+      let f!: ReadonlyFieldTree<{ email: string }>;
+
+      @Component({
+        selector: 'ngx-test-adapter-kind-fold-to-empty',
+        imports: [FormField],
+
+        template: `<input [formField]="f.email" />`,
+      })
+      class TestComponent {
+        readonly model = signal({ email: '' });
+        readonly f = form(this.model, (path) => {
+          validateVest(path, suite, { includeWarnings: true });
+        });
+
+        constructor() {
+          f = this.f;
+        }
+      }
+
+      await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const [error] = f.email().errors();
+      expect(error).toBeDefined();
+      expect(error?.kind).toMatch(/^warn:vest:email:[0-9a-f]{4}:0$/u);
+    });
 
     it('gives two messages that fold to the same normalized segment ("user.email" vs "user_email") distinct kinds', async () => {
       // Both 'user.email' and 'user_email' fold '.' / '_' to '-', producing

--- a/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
+++ b/packages/toolkit/vest/src/vest-adapter-guarantees.spec.ts
@@ -540,20 +540,20 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
   });
 
   describe('kind sanitiser: same-segment message collision', () => {
-    it('assigns distinct occurrence indices to two distinct short messages that normalize to the same kind segment', async () => {
-      // 'Too long!' and 'Too long?' both strip their trailing punctuation
-      // down to the same normalized segment ('too-long'). Neither exceeds
-      // VEST_KIND_SEGMENT_MAX_LEN, so the hash-suffix branch never engages --
-      // the occurrence index is the only thing that can keep their kinds
-      // apart. See issue #323.
+    it('gives two distinct messages that fold to the same normalized segment distinct kinds via the lossy-normalization hash suffix', async () => {
+      // 'Too long!' and 'Too long?' both strip their case/punctuation down to
+      // the same normalized segment ('too-long') -- but normalization is
+      // LOSSY for both (the sanitized string differs from the original), so
+      // `normalizeWarningKindSegment` now appends an `fnv1a4Hex` suffix of
+      // each ORIGINAL message. The two originals differ, so their hashes
+      // differ, so the two kinds are already distinct at occurrence 0 --
+      // no fold-collision reaches the occurrence counter at all. See issue
+      // #219 / #260 (character-folding collision hardening).
       //
       // Both `vestTest`s use `warn()`: Vest's default (blocking) error mode
       // only surfaces the FIRST failing test per field, so two colliding
-      // blocking messages on one field can never both appear at once --
-      // there would be nothing to collide. `warn()` mode accumulates every
-      // failing test's message per field, which is what actually exercises
-      // `createVestEntriesForField`'s occurrence counting for more than one
-      // entry.
+      // blocking messages on one field can never both appear at once.
+      // `warn()` mode accumulates every failing test's message per field.
       const suite = create((data: { email: string }) => {
         vestTest('email', 'Too long!', () => {
           warn();
@@ -591,40 +591,41 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
       expect(errors).toHaveLength(2);
 
       const kinds = errors.map((error) => error.kind);
-      // Both share the same field + normalized-message prefix ...
+      // Both share the same field + folded-message prefix, each carrying its
+      // own DISTINCT hash suffix (derived from the two different original
+      // messages) ...
       for (const kind of kinds) {
-        expect(kind).toMatch(/^warn:vest:email:too-long:\d$/u);
+        expect(kind).toMatch(/^warn:vest:email:too-long-[0-9a-f]{4}:\d$/u);
       }
-      // ... but the occurrence suffix keeps them distinct.
-      expect(new Set(kinds)).toEqual(
-        new Set(['warn:vest:email:too-long:0', 'warn:vest:email:too-long:1']),
-      );
+      // ... and both land at occurrence 0, because the hash suffix alone
+      // already keeps the two kinds apart -- no fold-collision reaches the
+      // occurrence counter.
+      expect(new Set(kinds).size).toBe(2);
+      expect(kinds[0]).toMatch(/:0$/u);
+      expect(kinds[1]).toMatch(/:0$/u);
     });
 
-    it('assigns distinct occurrence indices when one message normalizes to empty and falls back to the literal "warning" segment, colliding with an actual "warning" message', async () => {
-      // '!!!' has no alphanumeric characters, so normalizeWarningKindSegment
-      // returns '' and createVestValidationKind falls back to the literal
-      // segment 'warning'. A second message that IS literally 'warning'
-      // normalizes to that same segment directly. Both must render the
-      // 'warning' segment, so occurrence counting must key on the same
-      // fallback-applied segment kind generation uses -- keying on the raw
-      // message, or on the normalized segment WITHOUT the fallback, would
-      // give both occurrence 0. See issue #323 (Copilot review follow-up).
+    it('assigns distinct occurrence indices to two occurrences of the exact same message on one field', async () => {
+      // Two `vestTest`s sharing the exact same, already-clean message
+      // ('too-long', no folding needed) normalize identically and are
+      // non-lossy, so no hash suffix is appended to either. The occurrence
+      // index is the ONLY thing that can keep their kinds apart. See issue
+      // #323.
       const suite = create((data: { email: string }) => {
-        vestTest('email', '!!!', () => {
+        vestTest('email', 'too-long', () => {
           warn();
           enforce(data.email).longerThan(10);
         });
-        vestTest('email', 'warning', () => {
+        vestTest('email', 'too-long', () => {
           warn();
-          enforce(data.email).longerThan(10);
+          enforce(data.email).longerThan(100);
         });
       });
 
       let f!: ReadonlyFieldTree<{ email: string }>;
 
       @Component({
-        selector: 'ngx-test-adapter-kind-collision-fallback',
+        selector: 'ngx-test-adapter-kind-collision-identical',
         imports: [FormField],
 
         template: `<input [formField]="f.email" />`,
@@ -648,11 +649,83 @@ describe('VestSuiteAdapter — exported-interface guarantees', () => {
 
       const kinds = errors.map((error) => error.kind);
       for (const kind of kinds) {
-        expect(kind).toMatch(/^warn:vest:email:warning:\d$/u);
+        expect(kind).toMatch(/^warn:vest:email:too-long:\d$/u);
       }
       expect(new Set(kinds)).toEqual(
-        new Set(['warn:vest:email:warning:0', 'warn:vest:email:warning:1']),
+        new Set(['warn:vest:email:too-long:0', 'warn:vest:email:too-long:1']),
       );
+    });
+
+    // NOTE (issue #219 / #260): the previous version of this describe block
+    // had a test pairing a punctuation-only message (`'!!!'`) with the
+    // literal message `'warning'` to exercise `createVestValidationKind`'s
+    // `|| 'warning'` fallback colliding with a genuine `'warning'` message.
+    // That scenario no longer applies: `normalizeWarningKindSegment` now
+    // hashes ANY lossily-normalized input -- including one that folds to
+    // nothing -- so `'!!!'` now gets its own hash-suffixed segment instead of
+    // falling back to the bare `'warning'` literal (see the fold-collision
+    // test above/below for the replacement coverage of that code path). The
+    // `'field'`/`'warning'` fallback literals in `createVestValidationKind`
+    // are only reachable by a truly empty (`''`) raw fieldPath/message now,
+    // and Vest itself silently drops a `test(fieldName, '', ...)` call (it
+    // registers no error/warning at all -- verified empirically against
+    // vest@6.3.2), so that fallback is defensive-only and not exercisable
+    // through the public `validateVest` surface. It remains covered
+    // structurally: `normalizeWarningKindSegment('')` returns `''` unchanged
+    // (non-lossy, since `''` sanitizes to itself), which is exactly the
+    // input the `|| 'field'`/`|| 'warning'` fallback exists to catch.
+
+    it('gives two messages that fold to the same normalized segment ("user.email" vs "user_email") distinct kinds', async () => {
+      // Both 'user.email' and 'user_email' fold '.' / '_' to '-', producing
+      // the identical normalized segment 'user-email'. `normalizeWarningKindSegment`
+      // is applied the same way to field-path AND message segments, so this
+      // exercises the exact character-folding collision issue #219 / #260
+      // targets (the concrete field-path scenario just names it). Both
+      // inputs are lossily normalized (the sanitized string differs from the
+      // original), so each gets its own `fnv1a4Hex` hash suffix of its
+      // original (distinct) text, keeping the two kinds apart without
+      // relying on occurrence indices.
+      const suite = create((data: { email: string }) => {
+        vestTest('email', 'user.email', () => {
+          warn();
+          enforce(data.email).isNotBlank();
+        });
+        vestTest('email', 'user_email', () => {
+          warn();
+          enforce(data.email).isNotBlank();
+        });
+      });
+
+      let f!: ReadonlyFieldTree<{ email: string }>;
+
+      @Component({
+        selector: 'ngx-test-adapter-kind-fold-collision',
+        imports: [FormField],
+
+        template: `<input [formField]="f.email" />`,
+      })
+      class TestComponent {
+        readonly model = signal({ email: '' });
+        readonly f = form(this.model, (path) => {
+          validateVest(path, suite, { includeWarnings: true });
+        });
+
+        constructor() {
+          f = this.f;
+        }
+      }
+
+      await render(TestComponent);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const errors = f.email().errors();
+      expect(errors).toHaveLength(2);
+
+      const kinds = errors.map((error) => error.kind);
+      for (const kind of kinds) {
+        expect(kind).toMatch(/^warn:vest:email:user-email-[0-9a-f]{4}:0$/u);
+      }
+      expect(new Set(kinds).size).toBe(2);
     });
   });
 });

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -179,9 +179,17 @@ function fnv1a4Hex(value: string): string {
  * caller's fallback-literal note below) rather than renamed, to avoid
  * unrelated churn across every call site.
  *
- * When the sanitized value exceeds {@link VEST_KIND_SEGMENT_MAX_LEN}, a short
- * FNV-1a hash suffix of the *original* value is appended to guarantee that
- * two long, otherwise-identical prefixes do not collide.
+ * The sanitize step is LOSSY -- case folding and collapsing every run of
+ * non `[a-z0-9]` characters to a single `-` can map distinct inputs onto the
+ * same segment (e.g. `'user.email'` and `'user_email'` both normalize to
+ * `'user-email'`; so do `'Email'` and `'email'`). Whenever normalization was
+ * lossy -- i.e. the normalized string differs from the original `value` --
+ * or the normalized value exceeds {@link VEST_KIND_SEGMENT_MAX_LEN}, a short
+ * FNV-1a hash suffix of the *original* value is appended so that two inputs
+ * which fold or truncate to the same segment do not collide. A `value` that
+ * survives normalization unchanged (already lowercase, already
+ * alnum-and-hyphen-only, within the length limit) is by definition
+ * collision-free and returned as-is, with no hash suffix.
  */
 function normalizeWarningKindSegment(value: string): string {
   const normalized = value
@@ -189,11 +197,19 @@ function normalizeWarningKindSegment(value: string): string {
     .replaceAll(/[^a-z0-9]+/gu, '-')
     .replaceAll(/^-+|-+$/gu, '');
 
-  if (normalized.length <= VEST_KIND_SEGMENT_MAX_LEN) {
+  const lossy =
+    normalized !== value || normalized.length > VEST_KIND_SEGMENT_MAX_LEN;
+
+  if (!lossy) {
     return normalized;
   }
 
-  return `${normalized.slice(0, VEST_KIND_SEGMENT_MAX_LEN)}-${fnv1a4Hex(value)}`;
+  const truncated =
+    normalized.length > VEST_KIND_SEGMENT_MAX_LEN
+      ? normalized.slice(0, VEST_KIND_SEGMENT_MAX_LEN)
+      : normalized;
+
+  return `${truncated}-${fnv1a4Hex(value)}`;
 }
 
 /**
@@ -201,8 +217,13 @@ function normalizeWarningKindSegment(value: string): string {
  * error or warning.
  *
  * The `'field'`/`'warning'` fallback literals below are generic placeholders
- * for "the sanitized segment came out empty" (e.g. a message that is only
- * punctuation) — they are NOT a mode indicator. In particular, the
+ * for "the sanitized segment came out empty" -- which, since
+ * {@link normalizeWarningKindSegment} now appends a hash suffix to any
+ * lossily-normalized input (including one that folds to nothing, e.g. a
+ * message that is only punctuation), can only happen for a literal empty
+ * `''` fieldPath/message: normalizing `''` is non-lossy (it stays `''`), so
+ * no hash is appended and the fallback literal applies. They are NOT a mode
+ * indicator. In particular, the
  * `'warning'` fallback also applies when `mode === 'error'`, so a blocking
  * error whose message sanitizes to empty can produce a kind that literally
  * contains the substring `warning` (e.g. `vest:field:warning:0`). This is a

--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -154,9 +154,10 @@ function isFieldTree(value: unknown): value is ReadonlyFieldTree<unknown> {
 }
 
 /**
- * Compact FNV-1a hash returning a 4-character lowercase hex digest. Used as a
- * collision-safe suffix when the raw kind segment exceeds
- * {@link VEST_KIND_SEGMENT_MAX_LEN}.
+ * Compact FNV-1a hash returning a 4-character lowercase hex digest. Used by
+ * {@link normalizeWarningKindSegment} as a collision-safe suffix whenever
+ * normalization was lossy — whether from character folding/case folding or
+ * from truncation past {@link VEST_KIND_SEGMENT_MAX_LEN}.
  */
 function fnv1a4Hex(value: string): string {
   let hash = 0x8_11c_9dc5;
@@ -179,17 +180,26 @@ function fnv1a4Hex(value: string): string {
  * caller's fallback-literal note below) rather than renamed, to avoid
  * unrelated churn across every call site.
  *
- * The sanitize step is LOSSY -- case folding and collapsing every run of
+ * The sanitize step is LOSSY — case folding and collapsing every run of
  * non `[a-z0-9]` characters to a single `-` can map distinct inputs onto the
  * same segment (e.g. `'user.email'` and `'user_email'` both normalize to
  * `'user-email'`; so do `'Email'` and `'email'`). Whenever normalization was
- * lossy -- i.e. the normalized string differs from the original `value` --
+ * lossy — i.e. the normalized string differs from the original `value` —
  * or the normalized value exceeds {@link VEST_KIND_SEGMENT_MAX_LEN}, a short
  * FNV-1a hash suffix of the *original* value is appended so that two inputs
  * which fold or truncate to the same segment do not collide. A `value` that
  * survives normalization unchanged (already lowercase, already
  * alnum-and-hyphen-only, within the length limit) is by definition
  * collision-free and returned as-is, with no hash suffix.
+ *
+ * A `value` that folds to nothing (e.g. punctuation-only, like `'!!!'`)
+ * returns the BARE hash with no leading hyphen — joining an empty folded
+ * segment to the hash with `-` would reintroduce the leading hyphen the trim
+ * step above just stripped, producing both an invalid CSS-identifier start
+ * and an ugly kind (`warn:vest:email:-a1b2:0`). Only a literal empty-string
+ * `value` (which normalizes to `''` non-lossily, so no hash is appended)
+ * still reaches the `|| 'field'`/`|| 'warning'` fallback in
+ * {@link createVestValidationKind}.
  */
 function normalizeWarningKindSegment(value: string): string {
   const normalized = value
@@ -209,7 +219,9 @@ function normalizeWarningKindSegment(value: string): string {
       ? normalized.slice(0, VEST_KIND_SEGMENT_MAX_LEN)
       : normalized;
 
-  return `${truncated}-${fnv1a4Hex(value)}`;
+  const hash = fnv1a4Hex(value);
+
+  return truncated === '' ? hash : `${truncated}-${hash}`;
 }
 
 /**
@@ -217,7 +229,7 @@ function normalizeWarningKindSegment(value: string): string {
  * error or warning.
  *
  * The `'field'`/`'warning'` fallback literals below are generic placeholders
- * for "the sanitized segment came out empty" -- which, since
+ * for "the sanitized segment came out empty" — which, since
  * {@link normalizeWarningKindSegment} now appends a hash suffix to any
  * lossily-normalized input (including one that folds to nothing, e.g. a
  * message that is only punctuation), can only happen for a literal empty

--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -798,8 +798,8 @@ describe('isVestResultLike', () => {
   });
 
   it('rejects an object whose isPending is a boolean field rather than a method', () => {
-    // Guards against the incorrect fix once proposed for this guard --
-    // `typeof isPending === 'boolean'` -- which would accept this shape even
+    // Guards against the incorrect fix once proposed for this guard —
+    // `typeof isPending === 'boolean'` — which would accept this shape even
     // though Vest's real `isPending` is a zero-arg method, not a field.
     const booleanIsPending: unknown = {
       getErrors: () => [],

--- a/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.spec.ts
@@ -1,6 +1,8 @@
+import { create, enforce, test as vestTest } from 'vest';
 import { describe, expect, it, vi } from 'vitest';
 import {
   createVestRunCoordinator,
+  isVestResultLike,
   type VestResultLike,
   type VestRunnableSuite,
 } from './vest-run-coordinator';
@@ -764,5 +766,47 @@ describe('createVestRunCoordinator', () => {
           .fromCache,
       ).toBe(true);
     });
+  });
+});
+
+describe('isVestResultLike', () => {
+  it('accepts a genuine Vest SuiteResult', () => {
+    const suite = create((data: { email: string }) => {
+      vestTest('email', 'is required', () => {
+        enforce(data.email).isNotBlank();
+      });
+    });
+
+    suite.run({ email: '' });
+    const result: unknown = suite.get();
+
+    expect(isVestResultLike(result)).toBe(true);
+  });
+
+  it('rejects an object with callable getErrors/getWarnings but no isPending method', () => {
+    // `VestResultLike` also requires `isPending` (`Pick<SuiteResult, 'isPending'>`),
+    // which both `suite.get().isPending()` and
+    // `entry.initialResult.isPending()` invoke as a METHOD later. A
+    // consumer-supplied object missing it must fail the guard rather than
+    // pass and crash downstream.
+    const missingIsPending: unknown = {
+      getErrors: () => [],
+      getWarnings: () => [],
+    };
+
+    expect(isVestResultLike(missingIsPending)).toBe(false);
+  });
+
+  it('rejects an object whose isPending is a boolean field rather than a method', () => {
+    // Guards against the incorrect fix once proposed for this guard --
+    // `typeof isPending === 'boolean'` -- which would accept this shape even
+    // though Vest's real `isPending` is a zero-arg method, not a field.
+    const booleanIsPending: unknown = {
+      getErrors: () => [],
+      getWarnings: () => [],
+      isPending: false,
+    };
+
+    expect(isVestResultLike(booleanIsPending)).toBe(false);
   });
 });

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -352,8 +352,8 @@ const VEST_FOCUS_NOTHING_SENTINEL = `${VEST_KEY_SEPARATOR}nothing${VEST_KEY_SEPA
  * Runtime guard for the subset of Vest's public result object that the adapter
  * consumes.
  *
- * Checks all three members {@link VestResultLike} requires -- `getErrors`,
- * `getWarnings`, AND `isPending` -- are present and callable. `isPending` is
+ * Checks all three members {@link VestResultLike} requires — `getErrors`,
+ * `getWarnings`, AND `isPending` — are present and callable. `isPending` is
  * a METHOD on Vest's `SuiteResult` (not a boolean field), so it is checked
  * the same way as the other two. Omitting this check let a consumer-supplied
  * object with only `getErrors`/`getWarnings` pass the guard and then crash

--- a/packages/toolkit/vest/src/vest-run-coordinator.ts
+++ b/packages/toolkit/vest/src/vest-run-coordinator.ts
@@ -351,13 +351,23 @@ const VEST_FOCUS_NOTHING_SENTINEL = `${VEST_KEY_SEPARATOR}nothing${VEST_KEY_SEPA
 /**
  * Runtime guard for the subset of Vest's public result object that the adapter
  * consumes.
+ *
+ * Checks all three members {@link VestResultLike} requires -- `getErrors`,
+ * `getWarnings`, AND `isPending` -- are present and callable. `isPending` is
+ * a METHOD on Vest's `SuiteResult` (not a boolean field), so it is checked
+ * the same way as the other two. Omitting this check let a consumer-supplied
+ * object with only `getErrors`/`getWarnings` pass the guard and then crash
+ * later when the adapter invoked `.isPending()` on it (see the crash sites at
+ * `suite.get().isPending()` and `entry.initialResult.isPending()` in this
+ * file).
  */
 export function isVestResultLike(value: unknown): value is VestResultLike {
   return (
     value !== null &&
     (typeof value === 'object' || typeof value === 'function') &&
     typeof Reflect.get(value, 'getErrors') === 'function' &&
-    typeof Reflect.get(value, 'getWarnings') === 'function'
+    typeof Reflect.get(value, 'getWarnings') === 'function' &&
+    typeof Reflect.get(value, 'isPending') === 'function'
   );
 }
 


### PR DESCRIPTION
## What / why

The two remaining bullets of the pre-v1 vest audit backlog (#219); the third bullet (dead field-scoped branch) already landed via the vest-lane rework and is untouched here.

1. **`isVestResultLike` now verifies `isPending`.** The exported guard accepted objects with only `getErrors`/`getWarnings`, which then crashed at `suite.get().isPending()` / `entry.initialResult.isPending()`. Note: the issue's proposed `typeof … === 'boolean'` check was falsified during re-verification — `isPending` is a **method** on `SuiteResult`, so the guard checks it is callable (see the [issue comment](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/219#issuecomment-5251799042)); a spec pins the boolean-field variant as rejected too.
2. **`normalizeWarningKindSegment` appends the `fnv1a4Hex` suffix whenever normalization was lossy**, not only on truncation (decided in #260). Character folding (`user.email`/`user_email` → `user-email`) and case folding (`Email`/`email`) no longer collide. A value that survives normalization unchanged keeps its exact segment, hash-free. Review follow-up: fold-to-empty inputs (punctuation-only messages) return the bare hash — no leading-hyphen segment, keeping kinds CSS/DOM-friendly.

Breaking for kind strings derived from lossy inputs (pre-v1, intended — no compat shim); the `''`-input `field`/`warning` fallback literals still behave exactly as documented.

Closes #219

## Acceptance criteria

- [x] `isPending` guard + spec — `rejects an object with callable getErrors/getWarnings but no isPending method`, `accepts a genuine Vest SuiteResult`, plus the boolean-variant rejection spec (`vest-run-coordinator.spec.ts`, new `isVestResultLike` describe).
- [x] Lossy-normalizer hash + spec — `'user.email'` vs `'user_email'` produce distinct hash-suffixed kinds (Set-distinctness + shape regex, no hardcoded hashes); `'Too long!'`/`'Too long?'` reworked to the new guarantee; occurrence-index coverage preserved via a genuinely identical-message test; punctuation-only input pinned to `/^warn:vest:email:[0-9a-f]{4}:0$/u`.
- [x] Third bullet untouched — no `VEST_ROOT_FIELD_SENTINEL` / `isVestFieldMessages` reintroduction anywhere in `packages/toolkit/vest/`.

Evidence: `pnpm nx run-many -t lint test build -p toolkit` → `1392 passed (1392)`; `test-browser` → `79 passed (79)`.

## Verified against

Orchestrator re-verification at `main` @ `6cb46d48` (2026-08-11): both bullets reproduced at their re-recorded coordinates (`vest-run-coordinator.ts:355`, `vest-adapter.ts:186`); the `'boolean'` premise falsified and corrected per protocol. Two-axis review before push: leading-hyphen edge fixed and pinned, stale `fnv1a4Hex` JSDoc updated, prose dash style normalized. The old `'!!!'`-vs-`'warning'` fallback-collision spec was removed as unreachable under the new behaviour (documented in-file) and replaced by the bare-hash spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)