### PR TITLE
refactor(headless): extract fieldset/error-summary aggregation into factories

### DIFF
--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -106,6 +106,8 @@ export {
 export {
   createCharacterCount,
   createErrorState,
+  createErrorSummaryEntries,
+  createFieldsetAggregation,
   createFieldStateFlags,
   createUniqueId,
   dedupeValidationErrors,
@@ -121,8 +123,12 @@ export {
   type CharacterCountValue,
   type CreateCharacterCountOptions,
   type CreateErrorStateOptions,
+  type CreateErrorSummaryEntriesOptions,
+  type CreateFieldsetAggregationOptions,
   type ErrorStateResult,
+  type ErrorSummaryEntriesResult,
   type ErrorSummaryEntryData,
+  type FieldsetAggregationResult,
   type FieldStateLike,
   type FieldStateFlags,
 } from './lib/utilities';

--- a/packages/toolkit/headless/src/lib/error-state.ts
+++ b/packages/toolkit/headless/src/lib/error-state.ts
@@ -27,15 +27,17 @@ import {
   NGX_ERROR_MESSAGES,
 } from '@ngx-signal-forms/toolkit/core';
 
-import { buildHeadlessErrorState, resolveErrorMessage } from './utilities';
+import {
+  buildHeadlessErrorState,
+  resolveErrorMessage,
+  type ResolvedError,
+} from './utilities';
 
-/**
- * Resolved error with kind and message.
- */
-export interface ResolvedError {
-  readonly kind: string;
-  readonly message: string;
-}
+// Re-exported so the public barrel's `export { type ResolvedError } from
+// './lib/error-state'` keeps resolving after the type moved to the shared
+// `utilities.ts` module (see that file's docblock for why — it now also
+// backs `createFieldsetAggregation()`'s return shape).
+export type { ResolvedError };
 
 /**
  * Error state signals exposed by the headless directive.

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -1,11 +1,10 @@
 import { computed, Directive, inject, input, type Signal } from '@angular/core';
-import type { FieldTree, ValidationError } from '@angular/forms/signals';
+import type { FieldTree } from '@angular/forms/signals';
 import {
   createErrorVisibility,
   injectFormContext,
   NGX_SIGNAL_FORMS_CONFIG,
   resolveStrategyFromContext,
-  splitByKind,
   type ErrorDisplayStrategy,
   type ResolvedErrorDisplayStrategy,
   type SubmittedStatus,
@@ -17,14 +16,9 @@ import {
 } from '@ngx-signal-forms/toolkit/core';
 
 import {
-  dedupeValidationErrorsByField,
-  isErrorOnInteractiveField,
-  readErrors,
-  toErrorSummaryEntry,
+  createErrorSummaryEntries,
   type ErrorSummaryEntryData,
 } from './utilities';
-
-const STRIP_WARNING_PREFIX = { stripWarningPrefix: true } as const;
 
 /**
  * A resolved error-summary entry with kind, message, and focus capability.
@@ -170,60 +164,32 @@ export class NgxHeadlessErrorSummary implements ErrorSummarySignals {
   });
 
   /**
-   * Errors with `errorSummary()` traversal, then filtered to drop entries
-   * whose underlying field is `hidden()` or `disabled()`. Angular's docs say
-   * hidden/disabled fields do not contribute to form validation state, but
-   * they may still appear in `errorSummary()`. A summary entry for such a
-   * field has no actionable target — `focus()` would either throw or strand
-   * focus on a non-interactive control — so we exclude them before dedupe.
-   *
-   * `readonly()` is intentionally **not** filtered: the field is visible and
-   * focusable, and its error is usually still meaningful to the user.
-   *
-   * Deduplication is per-field (see {@link dedupeValidationErrorsByField}):
-   * unlike `NgxHeadlessFieldset`'s grouped-message dedupe, two different
-   * fields sharing the same kind/message (e.g. two `required()` fields with
-   * no custom message) must both keep their own summary entry.
+   * Entry-mapping pipeline, delegated to {@link createErrorSummaryEntries} —
+   * this directive is a pure projection over its result. The pipeline reads
+   * `errorSummary()`, drops entries whose underlying field is `hidden()` or
+   * `disabled()` (a summary entry for such a field has no actionable
+   * target — `focus()` would either throw or strand focus on a
+   * non-interactive control), dedupes **per field** (unlike
+   * `NgxHeadlessFieldset`'s grouped-message dedupe, two different fields
+   * sharing the same kind/message — e.g. two `required()` fields with no
+   * custom message — must both keep their own summary entry), and maps to
+   * focusable entries. `readonly()` fields are intentionally **not**
+   * filtered: the field is visible and focusable, and its error is usually
+   * still meaningful to the user.
    */
-  readonly #split = computed(() => {
-    const visibleErrors = readErrors(this.#fieldState()).filter(
-      (error: ValidationError) => isErrorOnInteractiveField(error),
-    );
-    return splitByKind(dedupeValidationErrorsByField(visibleErrors));
+  readonly #entries = createErrorSummaryEntries({
+    fieldState: this.#fieldState,
+    showErrors: this.#showErrorsSignal,
+    errorMessages: this.#errorMessagesRegistry,
+    labelResolver: this.#labelResolver,
   });
 
-  readonly entries = computed(() =>
-    this.#split().blocking.map((error) =>
-      toErrorSummaryEntry(
-        error,
-        this.#errorMessagesRegistry,
-        undefined,
-        this.#labelResolver,
-      ),
-    ),
-  );
-
-  readonly warningEntries = computed(() =>
-    this.#split().warnings.map((error) =>
-      toErrorSummaryEntry(
-        error,
-        this.#errorMessagesRegistry,
-        STRIP_WARNING_PREFIX,
-        this.#labelResolver,
-      ),
-    ),
-  );
-
-  readonly hasErrors = computed(() => this.#split().blocking.length > 0);
-  readonly hasWarnings = computed(() => this.#split().warnings.length > 0);
-
-  readonly shouldShow = computed(
-    () => this.#showErrorsSignal() && this.hasErrors(),
-  );
-
-  readonly shouldShowWarnings = computed(
-    () => this.#showErrorsSignal() && this.hasWarnings(),
-  );
+  readonly entries = this.#entries.entries;
+  readonly warningEntries = this.#entries.warningEntries;
+  readonly hasErrors = this.#entries.hasErrors;
+  readonly hasWarnings = this.#entries.hasWarnings;
+  readonly shouldShow = this.#entries.shouldShow;
+  readonly shouldShowWarnings = this.#entries.shouldShowWarnings;
 
   readonly focusFirst = (): void => {
     const first = this.entries()[0];

--- a/packages/toolkit/headless/src/lib/fieldset.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.ts
@@ -305,8 +305,8 @@ export class NgxHeadlessFieldset<
 
   /**
    * Error/warning aggregation, delegated to {@link createFieldsetAggregation}
-   * — this directive is a pure projection over its result. Pass the already
-   * -resolved {@link #showErrorsSignal} / {@link #showWarningsSignal} rather
+   * — this directive is a pure projection over its result. Pass the
+   * already-resolved {@link #showErrorsSignal} / {@link #showWarningsSignal} rather
    * than raw strategy inputs: the factory itself never calls `inject()`
    * (ADR-0005), so visibility timing stays owned by this directive's single
    * `createErrorVisibility()` / `createShowErrorsComputed()` seam call

--- a/packages/toolkit/headless/src/lib/fieldset.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.ts
@@ -11,12 +11,10 @@ import {
   createErrorVisibility,
   injectFormContext,
   NGX_SIGNAL_FORMS_CONFIG,
-  readDirectErrors,
   resolveStrategyFromContext,
   resolveSubmittedStatusFromContext,
   resolveWarningStrategyFromContext,
   createShowErrorsComputed,
-  splitByKind,
   type ErrorDisplayStrategy,
   type ResolvedErrorDisplayStrategy,
   type ResolvedWarningDisplayStrategy,
@@ -28,13 +26,11 @@ import {
   NGX_ERROR_MESSAGES,
 } from '@ngx-signal-forms/toolkit/core';
 
-import type { ResolvedError } from './error-state';
 import {
+  createFieldsetAggregation,
   createFieldStateFlags,
   createUniqueId,
-  dedupeValidationErrors,
-  readErrors,
-  resolveErrorMessage,
+  type ResolvedError,
 } from './utilities';
 
 /**
@@ -308,61 +304,45 @@ export class NgxHeadlessFieldset<
   );
 
   /**
-   * Aggregated and deduplicated validation messages.
-   * Uses shared utilities from utilities.ts.
+   * Error/warning aggregation, delegated to {@link createFieldsetAggregation}
+   * — this directive is a pure projection over its result. Pass the already
+   * -resolved {@link #showErrorsSignal} / {@link #showWarningsSignal} rather
+   * than raw strategy inputs: the factory itself never calls `inject()`
+   * (ADR-0005), so visibility timing stays owned by this directive's single
+   * `createErrorVisibility()` / `createShowErrorsComputed()` seam call
+   * (ADR-0006).
    */
-  readonly #allMessages = computed(() => {
-    const override = this.fields();
-    const readFn = this.includeNestedErrors() ? readErrors : readDirectErrors;
-
-    // `null` means "not provided" → aggregate the fieldset's own errors.
-    // An explicitly bound `[]` means "provided but empty" → aggregate
-    // nothing. Distinguishing these (instead of `override.length > 0`)
-    // keeps a dynamically-computed field list that becomes empty from
-    // silently falling back to the fieldset's own (possibly unrelated)
-    // errors.
-    if (override !== null) {
-      const messages = override.flatMap((field) => readFn(field()));
-      return dedupeValidationErrors(messages);
-    }
-
-    return dedupeValidationErrors(readFn(this.#fieldsetState()));
+  readonly #aggregation = createFieldsetAggregation({
+    fieldState: this.#fieldsetState,
+    fields: this.fields,
+    includeNestedErrors: this.includeNestedErrors,
+    showErrors: this.#showErrorsSignal,
+    showWarnings: this.#showWarningsSignal,
+    errorMessages: this.#errorMessagesRegistry,
   });
 
-  readonly #split = computed(() => splitByKind(this.#allMessages()));
-
-  readonly aggregatedErrors = computed(() => this.#split().blocking);
-  readonly aggregatedWarnings = computed(() => this.#split().warnings);
-  readonly hasErrors = computed(() => this.#split().blocking.length > 0);
-  readonly hasWarnings = computed(() => this.#split().warnings.length > 0);
+  readonly aggregatedErrors = this.#aggregation.aggregatedErrors;
+  readonly aggregatedWarnings = this.#aggregation.aggregatedWarnings;
 
   /**
    * {@link aggregatedErrors}, resolved to display messages. See the class
    * doc's usage note for why this (not `error.message`) is the recommended
    * rendering surface.
    */
-  readonly resolvedErrors: Signal<readonly ResolvedError[]> = computed(() =>
-    this.aggregatedErrors().map((error) => this.#toResolvedError(error)),
-  );
+  readonly resolvedErrors: Signal<readonly ResolvedError[]> =
+    this.#aggregation.resolvedErrors;
 
   /** {@link aggregatedWarnings}, resolved the same way as {@link resolvedErrors}. */
-  readonly resolvedWarnings: Signal<readonly ResolvedError[]> = computed(() =>
-    this.aggregatedWarnings().map((error) => this.#toResolvedError(error)),
-  );
+  readonly resolvedWarnings: Signal<readonly ResolvedError[]> =
+    this.#aggregation.resolvedWarnings;
 
-  #toResolvedError(error: ValidationError): ResolvedError {
-    return {
-      kind: error.kind,
-      message: resolveErrorMessage(error, this.#errorMessagesRegistry),
-    };
-  }
+  readonly hasErrors = this.#aggregation.hasErrors;
+  readonly hasWarnings = this.#aggregation.hasWarnings;
 
   /**
    * Whether to show errors based on strategy.
    */
-  readonly shouldShowErrors = computed(
-    () => this.#showErrorsSignal() && this.hasErrors(),
-  );
+  readonly shouldShowErrors = this.#aggregation.shouldShowErrors;
 
   /**
    * Whether to show warnings, timed by {@link resolvedWarningStrategy}.
@@ -381,9 +361,7 @@ export class NgxHeadlessFieldset<
    * `filteredErrorsSignal` and its `--warning` host class, which explicitly
    * guard on `!shouldShowErrors()` for that reason.
    */
-  readonly shouldShowWarnings = computed(
-    () => this.#showWarningsSignal() && this.hasWarnings(),
-  );
+  readonly shouldShowWarnings = this.#aggregation.shouldShowWarnings;
 
   readonly #flags = createFieldStateFlags(this.#fieldsetState);
 

--- a/packages/toolkit/headless/src/lib/utilities.spec.ts
+++ b/packages/toolkit/headless/src/lib/utilities.spec.ts
@@ -4,6 +4,7 @@ import {
   form,
   schema,
   validate,
+  type FieldTree,
   type ValidationError,
 } from '@angular/forms/signals';
 import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
@@ -11,6 +12,8 @@ import { NGX_SIGNAL_FORM_CONTEXT } from '@ngx-signal-forms/toolkit/core';
 import { describe, expect, it } from 'vitest';
 import {
   createErrorState,
+  createErrorSummaryEntries,
+  createFieldsetAggregation,
   createUniqueId,
   dedupeValidationErrors,
   humanizeFieldPath,
@@ -895,6 +898,305 @@ describe('Headless Utilities', () => {
       emailForm.email().markAsTouched();
       expect(errorState.hasErrors()).toBe(true);
       expect(errorState.shouldShowErrors()).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // createFieldsetAggregation — extracted from NgxHeadlessFieldset (#351)
+  // ============================================================================
+
+  describe('createFieldsetAggregation', () => {
+    // Pure function: no `inject()` calls, so plain signal mocks exercise the
+    // full contract without TestBed/injection context (ADR-0005).
+
+    it('aggregates direct errors by default and resolves display messages', () => {
+      const fieldState = signal({
+        errors: () => [{ kind: 'required', message: 'Required' }],
+      });
+      const showErrors = signal(true);
+      const showWarnings = signal(true);
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        showErrors,
+        showWarnings,
+      });
+
+      expect(result.aggregatedErrors()).toEqual([
+        { kind: 'required', message: 'Required' },
+      ]);
+      expect(result.resolvedErrors()).toEqual([
+        { kind: 'required', message: 'Required' },
+      ]);
+      expect(result.hasErrors()).toBe(true);
+      expect(result.shouldShowErrors()).toBe(true);
+    });
+
+    it('aggregates nested errors via errorSummary() when includeNestedErrors is true', () => {
+      const fieldState = signal({
+        errors: () => [],
+        errorSummary: () => [
+          { kind: 'required', message: 'Street required' },
+          { kind: 'required', message: 'City required' },
+        ],
+      });
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        includeNestedErrors: true,
+        showErrors: signal(true),
+        showWarnings: signal(true),
+      });
+
+      expect(result.aggregatedErrors()).toHaveLength(2);
+    });
+
+    it('dedupes aggregated messages by kind + message', () => {
+      const fieldState = signal({
+        errorSummary: () => [
+          { kind: 'required', message: 'Required' },
+          { kind: 'required', message: 'Required' },
+        ],
+      });
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        includeNestedErrors: true,
+        showErrors: signal(true),
+        showWarnings: signal(true),
+      });
+
+      expect(result.aggregatedErrors()).toHaveLength(1);
+    });
+
+    it('splits blocking errors from warn:-prefixed warnings', () => {
+      const fieldState = signal({
+        errors: () => [
+          { kind: 'required', message: 'Required' },
+          { kind: 'warn:optional', message: 'Consider filling this in' },
+        ],
+      });
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        showErrors: signal(true),
+        showWarnings: signal(true),
+      });
+
+      expect(result.aggregatedErrors()).toEqual([
+        { kind: 'required', message: 'Required' },
+      ]);
+      expect(result.aggregatedWarnings()).toEqual([
+        { kind: 'warn:optional', message: 'Consider filling this in' },
+      ]);
+      expect(result.hasWarnings()).toBe(true);
+    });
+
+    it('treats an explicitly bound empty `fields` override as "aggregate nothing", not "not provided"', () => {
+      const fieldState = signal({
+        errors: () => [{ kind: 'required', message: 'Own error' }],
+      });
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        fields: signal([]),
+        showErrors: signal(true),
+        showWarnings: signal(true),
+      });
+
+      expect(result.aggregatedErrors()).toEqual([]);
+    });
+
+    it('aggregates from an explicit `fields` override when provided', () => {
+      const fieldState = signal({ errors: () => [] });
+      const overrideField = (() => ({
+        errors: () => [{ kind: 'required', message: 'Field required' }],
+      })) as unknown as FieldTree<unknown>;
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        fields: signal([overrideField]),
+        showErrors: signal(true),
+        showWarnings: signal(true),
+      });
+
+      expect(result.aggregatedErrors()).toEqual([
+        { kind: 'required', message: 'Field required' },
+      ]);
+    });
+
+    it('gates shouldShowErrors/shouldShowWarnings on the caller-supplied visibility signals', () => {
+      const fieldState = signal({
+        errors: () => [{ kind: 'required', message: 'Required' }],
+      });
+
+      const result = createFieldsetAggregation({
+        fieldState,
+        showErrors: signal(false),
+        showWarnings: signal(false),
+      });
+
+      expect(result.hasErrors()).toBe(true);
+      expect(result.shouldShowErrors()).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // createErrorSummaryEntries — extracted from NgxHeadlessErrorSummary (#351)
+  // ============================================================================
+
+  describe('createErrorSummaryEntries', () => {
+    // Pure function: no `inject()` calls, so plain signal mocks exercise the
+    // full contract without TestBed/injection context (ADR-0005).
+
+    function fieldTreeFor(
+      name: string,
+      overrides: Readonly<{ hidden?: boolean; disabled?: boolean }> = {},
+    ) {
+      return () => ({
+        name: () => name,
+        hidden: () => overrides.hidden ?? false,
+        disabled: () => overrides.disabled ?? false,
+        focusBoundControl: () => {
+          /* no-op for spec */
+        },
+      });
+    }
+
+    it('maps blocking errors to focusable entries with resolved messages and field names', () => {
+      const error: ValidationError = {
+        kind: 'required',
+        message: 'Required',
+        fieldTree: fieldTreeFor('email'),
+      } as ValidationError;
+
+      const fieldState = signal({ errorSummary: () => [error] });
+
+      const result = createErrorSummaryEntries({
+        fieldState,
+        showErrors: signal(true),
+      });
+
+      expect(result.entries()).toHaveLength(1);
+      expect(result.entries()[0]?.kind).toBe('required');
+      expect(result.entries()[0]?.message).toBe('Required');
+      expect(result.hasErrors()).toBe(true);
+    });
+
+    it('separates warn:-prefixed entries into warningEntries', () => {
+      const warning: ValidationError = {
+        kind: 'warn:street-optional',
+        message: 'Street can be left blank',
+        fieldTree: fieldTreeFor('street'),
+      } as ValidationError;
+
+      const fieldState = signal({ errorSummary: () => [warning] });
+
+      const result = createErrorSummaryEntries({
+        fieldState,
+        showErrors: signal(true),
+      });
+
+      expect(result.entries()).toHaveLength(0);
+      expect(result.warningEntries()).toHaveLength(1);
+      expect(result.hasWarnings()).toBe(true);
+    });
+
+    it('omits entries for hidden or disabled fields', () => {
+      const hiddenError: ValidationError = {
+        kind: 'required',
+        message: 'Secret required',
+        fieldTree: fieldTreeFor('secret', { hidden: true }),
+      } as ValidationError;
+      const disabledError: ValidationError = {
+        kind: 'required',
+        message: 'Token required',
+        fieldTree: fieldTreeFor('token', { disabled: true }),
+      } as ValidationError;
+      const visibleError: ValidationError = {
+        kind: 'required',
+        message: 'Email required',
+        fieldTree: fieldTreeFor('email'),
+      } as ValidationError;
+
+      const fieldState = signal({
+        errorSummary: () => [hiddenError, disabledError, visibleError],
+      });
+
+      const result = createErrorSummaryEntries({
+        fieldState,
+        showErrors: signal(true),
+      });
+
+      expect(result.entries().map((entry) => entry.fieldName)).toEqual([
+        'Email',
+      ]);
+    });
+
+    it('keeps a separate entry per field when two fields share kind and a message-less error', () => {
+      const first: ValidationError = {
+        kind: 'required',
+        fieldTree: fieldTreeFor('email'),
+      } as ValidationError;
+      const second: ValidationError = {
+        kind: 'required',
+        fieldTree: fieldTreeFor('name'),
+      } as ValidationError;
+
+      const fieldState = signal({ errorSummary: () => [first, second] });
+
+      const result = createErrorSummaryEntries({
+        fieldState,
+        showErrors: signal(true),
+      });
+
+      expect(result.entries()).toHaveLength(2);
+    });
+
+    it('gates shouldShow/shouldShowWarnings on the caller-supplied showErrors signal', () => {
+      const error: ValidationError = {
+        kind: 'required',
+        message: 'Required',
+        fieldTree: fieldTreeFor('email'),
+      } as ValidationError;
+
+      const fieldState = signal({ errorSummary: () => [error] });
+      const showErrors = signal(false);
+
+      const result = createErrorSummaryEntries({ fieldState, showErrors });
+
+      expect(result.hasErrors()).toBe(true);
+      expect(result.shouldShow()).toBe(false);
+
+      showErrors.set(true);
+
+      expect(result.shouldShow()).toBe(true);
+    });
+
+    it("focus() on an entry calls the field's focusBoundControl()", () => {
+      let focused = false;
+      const error: ValidationError = {
+        kind: 'required',
+        message: 'Required',
+        fieldTree: () => ({
+          name: () => 'email',
+          hidden: () => false,
+          disabled: () => false,
+          focusBoundControl: () => {
+            focused = true;
+          },
+        }),
+      } as ValidationError;
+
+      const fieldState = signal({ errorSummary: () => [error] });
+
+      const result = createErrorSummaryEntries({
+        fieldState,
+        showErrors: signal(true),
+      });
+
+      result.entries()[0]?.focus();
+      expect(focused).toBe(true);
     });
   });
 });

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -32,6 +32,21 @@ import {
   type CharacterCountValue,
 } from './character-count-types';
 
+/**
+ * A resolved error with kind and message.
+ *
+ * Canonical home for this type — `error-state.ts` re-exports it (the public
+ * barrel resolves `ResolvedError` from `./lib/error-state` and stays
+ * unchanged) so both `createFieldsetAggregation()` here and
+ * `NgxHeadlessErrorState` share one definition. Mirrors the
+ * `CharacterCountValue` re-export above for the same reason: the type moved,
+ * the public export path did not.
+ */
+export interface ResolvedError {
+  readonly kind: string;
+  readonly message: string;
+}
+
 // Re-exported so the public barrel's `export { type CharacterCountValue }
 // from './lib/utilities'` keeps resolving after the type moved to the
 // shared character-count-types module (see that file's docblock for why).
@@ -623,6 +638,133 @@ export function createCharacterCount(
 }
 
 // ============================================================================
+// Fieldset Aggregation
+// ============================================================================
+
+/**
+ * Options for {@link createFieldsetAggregation}.
+ *
+ * `showErrors`/`showWarnings` are pre-resolved visibility signals, not raw
+ * strategy inputs — per ADR-0005 (factories take DI-resolved values as
+ * inputs and never call `inject()` themselves). `NgxHeadlessFieldset` keeps
+ * owning the single `createErrorVisibility()`/`createShowErrorsComputed()`
+ * seam call (ADR-0006) and threads the results in here; this factory only
+ * combines them with the (visibility-independent) presence check.
+ */
+export interface CreateFieldsetAggregationOptions {
+  /** Reactive reader for the fieldset's own field state (from `field()()`). */
+  readonly fieldState: ReadSignal<unknown>;
+  /**
+   * Explicit field-list override. `null`/omitted means "not provided" —
+   * aggregate `fieldState`'s own errors. See `NgxHeadlessFieldset.fields`
+   * for the "not provided" vs "explicitly empty" distinction this preserves.
+   */
+  readonly fields?: ReactiveOrStatic<readonly FieldTree<unknown>[] | null>;
+  /** Whether to aggregate nested field errors (`errorSummary()`) instead of direct ones (`errors()`). */
+  readonly includeNestedErrors?: ReactiveOrStatic<boolean>;
+  /** Pre-resolved blocking-error visibility (from the caller's own visibility seam call). */
+  readonly showErrors: ReadSignal<boolean>;
+  /** Pre-resolved warning visibility, timed independently of {@link showErrors}. */
+  readonly showWarnings: ReadSignal<boolean>;
+  /** Error message registry for 3-tier message resolution. */
+  readonly errorMessages?: Readonly<ErrorMessageRegistry> | null;
+}
+
+/**
+ * Fieldset error/warning aggregation result.
+ */
+export interface FieldsetAggregationResult {
+  /** Aggregated and deduplicated blocking errors. */
+  readonly aggregatedErrors: Signal<readonly ValidationError[]>;
+  /** Aggregated and deduplicated warnings. */
+  readonly aggregatedWarnings: Signal<readonly ValidationError[]>;
+  /** {@link aggregatedErrors}, resolved to display messages. */
+  readonly resolvedErrors: Signal<readonly ResolvedError[]>;
+  /** {@link aggregatedWarnings}, resolved to display messages. */
+  readonly resolvedWarnings: Signal<readonly ResolvedError[]>;
+  /** Whether there are blocking errors. */
+  readonly hasErrors: Signal<boolean>;
+  /** Whether there are warnings. */
+  readonly hasWarnings: Signal<boolean>;
+  /** `showErrors() && hasErrors()`. */
+  readonly shouldShowErrors: Signal<boolean>;
+  /** `showWarnings() && hasWarnings()`. */
+  readonly shouldShowWarnings: Signal<boolean>;
+}
+
+/**
+ * Aggregates, deduplicates, and resolves field/warning errors for a
+ * fieldset-shaped surface.
+ *
+ * Extracted from `NgxHeadlessFieldset`, which used to inline this pipeline
+ * (issue #351). Deliberately pure — no `inject()` calls — so it is testable
+ * with plain signal mocks and no `TestBed`, matching the other headless
+ * factories (`createFieldStateFlags`, `createCharacterCount`). Visibility
+ * timing is NOT resolved here; callers pass already-resolved `showErrors`/
+ * `showWarnings` signals from their own `createErrorVisibility()` /
+ * `createShowErrorsComputed()` call (ADR-0006's single seam).
+ *
+ * @remarks Does not require an injection context.
+ */
+export function createFieldsetAggregation(
+  options: Readonly<CreateFieldsetAggregationOptions>,
+): FieldsetAggregationResult {
+  const {
+    fieldState,
+    fields,
+    includeNestedErrors,
+    showErrors,
+    showWarnings,
+    errorMessages,
+  } = options;
+
+  const allMessages = computed(() => {
+    const override = fields === undefined ? null : unwrapValue(fields);
+    const readFn = unwrapValue(includeNestedErrors ?? false)
+      ? readErrors
+      : readDirectErrors;
+
+    // `null` means "not provided" → aggregate `fieldState`'s own errors. An
+    // explicitly bound `[]` means "provided but empty" → aggregate nothing.
+    if (override !== null) {
+      const messages = override.flatMap((field) => readFn(field()));
+      return dedupeValidationErrors(messages);
+    }
+
+    return dedupeValidationErrors(readFn(fieldState()));
+  });
+
+  const split = computed(() => splitByKind(allMessages()));
+
+  const aggregatedErrors = computed(() => split().blocking);
+  const aggregatedWarnings = computed(() => split().warnings);
+  const hasErrors = computed(() => split().blocking.length > 0);
+  const hasWarnings = computed(() => split().warnings.length > 0);
+
+  const toResolved = (error: ValidationError): ResolvedError => ({
+    kind: error.kind,
+    message: resolveErrorMessage(error, errorMessages),
+  });
+
+  const resolvedErrors = computed(() => aggregatedErrors().map(toResolved));
+  const resolvedWarnings = computed(() => aggregatedWarnings().map(toResolved));
+
+  const shouldShowErrors = computed(() => showErrors() && hasErrors());
+  const shouldShowWarnings = computed(() => showWarnings() && hasWarnings());
+
+  return {
+    aggregatedErrors,
+    aggregatedWarnings,
+    resolvedErrors,
+    resolvedWarnings,
+    hasErrors,
+    hasWarnings,
+    shouldShowErrors,
+    shouldShowWarnings,
+  };
+}
+
+// ============================================================================
 // Error Summary Entry Utilities
 // ============================================================================
 
@@ -804,4 +946,101 @@ export function resolveErrorMessage(
   stripWarningPrefix = true,
 ): string {
   return resolveValidationErrorMessage(error, registry, { stripWarningPrefix });
+}
+
+const STRIP_WARNING_PREFIX_OPTION = { stripWarningPrefix: true } as const;
+
+/**
+ * Options for {@link createErrorSummaryEntries}.
+ *
+ * `showErrors` is a pre-resolved visibility signal, not a raw strategy
+ * input — mirrors {@link CreateFieldsetAggregationOptions}'s contract
+ * (ADR-0005: factories take DI-resolved values as inputs, never `inject()`
+ * themselves).
+ */
+export interface CreateErrorSummaryEntriesOptions {
+  /** Reactive reader for the root field state (from `formTree()()`). */
+  readonly fieldState: ReadSignal<unknown>;
+  /** Pre-resolved visibility, shared by both the error and warning channel. */
+  readonly showErrors: ReadSignal<boolean>;
+  /** Error message registry for 3-tier message resolution. */
+  readonly errorMessages?: Readonly<ErrorMessageRegistry> | null;
+  /** Optional field-label resolver; falls back to `humanizeFieldPath`. */
+  readonly labelResolver?: FieldLabelResolver | null;
+}
+
+/**
+ * Error-summary entry-mapping result.
+ */
+export interface ErrorSummaryEntriesResult {
+  /** Resolved blocking error entries ready for rendering. */
+  readonly entries: Signal<readonly ErrorSummaryEntryData[]>;
+  /** Resolved warning entries. */
+  readonly warningEntries: Signal<readonly ErrorSummaryEntryData[]>;
+  /** Whether there are any blocking errors. */
+  readonly hasErrors: Signal<boolean>;
+  /** Whether there are any warnings. */
+  readonly hasWarnings: Signal<boolean>;
+  /** `showErrors() && hasErrors()`. */
+  readonly shouldShow: Signal<boolean>;
+  /** `showErrors() && hasWarnings()`. */
+  readonly shouldShowWarnings: Signal<boolean>;
+}
+
+/**
+ * Builds the `errorSummary()` entry-mapping pipeline: read → filter out
+ * non-interactive (hidden/disabled) fields → dedupe per field → split by
+ * kind → map to focusable {@link ErrorSummaryEntryData} entries.
+ *
+ * Extracted from `NgxHeadlessErrorSummary`, which used to inline this
+ * pipeline (issue #351). Deliberately pure — no `inject()` calls — so it is
+ * testable with plain signal mocks and no `TestBed`, matching the other
+ * headless factories (`createFieldStateFlags`, `createCharacterCount`,
+ * `createFieldsetAggregation`).
+ *
+ * @remarks Does not require an injection context.
+ */
+export function createErrorSummaryEntries(
+  options: Readonly<CreateErrorSummaryEntriesOptions>,
+): ErrorSummaryEntriesResult {
+  const { fieldState, showErrors, errorMessages, labelResolver } = options;
+
+  const split = computed(() => {
+    const visibleErrors = readErrors(fieldState()).filter(
+      (error: ValidationError) => isErrorOnInteractiveField(error),
+    );
+    return splitByKind(dedupeValidationErrorsByField(visibleErrors));
+  });
+
+  const entries = computed(() =>
+    split().blocking.map((error) =>
+      toErrorSummaryEntry(error, errorMessages, undefined, labelResolver),
+    ),
+  );
+
+  const warningEntries = computed(() =>
+    split().warnings.map((error) =>
+      toErrorSummaryEntry(
+        error,
+        errorMessages,
+        STRIP_WARNING_PREFIX_OPTION,
+        labelResolver,
+      ),
+    ),
+  );
+
+  const hasErrors = computed(() => split().blocking.length > 0);
+  const hasWarnings = computed(() => split().warnings.length > 0);
+
+  const shouldShow = computed(() => showErrors() && hasErrors());
+  const shouldShowWarnings = computed(() => showErrors() && hasWarnings());
+
+  return {
+    entries,
+    warningEntries,
+    hasErrors,
+    hasWarnings,
+    shouldShow,
+    shouldShowWarnings,
+  };
 }


### PR DESCRIPTION
`NgxHeadlessFieldset` and `NgxHeadlessErrorSummary` were the last two headless directives that inlined their aggregation instead of delegating to a factory. This extracts that logic into two pure factories in `utilities.ts` — `createFieldsetAggregation()` and `createErrorSummaryEntries()` — and rewrites both directives as pure projections: every public signal is now a direct forward of the factory's own signal, and the directive-private plumbing that re-derived the same state (`#allMessages`, `#split`, `#toResolvedError`) is deleted. Callers composing state programmatically can now call the factories directly, and the new contract specs assert them with plain `signal()` mocks — no TestBed.

Both factories follow ADR-0005's contract (no `inject()`; the directives thread their already-resolved `showErrors`/`showWarnings` in as inputs) so ADR-0006's single visibility seam stays where it was, in the directives.

**Not breaking, despite the issue's `!` title.** Issue #351 predicted removing duplicated signals would shrink the public surface. It didn't: `FieldsetStateSignals` and `ErrorSummarySignals` are byte-identical before/after, and `ResolvedError` (moved to `utilities.ts` as its canonical home) keeps its public import path via a re-export in `error-state.ts` — the same pattern as `CharacterCountValue`. The "duplicates" were already the canonical public signals; only their backing implementation changed. Hence `refactor(headless):` without a breaking marker and no migration note, mirroring the `NgxHeadlessCharacterCount` → `createCharacterCount()` precedent (#328).

Two deliberate deviations from the issue's literal factory shape, for review: the results include `hasErrors`/`hasWarnings` beyond the six listed fields (the directives expose these publicly, and omitting them would force exactly the local-`computed` alias the issue eliminates), and `error-state.ts` gained the `ResolvedError` re-export shim (the issue listed it only as a pattern reference).

Review order: `utilities.ts` (the two factories), then `fieldset.ts` / `error-summary.ts` (projection rewrite), then `utilities.spec.ts` (contract specs).

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
