### PR TITLE
refactor(vest): extract the result-mapping pipeline into vest-result-mapper.ts

### DIFF
--- a/packages/toolkit/vest/src/vest-adapter.ts
+++ b/packages/toolkit/vest/src/vest-adapter.ts
@@ -11,15 +11,21 @@ import {
 import {
   createVestRunCoordinator,
   isVestResultLike,
-  VEST_KEY_SEPARATOR,
   type VestCoordinatedSuite,
-  type VestFailureMessages,
   type VestFieldExclusion,
   type VestResultLike,
   type VestRunCoordinator,
   type VestRunHandle,
   type VestRunnableSuite,
 } from './vest-run-coordinator';
+import {
+  createVestValidationSnapshot,
+  mapVestValidationResult,
+  shouldDeferVestWarnings,
+  VEST_ERROR_KIND_PREFIX,
+  VEST_WARNING_KIND_PREFIX,
+  type VestValidationSnapshot,
+} from './vest-result-mapper';
 
 /* oxlint-disable @typescript-eslint/prefer-readonly-parameter-types -- Angular Signal Forms validator callbacks and lightweight path parsing helpers operate on framework/runtime types that are not modeled as readonly. */
 
@@ -34,20 +40,11 @@ export type {
   VestRunnableSuite,
 } from './vest-run-coordinator';
 
-/**
- * Public constant kind prefix used for Vest `warn()` messages surfaced through
- * the toolkit. Exported so downstream code (error strategies, tests, debug
- * tooling) can filter warning-mode validation errors without re-deriving the
- * string literal.
- */
-export const VEST_WARNING_KIND_PREFIX = 'warn:vest:';
-
-/**
- * Public constant kind prefix used for blocking Vest errors surfaced through
- * the toolkit. Mirrors {@link VEST_WARNING_KIND_PREFIX} so consumers can match
- * both shapes with a single source of truth.
- */
-export const VEST_ERROR_KIND_PREFIX = 'vest:';
+// `VEST_WARNING_KIND_PREFIX` / `VEST_ERROR_KIND_PREFIX` are defined in
+// `./vest-result-mapper.ts` (their kind-generation logic lives there) and
+// re-exported below so `./index.ts` keeps importing them from this module
+// unchanged.
+export { VEST_ERROR_KIND_PREFIX, VEST_WARNING_KIND_PREFIX };
 
 /**
  * Callback supplied via {@link VestRegisterOptions.only} to enable per-field
@@ -73,31 +70,11 @@ export type VestOnlyFieldSelector<TValue, F extends string = string> = (
  */
 export type VestFieldPath<TValue> = SchemaPath<TValue> & SchemaPathTree<TValue>;
 
-/**
- * Adapter-local severity mapping used to generate Angular validation error
- * kinds. Vest exposes warn/error behavior through result selectors, but not as
- * a public severity union type.
- */
-type VestValidationMode = 'error' | 'warning';
-
-/**
- * Canonical representation of a Vest message after normalizing field targeting
- * and duplicate-message occurrence tracking.
- */
-interface VestValidationEntry {
-  fieldPath: string;
-  message: string;
-  occurrence: number;
-}
-
-/**
- * Snapshot of the initial sync result from a Vest run. Async completion uses
- * this to emit only the delta once pending tests finish.
- */
-interface VestValidationSnapshot {
-  readonly errors: readonly VestValidationEntry[];
-  readonly warnings: readonly VestValidationEntry[];
-}
+// `VestValidationMode`, `VestValidationEntry` and `VestValidationSnapshot`
+// (the mapping pipeline's own vocabulary) now live in
+// `./vest-result-mapper.ts`. `VestValidationSnapshot` is imported above --
+// `PendingVestValidationPayload` and `ResolvedVestValidationPayload` below
+// still need it for the resource-loader payload shapes registration owns.
 
 /**
  * Internal registration flags that decide whether blocking errors, warnings, or
@@ -127,7 +104,6 @@ interface ResolvedVestValidationPayload {
 }
 
 const VEST_PATH_SEGMENT = /[^.[\]]+/gu;
-const VEST_KIND_SEGMENT_MAX_LEN = 48;
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
   return (
@@ -153,112 +129,9 @@ function isFieldTree(value: unknown): value is ReadonlyFieldTree<unknown> {
   return typeof value === 'function';
 }
 
-/**
- * Compact FNV-1a hash returning a 4-character lowercase hex digest. Used by
- * {@link normalizeWarningKindSegment} as a collision-safe suffix whenever
- * normalization was lossy — whether from character folding/case folding or
- * from truncation past {@link VEST_KIND_SEGMENT_MAX_LEN}.
- */
-function fnv1a4Hex(value: string): string {
-  let hash = 0x8_11c_9dc5;
-  for (let index = 0; index < value.length; index++) {
-    hash ^= value.codePointAt(index) ?? 0;
-    hash = Math.imul(hash, 0x01_00_01_93);
-  }
-
-  return (hash >>> 16).toString(16).padStart(4, '0');
-}
-
-/**
- * Sanitizes arbitrary Vest field/message fragments so generated validation
- * kinds remain stable and CSS/DOM-friendly.
- *
- * Despite the name, this is mode-agnostic: {@link createVestValidationKind}
- * calls it for BOTH blocking-error and warning kinds, not just warnings — the
- * name predates the toolkit surfacing Vest `test()` failures as `vest:*`
- * kinds alongside `warn()` results as `warn:vest:*`. Kept as-is (see the
- * caller's fallback-literal note below) rather than renamed, to avoid
- * unrelated churn across every call site.
- *
- * The sanitize step is LOSSY — case folding and collapsing every run of
- * non `[a-z0-9]` characters to a single `-` can map distinct inputs onto the
- * same segment (e.g. `'user.email'` and `'user_email'` both normalize to
- * `'user-email'`; so do `'Email'` and `'email'`). Whenever normalization was
- * lossy — i.e. the normalized string differs from the original `value` —
- * or the normalized value exceeds {@link VEST_KIND_SEGMENT_MAX_LEN}, a short
- * FNV-1a hash suffix of the *original* value is appended so that two inputs
- * which fold or truncate to the same segment do not collide. A `value` that
- * survives normalization unchanged (already lowercase, already
- * alnum-and-hyphen-only, within the length limit) is by definition
- * collision-free and returned as-is, with no hash suffix.
- *
- * A `value` that folds to nothing (e.g. punctuation-only, like `'!!!'`)
- * returns the BARE hash with no leading hyphen — joining an empty folded
- * segment to the hash with `-` would reintroduce the leading hyphen the trim
- * step above just stripped, producing both an invalid CSS-identifier start
- * and an ugly kind (`warn:vest:email:-a1b2:0`). Only a literal empty-string
- * `value` (which normalizes to `''` non-lossily, so no hash is appended)
- * still reaches the `|| 'field'`/`|| 'warning'` fallback in
- * {@link createVestValidationKind}.
- */
-function normalizeWarningKindSegment(value: string): string {
-  const normalized = value
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/gu, '-')
-    .replaceAll(/^-+|-+$/gu, '');
-
-  const lossy =
-    normalized !== value || normalized.length > VEST_KIND_SEGMENT_MAX_LEN;
-
-  if (!lossy) {
-    return normalized;
-  }
-
-  const truncated =
-    normalized.length > VEST_KIND_SEGMENT_MAX_LEN
-      ? normalized.slice(0, VEST_KIND_SEGMENT_MAX_LEN)
-      : normalized;
-
-  const hash = fnv1a4Hex(value);
-
-  return truncated === '' ? hash : `${truncated}-${hash}`;
-}
-
-/**
- * Creates a deterministic Angular validation error kind for a mapped Vest
- * error or warning.
- *
- * The `'field'`/`'warning'` fallback literals below are generic placeholders
- * for "the sanitized segment came out empty" — which, since
- * {@link normalizeWarningKindSegment} now appends a hash suffix to any
- * lossily-normalized input (including one that folds to nothing, e.g. a
- * message that is only punctuation), can only happen for a literal empty
- * `''` fieldPath/message: normalizing `''` is non-lossy (it stays `''`), so
- * no hash is appended and the fallback literal applies. They are NOT a mode
- * indicator. In particular, the
- * `'warning'` fallback also applies when `mode === 'error'`, so a blocking
- * error whose message sanitizes to empty can produce a kind that literally
- * contains the substring `warning` (e.g. `vest:field:warning:0`). This is a
- * cosmetic quirk of the placeholder text, not a mode misclassification: the
- * kind's PREFIX (`vest:` vs `warn:vest:`, from {@link VEST_ERROR_KIND_PREFIX}
- * / {@link VEST_WARNING_KIND_PREFIX}) is what callers actually match on to
- * tell errors and warnings apart.
- */
-function createVestValidationKind(
-  mode: VestValidationMode,
-  fieldPath: string,
-  message: string,
-  occurrence: number,
-): string {
-  const normalizedField = normalizeWarningKindSegment(fieldPath) || 'field';
-  const normalizedMessage = normalizeWarningKindSegment(message) || 'warning';
-
-  if (mode === 'warning') {
-    return `${VEST_WARNING_KIND_PREFIX}${normalizedField}:${normalizedMessage}:${occurrence}`;
-  }
-
-  return `${VEST_ERROR_KIND_PREFIX}${normalizedField}:${normalizedMessage}:${occurrence}`;
-}
+// `fnv1a4Hex`, `normalizeWarningKindSegment` and `createVestValidationKind`
+// (kind hashing and generation, part of the mapping pipeline) now live in
+// `./vest-result-mapper.ts`.
 
 /**
  * Parses a Vest dotted/bracket field path into object/array segments that can
@@ -430,8 +303,13 @@ function reportInvalidVestFieldResolution(
  * reporting (per {@link reportInvalidVestFieldResolution}) any `'invalid'`
  * miss along the way. A `'virtual'` miss attaches to `fieldTree` silently —
  * see {@link VestFieldResolution}'s doc comment.
+ *
+ * Exported only for `./vest-result-mapper.ts` — not part of the public
+ * surface (the barrel re-exports by name and never includes it).
+ *
+ * @internal
  */
-function resolveVestValidationFieldTree(
+export function resolveVestValidationFieldTree(
   fieldTree: ReadonlyFieldTree<unknown>,
   fieldPath: string,
 ): ReadonlyFieldTree<unknown> {
@@ -448,245 +326,15 @@ function resolveVestValidationFieldTree(
   return fieldTree;
 }
 
-/**
- * Normalizes Vest selector output into a flat list of field-targeted messages.
- *
- * Only takes the whole-suite {@link VestFailureMessages} map, not Vest's
- * field-scoped `getErrors('fieldName')`/`getWarnings('fieldName')` array
- * shape: every internal call site (`createVestValidationSnapshot`,
- * `mapVestValidationResult`) calls `getErrors()`/`getWarnings()` with zero
- * arguments only, so the array shape never reaches this function — verified
- * against vest@6.3.2. A prior version of this helper also accepted and
- * branched on the array shape; that branch was dead code and has been
- * removed. See {@link VestResultLike}'s doc comment for why the array-typed
- * overload still exists on the result type itself.
- */
-function toVestValidationEntries(
-  messages: VestFailureMessages | undefined,
-): readonly VestValidationEntry[] {
-  if (!messages) {
-    return [];
-  }
-
-  return Object.entries(messages).flatMap(([fieldPath, fieldMessages]) =>
-    createVestEntriesForField(fieldPath, fieldMessages),
-  );
-}
-
-/**
- * Annotates repeated messages with an occurrence index so duplicate kinds
- * remain deterministic and unique.
- *
- * The occurrence count is keyed on the EXACT message segment
- * {@link createVestValidationKind} renders into the `kind` string — the
- * normalized segment (see {@link normalizeWarningKindSegment}), falling
- * back to the literal `'warning'` when normalization empties it out (a
- * message like `'!!!'` has no alphanumeric characters to keep). Two
- * distinct raw messages can render the same segment two different ways:
- *
- * - Both normalize to the same non-empty segment (e.g. `'Too long!'` and
- *   `'Too long?'` both normalize to `too-long`).
- * - One normalizes to empty and falls back to `'warning'`, while another
- *   message is literally `'warning'` (e.g. `'!!!'` and `'warning'` both
- *   render the `warning` segment).
- *
- * Keying on anything other than the rendered segment — the raw message, or
- * the normalized segment without the fallback — would give two such
- * messages the same `occurrence: 0` and let
- * {@link createVestValidationKind} emit the same `kind` for two different
- * `ValidationError`s.
- */
-function createVestEntriesForField(
-  fieldPath: string,
-  messages: readonly string[],
-): readonly VestValidationEntry[] {
-  const occurrences = new Map<string, number>();
-
-  return messages.map((message) => {
-    const renderedSegment = normalizeWarningKindSegment(message) || 'warning';
-    const occurrence = occurrences.get(renderedSegment) ?? 0;
-    occurrences.set(renderedSegment, occurrence + 1);
-
-    return {
-      fieldPath,
-      message,
-      occurrence,
-    };
-  });
-}
-
-/**
- * Removes messages already emitted during the initial sync pass so async
- * completion only contributes newly resolved Vest errors or warnings.
- */
-function filterExistingVestEntries(
-  entries: readonly VestValidationEntry[],
-  baseline: readonly VestValidationEntry[],
-): readonly VestValidationEntry[] {
-  if (baseline.length === 0) {
-    return entries;
-  }
-
-  const remainingCounts = new Map<string, number>();
-
-  for (const entry of baseline) {
-    const key = `${entry.fieldPath}${VEST_KEY_SEPARATOR}${entry.message}`;
-    remainingCounts.set(key, (remainingCounts.get(key) ?? 0) + 1);
-  }
-
-  return entries.filter((entry) => {
-    const key = `${entry.fieldPath}${VEST_KEY_SEPARATOR}${entry.message}`;
-    const remainingCount = remainingCounts.get(key) ?? 0;
-
-    if (remainingCount === 0) {
-      return true;
-    }
-
-    remainingCounts.set(key, remainingCount - 1);
-    return false;
-  });
-}
-
-/**
- * Maps normalized Vest messages into Angular validation errors targeted at the
- * correct field tree.
- */
-function toVestValidationErrors(
-  entries: readonly VestValidationEntry[],
-  fieldTree: ReadonlyFieldTree<unknown>,
-  mode: VestValidationMode,
-): readonly ValidationError.WithFieldTree[] {
-  return entries.map(({ fieldPath, message, occurrence }) => {
-    const targetFieldTree = resolveVestValidationFieldTree(
-      fieldTree,
-      fieldPath,
-    );
-
-    return {
-      kind: createVestValidationKind(mode, fieldPath, message, occurrence),
-      message,
-      fieldTree: targetFieldTree,
-    };
-  });
-}
-
-/**
- * The subset of {@link VestValidationRegistrationOptions} that
- * {@link createVestValidationSnapshot}, {@link mapVestValidationResult}, and
- * {@link shouldDeferVestWarnings} actually read. Narrowed to exclude `only`
- * deliberately: `only`'s type carries the suite's field-name union `F`, and
- * these three helpers never call it — Picking just the two flags they use
- * lets them stay non-generic in `F` and accept a
- * `VestValidationRegistrationOptions<TValue, F>` of ANY `F` without a cast
- * (an object with a narrower, `F`-typed `only` is still assignable to a
- * `Pick` that never mentions `only`).
- */
-type VestValidationFlags = Pick<
-  VestValidationRegistrationOptions<unknown>,
-  'includeErrors' | 'includeWarnings'
->;
-
-// Those same three helpers stay generic in `F` for their `result` parameter:
-// each calls `getErrors()`/`getWarnings()` with ZERO arguments only — the
-// whole-suite overload, identical for every field-name union — so accepting
-// `VestResultLike<F>` costs nothing and spares every call site holding a
-// typed suite's narrower result a cast back to `VestResultLike<string>`.
-
-/**
- * Captures the sync snapshot from a Vest result so pending async validation can
- * later calculate only the newly resolved delta.
- */
-function createVestValidationSnapshot<F extends string = string>(
-  result: VestResultLike<F>,
-  options: VestValidationFlags,
-): VestValidationSnapshot {
-  return {
-    errors: options.includeErrors
-      ? toVestValidationEntries(result.getErrors())
-      : [],
-    warnings: options.includeWarnings
-      ? toVestValidationEntries(result.getWarnings())
-      : [],
-  };
-}
-
-/**
- * Converts a Vest result into Angular validation errors, optionally subtracting
- * the sync snapshot that was already surfaced on the initial pass.
- *
- * Every entry's `fieldPath` is resolved relative to the validator's own bound
- * field tree (`fieldTree` — per ADR-0008, the only base there is), so no
- * separate "which fields belong to this registration" filter is needed: each
- * entry already routes to its own correct target via
- * {@link resolveVestValidationFieldTree}.
- */
-function mapVestValidationResult<F extends string = string>(
-  result: VestResultLike<F>,
-  fieldTree: ReadonlyFieldTree<unknown>,
-  options: VestValidationFlags,
-  baseline?: VestValidationSnapshot,
-): readonly ValidationError.WithFieldTree[] {
-  const errors = options.includeErrors
-    ? toVestValidationErrors(
-        filterExistingVestEntries(
-          toVestValidationEntries(result.getErrors()),
-          baseline?.errors ?? [],
-        ),
-        fieldTree,
-        'error',
-      )
-    : [];
-
-  const warnings = options.includeWarnings
-    ? toVestValidationErrors(
-        filterExistingVestEntries(
-          toVestValidationEntries(result.getWarnings()),
-          baseline?.warnings ?? [],
-        ),
-        fieldTree,
-        'warning',
-      )
-    : [];
-
-  return [...errors, ...warnings];
-}
-
-/**
- * Reports whether sync warning surfacing should be deferred for this
- * validation pass.
- *
- * Angular's `validateAsync` only schedules its resource when the bound
- * node's `syncValid()` is true, and `syncValid()` requires zero sync errors
- * across the ENTIRE bound subtree. Toolkit warnings are ordinary
- * `ValidationError`s (`warn:vest:*`), so a sync warning surfaced while the
- * suite still has pending async tests would make `syncValid()` false and
- * permanently prevent the async phase — including blocking async Vest
- * errors — from ever running. Defer warnings only while pending; once the
- * suite settles, {@link mapVestValidationResult}'s async `onSuccess` mapping
- * surfaces them together with the final result.
- *
- * Deferral is gated on `includeErrors`: it exists solely to protect THIS
- * registration's own blocking async Vest errors from being masked by its own
- * sync warning. A warning-only registration (`includeErrors: false`, e.g.
- * `validateVestWarnings`) has no blocking error of its own to protect, so
- * deferring buys nothing — and costs a real risk. `validateAsync` needs the
- * WHOLE bound subtree sync-valid before it schedules, so a separate,
- * unrelated blocking validator on the same subtree (an Angular `required()`,
- * a Zod issue) can keep the async phase from ever running. A warning deferred
- * on the strength of `isPending()` alone would then never resurface. Skipping
- * deferral when there are no errors to protect keeps the warning-only path
- * safe from that starvation.
- */
-function shouldDeferVestWarnings<F extends string = string>(
-  options: VestValidationFlags,
-  initialResult: VestResultLike<F>,
-): boolean {
-  return (
-    options.includeErrors &&
-    options.includeWarnings &&
-    initialResult.isPending()
-  );
-}
+// `toVestValidationEntries`, `createVestEntriesForField`,
+// `filterExistingVestEntries`, `toVestValidationErrors`,
+// `VestValidationFlags`, `createVestValidationSnapshot`,
+// `mapVestValidationResult` and `shouldDeferVestWarnings` (the result-mapping
+// pipeline itself) now live in `./vest-result-mapper.ts`, imported above.
+// `resolveVestValidationFieldTree` is exported (not just module-private) so
+// that module can call back into this one for the one piece of field-name
+// resolution its `toVestValidationErrors` still needs -- see the comment atop
+// `./vest-result-mapper.ts`.
 
 /**
  * Options accepted by {@link createVestAdapter}.

--- a/packages/toolkit/vest/src/vest-result-mapper.spec.ts
+++ b/packages/toolkit/vest/src/vest-result-mapper.spec.ts
@@ -1,0 +1,359 @@
+import type { ReadonlyFieldTree } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+import {
+  createVestValidationSnapshot,
+  mapVestValidationResult,
+  shouldDeferVestWarnings,
+  VEST_ERROR_KIND_PREFIX,
+  VEST_WARNING_KIND_PREFIX,
+  type VestValidationSnapshot,
+} from './vest-result-mapper';
+import type { VestResultLike } from './vest-run-coordinator';
+
+/**
+ * Unit coverage for the result-mapping pipeline in isolation -- no Vest
+ * `create()`/`test()`/`warn()` suite, no `TestBed`, no rendered component.
+ * `mapVestValidationResult`, `createVestValidationSnapshot` and
+ * `shouldDeferVestWarnings` are driven directly with a hand-rolled
+ * {@link VestResultLike}, the same way `vest-run-coordinator.spec.ts` drives
+ * the coordinator with a hand-rolled suite. End-to-end behaviour through a
+ * real suite stays covered by `validate-vest.spec.ts`,
+ * `vest-adapter.spec.ts` and `vest-adapter-guarantees.spec.ts`.
+ */
+
+/** A field tree stand-in whose Vest field paths never resolve (no own
+ * properties), so every entry lands on this SAME root tree via the
+ * `'virtual'` fallback documented on `resolveVestFieldName` in
+ * `./vest-adapter.ts`. That fallback is field-name-resolution behaviour, not
+ * this module's concern -- these tests only assert on the mapped `kind`,
+ * `message` and that `fieldTree` is passed through unchanged. */
+const fieldTree = (() => undefined) as unknown as ReadonlyFieldTree<unknown>;
+
+/** Builds a minimal {@link VestResultLike} from plain error/warning maps. */
+function fakeResult(
+  errors: Readonly<Record<string, readonly string[]>>,
+  warnings: Readonly<Record<string, readonly string[]>> = {},
+  pending = false,
+): VestResultLike {
+  return {
+    getErrors: () => errors,
+    getWarnings: () => warnings,
+    isPending: () => pending,
+  } as VestResultLike;
+}
+
+describe('mapVestValidationResult', () => {
+  it('maps a blocking error to a vest: kind with the bound field tree', () => {
+    const result = fakeResult({ email: ['Email is required'] });
+
+    const mapped = mapVestValidationResult(result, fieldTree, {
+      includeErrors: true,
+      includeWarnings: false,
+    });
+
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]).toMatchObject({
+      message: 'Email is required',
+      fieldTree,
+    });
+    expect(mapped[0]?.kind.startsWith(VEST_ERROR_KIND_PREFIX)).toBe(true);
+  });
+
+  it('maps a warn() message to a warn:vest: kind', () => {
+    const result = fakeResult({}, { email: ['Consider a longer email'] });
+
+    const mapped = mapVestValidationResult(result, fieldTree, {
+      includeErrors: false,
+      includeWarnings: true,
+    });
+
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]?.kind.startsWith(VEST_WARNING_KIND_PREFIX)).toBe(true);
+  });
+
+  it('skips errors when includeErrors is false, and warnings when includeWarnings is false', () => {
+    const result = fakeResult(
+      { email: ['Email is required'] },
+      { email: ['Consider a longer email'] },
+    );
+
+    expect(
+      mapVestValidationResult(result, fieldTree, {
+        includeErrors: false,
+        includeWarnings: true,
+      }),
+    ).toHaveLength(1);
+    expect(
+      mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      }),
+    ).toHaveLength(1);
+    expect(
+      mapVestValidationResult(result, fieldTree, {
+        includeErrors: false,
+        includeWarnings: false,
+      }),
+    ).toHaveLength(0);
+  });
+
+  describe('warning-kind segment normalization', () => {
+    it('leaves an already-clean field/message pair unchanged (no hash suffix)', () => {
+      const result = fakeResult({ email: ['too-long'] });
+
+      const [mapped] = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      // Both 'email' and 'too-long' are already lowercase, alnum-and-hyphen
+      // only, and within VEST_KIND_SEGMENT_MAX_LEN -- normalization is a
+      // no-op (non-lossy), so no FNV-1a hash suffix is appended.
+      expect(mapped?.kind).toBe(`${VEST_ERROR_KIND_PREFIX}email:too-long:0`);
+    });
+
+    it('appends a hash suffix whenever folding changes the input (case, whitespace, punctuation)', () => {
+      const result = fakeResult({ email: ['Required'] });
+
+      const [mapped] = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      // 'Required' folds to 'required', which differs from the original --
+      // lossy, so an FNV-1a hash suffix of the ORIGINAL text is appended.
+      expect(mapped?.kind).toBe(
+        `${VEST_ERROR_KIND_PREFIX}email:required-51e4:0`,
+      );
+    });
+
+    it('appends a distinct FNV-1a hash suffix so distinct inputs that fold to the same segment do not collide', () => {
+      // 'user.email' and 'user_email' both fold to 'user-email', but are
+      // different raw field paths -- each gets its own hash of the ORIGINAL
+      // value, computed independently of this module's own hashing pass.
+      const result = fakeResult({
+        'user.email': ['Too long!'],
+        user_email: ['Too long?'],
+      });
+
+      const mapped = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      expect(mapped.map((entry) => entry.kind)).toEqual([
+        `${VEST_ERROR_KIND_PREFIX}user-email-5ea7:too-long-7e11:0`,
+        `${VEST_ERROR_KIND_PREFIX}user-email-2981:too-long-6411:0`,
+      ]);
+    });
+
+    it('falls back to the bare hash (no leading hyphen) when a message folds to nothing', () => {
+      const result = fakeResult({ email: ['!!!'] });
+
+      const [mapped] = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      expect(mapped?.kind).toBe(`${VEST_ERROR_KIND_PREFIX}email:2d53:0`);
+    });
+  });
+
+  describe('occurrence-key dedup', () => {
+    it('numbers repeated identical messages on the same field 0, 1, 2, ...', () => {
+      // Same message repeated three times -> same rendered segment each
+      // time (`required-51e4`), so the occurrence index is the ONLY thing
+      // keeping the three kinds apart.
+      const result = fakeResult({
+        email: ['Required', 'Required', 'Required'],
+      });
+
+      const mapped = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      expect(mapped.map((entry) => entry.kind)).toEqual([
+        `${VEST_ERROR_KIND_PREFIX}email:required-51e4:0`,
+        `${VEST_ERROR_KIND_PREFIX}email:required-51e4:1`,
+        `${VEST_ERROR_KIND_PREFIX}email:required-51e4:2`,
+      ]);
+    });
+
+    it('gives two DIFFERENT messages that fold to the same core segment distinct kinds without touching the occurrence counter', () => {
+      // 'Too long!' and 'Too long?' both strip down to the same core
+      // segment ('too-long'), but normalization is lossy for both (each
+      // differs from its original), so each gets its own FNV-1a hash suffix
+      // of its own original text. The two kinds are already distinct at
+      // occurrence 0 -- no fold-collision ever reaches the occurrence
+      // counter itself.
+      const result = fakeResult({ email: ['Too long!', 'Too long?'] });
+
+      const mapped = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      expect(mapped.map((entry) => entry.kind)).toEqual([
+        `${VEST_ERROR_KIND_PREFIX}email:too-long-7e11:0`,
+        `${VEST_ERROR_KIND_PREFIX}email:too-long-6411:0`,
+      ]);
+    });
+  });
+
+  describe('sync/async delta filtering', () => {
+    it('subtracts baseline entries so only the newly resolved delta is mapped', () => {
+      const result = fakeResult({ email: ['Email is required'] });
+      const baseline: VestValidationSnapshot = {
+        errors: [
+          { fieldPath: 'email', message: 'Email is required', occurrence: 0 },
+        ],
+        warnings: [],
+      };
+
+      const mapped = mapVestValidationResult(
+        result,
+        fieldTree,
+        { includeErrors: true, includeWarnings: false },
+        baseline,
+      );
+
+      expect(mapped).toHaveLength(0);
+    });
+
+    it('computes occurrence numbers from the FULL entry list before subtracting the baseline', () => {
+      // Two identical messages; the baseline already reported ONE of them.
+      // The occurrence index each entry gets is assigned against the full,
+      // unfiltered list (0 then 1) -- filtering removes the FIRST matching
+      // occurrence it walks into, so the entry that survives keeps its
+      // ORIGINAL occurrence (1), not a renumbered 0.
+      const result = fakeResult({ email: ['Required', 'Required'] });
+      const baseline: VestValidationSnapshot = {
+        errors: [{ fieldPath: 'email', message: 'Required', occurrence: 0 }],
+        warnings: [],
+      };
+
+      const mapped = mapVestValidationResult(
+        result,
+        fieldTree,
+        { includeErrors: true, includeWarnings: false },
+        baseline,
+      );
+
+      expect(mapped).toHaveLength(1);
+      expect(mapped[0]?.kind).toBe(
+        `${VEST_ERROR_KIND_PREFIX}email:required-51e4:1`,
+      );
+    });
+
+    it('only subtracts warnings from the warnings baseline, not from errors (and vice versa)', () => {
+      const result = fakeResult(
+        { email: ['Email is required'] },
+        { email: ['Email is required'] },
+      );
+      const baseline: VestValidationSnapshot = {
+        errors: [
+          { fieldPath: 'email', message: 'Email is required', occurrence: 0 },
+        ],
+        warnings: [],
+      };
+
+      const mapped = mapVestValidationResult(
+        result,
+        fieldTree,
+        { includeErrors: true, includeWarnings: true },
+        baseline,
+      );
+
+      // The error was already in the baseline (subtracted); the identically
+      // worded warning was not, so it still comes through.
+      expect(mapped).toHaveLength(1);
+      expect(mapped[0]?.kind.startsWith(VEST_WARNING_KIND_PREFIX)).toBe(true);
+    });
+
+    it('maps every entry when no baseline is supplied', () => {
+      const result = fakeResult({ email: ['Email is required'] });
+
+      const mapped = mapVestValidationResult(result, fieldTree, {
+        includeErrors: true,
+        includeWarnings: false,
+      });
+
+      expect(mapped).toHaveLength(1);
+    });
+  });
+});
+
+describe('createVestValidationSnapshot', () => {
+  it('captures errors and warnings from the result when both flags are on', () => {
+    const result = fakeResult(
+      { email: ['Email is required'] },
+      { email: ['Consider a longer email'] },
+    );
+
+    const snapshot = createVestValidationSnapshot(result, {
+      includeErrors: true,
+      includeWarnings: true,
+    });
+
+    expect(snapshot.errors).toEqual([
+      { fieldPath: 'email', message: 'Email is required', occurrence: 0 },
+    ]);
+    expect(snapshot.warnings).toEqual([
+      { fieldPath: 'email', message: 'Consider a longer email', occurrence: 0 },
+    ]);
+  });
+
+  it('captures an empty array for a flag that is off, even when the result has messages', () => {
+    const result = fakeResult(
+      { email: ['Email is required'] },
+      { email: ['Consider a longer email'] },
+    );
+
+    const snapshot = createVestValidationSnapshot(result, {
+      includeErrors: true,
+      includeWarnings: false,
+    });
+
+    expect(snapshot.errors).toHaveLength(1);
+    expect(snapshot.warnings).toEqual([]);
+  });
+});
+
+describe('shouldDeferVestWarnings', () => {
+  it('defers only when errors and warnings are both included AND the result is pending', () => {
+    const pending = fakeResult({}, {}, true);
+    const settled = fakeResult({}, {}, false);
+
+    expect(
+      shouldDeferVestWarnings(
+        { includeErrors: true, includeWarnings: true },
+        pending,
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldDeferVestWarnings(
+        { includeErrors: true, includeWarnings: true },
+        settled,
+      ),
+    ).toBe(false);
+
+    // No blocking error of its own to protect (warning-only registration) --
+    // never defers, even while pending.
+    expect(
+      shouldDeferVestWarnings(
+        { includeErrors: false, includeWarnings: true },
+        pending,
+      ),
+    ).toBe(false);
+
+    // No warnings requested at all -- nothing to defer.
+    expect(
+      shouldDeferVestWarnings(
+        { includeErrors: true, includeWarnings: false },
+        pending,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/toolkit/vest/src/vest-result-mapper.ts
+++ b/packages/toolkit/vest/src/vest-result-mapper.ts
@@ -1,0 +1,433 @@
+import type {
+  ReadonlyFieldTree,
+  ValidationError,
+} from '@angular/forms/signals';
+import {
+  VEST_KEY_SEPARATOR,
+  type VestFailureMessages,
+  type VestResultLike,
+} from './vest-run-coordinator';
+import { resolveVestValidationFieldTree } from './vest-adapter';
+
+/* oxlint-disable @typescript-eslint/prefer-readonly-parameter-types -- mirrors the readonly-parameter suppression on the pipeline this module was extracted from (see `./vest-adapter.ts`); the underlying Angular Signal Forms / Vest types are not modeled as readonly. */
+
+// This module is the private "result mapping" seam named by ADR-0009
+// (`docs/decisions/0009-vest-run-coordination-is-its-own-seam.md`, closing
+// note: "Further splitting (field-name resolution, result mapping) stays
+// open. One seam at a time."). It owns the transformation from Vest
+// `getErrors()`/`getWarnings()` output to typed
+// `ValidationError.WithFieldTree[]` -- normalization, FNV-1a kind-segment
+// hashing, occurrence dedup (keyed on the rendered segment), and sync/async
+// delta filtering.
+//
+// Field-name RESOLUTION (walking a Vest field path against the bound Angular
+// field tree) stays in `./vest-adapter.ts` per ADR-0009 -- it is a different
+// concern from mapping the already-resolved messages into validation errors.
+// `toVestValidationErrors` below still needs a per-entry resolved field tree,
+// so it imports `resolveVestValidationFieldTree` from `./vest-adapter`. That
+// import is the one deliberate two-way edge between this module and
+// `./vest-adapter.ts` (which imports the mapping entry points back): both
+// files are internal to this package, never reached directly from outside
+// it, and the shared functions are only ever invoked from within other
+// functions -- never at module top-level -- so the circular import resolves
+// safely under ESM's live-binding semantics.
+//
+// Not exported from `./index.ts` or any other barrel: this module has zero
+// public surface. `./vest-adapter.ts` is still the documented public home for
+// every behavior this module implements.
+
+const VEST_KIND_SEGMENT_MAX_LEN = 48;
+
+/**
+ * Public constant kind prefix used for Vest `warn()` messages surfaced through
+ * the toolkit. Exported so downstream code (error strategies, tests, debug
+ * tooling) can filter warning-mode validation errors without re-deriving the
+ * string literal.
+ */
+export const VEST_WARNING_KIND_PREFIX = 'warn:vest:';
+
+/**
+ * Public constant kind prefix used for blocking Vest errors surfaced through
+ * the toolkit. Mirrors {@link VEST_WARNING_KIND_PREFIX} so consumers can match
+ * both shapes with a single source of truth.
+ */
+export const VEST_ERROR_KIND_PREFIX = 'vest:';
+
+/**
+ * Adapter-local severity mapping used to generate Angular validation error
+ * kinds. Vest exposes warn/error behavior through result selectors, but not as
+ * a public severity union type.
+ */
+export type VestValidationMode = 'error' | 'warning';
+
+/**
+ * Canonical representation of a Vest message after normalizing field targeting
+ * and duplicate-message occurrence tracking.
+ */
+export interface VestValidationEntry {
+  fieldPath: string;
+  message: string;
+  occurrence: number;
+}
+
+/**
+ * Snapshot of the initial sync result from a Vest run. Async completion uses
+ * this to emit only the delta once pending tests finish.
+ */
+export interface VestValidationSnapshot {
+  readonly errors: readonly VestValidationEntry[];
+  readonly warnings: readonly VestValidationEntry[];
+}
+
+/**
+ * The subset of the adapter's per-field registration options that
+ * {@link createVestValidationSnapshot}, {@link mapVestValidationResult}, and
+ * {@link shouldDeferVestWarnings} actually read. Narrowed to exclude `only`
+ * deliberately: `only`'s type carries the suite's field-name union `F`, and
+ * these three helpers never call it — Picking just the two flags they use
+ * lets them stay non-generic in `F` and accept any registration options
+ * object (of ANY `F`) without a cast (an object with a narrower, `F`-typed
+ * `only` is still assignable to a type that never mentions `only`).
+ *
+ * Mirrors the `includeErrors`/`includeWarnings` members of the adapter's
+ * `VestValidationRegistrationOptions` by hand — a `Pick` would add a type
+ * edge back to `./vest-adapter.ts` and deepen the module cycle. A rename
+ * there must be mirrored here.
+ */
+export interface VestValidationFlags {
+  readonly includeErrors: boolean;
+  readonly includeWarnings: boolean;
+}
+
+// Those same three helpers stay generic in `F` for their `result` parameter:
+// each calls `getErrors()`/`getWarnings()` with ZERO arguments only — the
+// whole-suite overload, identical for every field-name union — so accepting
+// `VestResultLike<F>` costs nothing and spares every call site holding a
+// typed suite's narrower result a cast back to `VestResultLike<string>`.
+
+/**
+ * Compact FNV-1a hash returning a 4-character lowercase hex digest. Used by
+ * {@link normalizeWarningKindSegment} as a collision-safe suffix whenever
+ * normalization was lossy — whether from character folding/case folding or
+ * from truncation past {@link VEST_KIND_SEGMENT_MAX_LEN}.
+ */
+function fnv1a4Hex(value: string): string {
+  let hash = 0x8_11c_9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.codePointAt(index) ?? 0;
+    hash = Math.imul(hash, 0x01_00_01_93);
+  }
+
+  return (hash >>> 16).toString(16).padStart(4, '0');
+}
+
+/**
+ * Sanitizes arbitrary Vest field/message fragments so generated validation
+ * kinds remain stable and CSS/DOM-friendly.
+ *
+ * Despite the name, this is mode-agnostic: {@link createVestValidationKind}
+ * calls it for BOTH blocking-error and warning kinds, not just warnings — the
+ * name predates the toolkit surfacing Vest `test()` failures as `vest:*`
+ * kinds alongside `warn()` results as `warn:vest:*`. Kept as-is (see the
+ * caller's fallback-literal note below) rather than renamed, to avoid
+ * unrelated churn across every call site.
+ *
+ * The sanitize step is LOSSY — case folding and collapsing every run of
+ * non `[a-z0-9]` characters to a single `-` can map distinct inputs onto the
+ * same segment (e.g. `'user.email'` and `'user_email'` both normalize to
+ * `'user-email'`; so do `'Email'` and `'email'`). Whenever normalization was
+ * lossy — i.e. the normalized string differs from the original `value` —
+ * or the normalized value exceeds {@link VEST_KIND_SEGMENT_MAX_LEN}, a short
+ * FNV-1a hash suffix of the *original* value is appended so that two inputs
+ * which fold or truncate to the same segment do not collide. A `value` that
+ * survives normalization unchanged (already lowercase, already
+ * alnum-and-hyphen-only, within the length limit) is by definition
+ * collision-free and returned as-is, with no hash suffix.
+ *
+ * A `value` that folds to nothing (e.g. punctuation-only, like `'!!!'`)
+ * returns the BARE hash with no leading hyphen — joining an empty folded
+ * segment to the hash with `-` would reintroduce the leading hyphen the trim
+ * step above just stripped, producing both an invalid CSS-identifier start
+ * and an ugly kind (`warn:vest:email:-a1b2:0`). Only a literal empty-string
+ * `value` (which normalizes to `''` non-lossily, so no hash is appended)
+ * still reaches the `|| 'field'`/`|| 'warning'` fallback in
+ * {@link createVestValidationKind}.
+ */
+function normalizeWarningKindSegment(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/gu, '-')
+    .replaceAll(/^-+|-+$/gu, '');
+
+  const lossy =
+    normalized !== value || normalized.length > VEST_KIND_SEGMENT_MAX_LEN;
+
+  if (!lossy) {
+    return normalized;
+  }
+
+  const truncated =
+    normalized.length > VEST_KIND_SEGMENT_MAX_LEN
+      ? normalized.slice(0, VEST_KIND_SEGMENT_MAX_LEN)
+      : normalized;
+
+  const hash = fnv1a4Hex(value);
+
+  return truncated === '' ? hash : `${truncated}-${hash}`;
+}
+
+/**
+ * Creates a deterministic Angular validation error kind for a mapped Vest
+ * error or warning.
+ *
+ * The `'field'`/`'warning'` fallback literals below are generic placeholders
+ * for "the sanitized segment came out empty" — which, since
+ * {@link normalizeWarningKindSegment} now appends a hash suffix to any
+ * lossily-normalized input (including one that folds to nothing, e.g. a
+ * message that is only punctuation), can only happen for a literal empty
+ * `''` fieldPath/message: normalizing `''` is non-lossy (it stays `''`), so
+ * no hash is appended and the fallback literal applies. They are NOT a mode
+ * indicator. In particular, the
+ * `'warning'` fallback also applies when `mode === 'error'`, so a blocking
+ * error whose message sanitizes to empty can produce a kind that literally
+ * contains the substring `warning` (e.g. `vest:field:warning:0`). This is a
+ * cosmetic quirk of the placeholder text, not a mode misclassification: the
+ * kind's PREFIX (`vest:` vs `warn:vest:`, from {@link VEST_ERROR_KIND_PREFIX}
+ * / {@link VEST_WARNING_KIND_PREFIX}) is what callers actually match on to
+ * tell errors and warnings apart.
+ */
+function createVestValidationKind(
+  mode: VestValidationMode,
+  fieldPath: string,
+  message: string,
+  occurrence: number,
+): string {
+  const normalizedField = normalizeWarningKindSegment(fieldPath) || 'field';
+  const normalizedMessage = normalizeWarningKindSegment(message) || 'warning';
+
+  if (mode === 'warning') {
+    return `${VEST_WARNING_KIND_PREFIX}${normalizedField}:${normalizedMessage}:${occurrence}`;
+  }
+
+  return `${VEST_ERROR_KIND_PREFIX}${normalizedField}:${normalizedMessage}:${occurrence}`;
+}
+
+/**
+ * Annotates repeated messages with an occurrence index so duplicate kinds
+ * remain deterministic and unique.
+ *
+ * The occurrence count is keyed on the EXACT message segment
+ * {@link createVestValidationKind} renders into the `kind` string — the
+ * normalized segment (see {@link normalizeWarningKindSegment}), falling
+ * back to the literal `'warning'` when normalization empties it out (a
+ * message like `'!!!'` has no alphanumeric characters to keep). Two
+ * distinct raw messages can render the same segment two different ways:
+ *
+ * - Both normalize to the same non-empty segment (e.g. `'Too long!'` and
+ *   `'Too long?'` both normalize to `too-long`).
+ * - One normalizes to empty and falls back to `'warning'`, while another
+ *   message is literally `'warning'` (e.g. `'!!!'` and `'warning'` both
+ *   render the `warning` segment).
+ *
+ * Keying on anything other than the rendered segment — the raw message, or
+ * the normalized segment without the fallback — would give two such
+ * messages the same `occurrence: 0` and let
+ * {@link createVestValidationKind} emit the same `kind` for two different
+ * `ValidationError`s.
+ */
+function createVestEntriesForField(
+  fieldPath: string,
+  messages: readonly string[],
+): readonly VestValidationEntry[] {
+  const occurrences = new Map<string, number>();
+
+  return messages.map((message) => {
+    const renderedSegment = normalizeWarningKindSegment(message) || 'warning';
+    const occurrence = occurrences.get(renderedSegment) ?? 0;
+    occurrences.set(renderedSegment, occurrence + 1);
+
+    return {
+      fieldPath,
+      message,
+      occurrence,
+    };
+  });
+}
+
+/**
+ * Normalizes Vest selector output into a flat list of field-targeted messages.
+ *
+ * Only takes the whole-suite {@link VestFailureMessages} map, not Vest's
+ * field-scoped `getErrors('fieldName')`/`getWarnings('fieldName')` array
+ * shape: every internal call site (`createVestValidationSnapshot`,
+ * `mapVestValidationResult`) calls `getErrors()`/`getWarnings()` with zero
+ * arguments only, so the array shape never reaches this function — verified
+ * against vest@6.3.2. A prior version of this helper also accepted and
+ * branched on the array shape; that branch was dead code and has been
+ * removed. See {@link VestResultLike}'s doc comment for why the array-typed
+ * overload still exists on the result type itself.
+ */
+function toVestValidationEntries(
+  messages: VestFailureMessages | undefined,
+): readonly VestValidationEntry[] {
+  if (!messages) {
+    return [];
+  }
+
+  return Object.entries(messages).flatMap(([fieldPath, fieldMessages]) =>
+    createVestEntriesForField(fieldPath, fieldMessages),
+  );
+}
+
+/**
+ * Removes messages already emitted during the initial sync pass so async
+ * completion only contributes newly resolved Vest errors or warnings.
+ */
+function filterExistingVestEntries(
+  entries: readonly VestValidationEntry[],
+  baseline: readonly VestValidationEntry[],
+): readonly VestValidationEntry[] {
+  if (baseline.length === 0) {
+    return entries;
+  }
+
+  const remainingCounts = new Map<string, number>();
+
+  for (const entry of baseline) {
+    const key = `${entry.fieldPath}${VEST_KEY_SEPARATOR}${entry.message}`;
+    remainingCounts.set(key, (remainingCounts.get(key) ?? 0) + 1);
+  }
+
+  return entries.filter((entry) => {
+    const key = `${entry.fieldPath}${VEST_KEY_SEPARATOR}${entry.message}`;
+    const remainingCount = remainingCounts.get(key) ?? 0;
+
+    if (remainingCount === 0) {
+      return true;
+    }
+
+    remainingCounts.set(key, remainingCount - 1);
+    return false;
+  });
+}
+
+/**
+ * Maps normalized Vest messages into Angular validation errors targeted at the
+ * correct field tree.
+ */
+function toVestValidationErrors(
+  entries: readonly VestValidationEntry[],
+  fieldTree: ReadonlyFieldTree<unknown>,
+  mode: VestValidationMode,
+): readonly ValidationError.WithFieldTree[] {
+  return entries.map(({ fieldPath, message, occurrence }) => {
+    const targetFieldTree = resolveVestValidationFieldTree(
+      fieldTree,
+      fieldPath,
+    );
+
+    return {
+      kind: createVestValidationKind(mode, fieldPath, message, occurrence),
+      message,
+      fieldTree: targetFieldTree,
+    };
+  });
+}
+
+/**
+ * Captures the sync snapshot from a Vest result so pending async validation can
+ * later calculate only the newly resolved delta.
+ */
+export function createVestValidationSnapshot<F extends string = string>(
+  result: VestResultLike<F>,
+  options: VestValidationFlags,
+): VestValidationSnapshot {
+  return {
+    errors: options.includeErrors
+      ? toVestValidationEntries(result.getErrors())
+      : [],
+    warnings: options.includeWarnings
+      ? toVestValidationEntries(result.getWarnings())
+      : [],
+  };
+}
+
+/**
+ * Converts a Vest result into Angular validation errors, optionally subtracting
+ * the sync snapshot that was already surfaced on the initial pass.
+ *
+ * Every entry's `fieldPath` is resolved relative to the validator's own bound
+ * field tree (`fieldTree` — per ADR-0008, the only base there is), so no
+ * separate "which fields belong to this registration" filter is needed: each
+ * entry already routes to its own correct target via
+ * `resolveVestValidationFieldTree` (`./vest-adapter.ts`, per ADR-0009).
+ */
+export function mapVestValidationResult<F extends string = string>(
+  result: VestResultLike<F>,
+  fieldTree: ReadonlyFieldTree<unknown>,
+  options: VestValidationFlags,
+  baseline?: VestValidationSnapshot,
+): readonly ValidationError.WithFieldTree[] {
+  const errors = options.includeErrors
+    ? toVestValidationErrors(
+        filterExistingVestEntries(
+          toVestValidationEntries(result.getErrors()),
+          baseline?.errors ?? [],
+        ),
+        fieldTree,
+        'error',
+      )
+    : [];
+
+  const warnings = options.includeWarnings
+    ? toVestValidationErrors(
+        filterExistingVestEntries(
+          toVestValidationEntries(result.getWarnings()),
+          baseline?.warnings ?? [],
+        ),
+        fieldTree,
+        'warning',
+      )
+    : [];
+
+  return [...errors, ...warnings];
+}
+
+/**
+ * Reports whether sync warning surfacing should be deferred for this
+ * validation pass.
+ *
+ * Angular's `validateAsync` only schedules its resource when the bound
+ * node's `syncValid()` is true, and `syncValid()` requires zero sync errors
+ * across the ENTIRE bound subtree. Toolkit warnings are ordinary
+ * `ValidationError`s (`warn:vest:*`), so a sync warning surfaced while the
+ * suite still has pending async tests would make `syncValid()` false and
+ * permanently prevent the async phase — including blocking async Vest
+ * errors — from ever running. Defer warnings only while pending; once the
+ * suite settles, {@link mapVestValidationResult}'s async `onSuccess` mapping
+ * surfaces them together with the final result.
+ *
+ * Deferral is gated on `includeErrors`: it exists solely to protect THIS
+ * registration's own blocking async Vest errors from being masked by its own
+ * sync warning. A warning-only registration (`includeErrors: false`, e.g.
+ * `validateVestWarnings`) has no blocking error of its own to protect, so
+ * deferring buys nothing — and costs a real risk. `validateAsync` needs the
+ * WHOLE bound subtree sync-valid before it schedules, so a separate,
+ * unrelated blocking validator on the same subtree (an Angular `required()`,
+ * a Zod issue) can keep the async phase from ever running. A warning deferred
+ * on the strength of `isPending()` alone would then never resurface. Skipping
+ * deferral when there are no errors to protect keeps the warning-only path
+ * safe from that starvation.
+ */
+export function shouldDeferVestWarnings<F extends string = string>(
+  options: VestValidationFlags,
+  initialResult: VestResultLike<F>,
+): boolean {
+  return (
+    options.includeErrors &&
+    options.includeWarnings &&
+    initialResult.isPending()
+  );
+}
+
+/* oxlint-enable @typescript-eslint/prefer-readonly-parameter-types */


### PR DESCRIPTION
Extracts the Vest result-mapping pipeline — `getErrors()`/`getWarnings()` output → typed `ValidationError.WithFieldTree[]`, with FNV-1a kind-segment hashing, occurrence dedup, and sync/async delta filtering — out of `vest-adapter.ts` into a private `vest-result-mapper.ts`. This is the "result mapping" seam ADR-0009 left open; field-name resolution stays in the adapter, as the ADR defers that seam.

The move is verbatim: every extracted function body is statement-identical to its pre-move source (only doc-comment cross-references changed), and the full pre-existing vest suite — including the #358 `sharedVestAdapter` specs pinned specifically so this move could be verified against them — passes unchanged. No barrel changes; the module is unreachable from any entry point.

The payoff is the new `vest-result-mapper.spec.ts`: 16 unit tests that drive `mapVestValidationResult` / `createVestValidationSnapshot` / `shouldDeferVestWarnings` directly against a hand-rolled result object — no Vest suites, no TestBed. They pin kind prefixing, lossy/non-lossy segment folding (including the distinct-hash collision case), occurrence indices, baseline delta subtraction, and the subtle contract that occurrence indices are computed on the full entry list *before* baseline subtraction.

One deliberate tradeoff, documented in both files: the mapper imports `resolveVestValidationFieldTree` back from the adapter while the adapter imports the mapper's three entry points — a two-way edge between two same-package internal files. It is ESM-safe (no top-level evaluation of the shared references). Removing the cycle cleanly belongs to the field-name-resolution seam ADR-0009 already forecasts; passing the resolver as a parameter now would stop this change being provably move-only.

Refs ADR-0009. Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
