### PR TITLE
refactor(assistive)!: move character-count color thresholds to CSS custom properties

### DIFF
--- a/.agents/skills/ngx-signal-forms/assistive/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/assistive/SKILL.md
@@ -28,7 +28,7 @@ The assistive entry point provides accessible feedback rendering that sits betwe
 4. **`NgxFormFieldCharacterCount`** — live character count with progressive color states:
    - Provide `[formField]` for the bound field.
    - Omit `maxLength` when a `maxLength` validator on the field provides it.
-   - Use `colorThresholds` to customize warning/danger thresholds (default: 80% warning, 95% danger).
+   - Warning/danger thresholds are CSS-only (no component input): override `--ngx-form-field-char-count-warning-threshold` / `--ngx-form-field-char-count-danger-threshold` (plain numbers, percent of `maxLength`, default 80/95).
 
 5. Grouped validation notification for fieldsets, summary cards, or custom sections is `NgxFormFieldError` with `presentation="panel"` (see step 2 above) — there is no separate notification component:
 

--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -490,13 +490,14 @@ For full DOM control over the error summary (incl. warning entries), use `NgxHea
 
 ### NgxFormFieldCharacterCount inputs
 
-| Input             | Type                                  | Notes                                   |
-| ----------------- | ------------------------------------- | --------------------------------------- |
-| `formField`       | field                                 | Required                                |
-| `maxLength`       | number                                | Auto-detected from validator if omitted |
-| `showLimitColors` | boolean                               | Default: `true`                         |
-| `colorThresholds` | `{ warning: number, danger: number }` | Default: `{ warning: 80, danger: 95 }`  |
-| `liveAnnounce`    | boolean                               | SR live announcement                    |
+| Input             | Type    | Notes                                   |
+| ----------------- | ------- | --------------------------------------- |
+| `formField`       | field   | Required                                |
+| `maxLength`       | number  | Auto-detected from validator if omitted |
+| `showLimitColors` | boolean | Default: `true`                         |
+| `liveAnnounce`    | boolean | SR live announcement                    |
+
+Warning/danger color thresholds are CSS-only — no `colorThresholds` input. Override `--ngx-form-field-char-count-warning-threshold` / `--ngx-form-field-char-count-danger-threshold` (default `80`/`95`).
 
 ---
 

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -59,6 +59,7 @@ releases will not include any of the renames below.
 - **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§8](#8-headless-audit-fixes-v100))
 - **BREAKING: `CharacterCountResult` members are now typed `Signal<T>`** (was the looser `ReadSignal<T>` alias); a new `hasLimit` member was added — compile-time tightening only, no runtime change
 - **Bug fix** — error summary no longer drops a second field's error when two different fields share the same kind + message-less default; `NgxHeadlessNotification` no longer leaks the internal `warn:` prefix; `createErrorMessageSignal`'s ID fallback strips Angular's internal `{appId}.form{n}.` prefix; required `Date`/`File`/`Map`-valued leaves no longer vanish from field-optionality summaries
+- **BREAKING: `NgxFormFieldCharacterCount`'s `colorThresholds` input removed** — warning/danger color breakpoints are now CSS-only via `--ngx-form-field-char-count-warning-threshold` / `-danger-threshold` (default `80`/`95`); `[liveAnnounce]` wording stays fixed at those defaults regardless of a CSS override (see [§13](#13-ngxformfieldcharactercount-colorthresholds-removed--thresholds-are-css-only-355))
 
 ---
 
@@ -1515,3 +1516,76 @@ hardcoded `<span class="text-red-500">*</span>` markers have been removed
 from `traveler-step.ts` / `trip-step.ts` — the wrapper's auto-marker now
 covers them, consistent with every other demo. Purely additive; no existing
 API changed.
+
+## 13. NgxFormFieldCharacterCount colorThresholds removed — thresholds are CSS-only (#355)
+
+**Root cause:** `colorThresholds: { warning: 80, danger: 95 }` exposed a
+Tailwind-relative presentation detail — the warning/danger color
+breakpoints — as a public component input. That leaked a design-system
+detail across the code/CSS seam and constrained any consumer restyling the
+component (Material, PrimeNG, a custom design system) to also thread a
+TypeScript binding through their wrapper just to change where a color kicks
+in.
+
+**Breaking change:** the `colorThresholds` input is gone. Warning/danger
+thresholds are now two CSS custom properties on
+`ngx-form-field-character-count`:
+
+| Custom property                                 | Default | Meaning                                                 |
+| ----------------------------------------------- | ------- | ------------------------------------------------------- |
+| `--ngx-form-field-char-count-warning-threshold` | `80`    | Percent of `maxLength` at which the color turns warning |
+| `--ngx-form-field-char-count-danger-threshold`  | `95`    | Percent of `maxLength` at which the color turns danger  |
+
+```html
+<!-- before -->
+<ngx-form-field-character-count
+  [formField]="form.bio"
+  [maxLength]="500"
+  [colorThresholds]="{ warning: 90, danger: 98 }"
+/>
+
+<!-- after -->
+<ngx-form-field-character-count [formField]="form.bio" [maxLength]="500" />
+```
+
+```css
+/* after — CSS-only, scoped however you like (element, class, :root) */
+ngx-form-field-character-count {
+  --ngx-form-field-char-count-warning-threshold: 90;
+  --ngx-form-field-char-count-danger-threshold: 98;
+}
+```
+
+Values are plain numbers (percent of `maxLength`, no `%` unit), matching the
+old input's percentages 1:1 — a direct find/replace from
+`colorThresholds.warning` / `.danger` to the two custom properties covers
+every existing caller. If you never set `colorThresholds`, there is nothing
+to change — the CSS defaults (`80`/`95`) reproduce the exact prior behavior.
+
+**How it works:** the component publishes a
+`--ngx-form-field-char-count-percent-used` custom property — an internal
+coordination hook, not a theming knob (same status as
+`--ngx-form-field-hint-display`; set by the component, never meant to be
+overridden) — and a pure-CSS `color-mix()` + `clamp()` expression compares
+it against the two threshold tokens (via pseudo-private
+`--_char-count-warning-threshold` / `-danger-threshold` /
+`-is-warning` / `-is-danger` intermediates — internal-only, not part of the
+public contract, see `packages/toolkit/form-field/THEMING.md`) to pick
+ok/warning/danger, entirely in the stylesheet. No `@property`, no
+container style queries — both are less broadly supported than the
+`calc()`/`clamp()` technique used here. The `exceeded` state (>100% used)
+is **not** configurable via these tokens: it is tied to the field's actual
+`maxLength`, not a percentage, matching the prior behavior.
+
+**Accessibility (why announcements did not move to CSS too):**
+`[liveAnnounce]`'s polite announcements ("Approaching limit…", "Almost at
+limit…", "Character limit exceeded…") continue to fire at the fixed
+80%/95% defaults, **independent of any CSS threshold override**. A
+CSS-driven visual restyle must not silently retime what screen reader users
+hear — announcement wording is accessible behavior, not presentation, and
+there is no reliable, SSR-safe way for the component to read back a
+consumer's CSS custom property value at runtime to keep the two in sync.
+Restyling the color threshold is a pure presentation change; the
+announcement timing stays exactly where it was.
+
+**Files:** `packages/toolkit/assistive/character-count.ts`.

--- a/packages/toolkit/assistive/README.md
+++ b/packages/toolkit/assistive/README.md
@@ -162,17 +162,24 @@ Character counter with progressive color states (ok → warning → danger → e
 <ngx-form-field-character-count [formField]="form.bio" [maxLength]="500" />
 ```
 
-| Input                   | Type                                           | Default                       | Description                                                              |
-| ----------------------- | ---------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------ |
-| `formField`             | `FieldTree<NgxCharacterCountValue>` (required) | —                             | Field to track the character count for                                   |
-| `maxLength`             | `number \| undefined`                          | Auto-detected from validator  | Character limit; auto-detected from a `maxLength` validator when omitted |
-| `position`              | `'left' \| 'right'`                            | `'right'`                     | Text alignment within the assistive row                                  |
-| `showLimitColors`       | `boolean`                                      | `true`                        | Progressive color states as the count nears the limit                    |
-| `liveAnnounce`          | `boolean`                                      | `false`                       | Polite live announcements when the limit state changes                   |
-| `announcementFormatter` | `NgxCharacterCountAnnouncementFormatter`       | Built-in English strings      | Custom formatter for localizing announcements                            |
-| `colorThresholds`       | `{ warning: number; danger: number }`          | `{ warning: 80, danger: 95 }` | Percentage thresholds for the warning and danger color states            |
+| Input                   | Type                                           | Default                      | Description                                                              |
+| ----------------------- | ---------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------ |
+| `formField`             | `FieldTree<NgxCharacterCountValue>` (required) | —                            | Field to track the character count for                                   |
+| `maxLength`             | `number \| undefined`                          | Auto-detected from validator | Character limit; auto-detected from a `maxLength` validator when omitted |
+| `position`              | `'left' \| 'right'`                            | `'right'`                    | Text alignment within the assistive row                                  |
+| `showLimitColors`       | `boolean`                                      | `true`                       | Progressive color states as the count nears the limit                    |
+| `liveAnnounce`          | `boolean`                                      | `false`                      | Polite live announcements when the limit state changes                   |
+| `announcementFormatter` | `NgxCharacterCountAnnouncementFormatter`       | Built-in English strings     | Custom formatter for localizing announcements                            |
 
 When a matching max-length validator is present, `maxLength` can be omitted and detected automatically. Add `liveAnnounce` for polite screen reader announcements.
+
+Warning/danger color thresholds are CSS-only — there is no `colorThresholds`
+input. Override `--ngx-form-field-char-count-warning-threshold` /
+`--ngx-form-field-char-count-danger-threshold` (plain numbers, percent of
+`maxLength`, default `80` / `95`) to retune where the color changes; see the
+[Theming guide](../form-field/THEMING.md#character-count). `[liveAnnounce]`
+wording always uses the fixed 80%/95% defaults, independent of any CSS
+override — see [Migrating: beta to v1](../../../docs/MIGRATING_BETA_TO_V1.md).
 
 The component accepts `string`, `readonly string[]`, `null`, and `undefined`
 field values. Strings are counted by character length; arrays are counted by

--- a/packages/toolkit/assistive/character-count.a11y.browser.spec.ts
+++ b/packages/toolkit/assistive/character-count.a11y.browser.spec.ts
@@ -75,3 +75,213 @@ describe('NgxFormFieldCharacterCount — WCAG 2.2 AA conformance', () => {
     await expectNoA11yViolations(container);
   });
 });
+
+/**
+ * Parses a `getComputedStyle(...).color` string into 0-255 RGB channels
+ * (+ alpha 0-1). Browsers serialize `color-mix(in srgb, …)` output through
+ * the `color(srgb r g b[ / a])` function notation (0-1 floats) rather than
+ * `rgb()`/`rgba()` (0-255 ints) — this normalizes either so assertions don't
+ * depend on which notation a given engine/version happens to emit.
+ */
+function parseComputedColor(color: string): {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+} {
+  // Accepts both the legacy comma-separated form (`rgb(1, 2, 3)`,
+  // `rgba(1, 2, 3, 0.5)`) and the modern space-separated form
+  // (`rgb(1 2 3)`, `rgb(1 2 3 / 0.5)`) — serialization differs across
+  // engines and versions.
+  const rgbMatch = color.match(
+    /^rgba?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*(?:[,/]\s*([\d.]+)\s*)?\)$/u,
+  );
+  if (rgbMatch) {
+    return {
+      r: Number(rgbMatch[1]),
+      g: Number(rgbMatch[2]),
+      b: Number(rgbMatch[3]),
+      a: rgbMatch[4] === undefined ? 1 : Number(rgbMatch[4]),
+    };
+  }
+
+  const srgbMatch = color.match(
+    /^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*(?:\/\s*([\d.]+)\s*)?\)$/u,
+  );
+  if (srgbMatch) {
+    return {
+      r: Number(srgbMatch[1]) * 255,
+      g: Number(srgbMatch[2]) * 255,
+      b: Number(srgbMatch[3]) * 255,
+      a: srgbMatch[4] === undefined ? 1 : Number(srgbMatch[4]),
+    };
+  }
+
+  throw new Error(`Unrecognized computed color format: "${color}"`);
+}
+
+/**
+ * Asserts a computed `color` string matches an expected RGB(A) color within
+ * a tolerance — survives serialization differences (`rgb()` vs
+ * `color(srgb …)`, float rounding) instead of pinning one exact string.
+ */
+function expectColorClose(
+  actualColor: string,
+  expected: { r: number; g: number; b: number; a?: number },
+  tolerance = 2,
+): void {
+  const actual = parseComputedColor(actualColor);
+  // `a` defaults to 1 (fully opaque) — every design token under test here is
+  // either explicitly opaque or explicitly `rgba(…, 0.75)`, so the default
+  // always matches an intentional expectation; this also keeps every branch
+  // below unconditional, which a bare `if (expected.a !== undefined)` guard
+  // around a lone `expect()` call would not be (flagged by
+  // vitest/no-conditional-expect).
+  const expectedAlpha = expected.a ?? 1;
+  expect(Math.abs(actual.r - expected.r)).toBeLessThanOrEqual(tolerance);
+  expect(Math.abs(actual.g - expected.g)).toBeLessThanOrEqual(tolerance);
+  expect(Math.abs(actual.b - expected.b)).toBeLessThanOrEqual(tolerance);
+  expect(Math.abs(actual.a - expectedAlpha)).toBeLessThanOrEqual(0.02);
+}
+
+// Design tokens under test — see character-count.ts `styles` defaults.
+const OK_COLOR = { r: 50, g: 65, b: 85, a: 0.75 }; // rgba(50, 65, 85, 0.75)
+const WARNING_COLOR = { r: 161, g: 98, b: 7 }; // #a16207
+const DANGER_COLOR = { r: 219, g: 24, b: 24 }; // #db1818
+
+describe('NgxFormFieldCharacterCount — CSS custom property threshold contract (#355)', () => {
+  // `colorThresholds` was removed pre-v1 — thresholds are CSS-only now via
+  // `--ngx-form-field-char-count-warning-threshold` /
+  // `-danger-threshold`. These assertions read real computed styles (only
+  // possible in a real browser — jsdom does not evaluate `color-mix()` /
+  // `clamp()`), so they are the only place the actual color-switching
+  // contract is verified end to end.
+
+  it('renders the neutral "ok" color below the default 80% warning threshold', async () => {
+    // Regression guard for the clamp()/calc() toggle expression getting
+    // "stuck at 1" (i.e. always reporting "threshold crossed") — 50% is
+    // comfortably under both the 80% warning and 95% danger thresholds, so
+    // both toggles must resolve to 0 and the color must stay the neutral
+    // "ok" token, not warning or danger.
+    @Component({
+      selector: 'ngx-test-css-threshold-ok',
+      imports: [FormField, NgxFormFieldCharacterCount],
+      template: `
+        <textarea aria-label="bio" [formField]="testForm.bio"></textarea>
+        <ngx-form-field-character-count [formField]="testForm.bio" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ bio: 'a'.repeat(50) });
+      readonly testForm = form(this.#model, (path) => {
+        maxLength(path.bio, 100);
+      });
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const host = container.querySelector(
+      'ngx-form-field-character-count',
+    ) as HTMLElement;
+
+    expectColorClose(getComputedStyle(host).color, OK_COLOR);
+    expect(host).toHaveAttribute('data-limit-state', 'ok');
+  });
+
+  it('renders the default warning color at the default 80% threshold', async () => {
+    @Component({
+      selector: 'ngx-test-css-threshold-default',
+      imports: [FormField, NgxFormFieldCharacterCount],
+      template: `
+        <textarea aria-label="bio" [formField]="testForm.bio"></textarea>
+        <ngx-form-field-character-count [formField]="testForm.bio" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ bio: 'a'.repeat(80) });
+      readonly testForm = form(this.#model, (path) => {
+        maxLength(path.bio, 100);
+      });
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const host = container.querySelector(
+      'ngx-form-field-character-count',
+    ) as HTMLElement;
+
+    expectColorClose(getComputedStyle(host).color, WARNING_COLOR);
+    expect(host).toHaveAttribute('data-limit-state', 'warning');
+  });
+
+  it('renders the danger color at/above the 95% danger threshold — danger wins over warning', async () => {
+    // At exactly 95%, both the warning toggle (>= 80%) and the danger toggle
+    // (>= 95%) are "crossed" — the outer color-mix() must resolve fully to
+    // the danger color, not a blend, proving danger takes priority over an
+    // also-true warning condition.
+    @Component({
+      selector: 'ngx-test-css-threshold-danger',
+      imports: [FormField, NgxFormFieldCharacterCount],
+      template: `
+        <textarea aria-label="bio" [formField]="testForm.bio"></textarea>
+        <ngx-form-field-character-count [formField]="testForm.bio" />
+      `,
+    })
+    class TestComponent {
+      readonly #model = signal({ bio: 'a'.repeat(95) });
+      readonly testForm = form(this.#model, (path) => {
+        maxLength(path.bio, 100);
+      });
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const host = container.querySelector(
+      'ngx-form-field-character-count',
+    ) as HTMLElement;
+
+    expectColorClose(getComputedStyle(host).color, DANGER_COLOR);
+    expect(host).toHaveAttribute('data-limit-state', 'danger');
+  });
+
+  it('shifts the warning color to fire earlier when the threshold custom property is overridden', async () => {
+    @Component({
+      selector: 'ngx-test-css-threshold-override',
+      imports: [FormField, NgxFormFieldCharacterCount],
+      styles: `
+        ngx-form-field-character-count {
+          --ngx-form-field-char-count-warning-threshold: 30;
+        }
+      `,
+      template: `
+        <textarea aria-label="bio" [formField]="testForm.bio"></textarea>
+        <ngx-form-field-character-count [formField]="testForm.bio" />
+      `,
+    })
+    class TestComponent {
+      // 40% used — below the toolkit default 80% warning threshold (would
+      // render the neutral "ok" color by default), but above the
+      // CSS-overridden 30% threshold used by this component's own styles.
+      readonly #model = signal({ bio: 'a'.repeat(40) });
+      readonly testForm = form(this.#model, (path) => {
+        maxLength(path.bio, 100);
+      });
+    }
+
+    const { container } = await render(TestComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const host = container.querySelector(
+      'ngx-form-field-character-count',
+    ) as HTMLElement;
+
+    // The `data-limit-state` attribute stays 'ok' (fixed 80%/95% defaults —
+    // see character-count.spec.ts), but the rendered *color* follows the
+    // CSS-only threshold override, proving the two are decoupled.
+    expectColorClose(getComputedStyle(host).color, WARNING_COLOR);
+    expect(host).toHaveAttribute('data-limit-state', 'ok');
+  });
+});

--- a/packages/toolkit/assistive/character-count.spec.ts
+++ b/packages/toolkit/assistive/character-count.spec.ts
@@ -39,24 +39,13 @@ import { NgxFormFieldCharacterCount } from './character-count';
   standalone: true,
   imports: [NgxFormFieldCharacterCount],
   template: `
-    @if (colorThresholds(); as thresholds) {
-      <ngx-form-field-character-count
-        [formField]="testForm.text"
-        [maxLength]="maxLength()"
-        [position]="position()"
-        [showLimitColors]="showLimitColors()"
-        [liveAnnounce]="liveAnnounce()"
-        [colorThresholds]="thresholds"
-      />
-    } @else {
-      <ngx-form-field-character-count
-        [formField]="testForm.text"
-        [maxLength]="maxLength()"
-        [position]="position()"
-        [showLimitColors]="showLimitColors()"
-        [liveAnnounce]="liveAnnounce()"
-      />
-    }
+    <ngx-form-field-character-count
+      [formField]="testForm.text"
+      [maxLength]="maxLength()"
+      [position]="position()"
+      [showLimitColors]="showLimitColors()"
+      [liveAnnounce]="liveAnnounce()"
+    />
   `,
 })
 class TestWrapperComponent {
@@ -65,9 +54,6 @@ class TestWrapperComponent {
   readonly position = input<'left' | 'right'>('right');
   readonly showLimitColors = input(true);
   readonly liveAnnounce = input(false);
-  readonly colorThresholds = input<
-    { warning: number; danger: number } | undefined
-  >();
 
   readonly #model = signal({ text: '' });
   protected readonly testForm = form(this.#model);
@@ -269,96 +255,90 @@ describe('NgxFormFieldCharacterCount', () => {
     });
   });
 
-  describe('Custom thresholds', () => {
-    it('should use custom warning threshold', async () => {
+  describe('CSS custom property contract (colorThresholds removed, #355)', () => {
+    // `colorThresholds` is gone — thresholds are CSS-only, driven by
+    // `--ngx-form-field-char-count-warning-threshold` /
+    // `-danger-threshold`, which default to 80/95 in the component's own
+    // styles (not asserted here — see the browser a11y spec for a real
+    // computed-style assertion, since jsdom doesn't evaluate CSS
+    // `color-mix()`/`clamp()`). This suite pins the piece jsdom *can*
+    // verify: the component publishes its percent-used as an inline custom
+    // property, which is the only input the CSS side needs.
+
+    it('publishes --ngx-form-field-char-count-percent-used as an inline custom property', async () => {
       const { container } = await render(TestWrapperComponent, {
-        componentInputs: {
-          textModel: 'a'.repeat(85),
-          maxLength: 100,
-          colorThresholds: { warning: 85, danger: 95 },
-        },
+        componentInputs: { textModel: 'a'.repeat(42), maxLength: 100 },
       });
 
-      const host = container.querySelector('ngx-form-field-character-count');
-      expect(host).toHaveAttribute('data-limit-state', 'warning');
-      expect(screen.getByText('85/100')).toBeInTheDocument();
+      const host = container.querySelector(
+        'ngx-form-field-character-count',
+      ) as HTMLElement;
+      expect(
+        host.style.getPropertyValue('--ngx-form-field-char-count-percent-used'),
+      ).toBe('42');
     });
 
-    it('should use custom danger threshold', async () => {
-      const { container } = await render(TestWrapperComponent, {
-        componentInputs: {
-          textModel: 'a'.repeat(98),
-          maxLength: 100,
-          colorThresholds: { warning: 90, danger: 98 },
-        },
+    it('updates the published percent-used as the field value changes', async () => {
+      const { container, rerender } = await render(TestWrapperComponent, {
+        componentInputs: { textModel: 'a'.repeat(10), maxLength: 100 },
       });
 
-      const host = container.querySelector('ngx-form-field-character-count');
-      expect(host).toHaveAttribute('data-limit-state', 'danger');
-      expect(screen.getByText('98/100')).toBeInTheDocument();
-    });
+      const host = container.querySelector(
+        'ngx-form-field-character-count',
+      ) as HTMLElement;
+      expect(
+        host.style.getPropertyValue('--ngx-form-field-char-count-percent-used'),
+      ).toBe('10');
 
-    it('does NOT clamp out-of-range thresholds — values above 100 are passed straight through', async () => {
-      // Regression/documentation test: `colorThresholds` is entirely
-      // unvalidated (see character-count.ts `#charCountState`). Percentages
-      // are divided by 100 and used as raw ratios with no clamping, so a
-      // `warning`/`danger` above 100 produces a ratio the component can
-      // never reach via the normal 0-100% "ok" range — those thresholds
-      // become unreachable and the state jumps straight from 'ok' to
-      // 'exceeded' once `current > maxLength`. This is the actual current
-      // behavior; a real "clamp to 0-100" feature does not exist.
-      const { rerender, container } = await render(TestWrapperComponent, {
-        componentInputs: {
-          textModel: 'a'.repeat(50),
-          maxLength: 100,
-          colorThresholds: { warning: 150, danger: 200 },
-        },
-      });
-
-      const host = () =>
-        container.querySelector('ngx-form-field-character-count');
-
-      // 50% — nowhere near the (unreachable) 150%/200% thresholds.
-      expect(host()).toHaveAttribute('data-limit-state', 'ok');
-
-      // Even at exactly the limit (ratio === 1), the unreachable thresholds
-      // mean the state is still 'ok' — never 'warning' or 'danger'.
       await rerender({
-        componentInputs: {
-          textModel: 'a'.repeat(100),
-          maxLength: 100,
-          colorThresholds: { warning: 150, danger: 200 },
-        },
+        componentInputs: { textModel: 'a'.repeat(150), maxLength: 100 },
       });
       await TestBed.inject(ApplicationRef).whenStable();
-      expect(host()).toHaveAttribute('data-limit-state', 'ok');
 
-      // One character over the limit flips straight to 'exceeded' — the
-      // ratio > 1 branch is checked before the (unreachable) danger/warning
-      // thresholds, so there is no intermediate 'warning'/'danger' state.
-      await rerender({
-        componentInputs: {
-          textModel: 'a'.repeat(101),
-          maxLength: 100,
-          colorThresholds: { warning: 150, danger: 200 },
-        },
-      });
-      await TestBed.inject(ApplicationRef).whenStable();
-      expect(host()).toHaveAttribute('data-limit-state', 'exceeded');
+      expect(
+        host.style.getPropertyValue('--ngx-form-field-char-count-percent-used'),
+      ).toBe('150');
     });
 
-    it('does NOT validate negative thresholds — a negative warning threshold makes every non-empty value "warning"', async () => {
-      // Further documents the "entirely unvalidated" contract: a negative
-      // percentage divides down to a negative ratio, which `ratio >=
-      // warning` satisfies immediately (any non-negative ratio is >= a
-      // negative number). This is a real gap, not desired behavior — noted
-      // for a future follow-up rather than fixed here (test-hardening pass).
+    it('publishes 0 when no maxLength is resolved (no configured or auto-detected limit)', async () => {
       const { container } = await render(TestWrapperComponent, {
-        componentInputs: {
-          textModel: 'a',
-          maxLength: 100,
-          colorThresholds: { warning: -10, danger: 95 },
-        },
+        componentInputs: { textModel: 'a'.repeat(42), maxLength: 0 },
+      });
+
+      const host = container.querySelector(
+        'ngx-form-field-character-count',
+      ) as HTMLElement;
+      expect(
+        host.style.getPropertyValue('--ngx-form-field-char-count-percent-used'),
+      ).toBe('0');
+      expect(host).toHaveAttribute('data-limit-state', 'disabled');
+    });
+
+    it('has no colorThresholds input in the compiled component metadata', () => {
+      // Static metadata check, not an instantiation — inputs are declared
+      // on the compiled `ɵcmp.inputs` map regardless of injection context.
+      const inputs = (
+        NgxFormFieldCharacterCount as unknown as {
+          ɵcmp: { inputs: Record<string, unknown> };
+        }
+      ).ɵcmp.inputs;
+
+      expect(Object.keys(inputs)).not.toContain('colorThresholds');
+      // Sanity check the reflection itself still finds the inputs that do
+      // exist, so a broken lookup can't silently pass the assertion above.
+      expect(Object.keys(inputs)).toContain('formField');
+      expect(Object.keys(inputs)).toContain('maxLength');
+    });
+  });
+
+  describe('Limit state uses the fixed 80%/95% defaults (no colorThresholds input)', () => {
+    it('is not affected by an unrelated custom threshold-shaped input on the host (documentation only)', async () => {
+      // Documents that limit-state transitions (and therefore the
+      // liveAnnounce wording) always use the toolkit's fixed 80%/95%
+      // defaults now — there is no way to shift them per-instance anymore.
+      // See 'Limit state calculation' above for the exact 80/95 breakpoints.
+      const { container } = await render(TestWrapperComponent, {
+        componentInputs: { textModel: 'a'.repeat(80), maxLength: 100 },
       });
 
       const host = container.querySelector('ngx-form-field-character-count');

--- a/packages/toolkit/assistive/character-count.ts
+++ b/packages/toolkit/assistive/character-count.ts
@@ -125,13 +125,12 @@ export type NgxCharacterCountAnnouncementFormatter = (
  * />
  * ```
  *
- * @example Custom thresholds
- * ```html
- * <ngx-form-field-character-count
- *   [formField]="form.description"
- *   [maxLength]="500"
- *   [colorThresholds]="{ warning: 90, danger: 98 }"
- * />
+ * @example Custom thresholds (CSS-only — no component input)
+ * ```css
+ * ngx-form-field-character-count {
+ *   --ngx-form-field-char-count-warning-threshold: 90;
+ *   --ngx-form-field-char-count-danger-threshold: 98;
+ * }
  * ```
  *
  * Color States (aligned with Figma design tokens):
@@ -139,6 +138,12 @@ export type NgxCharacterCountAnnouncementFormatter = (
  * - **warning**: 80-95% of limit (amber)
  * - **danger**: 95-100% of limit (interaction/danger)
  * - **exceeded**: >100% of limit (darker red, bold)
+ *
+ * The 80%/95% warning/danger split is a *presentation* detail, not a
+ * component input — see `--ngx-form-field-char-count-warning-threshold` /
+ * `--ngx-form-field-char-count-danger-threshold` below. The "exceeded" state
+ * (>100%) is not configurable — it is tied to the field's actual
+ * `maxLength`, not a percentage.
  *
  * Customization:
  * Use CSS custom properties to theme character count appearance:
@@ -152,12 +157,32 @@ export type NgxCharacterCountAnnouncementFormatter = (
  *   --ngx-form-field-char-count-color-danger: #db1818;
  *   --ngx-form-field-char-count-color-exceeded: #991b1b;
  *   --ngx-form-field-char-count-weight-exceeded: 600;
+ *   --ngx-form-field-char-count-warning-threshold: 80;
+ *   --ngx-form-field-char-count-danger-threshold: 95;
  * }
  * ```
+ *
+ * `-warning-threshold` / `-danger-threshold` are the two public, CSS-only
+ * configuration knobs — plain numbers (percent of `maxLength`, no `%`
+ * unit). The component publishes the live
+ * `--ngx-form-field-char-count-percent-used` custom property (an internal
+ * coordination hook, not a theming knob — same status as
+ * `--ngx-form-field-hint-display`, see THEMING.md — set by the component,
+ * not meant to be overridden), and a pure-CSS `color-mix()`/`clamp()`
+ * expression compares it against the two threshold knobs to pick the
+ * rendered color. No component input, no JS re-render on override — restyle
+ * a wrapper (Material, PrimeNG, …) purely in CSS.
  *
  * Accessibility:
  * - Ensure color is not the only indicator (text content also changes)
  * - Color contrast meets WCAG 2.2 Level AA (4.5:1 minimum)
+ * - `[liveAnnounce]` announcements ("Approaching limit…", "Almost at
+ *   limit…", "Character limit exceeded…") always fire at the toolkit's
+ *   fixed 80%/95% defaults, independent of any CSS threshold override.
+ *   Announcement wording is accessible *behavior* and must stay predictable
+ *   for screen reader users; restyling `-warning-threshold` /
+ *   `-danger-threshold` only shifts when the *color* changes, never when the
+ *   announcement fires.
  *
  * @see {@link createCharacterCount} for the underlying headless utility
  */
@@ -187,7 +212,6 @@ export type NgxCharacterCountAnnouncementFormatter = (
         var(--ngx-signal-form-feedback-font-size, 0.75rem)
       );
       line-height: var(--ngx-form-field-char-count-line-height, 1.25);
-      color: var(--ngx-form-field-char-count-color-ok, rgba(50, 65, 85, 0.75));
       transition:
         color 0.2s ease,
         font-weight 0.2s ease;
@@ -200,6 +224,78 @@ export type NgxCharacterCountAnnouncementFormatter = (
         --ngx-form-field-char-count-padding-inline-end,
         var(--ngx-signal-form-feedback-padding-horizontal, 0.5rem)
       );
+
+      /*
+       * Warning/danger thresholds: --ngx-form-field-char-count-*-threshold
+       * are the two PUBLIC, CSS-only configuration knobs — plain numbers
+       * (percent of maxLength, no unit). Restyle a wrapper (Material,
+       * PrimeNG, …) by overriding these two custom properties; no component
+       * input exists for them (see class docblock).
+       *
+       * --_char-count-*-threshold below are the resolved, pseudo-private
+       * copies the implementation actually consumes — same pattern as
+       * --_error-panel-* resolving --ngx-signal-form-error-panel-* (see
+       * THEMING.md). Keeps the public/internal split explicit instead of
+       * scattering var(--ngx-form-field-char-count-*-threshold, …) calls
+       * through every downstream expression.
+       *
+       * Default: Tailwind amber-700 (#a16207) for warning — ~5.17:1 on
+       * white meets WCAG 1.4.3 AA for normal text (#f59e0b previously used
+       * was 2.16:1). Kept consistent with the warning color in
+       * form-field-error.css.
+       */
+      --_char-count-warning-threshold: var(
+        --ngx-form-field-char-count-warning-threshold,
+        80
+      );
+      --_char-count-danger-threshold: var(
+        --ngx-form-field-char-count-danger-threshold,
+        95
+      );
+
+      /*
+       * Discrete 0/1 toggles for "percent used has crossed this threshold" —
+       * internal intermediates, never a theming knob, hence the _ prefix.
+       * Built from clamp()/calc() only (no @property, no container style
+       * queries — both are less broadly supported than this baseline-safe
+       * technique). The '+ 0.0001' before the large multiplier makes the
+       * comparison inclusive (percent === threshold counts as "crossed",
+       * matching the pre-CSS ratio >= threshold semantics), while the
+       * multiplier collapses any positive difference straight to the 1
+       * clamp() ceiling instead of a fractional (partially blended) value.
+       */
+      --_char-count-is-warning: clamp(
+        0,
+        (var(--ngx-form-field-char-count-percent-used, 0) -
+            var(--_char-count-warning-threshold) + 0.0001) *
+          1000000,
+        1
+      );
+      --_char-count-is-danger: clamp(
+        0,
+        (var(--ngx-form-field-char-count-percent-used, 0) -
+            var(--_char-count-danger-threshold) + 0.0001) *
+          1000000,
+        1
+      );
+
+      /*
+       * ok -> warning -> danger as a two-stage color-mix() blend driven by
+       * the toggles above. Each toggle is a plain 0/1 number; multiplying it
+       * by 100% turns it into the <percentage> color-mix() expects, so the
+       * blend always lands fully on one color, never a partial mix.
+       */
+      color: color-mix(
+        in srgb,
+        var(--ngx-form-field-char-count-color-danger, #db1818)
+          calc(var(--_char-count-is-danger) * 100%),
+        color-mix(
+          in srgb,
+          var(--ngx-form-field-char-count-color-warning, #a16207)
+            calc(var(--_char-count-is-warning) * 100%),
+          var(--ngx-form-field-char-count-color-ok, rgba(50, 65, 85, 0.75))
+        )
+      );
     }
 
     :host([position='left']) {
@@ -210,28 +306,18 @@ export type NgxCharacterCountAnnouncementFormatter = (
       text-align: right;
     }
 
-    /* Color progression states */
-    :host([data-limit-state='ok']) {
-      color: var(--ngx-form-field-char-count-color-ok, rgba(50, 65, 85, 0.75));
-    }
-
-    :host([data-limit-state='warning']) {
-      /* Default: Tailwind amber-700 (#a16207) — ~5.17:1 on white meets
-       * WCAG 1.4.3 AA for normal text (#f59e0b previously used was 2.16:1).
-       * Kept consistent with the warning color in form-field-error.css. */
-      color: var(--ngx-form-field-char-count-color-warning, #a16207);
-    }
-
-    :host([data-limit-state='danger']) {
-      color: var(--ngx-form-field-char-count-color-danger, #db1818);
-    }
-
+    /*
+     * 'exceeded' and 'disabled' stay attribute-selector overrides — both are
+     * fixed states outside the configurable warning/danger CSS thresholds
+     * above: 'exceeded' is tied to the field's actual maxLength (> 100% used,
+     * not a percent threshold), and 'disabled' unconditionally forces the
+     * neutral color regardless of percent-used.
+     */
     :host([data-limit-state='exceeded']) {
       color: var(--ngx-form-field-char-count-color-exceeded, #991b1b);
       font-weight: var(--ngx-form-field-char-count-weight-exceeded, 600);
     }
 
-    /* Disabled color progression */
     :host([data-limit-state='disabled']) {
       color: var(--ngx-form-field-char-count-color-ok, rgba(50, 65, 85, 0.75));
     }
@@ -252,6 +338,7 @@ export type NgxCharacterCountAnnouncementFormatter = (
   host: {
     '[attr.position]': 'position()',
     '[attr.data-limit-state]': 'displayLimitState()',
+    '[style.--ngx-form-field-char-count-percent-used]': 'percentUsed()',
   },
 })
 export class NgxFormFieldCharacterCount {
@@ -340,19 +427,6 @@ export class NgxFormFieldCharacterCount {
     input<NgxCharacterCountAnnouncementFormatter>();
 
   /**
-   * Percentage thresholds for color state changes.
-   *
-   * - `warning`: Percentage at which color changes to warning (default: 80%)
-   * - `danger`: Percentage at which color changes to danger (default: 95%)
-   *
-   * @default { warning: 80, danger: 95 }
-   */
-  readonly colorThresholds = input({
-    warning: 80,
-    danger: 95,
-  });
-
-  /**
    * Resolved maximum length.
    *
    * Priority:
@@ -390,18 +464,24 @@ export class NgxFormFieldCharacterCount {
 
   /**
    * Headless character count state from the toolkit.
-   * Re-created when maxLength or thresholds change (rare).
+   * Re-created when `maxLength` changes (rare).
+   *
+   * Uses `createCharacterCount()`'s own default thresholds (80%/95%) — the
+   * component no longer accepts a `colorThresholds` input (removed pre-v1,
+   * #355). Those defaults drive `displayLimitState` (the `data-limit-state`
+   * attribute) and, in turn, the `[liveAnnounce]` announcement wording,
+   * which must stay fixed and predictable for screen reader users. The
+   * *visible color* is independently, continuously reconfigurable via the
+   * `--ngx-form-field-char-count-warning-threshold` /
+   * `-danger-threshold` CSS custom properties — see the class docblock.
    */
   readonly #charCountState = computed(() => {
     const max = this.#resolvedMaxLength();
     if (max === null) return null;
 
-    const thresholds = this.colorThresholds();
     return createCharacterCount({
       field: this.formField(),
       maxLength: max,
-      warningThreshold: thresholds.warning / 100,
-      dangerThreshold: thresholds.danger / 100,
       // Without this, the unsupported-value dev warning would report the
       // factory's own default name ('createCharacterCount') instead of the
       // component the misconfigured `formField` binding actually lives on —
@@ -434,6 +514,20 @@ export class NgxFormFieldCharacterCount {
     if (state) return state.currentLength();
 
     return this.#fallbackLength();
+  });
+
+  /**
+   * Percentage of `maxLength` used (0-100+), published as the
+   * `--ngx-form-field-char-count-percent-used` custom property (see the
+   * `host` binding) so the pure-CSS threshold comparison in `styles` above
+   * can pick a color. `0` when no limit is resolved — the `disabled`
+   * `data-limit-state` attribute selector takes over the color in that
+   * case, so this value never actually feeds the color-mix() expression
+   * for "no limit configured" fields.
+   */
+  protected readonly percentUsed = computed(() => {
+    const state = this.#charCountState();
+    return state ? state.percentUsed() : 0;
   });
 
   /**

--- a/packages/toolkit/form-field/THEMING.md
+++ b/packages/toolkit/form-field/THEMING.md
@@ -286,22 +286,53 @@ enforced minimum width.
 
 Displays progress towards a character limit.
 
-| Property                                           | Default                                    | Description                                                                        |
-| :------------------------------------------------- | :----------------------------------------- | :--------------------------------------------------------------------------------- |
-| `--ngx-form-field-char-count-font-size`            | `var(--...feedback...)`                    | Text size                                                                          |
-| `--ngx-form-field-char-count-line-height`          | `1.25`                                     | Line height (char-count uses tighter line-height than the other feedback surfaces) |
-| `--ngx-form-field-char-count-color-ok`             | `rgba(50, 65, 85, 0.75)`                   | Neutral state color                                                                |
-| `--ngx-form-field-char-count-color-warning`        | `#a16207`                                  | Warning threshold color                                                            |
-| `--ngx-form-field-char-count-color-danger`         | `#db1818`                                  | Critical threshold color                                                           |
-| `--ngx-form-field-char-count-color-exceeded`       | `#991b1b`                                  | Limit exceeded color                                                               |
-| `--ngx-form-field-char-count-weight-exceeded`      | `600`                                      | Font weight when exceeded                                                          |
-| `--ngx-form-field-char-count-padding-inline-start` | `var(--...feedback-padding-horizontal...)` | Start-edge padding                                                                 |
-| `--ngx-form-field-char-count-padding-inline-end`   | `var(--...feedback-padding-horizontal...)` | End-edge padding                                                                   |
+| Property                                           | Default                                    | Description                                                                          |
+| :------------------------------------------------- | :----------------------------------------- | :----------------------------------------------------------------------------------- |
+| `--ngx-form-field-char-count-font-size`            | `var(--...feedback...)`                    | Text size                                                                            |
+| `--ngx-form-field-char-count-line-height`          | `1.25`                                     | Line height (char-count uses tighter line-height than the other feedback surfaces)   |
+| `--ngx-form-field-char-count-color-ok`             | `rgba(50, 65, 85, 0.75)`                   | Neutral state color                                                                  |
+| `--ngx-form-field-char-count-color-warning`        | `#a16207`                                  | Warning threshold color                                                              |
+| `--ngx-form-field-char-count-color-danger`         | `#db1818`                                  | Critical threshold color                                                             |
+| `--ngx-form-field-char-count-color-exceeded`       | `#991b1b`                                  | Limit exceeded color                                                                 |
+| `--ngx-form-field-char-count-weight-exceeded`      | `600`                                      | Font weight when exceeded                                                            |
+| `--ngx-form-field-char-count-padding-inline-start` | `var(--...feedback-padding-horizontal...)` | Start-edge padding                                                                   |
+| `--ngx-form-field-char-count-padding-inline-end`   | `var(--...feedback-padding-horizontal...)` | End-edge padding                                                                     |
+| `--ngx-form-field-char-count-warning-threshold`    | `80`                                       | Percent of `maxLength` at which the color switches to warning (plain number, no `%`) |
+| `--ngx-form-field-char-count-danger-threshold`     | `95`                                       | Percent of `maxLength` at which the color switches to danger (plain number, no `%`)  |
 
 Both padding tokens fall back to the shared
 `--ngx-signal-form-feedback-padding-horizontal` first — `0.5rem` inside the
 wrapper, where it aligns the count with the input text. Used fully standalone,
 the last-resort fallbacks are `0` (start) and `0.5rem` (end).
+
+**Threshold tokens (pre-v1 breaking change, #355):** there is no
+`colorThresholds` component input anymore. The warning/danger breakpoints
+are CSS-only, resolved by the component's own `color-mix()`/`clamp()`
+expression against the two public threshold tokens above. A wrapper
+restyling `ngx-form-field-character-count` overrides the thresholds purely
+in CSS — no template change, no new input to thread through. The `exceeded`
+state (>100% used) is not configurable: it is tied to the field's actual
+`maxLength`, not a percentage. `[liveAnnounce]` announcement wording always
+uses the fixed 80/95 defaults, regardless of any threshold-token override —
+see [Migrating: beta to v1](../../../docs/MIGRATING_BETA_TO_V1.md) for the
+accessibility rationale.
+
+Following the same pattern as the rest of the toolkit, the implementation
+resolves the two public threshold tokens into pseudo-private
+`--_char-count-warning-threshold` / `--_char-count-danger-threshold`
+copies, then derives two more `--_char-count-is-warning` /
+`--_char-count-is-danger` intermediates (the 0/1 "threshold crossed"
+toggles the `color-mix()` blend consumes). All four are internal-only —
+never override them; they are not part of the public contract and can
+change shape without notice.
+
+`--ngx-form-field-char-count-percent-used` is different from the four
+`--_char-count-*` internals above: it is set by the component itself and
+consumed by its own `color-mix()` expression, but it stays in the public
+`--ngx-form-field-*` namespace — same status as
+[`--ngx-form-field-hint-display`](#hints): an **internal coordination
+hook, not a theming knob**. It is documented here for transparency (e.g.
+debugging computed styles), not as something to set.
 
 ### Assistive Row
 


### PR DESCRIPTION
Removes the `colorThresholds: { warning, danger }` input from `NgxFormFieldCharacterCount` (pre-v1 breaking change, no shims per repo policy). The percentages were a design-system detail leaking through the code/CSS seam — any wrapper that restyles had to learn a TS input to move a color boundary.

Thresholds are now CSS-only:

```css
/* consumer override — no TS involved */
ngx-form-field-character-count {
  --ngx-form-field-char-count-warning-threshold: 60;
  --ngx-form-field-char-count-danger-threshold: 85;
}
```

The component publishes `--ngx-form-field-char-count-percent-used` (an internal coordination hook, same precedent as `--ngx-form-field-hint-display` — documented, not user-settable), and the color switch happens entirely in CSS via number-typed custom properties, `clamp()` boolean toggles, and nested `color-mix()` — a baseline-safe technique already used elsewhere in the toolkit's CSS. Internal intermediates use the pseudo-private `--_char-count-*` namespace per THEMING.md's convention. Boundary semantics match the old TS logic exactly (inclusive `>=`, danger wins over warning), pinned by browser specs at the 80/95 defaults, under a consumer override, below-threshold, and at the danger boundary, with tolerance-based color comparisons.

Deliberate decoupling, documented in the docblock, README, THEMING.md, and migration guide §13: the `[liveAnnounce]` wording and `data-limit-state` keep the fixed 80/95 defaults. Announcement timing is accessible *behavior*, not presentation — a CSS-only visual restyle must not silently move when screen-reader users hear "Approaching limit". There is no SSR-safe way to read a CSS custom property back into TS anyway.

No demo or wrapper used the input (verified by grep), so nothing else changes.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
