### PR TITLE
feat(testing): add createA11yValidator for tag-scoped a11y validators

### DIFF
--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -945,9 +945,11 @@ A small consumer-facing accessibility test harness. `axe-core` is an **optional 
 
 ```typescript
 import {
+  createA11yValidator,
   expectNoA11yViolations,
   findAlertContaining,
   WCAG_22_AA_TAGS,
+  type A11yValidator,
   type WCAG_22_AA_TAG,
 } from '@ngx-signal-forms/toolkit/testing';
 ```
@@ -964,6 +966,21 @@ expectNoA11yViolations(
 // baseline is applied after the options spread, so it wins at runtime even for
 // an axe.RunOptions-typed value smuggling one through. `resultTypes` stays
 // caller-overridable.
+
+// Builds a same-shaped validator scoped to a caller-chosen WCAG 2.2 AA tag
+// subset, instead of the full expectNoA11yViolations baseline — for custom
+// wrappers that only need part of the tag set checked at a given call site.
+// The toolkit's own specs keep the hard-coded baseline. `tags` is typed to
+// WCAG_22_AA_TAG (not string[]), so an invented tag is a compile error;
+// omitted, it defaults to the full WCAG_22_AA_TAGS baseline. `tags: []`
+// type-checks but throws synchronously at creation time (not a silently
+// always-passing validator). The returned validator keeps the same
+// non-overridable `runOnly` guarantee.
+createA11yValidator(options?: { tags?: readonly WCAG_22_AA_TAG[] }): A11yValidator
+type A11yValidator = (
+  context?: axe.ElementContext,
+  options?: Omit<axe.RunOptions, 'runOnly'>,
+) => Promise<void>
 
 // axe-core tag set mapping to WCAG 2.2 AA (additive across versions):
 WCAG_22_AA_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'] as const

--- a/.agents/skills/ngx-signal-forms/testing/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/testing/SKILL.md
@@ -24,9 +24,11 @@ fixture. One call per fixture scans the whole DOM subtree.
 
 ```typescript
 import {
+  createA11yValidator,
   expectNoA11yViolations,
   findAlertContaining,
   WCAG_22_AA_TAGS, // ['wcag2a','wcag2aa','wcag21a','wcag21aa','wcag22aa']
+  type A11yValidator,
   type WCAG_22_AA_TAG,
 } from '@ngx-signal-forms/toolkit/testing';
 ```
@@ -40,6 +42,19 @@ import {
   passing `runOnly` in a fresh literal is a compile error, and the baseline
   wins at runtime even when a pre-typed `axe.RunOptions` value smuggles one
   through. `resultTypes` stays caller-overridable.
+- `createA11yValidator(options?: { tags?: readonly WCAG_22_AA_TAG[] })` —
+  returns an `A11yValidator` (same `(context?, options?) => Promise<void>`
+  shape as `expectNoA11yViolations`) scoped to a caller-chosen tag subset.
+  Reach for this in a custom wrapper that legitimately only needs part of
+  the WCAG 2.2 AA tag set checked at a given call site — the toolkit's own
+  specs keep using `expectNoA11yViolations`'s hard-coded baseline. `tags` is
+  typed to `WCAG_22_AA_TAG`, so an invented or typo'd tag is a compile
+  error, not a silently-empty scan; omitted, it defaults to the full
+  `WCAG_22_AA_TAGS` baseline. `tags: []` type-checks (the type has no
+  minimum length) but throws synchronously at creation time instead of
+  returning a validator that would silently pass every scan. The returned
+  validator keeps the same non-overridable `runOnly` guarantee as
+  `expectNoA11yViolations`.
 - `WCAG_22_AA_TAGS` — the axe tag set the harness runs. There is no `wcag22a`
   tag: the two new 2.2 Level A criteria are non-automatable, so automated
   scanning covers only a subset of full 2.2 AA conformance.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,7 +26,12 @@ This guide does not cover:
   This guide's specs run in jsdom instead — assertions target specific
   attributes and text, not a full accessibility tree scan. See
   [ADR-0004](./decisions/0004-wcag22-testing-strategy.md) for why the two run
-  in different modes.
+  in different modes. A custom wrapper that only needs part of the WCAG 2.2
+  AA tag set checked at a given call site should use
+  `createA11yValidator({ tags })` from the same entry point instead. It
+  builds a scoped validator without bypassing `expectNoA11yViolations`'s
+  baseline through a raw `axe.RunOptions`. See the testing package's README
+  for the scoped-validator example.
 - **End-to-end tests.** Playwright specs (`*.e2e.spec.ts`) drive a real
   browser and are out of scope here.
 

--- a/packages/toolkit/testing/README.md
+++ b/packages/toolkit/testing/README.md
@@ -26,6 +26,7 @@ npm install --save-dev axe-core@^4.5.0
 
 ```typescript
 import {
+  createA11yValidator,
   expectNoA11yViolations,
   findAlertContaining,
   WCAG_22_AA_TAGS,
@@ -68,6 +69,44 @@ await expectNoA11yViolations(container, {
 > [!WARNING]
 > Keep waivers narrow and fixture-specific. If you disable a rule broadly,
 > you can accidentally hide regressions in production-facing components.
+
+## Scoping the tag baseline: `createA11yValidator(options?)`
+
+`expectNoA11yViolations` is deliberately locked to the full WCAG 2.2 AA tag
+set — that's the right call for the toolkit's own components, which are
+published primitives where any violation is a bug. A custom wrapper you're
+building doesn't always have that same all-or-nothing constraint: a fixture
+might only need a narrower rule subset checked at a given call site. Use
+`createA11yValidator` to build a validator scoped to your own tag subset,
+without giving up the same non-overridable `runOnly` guarantee:
+
+```typescript
+import { createA11yValidator } from '@ngx-signal-forms/toolkit/testing';
+
+// Scoped to Level A only — narrower than the toolkit's own baseline.
+const expectNoLevelAViolations = createA11yValidator({
+  tags: ['wcag2a', 'wcag21a'],
+});
+
+it('has no WCAG 2.2 Level A violations', async () => {
+  const { container } = await render(MyCustomWrapper);
+
+  await expectNoLevelAViolations(container);
+});
+```
+
+The validator `createA11yValidator` returns has the exact same call shape as
+`expectNoA11yViolations` — `(context?, options?)` — so it's a drop-in
+replacement anywhere you'd use the default helper. `tags` accepts only
+`WCAG_22_AA_TAG` values (the same union `WCAG_22_AA_TAGS` is drawn from), so
+a typo'd or invented tag is a compile error rather than a silently-empty
+scan; there's no escape hatch to widen it to an arbitrary `string[]`. An
+empty array (`tags: []`) does type-check — the type has no minimum length —
+but `createA11yValidator` throws synchronously at creation time instead of
+handing back a validator that would silently pass every scan. Omit `tags`
+(or call `createA11yValidator()` with no arguments) to get a validator that
+behaves exactly like `expectNoA11yViolations` — the full baseline is the
+default, not a special case.
 
 ## Utilities
 

--- a/packages/toolkit/testing/a11y.browser.spec.ts
+++ b/packages/toolkit/testing/a11y.browser.spec.ts
@@ -1,6 +1,16 @@
+import { ApplicationRef, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, required, schema } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
 import type axe from 'axe-core';
 import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
-import { expectNoA11yViolations, WCAG_22_AA_TAGS } from './a11y';
+import { NgxFormFieldError } from '@ngx-signal-forms/toolkit/assistive';
+import {
+  createA11yValidator,
+  expectNoA11yViolations,
+  WCAG_22_AA_TAGS,
+} from './a11y';
+import type { WCAG_22_AA_TAG } from './a11y';
 
 /**
  * Self-test / negative control for `expectNoA11yViolations`.
@@ -151,7 +161,7 @@ describe('expectNoA11yViolations WCAG 2.2 AA baseline', () => {
     // check is literal-only. A value already typed as the wider
     // `axe.RunOptions` (no cast needed — this is a legitimate, structurally
     // assignable value) can still carry a `runOnly` and pass the type
-    // checker. `expectNoA11yViolations` guards against that at runtime by
+    // validator. `expectNoA11yViolations` guards against that at runtime by
     // applying its own `runOnly` after spreading `options`, so the WCAG
     // 2.2 AA baseline wins regardless. Prove it: point a laundered
     // `runOnly` at a tag ('best-practice') that does not include
@@ -187,5 +197,208 @@ describe('WCAG_22_AA_TAGS', () => {
       'wcag21aa',
       'wcag22aa',
     ]);
+  });
+});
+
+/**
+ * `createA11yValidator` conformance gate.
+ *
+ * `expectNoA11yViolations` above is the toolkit's own hard-coded WCAG 2.2 AA
+ * baseline. `createA11yValidator` is the additive, consumer-facing
+ * counterpart (issue #357): it returns a same-shaped validator scoped to a
+ * caller-chosen `WCAG_22_AA_TAG` subset, for custom wrappers that don't want
+ * — or can't yet satisfy — the full baseline at a given call site.
+ *
+ * These specs use two axe-core rules confirmed (via `axe.getRules()`, which
+ * also confirms both are enabled by default — unlike `target-size`, which
+ * axe-core ships `enabled: false` and never runs even when its tag is in
+ * scope) to sit in disjoint tag sets, so scoping the validator demonstrably
+ * changes the result rather than coincidentally passing:
+ *
+ * - `label` (missing accessible name on a form control) is tagged only
+ *   `wcag2a`.
+ * - `color-contrast` (insufficient text/background contrast) is tagged only
+ *   `wcag2aa`.
+ *
+ * Fixtures render `NgxFormFieldError` — the post-rc.12 component
+ * `NgxFormFieldNotification` was folded into (see
+ * `docs/migrations/v1.0.0-rc.12.md`) — the same way the other standalone a11y
+ * specs in `packages/toolkit/assistive` do, so this exercises real toolkit
+ * markup rather than a synthetic fixture.
+ */
+describe('createA11yValidator', () => {
+  @Component({
+    selector: 'ngx-test-a11y-validator-labeled',
+    imports: [FormField, NgxFormFieldError],
+    template: `
+      <form (submit)="$event.preventDefault()" novalidate>
+        <label for="email">Email</label>
+        <input id="email" [formField]="testForm.email" />
+        <ngx-form-field-error
+          [formField]="testForm.email"
+          fieldName="email"
+          strategy="immediate"
+        />
+      </form>
+    `,
+  })
+  class LabeledFieldComponent {
+    readonly #model = signal({ email: '' });
+    readonly testForm = form(
+      this.#model,
+      schema((path) => {
+        required(path.email, { message: 'Email is required' });
+      }),
+    );
+  }
+
+  @Component({
+    selector: 'ngx-test-a11y-validator-unlabeled',
+    imports: [FormField, NgxFormFieldError],
+    template: `
+      <form (submit)="$event.preventDefault()" novalidate>
+        <!-- Deliberately no <label>: triggers axe's "label" rule, wcag2a-only. -->
+        <input id="email" [formField]="testForm.email" />
+        <ngx-form-field-error
+          [formField]="testForm.email"
+          fieldName="email"
+          strategy="immediate"
+        />
+      </form>
+    `,
+  })
+  class UnlabeledFieldComponent {
+    readonly #model = signal({ email: '' });
+    readonly testForm = form(
+      this.#model,
+      schema((path) => {
+        required(path.email, { message: 'Email is required' });
+      }),
+    );
+  }
+
+  @Component({
+    selector: 'ngx-test-a11y-validator-low-contrast',
+    imports: [FormField, NgxFormFieldError],
+    template: `
+      <form (submit)="$event.preventDefault()" novalidate>
+        <label for="email">Email</label>
+        <input id="email" [formField]="testForm.email" />
+        <ngx-form-field-error
+          [formField]="testForm.email"
+          fieldName="email"
+          strategy="immediate"
+        />
+        <!--
+          Fully labeled — no "label" (wcag2a) violation — but this text's
+          light-grey-on-white contrast ratio is well under the WCAG AA 4.5:1
+          minimum, tripping axe's "color-contrast" rule, tagged only
+          wcag2aa. Unrelated to the form field above; it exists purely to
+          give the fixture a violation outside a ['wcag2a']-scoped validator.
+        -->
+        <p style="color: #e5e5e5; background-color: #ffffff;">
+          Supplementary note text
+        </p>
+      </form>
+    `,
+  })
+  class LowContrastComponent {
+    readonly #model = signal({ email: '' });
+    readonly testForm = form(
+      this.#model,
+      schema((path) => {
+        required(path.email, { message: 'Email is required' });
+      }),
+    );
+  }
+
+  it('positive control: a compliant fixture passes a scoped validator', async () => {
+    const { container } = await render(LabeledFieldComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const checkLevelA = createA11yValidator({ tags: ['wcag2a'] });
+    await expect(checkLevelA(container)).resolves.toBeUndefined();
+  });
+
+  it('negative control: a violation inside the scoped tags fails the scoped validator', async () => {
+    const { container } = await render(UnlabeledFieldComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const checkLevelA = createA11yValidator({ tags: ['wcag2a'] });
+
+    await expect(checkLevelA(container)).rejects.toThrow(/label/u);
+  });
+
+  it('negative control: a violation outside the scoped tags does not fail the scoped validator', async () => {
+    const { container } = await render(LowContrastComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // Sanity check: the fixture genuinely has a violation under the full
+    // WCAG 2.2 AA baseline (color-contrast, wcag2aa-only) — otherwise the
+    // next assertion would pass for the wrong reason.
+    await expect(expectNoA11yViolations(container)).rejects.toThrow(
+      /color-contrast/u,
+    );
+
+    // The whole point of scoping: a validator built with `tags: ['wcag2a']`
+    // never asks axe to run the wcag2aa-only `color-contrast` rule, so the
+    // same fixture passes it even though it has a real, unrelated violation.
+    const checkLevelA = createA11yValidator({ tags: ['wcag2a'] });
+    await expect(checkLevelA(container)).resolves.toBeUndefined();
+  });
+
+  it('defaults to the full WCAG 2.2 AA baseline when no tags are given', async () => {
+    const { container } = await render(LowContrastComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const checkDefault = createA11yValidator();
+
+    await expect(checkDefault(container)).rejects.toThrow(/color-contrast/u);
+  });
+
+  it('accepts merged RunOptions the same way expectNoA11yViolations does', async () => {
+    const { container } = await render(UnlabeledFieldComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const checkLevelA = createA11yValidator({ tags: ['wcag2a'] });
+
+    await expect(
+      checkLevelA(container, { rules: { label: { enabled: false } } }),
+    ).resolves.toBeUndefined();
+  });
+
+  // Compile-time documentation: `tags` must stay constrained to
+  // `WCAG_22_AA_TAG`, not widen to an arbitrary `string[]` — an invented or
+  // typo'd tag should be a compile error, not a silently-empty scan.
+  it('constrains tags to WCAG_22_AA_TAG, not arbitrary strings', () => {
+    expectTypeOf(createA11yValidator)
+      .parameter(0)
+      .toMatchTypeOf<{ tags?: readonly WCAG_22_AA_TAG[] } | undefined>();
+    // And the reverse: an arbitrary string is NOT assignable to `tags`, so
+    // `createA11yValidator({ tags: ['not-a-real-tag'] })` is a compile error.
+    expectTypeOf<{ tags?: readonly string[] }>().not.toMatchTypeOf<
+      Parameters<typeof createA11yValidator>[0]
+    >();
+  });
+
+  // Same non-overridable `runOnly` guarantee as expectNoA11yViolations,
+  // carried through to every validator this factory returns.
+  it('excludes runOnly from the returned validator options parameter type', () => {
+    const validator = createA11yValidator({ tags: ['wcag2a'] });
+
+    expectTypeOf<Parameters<typeof validator>[1]>().not.toHaveProperty(
+      'runOnly',
+    );
+  });
+
+  // `tags: []` type-checks (the type has no minimum length) but would
+  // compile down to `runOnly: { type: 'tag', values: [] }` — axe-core runs
+  // that as "no tagged rules", so every scan would resolve regardless of
+  // real violations, silently disabling the gate. `createA11yValidator`
+  // must refuse to hand back such a validator at all.
+  it('throws synchronously at creation time when tags is an empty array', () => {
+    expect(() => createA11yValidator({ tags: [] })).toThrow(
+      /createA11yValidator: tags must not be empty/u,
+    );
   });
 });

--- a/packages/toolkit/testing/a11y.ts
+++ b/packages/toolkit/testing/a11y.ts
@@ -47,6 +47,90 @@ export async function expectNoA11yViolations(
   context: axe.ElementContext = document.body,
   options: Omit<axe.RunOptions, 'runOnly'> = {},
 ): Promise<void> {
+  return runA11yCheck(
+    WCAG_22_AA_TAGS,
+    context,
+    options,
+    (count) => `Found ${count} WCAG 2.2 AA accessibility violation(s):`,
+  );
+}
+
+/**
+ * Shape shared by {@link expectNoA11yViolations} and the validator returned
+ * by {@link createA11yValidator} — a `context`/`options` pair (mirroring
+ * `axe.run`'s own signature) that resolves on a clean scan and throws a
+ * formatted report otherwise.
+ */
+export type A11yValidator = (
+  context?: axe.ElementContext,
+  options?: Omit<axe.RunOptions, 'runOnly'>,
+) => Promise<void>;
+
+/**
+ * Builds a scoped {@link A11yValidator} — same call shape as
+ * {@link expectNoA11yViolations}, but audited against a caller-chosen subset
+ * of the WCAG 2.2 AA tag set instead of the full baseline.
+ *
+ * `expectNoA11yViolations` is deliberately a hard-coded, non-overridable
+ * baseline (see its own doc) because toolkit components are published
+ * primitives — any WCAG 2.2 AA violation in them is a bug. Consumers writing
+ * a custom wrapper don't have that same all-or-nothing constraint: a fixture
+ * might legitimately only need a rule subset checked at a given call site
+ * (e.g. contrast already gated elsewhere). Getting that today means widening
+ * to a raw `axe.RunOptions` to smuggle `runOnly` past the `Omit` guard —
+ * which silently drops the baseline altogether, with no compile-time signal
+ * of what is (and isn't) still covered.
+ *
+ * `tags` is typed as `readonly WCAG_22_AA_TAG[]` — the same union
+ * {@link WCAG_22_AA_TAGS} is drawn from — not an arbitrary `string[]`, so a
+ * typo'd or invented tag is a compile error rather than a silently-empty
+ * scan. There is no escape hatch back to `string[]` here: the validator this
+ * returns keeps the same `Omit<axe.RunOptions, 'runOnly'>` shape as
+ * `expectNoA11yViolations`, so `runOnly` still can't be smuggled back in
+ * through its own per-call `options` argument either.
+ *
+ * @param options `tags` — the axe tag subset to scan with; defaults to the
+ *   full {@link WCAG_22_AA_TAGS} baseline when omitted. Omitting `tags`
+ *   makes the returned validator behave exactly like
+ *   `expectNoA11yViolations`, including its failure message; passing a
+ *   narrower `tags` list labels the failure message with that scoped tag
+ *   set instead, so a failure report never overclaims WCAG 2.2 AA coverage
+ *   it didn't actually run.
+ * @throws {Error} Synchronously, at creation time, if `tags` is provided but
+ *   empty. An empty array is accepted by the type (`readonly
+ *   WCAG_22_AA_TAG[]` has no minimum length), but would compile down to
+ *   `runOnly: { type: 'tag', values: [] }`, which axe-core runs as "no
+ *   tagged rules" — every scan would silently pass regardless of real
+ *   violations. Failing fast here, before a validator is ever handed back to
+ *   a caller, turns that silent gate-disable into an immediate, loud error
+ *   instead of a validator that always resolves.
+ */
+export function createA11yValidator(
+  options: { tags?: readonly WCAG_22_AA_TAG[] } = {},
+): A11yValidator {
+  if (options.tags?.length === 0) {
+    throw new Error(
+      '[ngx-signal-forms] createA11yValidator: tags must not be empty — omit the option to use the full WCAG 2.2 AA baseline.',
+    );
+  }
+
+  const tags = options.tags ?? WCAG_22_AA_TAGS;
+  const describeViolations =
+    options.tags === undefined
+      ? (count: number) =>
+          `Found ${count} WCAG 2.2 AA accessibility violation(s):`
+      : (count: number) =>
+          `Found ${count} accessibility violation(s) for scoped tags ${tags.join(', ')}:`;
+  return (context = document.body, runOptions = {}) =>
+    runA11yCheck(tags, context, runOptions, describeViolations);
+}
+
+async function runA11yCheck(
+  tags: readonly WCAG_22_AA_TAG[],
+  context: axe.ElementContext,
+  options: Omit<axe.RunOptions, 'runOnly'>,
+  describeViolations: (count: number) => string,
+): Promise<void> {
   const results = await axe.run(context, {
     // `resultTypes` before `...options` so callers can still override it.
     resultTypes: ['violations'],
@@ -55,10 +139,10 @@ export async function expectNoA11yViolations(
     // `runOnly` on fresh object literals, so a caller could still widen a
     // value to `axe.RunOptions` and smuggle `runOnly` through `options`
     // (e.g. `const opts: axe.RunOptions = { runOnly: {...} }`). Applying
-    // the WCAG 2.2 AA baseline after the spread makes it win at runtime
-    // regardless, so the guarantee holds even when the type-level guard
-    // (the `Omit` above) is bypassed this way.
-    runOnly: { type: 'tag', values: [...WCAG_22_AA_TAGS] },
+    // the tag baseline after the spread makes it win at runtime regardless,
+    // so the guarantee holds even when the type-level guard (the `Omit`
+    // above) is bypassed this way.
+    runOnly: { type: 'tag', values: [...tags] },
   });
 
   if (results.violations.length === 0) {
@@ -79,7 +163,7 @@ export async function expectNoA11yViolations(
     .join('\n');
 
   throw new Error(
-    `Found ${results.violations.length} WCAG 2.2 AA accessibility violation(s):\n${report}`,
+    `${describeViolations(results.violations.length)}\n${report}`,
   );
 }
 

--- a/packages/toolkit/testing/index.ts
+++ b/packages/toolkit/testing/index.ts
@@ -5,8 +5,9 @@
 // only required if you import from this entry point.
 
 export {
+  createA11yValidator,
   expectNoA11yViolations,
   findAlertContaining,
   WCAG_22_AA_TAGS,
 } from './a11y';
-export type { WCAG_22_AA_TAG } from './a11y';
+export type { A11yValidator, WCAG_22_AA_TAG } from './a11y';


### PR DESCRIPTION
Wrapper authors could only consume `expectNoA11yViolations` as-is: its `Omit<axe.RunOptions, 'runOnly'>` guard (correctly) blocks tag overrides, so scoping a scan to a rule subset meant bypassing the testing entry entirely. This adds the second granularity the seam was missing:

```ts
import { createA11yValidator } from '@ngx-signal-forms/toolkit/testing';

const expectLevelA = createA11yValidator({ tags: ['wcag2a'] });
await expectLevelA(container);
```

- `tags` is constrained to the `WCAG_22_AA_TAG` union at compile time — a typo'd or invented tag is a compile error, not a silently-empty scan. The returned validator keeps the same `runOnly`-excluding call shape, so scoping can narrow the baseline but never smuggle arbitrary rules back in.
- Additive only: `expectNoA11yViolations`, `findAlertContaining`, and `WCAG_22_AA_TAGS` are unchanged (both now share a private `runA11yCheck`; the no-arg validator's failure message is byte-identical to `expectNoA11yViolations`', scoped validators say "for scoped tags …").
- Browser specs cover the positive control, an in-scope violation (missing label, `wcag2a`), an out-of-scope violation the scoped validator deliberately passes (`color-contrast`, `wcag2aa`-only — verified enabled in the installed axe-core), default-tags equivalence, options merging, and two compile-time type assertions. All fixtures assert against `NgxFormFieldError` (post-#353).
- Documented in the testing README and `docs/TESTING.md`; the `ngx-signal-forms` skill docs are kept in sync per repo convention.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
