### PR TITLE
fix(demo): only autosave and re-baseline debounce-settled values

### DIFF
--- a/apps/demo/src/app/05-advanced/autosave/README.md
+++ b/apps/demo/src/app/05-advanced/autosave/README.md
@@ -61,13 +61,25 @@ protected readonly dirtyValidPatch = computed(() => {
   const displayName = this.profileForm.displayName();
   const bio = this.profileForm.bio();
   const patch: Partial<AutosaveProfileModel> = {};
-  if (displayName.dirty() && displayName.valid()) patch.displayName = displayName.value();
-  if (bio.dirty() && bio.valid()) patch.bio = bio.value();
+  if (
+    displayName.dirty() &&
+    displayName.valid() &&
+    untracked(displayName.controlValue) === displayName.value()
+  ) {
+    patch.displayName = displayName.value();
+  }
+  if (
+    bio.dirty() &&
+    bio.valid() &&
+    untracked(bio.controlValue) === bio.value()
+  ) {
+    patch.bio = bio.value();
+  }
   return Object.keys(patch).length > 0 ? patch : undefined;
 });
 ```
 
-Both conditions matter independently:
+Three conditions matter independently:
 
 - `dirty()` excludes a pristine value — one that hasn't changed since the
   field's last reset baseline, including immediately after this demo's own
@@ -75,11 +87,25 @@ Both conditions matter independently:
   alone would keep re-including an already-saved value forever, since
   validity doesn't change just because a request resolved.
 - `valid()` excludes a settled invalid value. Without it, `dirty()` alone
-  would happily PATCH a value that currently fails validation. Neither
-  signal is affected by unrelated re-renders, and — because `debounce()`
-  delays what `dirty()`/`valid()` ever observe until the value has
-  settled — there is no "still typing" intermediate value to worry about
-  either; the gate only ever sees settled values.
+  would happily PATCH a value that currently fails validation.
+- `controlValue() === value()` excludes a value that's still mid-debounce.
+  This one is the counter-intuitive part, and got this demo wrong for a
+  while (see [#366](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/366)):
+  `debounce()` only delays `value()`, the field's canonical, model-facing
+  signal — writing to a control marks `dirty()` `true` **synchronously**,
+  on the same keystroke. `ReadonlyFieldState.value`'s own doc comment says
+  as much: "updates from the UI control are eventually reflected here,
+  they may be delayed if debounced." Gating on `dirty()` and `valid()`
+  alone reads `value()` while it is still the field's _previous_ settled
+  value — not the edit the user just made — and PATCHes that: a save that
+  fires before the user has even stopped typing, carrying stale content.
+  `ReadonlyFieldState.controlValue` (`@publicApi 22.0`) is the literal,
+  undebounced value of the bound control; it only ever equals `value()`
+  once the debounce has actually elapsed and synced. Peeking it with
+  `untracked` keeps every keystroke (which changes `controlValue()` on its
+  own) from re-running this computed — it still only re-runs when
+  `dirty()`, `valid()`, or `value()` change, exactly as the two-condition
+  version did.
 
 Each field is gated independently, so one invalid field never blocks the
 other from autosaving.
@@ -132,12 +158,21 @@ The fix, in `autosave.form.ts`:
    each field's **current** value. A field is safe to mark saved only if it
    was part of the request that resolved **and** its value hasn't moved on
    since.
-3. Each safe field gets its own no-argument `reset()` —
+3. Before resetting, `#reconcileAfterSave()` checks one more thing:
+   `field.controlValue() !== field.value()`. `FieldState.reset()` (no
+   argument) aborts that field's pending debounce sync internally, so
+   calling it while an edit is still buffered behind an _unelapsed_
+   debounce would discard those keystrokes instead of letting them sync
+   normally — the same race `dirtyValidPatch()`'s settledness check
+   guards against, on the other side of the request (see
+   [#366](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/366)).
+   `fieldsSafeToMarkSaved()` only sees `value()`, so it can't detect this
+   on its own.
+4. Each field that passes both checks gets its own no-argument `reset()` —
    `this.profileForm[key]().reset()` — which clears that field's
    `dirty()`/`touched()` alone, without touching its value or any sibling
-   field. A field that fails either check in step 2 is left dirty, so the
-   next debounce cycle autosaves it for real instead of silently dropping
-   it.
+   field. A field that fails any check is left dirty, so the next debounce
+   cycle autosaves it for real instead of silently dropping it.
 
 This works because Signal Forms' `FieldState.reset()` takes an optional
 value but doesn't require one: called on a single field with no argument, it
@@ -236,8 +271,10 @@ form.
 - [autosave.save-reconciliation.ts](autosave.save-reconciliation.ts) — the
   pure lost-update guard (`fieldsSafeToMarkSaved()`), with its own
   [spec](autosave.save-reconciliation.spec.ts).
-- [autosave.form.ts](autosave.form.ts) — the dirty+valid gate, `httpResource`,
-  the post-save reconciliation, save-status live regions.
+- [autosave.form.ts](autosave.form.ts) — the dirty+valid+settled gate,
+  `httpResource`, the post-save reconciliation, save-status live regions,
+  with its own [spec](autosave.form.spec.ts) covering the settled-value
+  race from #366.
 - [autosave.page.ts](autosave.page.ts) — page wrapper and debugger.
 - `apps/demo/src/mocks/handlers.ts` — the `PATCH /api/autosave/profile` MSW
   handler.

--- a/apps/demo/src/app/05-advanced/autosave/autosave.form.spec.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.form.spec.ts
@@ -1,0 +1,287 @@
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
+import { fireEvent, render, screen } from '@testing-library/angular';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AUTOSAVE_ENDPOINT } from './autosave.api';
+import { AutosaveComponent } from './autosave.form';
+
+/**
+ * Regression coverage for #366: `debounce()` marks a field `dirty()`
+ * *synchronously* on input, but only updates `value()` once the 500ms
+ * debounce elapses (`ReadonlyFieldState.value`'s own doc comment in
+ * `@angular/forms/signals`: "updates from the UI control are eventually
+ * reflected here, they may be delayed if debounced"). Before the fix in
+ * `autosave.form.ts`, the `dirtyValidPatch` gate read `dirty()` and
+ * `value()` together in that window and PATCHed the field's *previous*
+ * settled value — not the edit the user just made — and, because the
+ * mocked backend's 400ms delay is shorter than the 500ms debounce, that
+ * premature save resolved before the debounce elapsed: the post-save
+ * reconciliation's no-argument `reset()` then aborted the still-pending
+ * debounce sync and reverted the control.
+ *
+ * `vi.useFakeTimers()` + `HttpTestingController` drive the debounce and
+ * the HTTP round trip deterministically (no real timers, no real
+ * network), which is what makes it possible to assert on the request
+ * dispatched *before* 500ms has elapsed (there must be none) as well as
+ * the one dispatched after. This app is zoneless (see `main.ts`), so
+ * `@angular/core/testing`'s zone-based `fakeAsync`/`tick` are not
+ * available here — plain `vi.advanceTimersByTimeAsync` plus
+ * `fixture.detectChanges()` stands in for them.
+ */
+describe('AutosaveComponent (#366 — settled-value autosave)', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    httpMock?.verify();
+    vi.useRealTimers();
+  });
+
+  async function setup() {
+    const rendered = await render(AutosaveComponent, {
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNgxSignalFormsConfig({
+          defaultErrorStrategy: 'on-touch',
+          autoAria: true,
+        }),
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    return rendered;
+  }
+
+  it('never PATCHes before the debounce settles, then PATCHes exactly the settled value', async () => {
+    const { fixture } = await setup();
+
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+    const settledValue = 'Historian of computing, and so much more.';
+
+    fireEvent.input(bio, { target: { value: settledValue } });
+    fixture.detectChanges();
+
+    // Right after the input event — `dirty()` is already true, but the
+    // 500ms debounce has not elapsed. The fix must not have dispatched
+    // anything yet.
+    await vi.advanceTimersByTimeAsync(400);
+    fixture.detectChanges();
+    httpMock.expectNone(AUTOSAVE_ENDPOINT);
+
+    // Past the debounce window: exactly one PATCH, carrying the settled
+    // value (not the pre-edit value).
+    await vi.advanceTimersByTimeAsync(200);
+    fixture.detectChanges();
+    const req = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ bio: settledValue });
+
+    req.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    // The control must retain the settled edit — not revert.
+    expect(bio.value).toBe(settledValue);
+  });
+
+  it('leaves the field pristine once the settled save resolves', async () => {
+    const { fixture } = await setup();
+    const component = fixture.componentInstance;
+
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+    fireEvent.input(bio, { target: { value: 'A settled edit.' } });
+    fixture.detectChanges();
+
+    await vi.advanceTimersByTimeAsync(500);
+    fixture.detectChanges();
+    const req = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    req.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    expect(component.profileForm.bio().dirty()).toBe(false);
+  });
+
+  it('reaches the failure state on a settled value containing the failure marker, and Retry save reissues it', async () => {
+    const { fixture } = await setup();
+
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+    fireEvent.input(bio, { target: { value: 'FAIL_SAVE this please' } });
+    fixture.detectChanges();
+
+    await vi.advanceTimersByTimeAsync(500);
+    fixture.detectChanges();
+    const req = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    expect(req.request.body).toEqual({ bio: 'FAIL_SAVE this please' });
+    req.flush(
+      { error: 'Could not persist this change.' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    const retryButton = screen.getByRole('button', { name: /retry save/i });
+    expect(retryButton).toBeInTheDocument();
+    // The field is still unsaved after a failure.
+    expect(bio.value).toBe('FAIL_SAVE this please');
+
+    fireEvent.click(retryButton);
+    fixture.detectChanges();
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    const retryReq = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    // Retry re-issues the same (still-failing) value.
+    expect(retryReq.request.body).toEqual({ bio: 'FAIL_SAVE this please' });
+    retryReq.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+  });
+
+  it('succeeds on the next debounce cycle once the failure marker is removed', async () => {
+    const { fixture } = await setup();
+
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+    fireEvent.input(bio, { target: { value: 'FAIL_SAVE this please' } });
+    fixture.detectChanges();
+    await vi.advanceTimersByTimeAsync(500);
+    fixture.detectChanges();
+
+    const failingReq = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    failingReq.flush(
+      { error: 'Could not persist this change.' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    fireEvent.input(bio, { target: { value: 'This is fine now.' } });
+    fixture.detectChanges();
+    await vi.advanceTimersByTimeAsync(500);
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    expect(req.request.body).toEqual({ bio: 'This is fine now.' });
+    req.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    expect(bio.value).toBe('This is fine now.');
+    expect(
+      screen.queryByRole('button', { name: /retry save/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('omits an invalid field without blocking a valid sibling from saving', async () => {
+    const { fixture } = await setup();
+
+    const displayName = screen.getByLabelText(
+      /display name/i,
+    ) as HTMLInputElement;
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+
+    // Invalid: below the 2-character minimum.
+    fireEvent.input(displayName, { target: { value: 'A' } });
+    fireEvent.input(bio, { target: { value: 'A valid bio update.' } });
+    fixture.detectChanges();
+
+    await vi.advanceTimersByTimeAsync(500);
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    expect(req.request.body).toEqual({ bio: 'A valid bio update.' });
+    req.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+  });
+
+  it('keeps a field dirty when it is edited again, mid-debounce, while its earlier save is still in flight', async () => {
+    const { fixture } = await setup();
+    const component = fixture.componentInstance;
+
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+
+    // First edit settles and dispatches a PATCH.
+    fireEvent.input(bio, { target: { value: 'First settled edit.' } });
+    fixture.detectChanges();
+    await vi.advanceTimersByTimeAsync(500);
+    fixture.detectChanges();
+    const firstReq = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    expect(firstReq.request.body).toEqual({ bio: 'First settled edit.' });
+
+    // Before that request resolves, the user types again. This starts a
+    // new debounce for `bio`; `controlValue()` moves on immediately, but
+    // `value()` won't catch up until this second debounce elapses.
+    fireEvent.input(bio, { target: { value: 'Second edit, mid-flight.' } });
+    fixture.detectChanges();
+    // Still short of the second debounce's own 500ms.
+    await vi.advanceTimersByTimeAsync(200);
+    fixture.detectChanges();
+
+    // The first request now resolves. At this instant,
+    // `profileForm().value()` still equals what was sent (the second
+    // debounce hasn't synced yet), so `fieldsSafeToMarkSaved()` alone
+    // would call this field safe to mark saved. The reconcile guard must
+    // still refuse to reset it, because doing so would abort the second,
+    // still-pending debounce sync and discard "Second edit, mid-flight."
+    firstReq.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    expect(component.profileForm.bio().dirty()).toBe(true);
+    expect(bio.value).toBe('Second edit, mid-flight.');
+
+    // Once the second debounce elapses, the newer value settles and the
+    // next cycle autosaves it for real.
+    await vi.advanceTimersByTimeAsync(300);
+    fixture.detectChanges();
+    const secondReq = httpMock.expectOne(AUTOSAVE_ENDPOINT);
+    expect(secondReq.request.body).toEqual({
+      bio: 'Second edit, mid-flight.',
+    });
+    secondReq.flush({ savedAt: new Date().toISOString() });
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    expect(component.profileForm.bio().dirty()).toBe(false);
+    expect(bio.value).toBe('Second edit, mid-flight.');
+  });
+
+  it('reset demo restores the initial model and pristine state', async () => {
+    const { fixture } = await setup();
+    const component = fixture.componentInstance;
+
+    const bio = screen.getByLabelText(/bio/i) as HTMLTextAreaElement;
+    fireEvent.input(bio, { target: { value: 'A throwaway edit.' } });
+    fixture.detectChanges();
+
+    // A throwaway edit that never gets the chance to settle/save.
+    fireEvent.click(screen.getByRole('button', { name: /reset demo/i }));
+    fixture.detectChanges();
+    await vi.advanceTimersByTimeAsync(0);
+    fixture.detectChanges();
+
+    expect(component.profileForm.bio().dirty()).toBe(false);
+    expect(bio.value.startsWith('Mathematician and writer')).toBe(true);
+
+    // `reset(value)` must actually cancel the throwaway edit's pending
+    // debounce sync, not just leave it racing in the background — advance
+    // past its 500ms window before asserting nothing was ever dispatched,
+    // so a debounce that (wrongly) survived the reset would still have
+    // time to fire and be caught here.
+    await vi.advanceTimersByTimeAsync(600);
+    fixture.detectChanges();
+    httpMock.expectNone(AUTOSAVE_ENDPOINT);
+  });
+});

--- a/apps/demo/src/app/05-advanced/autosave/autosave.form.ts
+++ b/apps/demo/src/app/05-advanced/autosave/autosave.form.ts
@@ -9,7 +9,7 @@ import {
   signal,
   untracked,
 } from '@angular/core';
-import { form, FormField } from '@angular/forms/signals';
+import { form, FormField, type FieldState } from '@angular/forms/signals';
 import {
   type ResolvedErrorDisplayStrategy,
   type FormFieldAppearance,
@@ -215,6 +215,29 @@ export class AutosaveComponent {
    * `Object.keys` for the same `keyof` precision reason as
    * `server-integration.form.ts`'s `PROFILE_FIELD_KEYS` — there are only two
    * fields here, so the loop would cost more clarity than it saves.
+   *
+   * A third, easy-to-miss condition guards against a real race in
+   * `debounce()`: writing to a control marks the field `dirty()`
+   * *synchronously*, but `value()` only catches up once the debounce
+   * elapses — see `ReadonlyFieldState.value`'s doc comment in
+   * `@angular/forms/signals`: "updates from the UI control are eventually
+   * reflected here, they may be delayed if debounced." Between those two
+   * moments, `dirty()` is already `true` while `value()` is still the
+   * field's *previous* settled value, not the edit the user just made.
+   * Gating on `dirty()` and `valid()` alone would read that stale
+   * `value()` and PATCH it — a save that fires before the user has even
+   * stopped typing, carrying the wrong content (see #366).
+   *
+   * `field().controlValue()` is the undebounced counterpart — the literal
+   * value of the bound control right now (`ReadonlyFieldState.controlValue`,
+   * `@publicApi 22.0`). It equals `value()` exactly when nothing is
+   * buffered behind the debounce, i.e. once the 500ms has elapsed and the
+   * pending sync has copied it across. Peeking it with `untracked` keeps
+   * every keystroke (which changes `controlValue()` on its own) from
+   * re-running this computed — it still only re-runs when `dirty()`,
+   * `valid()`, or `value()` actually change, exactly as before; by the
+   * time any of those does, the peek tells us whether the debounce has
+   * actually settled.
    */
   protected readonly dirtyValidPatch = computed<
     Partial<AutosaveProfileModel> | undefined
@@ -223,15 +246,31 @@ export class AutosaveComponent {
     const bio = this.profileForm.bio();
     const patch: Partial<AutosaveProfileModel> = {};
 
-    if (displayName.dirty() && displayName.valid()) {
+    if (this.#isSettledDirtyValid(displayName)) {
       patch.displayName = displayName.value();
     }
-    if (bio.dirty() && bio.valid()) {
+    if (this.#isSettledDirtyValid(bio)) {
       patch.bio = bio.value();
     }
 
     return Object.keys(patch).length > 0 ? patch : undefined;
   });
+
+  /**
+   * The three-part gate `dirtyValidPatch()` applies to each field —
+   * `dirty()`, `valid()`, and settled (see the doc comment above). Both
+   * fields are strings, so one predicate covers both; the field's
+   * `.value()` is still read at each call site (not returned from here),
+   * to keep the `keyof`-precision assignment (`patch.displayName = …`,
+   * `patch.bio = …`) explicit rather than routed through a generic key.
+   */
+  #isSettledDirtyValid(field: FieldState<string>): boolean {
+    return (
+      field.dirty() &&
+      field.valid() &&
+      untracked(field.controlValue) === field.value()
+    );
+  }
 
   /**
    * The patch actually included in the most recently issued PATCH — a plain
@@ -305,10 +344,28 @@ export class AutosaveComponent {
     );
 
     for (const key of safeFields) {
+      const field = this.profileForm[key]();
+
+      // Guard against the same debounce race `dirtyValidPatch()` guards
+      // against, on the other side of the request: calling no-argument
+      // `FieldState.reset()` on a field with a pending, not-yet-elapsed
+      // debounce discards that buffered edit instead of letting it sync
+      // normally. `fieldsSafeToMarkSaved()` only compares `value()` —
+      // Angular's canonical, debounce-settled signal — against the sent
+      // snapshot, so it cannot see an edit still buffered behind an
+      // *unelapsed* debounce (`controlValue()` has moved on, `value()`
+      // hasn't yet). Skipping the reset here leaves the field dirty;
+      // once its debounce elapses, `dirtyValidPatch()` picks the newer
+      // value up on the next cycle exactly like any other edit made
+      // mid-flight (see #366).
+      if (field.controlValue() !== field.value()) {
+        continue;
+      }
+
       // No-argument `reset()` clears touched/dirty for this field alone,
       // without touching its value or any sibling field — see
       // `FieldState.reset()` in `@angular/forms/signals`.
-      this.profileForm[key]().reset();
+      field.reset();
     }
   }
 


### PR DESCRIPTION
The Autosave demo could PATCH a stale pre-debounce value and then revert the user's edit on success. Root cause is demo composition, not a framework defect: Signal Forms' `debounce(path, 500)` delays `value()` but marks `dirty()` synchronously (documented on `ReadonlyFieldState.value`: "updates from the UI control … may be delayed if debounced"). So the `dirty() && valid()` patch gate could fire with the *previous* settled value while the real edit was still buffered — and because the MSW mock's 400ms delay beats the 500ms debounce, that phantom request resolved first, and reconciliation's no-arg `reset()` discarded the buffered keystrokes by snapping the control back.

The fix gates on settledness using the public `ReadonlyFieldState.controlValue` (the undebounced control value, `@publicApi 22.0`), on both sides of the request:

- `dirtyValidPatch` includes a field only when `dirty() && valid() && untracked(controlValue) === value()` (via a shared `#isSettledDirtyValid` predicate) — a PATCH only ever carries settled values. `untracked` keeps the computed's recompute cadence unchanged (keystrokes alone don't re-run it).
- `#reconcileAfterSave()` skips `reset()` for a field whose newer edit is still buffered behind an unelapsed debounce, so it stays dirty and the next cycle saves the newer value. The `fieldsSafeToMarkSaved()` contract is untouched.

A new focused regression spec (`autosave.form.spec.ts`, `HttpTestingController` + fake timers — zoneless app, so no `fakeAsync`) covers: no premature PATCH, settled PATCH body + retained value, pristine-on-success, mid-debounce edit during an in-flight request staying dirty and saving next cycle, `FAIL_SAVE` failure + Retry reissue and recovery, invalid-sibling omission, and Reset demo. All 7 were verified to fail against the pre-fix code (or with the reconcile guard removed) and pass with the fix. The demo README's incorrect claim that the gate "only ever sees settled values" is corrected and now documents the settledness checks.

No toolkit (`packages/**`) changes. The follow-up E2E suite is #367.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
