### PR TITLE
fix(assistive): pick up a property-bound [id] on NgxFormFieldHint

### DIFF
--- a/packages/toolkit/assistive/hint.spec.ts
+++ b/packages/toolkit/assistive/hint.spec.ts
@@ -311,6 +311,89 @@ describe('NgxFormFieldHint', () => {
       expect(hint).toHaveAttribute('data-ngx-signal-form-hint', 'true');
     });
 
+    it('should reflect a property-bound [id] on the resolved id', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: {
+            hintId: 'bound-hint-id',
+          },
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint).toHaveAttribute('id', 'bound-hint-id');
+      expect(hint).toHaveAttribute('data-ngx-signal-form-hint', 'true');
+    });
+
+    it('should update the resolved id when the bound [id] input changes', async () => {
+      const { container, rerender } = await render(
+        `<ngx-form-field-hint [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: {
+            hintId: 'first-id',
+          },
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint).toHaveAttribute('id', 'first-id');
+
+      await rerender({ componentProperties: { hintId: 'second-id' } });
+
+      expect(hint).toHaveAttribute('id', 'second-id');
+    });
+
+    it('should fall back to the generated id when the bound [id] is null', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: {
+            hintId: null,
+          },
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint?.getAttribute('id')).toMatch(/^hint-/);
+    });
+
+    it('should fall back to the generated id when neither a static nor a bound id is present', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint>Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint?.getAttribute('id')).toMatch(/^hint-/);
+    });
+
+    it('should prefer the bound [id] over a field-context-derived id', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: {
+            hintId: 'bound-over-field',
+          },
+          providers: [
+            {
+              provide: NGX_SIGNAL_FORM_FIELD_CONTEXT,
+              useValue: { fieldName: signal('email') },
+            },
+          ],
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint).toHaveAttribute('id', 'bound-over-field');
+    });
+
     it('should derive id from field context when provided', async () => {
       const { container } = await render(
         `<ngx-form-field-hint>Hint</ngx-form-field-hint>`,
@@ -328,6 +411,66 @@ describe('NgxFormFieldHint', () => {
       const hint = container.querySelector('ngx-form-field-hint');
       expect(hint).toHaveAttribute('id', 'email-hint');
       expect(hint).toHaveAttribute('data-signal-field', 'email');
+    });
+  });
+
+  describe('SSR/hydration parity (approximation)', () => {
+    /**
+     * This repo has no `renderApplication`/`platform-server` SSR harness for
+     * the toolkit yet, so these specs approximate hydration parity: they
+     * assert the id resolved at first render is already the final, stable
+     * id — i.e. a later change-detection pass (standing in for the client
+     * picking up server-rendered markup during hydration) never produces a
+     * *different* id for the same inputs. A module-scoped `createUniqueId`
+     * counter or a value that only "settles" after the first render would
+     * fail this and would also mismatch across the server/client boundary.
+     */
+    it('keeps a static id attribute stable across change-detection passes', async () => {
+      const { container, detectChanges } = await render(
+        `<ngx-form-field-hint id="ssr-static-id">Hint</ngx-form-field-hint>`,
+        { imports: [NgxFormFieldHint] },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      const firstId = hint?.getAttribute('id');
+      expect(firstId).toBe('ssr-static-id');
+
+      detectChanges();
+
+      expect(hint?.getAttribute('id')).toBe(firstId);
+    });
+
+    it('keeps a property-bound [id] stable across change-detection passes', async () => {
+      const { container, detectChanges } = await render(
+        `<ngx-form-field-hint [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: { hintId: 'ssr-bound-id' },
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      const firstId = hint?.getAttribute('id');
+      expect(firstId).toBe('ssr-bound-id');
+
+      detectChanges();
+
+      expect(hint?.getAttribute('id')).toBe(firstId);
+    });
+
+    it('keeps a generated fallback id stable across change-detection passes', async () => {
+      const { container, detectChanges } = await render(
+        `<ngx-form-field-hint>Hint</ngx-form-field-hint>`,
+        { imports: [NgxFormFieldHint] },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      const firstId = hint?.getAttribute('id');
+      expect(firstId).toMatch(/^hint-/);
+
+      detectChanges();
+
+      expect(hint?.getAttribute('id')).toBe(firstId);
     });
   });
 

--- a/packages/toolkit/assistive/hint.spec.ts
+++ b/packages/toolkit/assistive/hint.spec.ts
@@ -394,6 +394,36 @@ describe('NgxFormFieldHint', () => {
       expect(hint).toHaveAttribute('id', 'bound-over-field');
     });
 
+    it('should prefer a bound [id] over a static id attribute on the same host', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint id="static-id" [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: {
+            hintId: 'bound-id',
+          },
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint).toHaveAttribute('id', 'bound-id');
+    });
+
+    it('should fall back to the static id attribute when the [id] binding is null', async () => {
+      const { container } = await render(
+        `<ngx-form-field-hint id="static-fallback-id" [id]="hintId">Hint</ngx-form-field-hint>`,
+        {
+          imports: [NgxFormFieldHint],
+          componentProperties: {
+            hintId: null,
+          },
+        },
+      );
+
+      const hint = container.querySelector('ngx-form-field-hint');
+      expect(hint).toHaveAttribute('id', 'static-fallback-id');
+    });
+
     it('should derive id from field context when provided', async () => {
       const { container } = await render(
         `<ngx-form-field-hint>Hint</ngx-form-field-hint>`,

--- a/packages/toolkit/assistive/hint.ts
+++ b/packages/toolkit/assistive/hint.ts
@@ -162,6 +162,17 @@ export class NgxFormFieldHint {
   readonly position = input<'left' | 'right' | null>(null);
 
   /**
+   * Explicit id, accepted as either a static `id="…"` attribute or a
+   * property-bound `[id]="expr"`. Angular maps both forms onto this input
+   * (static attributes matching a declared input are read as the input's
+   * initial value), so a parent-computed id is picked up reactively instead
+   * of being missed the way a one-shot constructor `getAttribute('id')` read
+   * misses it. Falls through to {@link resolvedId}'s other sources when
+   * `null` or empty.
+   */
+  readonly id = input<string | null>(null);
+
+  /**
    * Resolved field name from the wrapper's `NGX_SIGNAL_FORM_FIELD_CONTEXT`,
    * or `null` when the hint is rendered outside a wrapper. Public so wrappers
    * can expose it through `NGX_SIGNAL_FORM_HINT_REGISTRY` for auto-ARIA.
@@ -186,6 +197,10 @@ export class NgxFormFieldHint {
   readonly #generatedId = createUniqueId('hint');
 
   readonly resolvedId = computed(() => {
+    const bound = this.id();
+    // oxlint-disable-next-line @typescript-eslint/strict-boolean-expressions -- empty-string id/fieldName is intentionally treated as "not set"; freezing semantic for v1
+    if (bound) return bound;
+
     const explicit = this.#explicitId();
     // oxlint-disable-next-line @typescript-eslint/strict-boolean-expressions -- empty-string id/fieldName is intentionally treated as "not set"; freezing semantic for v1
     if (explicit) return explicit;
@@ -198,13 +213,17 @@ export class NgxFormFieldHint {
   });
 
   constructor() {
-    // Read the host `id` attribute at construction time so downstream
-    // consumers (auto-aria directive, hint registry) see the explicit
-    // id synchronously during their own initialisation. Runs on both
-    // platforms: Angular's server DOM supports `getAttribute`, and we
-    // want the server-rendered `id` to match what the client picks up
-    // on hydration (otherwise author-supplied ids would hydrate as a
-    // different generated value and the DOM would mismatch).
+    // Belt-and-braces: read the host `id` attribute at construction time too
+    // (`resolvedId` checks the `id` input first — see above). Angular maps a
+    // static `id="…"` attribute onto a declared `id` input as its initial
+    // value, so the input alone already covers both the static and the
+    // property-bound (`[id]="expr"`) cases reactively. This constructor read
+    // stays as a fallback for any consumer that inspects `resolvedId()`
+    // before inputs are set (e.g. a service constructed ahead of this
+    // directive) and to keep SSR/hydration parity for the static-attribute
+    // case belt-and-braces with the input path. Runs on both platforms:
+    // Angular's server DOM supports `getAttribute`, and the server-rendered
+    // `id` matches what the client resolves on hydration either way.
     const existingId = this.#elementRef.nativeElement.getAttribute('id');
     if (existingId !== null && existingId.length > 0) {
       this.#explicitId.set(existingId);

--- a/packages/toolkit/assistive/hint.ts
+++ b/packages/toolkit/assistive/hint.ts
@@ -198,7 +198,7 @@ export class NgxFormFieldHint {
 
   readonly resolvedId = computed(() => {
     const bound = this.id();
-    // oxlint-disable-next-line @typescript-eslint/strict-boolean-expressions -- empty-string id/fieldName is intentionally treated as "not set"; freezing semantic for v1
+    // oxlint-disable-next-line @typescript-eslint/strict-boolean-expressions -- empty-string is "not set", same as below
     if (bound) return bound;
 
     const explicit = this.#explicitId();
@@ -213,17 +213,17 @@ export class NgxFormFieldHint {
   });
 
   constructor() {
-    // Belt-and-braces: read the host `id` attribute at construction time too
-    // (`resolvedId` checks the `id` input first — see above). Angular maps a
-    // static `id="…"` attribute onto a declared `id` input as its initial
-    // value, so the input alone already covers both the static and the
-    // property-bound (`[id]="expr"`) cases reactively. This constructor read
-    // stays as a fallback for any consumer that inspects `resolvedId()`
-    // before inputs are set (e.g. a service constructed ahead of this
-    // directive) and to keep SSR/hydration parity for the static-attribute
-    // case belt-and-braces with the input path. Runs on both platforms:
-    // Angular's server DOM supports `getAttribute`, and the server-rendered
-    // `id` matches what the client resolves on hydration either way.
+    // Also read the host `id` attribute at construction time. `resolvedId`
+    // checks the `id` input first — see above. Angular maps a static
+    // `id="…"` attribute onto a declared `id` input. So the input already
+    // covers the static and the property-bound (`[id]="expr"`) cases.
+    // This read still matters for one case: `viewContainerRef.createComponent`
+    // with a `hostElement` that already has an `id` attribute. That path
+    // sets the DOM attribute directly. It does not go through template input
+    // mapping, so the `id` input stays `null` and this attribute read is the
+    // only way to pick up the id. This runs on both platforms. The server
+    // DOM supports `getAttribute`. The server-rendered `id` matches what the
+    // client resolves on hydration.
     const existingId = this.#elementRef.nativeElement.getAttribute('id');
     if (existingId !== null && existingId.length > 0) {
       this.#explicitId.set(existingId);

--- a/packages/toolkit/core/directives/auto-aria.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.spec.ts
@@ -638,6 +638,44 @@ describe('NgxSignalFormAutoAria', () => {
       expect(input?.getAttribute('aria-describedby')).toBe('email-hint');
     });
 
+    it('should include a property-bound hint id, and follow it when it changes', async () => {
+      @Component({
+        template: `
+          <ngx-form-field-wrapper>
+            <input id="email" [formField]="emailControl()" />
+            <ngx-form-field-hint [id]="hintId()">
+              Help text
+            </ngx-form-field-hint>
+          </ngx-form-field-wrapper>
+        `,
+        imports: [
+          MockFormFieldDirective,
+          NgxSignalFormAutoAria,
+          NgxFormFieldHint,
+          TestHintRegistryHostComponent,
+        ],
+      })
+      class TestComponent {
+        emailControl = createMockControl(false, true); // valid, touched
+        hintId = signal('email-hint-bound');
+      }
+
+      const { container, fixture } = await render(TestComponent);
+
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      const input = container.querySelector('input');
+      expect(input?.getAttribute('aria-describedby')).toBe('email-hint-bound');
+
+      fixture.componentInstance.hintId.set('email-hint-changed');
+      fixture.detectChanges();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(input?.getAttribute('aria-describedby')).toBe(
+        'email-hint-changed',
+      );
+    });
+
     it('should combine hint and error IDs when invalid', async () => {
       @Component({
         template: `


### PR DESCRIPTION
## What / why

`NgxFormFieldHint` read its host `id` once in the constructor, so a static `id="…"` worked but a property-bound `[id]="expr"` — applied during Angular's first update pass — was silently missed: the hint fell back to its generated id and `aria-describedby` pointed at an id the author never wrote.

Fix: declare an `id` input on the directive. Angular maps both the static attribute and the property binding onto it, and `resolvedId` now resolves **bound input → constructor-read attribute → field-context-derived → generated**. The constructor `getAttribute('id')` read stays for the one path the input cannot see: `viewContainerRef.createComponent(..., { hostElement })` with a pre-existing `id` attribute, which bypasses template input mapping (the comment now states exactly this).

**Constraint disposition (criterion 3): synchronous availability is preserved via the consumers being reactive — no consumer changes were needed.** Every `resolvedId` reader was traced and is signal-based: `toHintDescriptors` (`core/utilities/wrapper-helpers.ts`), `createHintIdsSignal`, the hint registry (`core/tokens.ts` / `form-field-wrapper.ts`), auto-aria's describedby computeds, and the host `[attr.id]` binding. A later-arriving bound value propagates through the whole chain, which the new end-to-end spec pins.

Closes #268

## Acceptance criteria

- [x] Bound `[id]` reflected in the resolved id AND in referencing `aria-describedby` — hint specs for the resolved id, plus the auto-aria integration spec `should include a property-bound hint id, and follow it when it changes` (asserts the control's `aria-describedby` uses the bound id and follows a change).
- [x] Static `id` keeps working exactly as today — pre-existing `should preserve explicit id attribute` unchanged, plus stability and precedence specs (`bound [id]` wins over a static attribute on the same host; `[id]="null"` falls back to the static attribute).
- [x] Synchronous availability preserved / consumers safe — stated above: all consumers verified reactive; constructor read retained for the `createComponent`-with-hostElement path.
- [x] SSR/hydration parity — covered by an explicitly-labelled **approximation**: the repo has no `platform-server` harness (verified), so `describe('SSR/hydration parity (approximation)')` asserts the first-render id equals the post-change-detection id for all three cases (no post-hydration drift). On the server, inputs are set before serialization, so `[attr.id]` renders the bound value; the client resolves the same input on hydration.
- [x] Specs for static / bound / no id — all three, plus bound-changes-after-init, null-bound fallback, and bound-over-field-context precedence.

Evidence: `pnpm nx run-many -t lint test build -p toolkit` → `1398 passed (1398)`; `assistive/hint.spec.ts` 47/47, `core/directives/auto-aria.spec.ts` 34/34, hint browser a11y spec green.

## Verified against

Orchestrator re-verification at `main` @ `6cb46d48` (2026-08-11): defect and constraint comment confirmed at `hint.ts:200-210`; the host already bound `[attr.id]` to `resolvedId()`, which made the input-based fix viable. Two-axis review before push: added the bound-id→describedby integration spec and the static+bound conflict specs, and replaced the constructor comment's impossible justification with the real residual case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)