### PR TITLE
ci(toolkit): extend packaging.spec to verify the published surface against the source barrels

### DIFF
--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -73,14 +73,23 @@ function readEntryFile(entryDir: string): string {
  *
  * Only used to check *name* existence across barrels, so type-only vs.
  * value exports are treated identically.
+ *
+ * Results are memoized per file, and `inProgress` guards against re-export
+ * cycles: a file re-entered while its own walk is still running contributes
+ * an empty set (for `export *`) or fails the stale-name check (for a named
+ * re-export) instead of recursing forever.
  */
+const exportedNamesCache = new Map<string, Set<string>>();
+
 function collectExportedNames(
   filePath: string,
-  visited = new Set<string>(),
+  inProgress = new Set<string>(),
 ): Set<string> {
+  const cached = exportedNamesCache.get(filePath);
+  if (cached) return cached;
   const names = new Set<string>();
-  if (visited.has(filePath)) return names;
-  visited.add(filePath);
+  if (inProgress.has(filePath)) return names;
+  inProgress.add(filePath);
 
   const source = ts.createSourceFile(
     filePath,
@@ -112,12 +121,8 @@ function collectExportedNames(
           ts.isStringLiteral(statement.moduleSpecifier)
             ? statement.moduleSpecifier.text
             : undefined;
-        // A fresh visited set on purpose: the shared one exists to keep the
-        // surrounding `export *` walk from double-counting, but here we need
-        // the target's complete name set even when another chain already
-        // visited it.
         const targetNames = specifier?.startsWith('.')
-          ? collectExportedNames(resolveRelativeModule(specifier))
+          ? collectExportedNames(resolveRelativeModule(specifier), inProgress)
           : undefined;
         for (const element of statement.exportClause.elements) {
           const importedName = (element.propertyName ?? element.name).text;
@@ -134,7 +139,7 @@ function collectExportedNames(
         ts.isStringLiteral(statement.moduleSpecifier)
       ) {
         const resolved = resolveRelativeModule(statement.moduleSpecifier.text);
-        for (const name of collectExportedNames(resolved, visited)) {
+        for (const name of collectExportedNames(resolved, inProgress)) {
           names.add(name);
         }
       }
@@ -165,6 +170,8 @@ function collectExportedNames(
     }
   }
 
+  inProgress.delete(filePath);
+  exportedNamesCache.set(filePath, names);
   return names;
 }
 

--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -23,12 +23,13 @@ const projectJson = JSON.parse(
 
 const toolkitDir = resolve(import.meta.dirname, '..');
 
-// The full set of entry points ng-packagr discovers when it builds the
-// package — the primary entry (`packages/toolkit/`) plus every directory
-// holding an `ng-package.json` (ng-packagr globs for the file itself; it
-// never reads a directory name allowlist). This mirrors
-// `findSecondaryPackagesPaths` in ng-packagr's `discover-packages.ts`
-// closely enough to catch drift without needing an actual build.
+// Every *secondary* entry point ng-packagr discovers when it builds the
+// package: each toolkit sub-directory holding an `ng-package.json`
+// (ng-packagr globs for the file itself; it never reads a directory name
+// allowlist). The primary entry (`packages/toolkit/` itself) is deliberately
+// not in this list. This mirrors `findSecondaryPackagesPaths` in ng-packagr's
+// `discover-packages.ts` closely enough to catch drift without needing an
+// actual build.
 const secondaryEntries = readdirSync(toolkitDir, { withFileTypes: true })
   .filter(
     (entry) =>
@@ -61,10 +62,14 @@ function readEntryFile(entryDir: string): string {
 /**
  * Collects the names a TypeScript barrel file exports, following local
  * (relative-path) `export * from '...'` re-export chains recursively.
- * Named re-exports (`export { a, b } from '...'`, including from a
- * package-name specifier like `@ngx-signal-forms/toolkit/core`) contribute
- * their listed names directly without needing to resolve the target file —
- * this codebase never uses a bare `export *` against a package specifier.
+ * Named re-exports from a relative specifier (`export { a, b } from './...'`)
+ * are verified against the target file — a name the target no longer exports
+ * throws instead of silently counting as exported, so a stale named re-export
+ * fails here without needing a typecheck. Named re-exports from a
+ * package-name specifier (e.g. `@ngx-signal-forms/toolkit/core`) contribute
+ * their listed names directly without resolving the target — those names are
+ * cross-checked against the entry barrels by the root-barrel test instead —
+ * and this codebase never uses a bare `export *` against a package specifier.
  *
  * Only used to check *name* existence across barrels, so type-only vs.
  * value exports are treated identically.
@@ -102,7 +107,26 @@ function collectExportedNames(
   for (const statement of source.statements) {
     if (ts.isExportDeclaration(statement)) {
       if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        const specifier =
+          statement.moduleSpecifier &&
+          ts.isStringLiteral(statement.moduleSpecifier)
+            ? statement.moduleSpecifier.text
+            : undefined;
+        // A fresh visited set on purpose: the shared one exists to keep the
+        // surrounding `export *` walk from double-counting, but here we need
+        // the target's complete name set even when another chain already
+        // visited it.
+        const targetNames = specifier?.startsWith('.')
+          ? collectExportedNames(resolveRelativeModule(specifier))
+          : undefined;
         for (const element of statement.exportClause.elements) {
+          const importedName = (element.propertyName ?? element.name).text;
+          if (targetNames && !targetNames.has(importedName)) {
+            throw new Error(
+              `${filePath}: re-exports '${importedName}' from ` +
+                `'${specifier}', but the target no longer exports that name.`,
+            );
+          }
           names.add(element.name.text);
         }
       } else if (

--- a/packages/toolkit/scripts/packaging.spec.ts
+++ b/packages/toolkit/scripts/packaging.spec.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 // Regression tests for packaging concerns that only surface once the
@@ -19,6 +20,129 @@ const projectJson = JSON.parse(
 ) as {
   targets: { 'post-build': { options: { commands: string[] } } };
 };
+
+const toolkitDir = resolve(import.meta.dirname, '..');
+
+// The full set of entry points ng-packagr discovers when it builds the
+// package — the primary entry (`packages/toolkit/`) plus every directory
+// holding an `ng-package.json` (ng-packagr globs for the file itself; it
+// never reads a directory name allowlist). This mirrors
+// `findSecondaryPackagesPaths` in ng-packagr's `discover-packages.ts`
+// closely enough to catch drift without needing an actual build.
+const secondaryEntries = readdirSync(toolkitDir, { withFileTypes: true })
+  .filter(
+    (entry) =>
+      entry.isDirectory() &&
+      existsSync(resolve(toolkitDir, entry.name, 'ng-package.json')),
+  )
+  .map((entry) => entry.name)
+  .toSorted();
+
+// `/core` is a real ng-packagr entry point (needed so sibling entries can
+// import its build-time plumbing) but `strip-internal-exports.mjs` deletes
+// `"./core"` from the *published* `exports` map post-build — so it must be
+// excluded from any check phrased in terms of the public surface.
+const publishedSecondaryEntries = secondaryEntries.filter(
+  (name) => name !== 'core',
+);
+
+/** Reads `lib.entryFile` out of an entry point's `ng-package.json`. */
+function readEntryFile(entryDir: string): string {
+  const ngPackageJson = JSON.parse(
+    readFileSync(resolve(entryDir, 'ng-package.json'), 'utf8'),
+  ) as { lib?: { entryFile?: string } };
+  const entryFile = ngPackageJson.lib?.entryFile;
+  if (!entryFile) {
+    throw new Error(`${entryDir}/ng-package.json is missing lib.entryFile`);
+  }
+  return resolve(entryDir, entryFile);
+}
+
+/**
+ * Collects the names a TypeScript barrel file exports, following local
+ * (relative-path) `export * from '...'` re-export chains recursively.
+ * Named re-exports (`export { a, b } from '...'`, including from a
+ * package-name specifier like `@ngx-signal-forms/toolkit/core`) contribute
+ * their listed names directly without needing to resolve the target file —
+ * this codebase never uses a bare `export *` against a package specifier.
+ *
+ * Only used to check *name* existence across barrels, so type-only vs.
+ * value exports are treated identically.
+ */
+function collectExportedNames(
+  filePath: string,
+  visited = new Set<string>(),
+): Set<string> {
+  const names = new Set<string>();
+  if (visited.has(filePath)) return names;
+  visited.add(filePath);
+
+  const source = ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+
+  const resolveRelativeModule = (specifier: string): string => {
+    if (!specifier.startsWith('.')) {
+      throw new Error(
+        `${filePath}: bare "export *" from a non-relative specifier ` +
+          `('${specifier}') is not supported by this spec's export walker.`,
+      );
+    }
+    const base = resolve(dirname(filePath), specifier);
+    for (const candidate of [`${base}.ts`, resolve(base, 'index.ts')]) {
+      if (existsSync(candidate)) return candidate;
+    }
+    throw new Error(`${filePath}: cannot resolve module '${specifier}'`);
+  };
+
+  for (const statement of source.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          names.add(element.name.text);
+        }
+      } else if (
+        statement.moduleSpecifier &&
+        ts.isStringLiteral(statement.moduleSpecifier)
+      ) {
+        const resolved = resolveRelativeModule(statement.moduleSpecifier.text);
+        for (const name of collectExportedNames(resolved, visited)) {
+          names.add(name);
+        }
+      }
+      continue;
+    }
+
+    const modifiers = ts.canHaveModifiers(statement)
+      ? ts.getModifiers(statement)
+      : undefined;
+    const isExported = modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!isExported) continue;
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) names.add(declaration.name.text);
+      }
+    } else if (
+      (ts.isClassDeclaration(statement) ||
+        ts.isFunctionDeclaration(statement) ||
+        ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement) ||
+        ts.isEnumDeclaration(statement)) &&
+      statement.name
+    ) {
+      names.add(statement.name.text);
+    }
+  }
+
+  return names;
+}
 
 describe('packages/toolkit/package.json', () => {
   it('declares @angular/common as a peer dependency with the same range as @angular/core', () => {
@@ -65,9 +189,13 @@ describe('secondary entry point configuration', () => {
   // is dead configuration that does nothing at build time. Each secondary
   // entry's ng-package.json should also declare `$schema` for editor
   // validation, matching the primary entry point's convention.
-  const secondaryEntries = ['assistive', 'form-field', 'headless', 'vest'];
+  //
+  // `publishedSecondaryEntries` is derived from the filesystem above (every
+  // `ng-package.json`-bearing directory, minus `/core`) rather than
+  // hand-listed, so a new entry — or one that escapes this check the way
+  // `testing` previously did — can't silently go uncovered again.
 
-  it.each(secondaryEntries)(
+  it.each(publishedSecondaryEntries)(
     '%s/ has no redundant legacy package.json stub',
     (entry) => {
       expect(
@@ -76,15 +204,18 @@ describe('secondary entry point configuration', () => {
     },
   );
 
-  it.each(secondaryEntries)('%s/ng-package.json declares $schema', (entry) => {
-    const ngPackageJson = JSON.parse(
-      readFileSync(
-        resolve(import.meta.dirname, `../${entry}/ng-package.json`),
-        'utf8',
-      ),
-    ) as { $schema?: string };
-    expect(ngPackageJson.$schema).toBeTruthy();
-  });
+  it.each(publishedSecondaryEntries)(
+    '%s/ng-package.json declares $schema',
+    (entry) => {
+      const ngPackageJson = JSON.parse(
+        readFileSync(
+          resolve(import.meta.dirname, `../${entry}/ng-package.json`),
+          'utf8',
+        ),
+      ) as { $schema?: string };
+      expect(ngPackageJson.$schema).toBeTruthy();
+    },
+  );
 });
 
 describe('COMPATIBILITY.md', () => {
@@ -95,5 +226,65 @@ describe('COMPATIBILITY.md', () => {
     );
     expect(packageJson.engines?.node).toBeTruthy();
     expect(compatibilityMd).toContain(packageJson.engines?.node);
+  });
+});
+
+describe('published exports map surface', () => {
+  // ng-packagr has no static "exports" field to read from source — it
+  // generates the published `package.json`'s `exports` map at build time
+  // purely by globbing for `ng-package.json` files (see
+  // `discoverPackages`/`findSecondaryPackagesPaths` in ng-packagr's
+  // `discover-packages.ts`). The other checked-in source of truth for that
+  // same subpath list is `tsconfig.base.json`'s `@ngx-signal-forms/toolkit/*`
+  // path mappings, which every in-repo consumer (and TypeScript itself)
+  // resolves against. This asserts those two sources agree, so an entry
+  // added to one without the other — e.g. a new `ng-package.json` with no
+  // matching path mapping, or vice versa — fails here instead of surfacing
+  // as a broken import or an unintentionally published subpath.
+  it('matches the tsconfig.base.json path-mapping entry list', () => {
+    const tsconfigBase = JSON.parse(
+      readFileSync(resolve(toolkitDir, '../../tsconfig.base.json'), 'utf8'),
+    ) as { compilerOptions: { paths: Record<string, string[]> } };
+
+    const toolkitPathPrefix = '@ngx-signal-forms/toolkit/';
+    const knownSecondaryEntries = Object.keys(
+      tsconfigBase.compilerOptions.paths,
+    )
+      .filter((specifier) => specifier.startsWith(toolkitPathPrefix))
+      .map((specifier) => specifier.slice(toolkitPathPrefix.length))
+      // `/core` is a build-time-only entry deliberately hidden from the
+      // published exports map by strip-internal-exports.mjs, so it is
+      // excluded from the tsconfig side too (see that script's own header).
+      .filter((name) => name !== 'core')
+      .toSorted();
+
+    expect(publishedSecondaryEntries).toEqual(knownSecondaryEntries);
+  });
+});
+
+describe('root barrel surface', () => {
+  // `packages/toolkit/index.ts` hand-enumerates its public API rather than
+  // re-exporting `/core` wholesale (see that file's own header for why:
+  // `/core` also carries `@internal` plumbing that must not leak). Nothing
+  // previously checked that the hand-enumerated list stays in sync with what
+  // the entry-point barrels actually export, so a rename or removal upstream
+  // could leave a stale name in the root barrel (a broken re-export) without
+  // any test catching it.
+  it('enumerates only names that exist in the entry-point barrels', () => {
+    const rootIndexPath = resolve(toolkitDir, 'index.ts');
+    const rootExportedNames = collectExportedNames(rootIndexPath);
+
+    const entryBarrelNames = new Set<string>();
+    for (const entry of secondaryEntries) {
+      const entryFile = readEntryFile(resolve(toolkitDir, entry));
+      for (const name of collectExportedNames(entryFile)) {
+        entryBarrelNames.add(name);
+      }
+    }
+
+    const staleNames = [...rootExportedNames].filter(
+      (name) => !entryBarrelNames.has(name),
+    );
+    expect(staleNames).toEqual([]);
   });
 });

--- a/packages/toolkit/testing/package.json
+++ b/packages/toolkit/testing/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "testing",
-  "description": "WCAG 2.2 AA accessibility test harness for @ngx-signal-forms/toolkit",
-  "sideEffects": false,
-  "ngPackage": {}
-}


### PR DESCRIPTION
The toolkit's public surface is declared in three checked-in places — the hand-enumerated root barrel, the per-entry `ng-package.json` files, and the `tsconfig.base.json` path mappings — and nothing verified they agree. This extends `packages/toolkit/scripts/packaging.spec.ts` so drift fails in a source-only spec run, without needing a build:

- **Root barrel staleness** — a small TS-AST walker collects every name each entry barrel exports (following relative `export * from` chains) and asserts the root `index.ts` re-exports only names that still exist upstream. A rename or removal in an entry barrel now fails here instead of shipping a broken re-export.
- **Entry-list parity** — the secondary-entry list is now derived from the filesystem (every directory with an `ng-package.json`, mirroring ng-packagr's own discovery) instead of hand-listed, and asserted against the `@ngx-signal-forms/toolkit/*` path mappings in `tsconfig.base.json`. `testing` — which previously escaped every secondary-entry check — is covered automatically, as is any future entry.
- **Dead stub removed** — `packages/toolkit/testing/package.json` (`"ngPackage": {}`) was dead configuration: ng-packagr never reads a sibling `package.json` for secondary entries. Verified by a real build + post-build run — the published exports map correctly gains `./testing` and drops `./core` without it.

Two interpretation notes for review, since the issue's wording didn't map 1:1 onto the source tree:

- The issue says to assert "the `exports` map in `package.json`" — but the source `package.json` has no static `exports` field (ng-packagr generates it at build time). Under the issue's own source-only decision, the spec asserts the two checked-in inputs that map is generated from (`ng-package.json` presence vs. tsconfig path mappings) agree instead.
- The root-barrel check is deliberately one-directional (root ⊆ union of entry barrels, per the acceptance criterion). The reverse would be wrong by design: the root barrel hand-curates a subset precisely so `/core` plumbing and entry-only symbols stay out of it.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
