### PR TITLE
docs(headless): @group JSDoc tags + README grouping for the barrel

### DIFF
--- a/packages/toolkit/core/providers/error-messages.provider.ts
+++ b/packages/toolkit/core/providers/error-messages.provider.ts
@@ -165,6 +165,14 @@ type ErrorMessageRegistryFactory = () => ErrorMessageRegistryInput;
  * ```
  *
  * @see {@link provideErrorMessages} Provider factory function
+ *
+ * `/headless`'s README documents this type only as the `errorMessages`
+ * option on `createErrorMessageSignal` (the Reactive Primitives section) —
+ * grouped there rather than under Utility Functions, which that README
+ * reserves for dependency-free helper *functions*, not provider-level
+ * configuration interfaces.
+ *
+ * @group Reactive Primitives
  */
 export interface ErrorMessageRegistry extends BuiltInErrorMessages {
   /**

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-bridge.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-bridge.ts
@@ -14,6 +14,7 @@ import { computed, signal, type Signal } from '@angular/core';
  * pulling in a runtime dependency on the design-system itself.
  *
  * @public
+ * @group ARIA Composition
  */
 export interface AriaDescribedByBridge {
   /**
@@ -33,6 +34,7 @@ export interface AriaDescribedByBridge {
  * Inputs for {@link createAriaDescribedByBridge}.
  *
  * @public
+ * @group ARIA Composition
  */
 export interface CreateAriaDescribedByBridgeOptions {
   /**
@@ -94,6 +96,7 @@ export interface CreateAriaDescribedByBridgeOptions {
  * ```
  *
  * @public
+ * @group ARIA Composition
  */
 export function createAriaDescribedByBridge(
   options: CreateAriaDescribedByBridgeOptions,

--- a/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-described-by-signal.ts
@@ -7,6 +7,8 @@ import { isBlockingError, isWarningError } from '../warning-error';
  * Reactive reader for the resolved field name. Invoked inside the resulting
  * computed so signal-backed readers stay tracked. Returns `null` when no
  * field name has been resolved yet.
+ *
+ * @group ARIA Composition
  */
 export type AriaDescribedByFieldNameReader = () => string | null;
 
@@ -15,6 +17,8 @@ export type AriaDescribedByFieldNameReader = () => string | null;
  * verbatim (hints stamped by template, descriptions, etc.). Called per
  * computed evaluation so consumers re-evaluating their preserved list see
  * fresh values without re-creating the factory.
+ *
+ * @group ARIA Composition
  */
 export type AriaDescribedByPreservedIdsReader = () => string | null;
 
@@ -25,6 +29,8 @@ export type AriaDescribedByPreservedIdsReader = () => string | null;
  * `aria-describedby` value tracks each of them reactively. `preservedIds`
  * and `fieldName` are plain readers so consumers can thread DOM reads or
  * service queries through without forcing them into a `Signal` shape.
+ *
+ * @group ARIA Composition
  */
 export interface CreateAriaDescribedBySignalOptions {
   /**
@@ -105,6 +111,7 @@ export interface CreateAriaDescribedBySignalOptions {
  * surface (custom wrappers built on Material, PrimeNG, Spartan, etc.).
  *
  * @public
+ * @group ARIA Composition
  */
 export function createAriaDescribedBySignal(
   options: CreateAriaDescribedBySignalOptions,

--- a/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-invalid-signal.ts
@@ -40,6 +40,7 @@ import { isBlockingError } from '../warning-error';
  * ```
  *
  * @public
+ * @group ARIA Composition
  */
 export function createAriaInvalidSignal(
   fieldState: Signal<FieldState<unknown> | null>,

--- a/packages/toolkit/core/utilities/aria/create-aria-required-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-aria-required-signal.ts
@@ -3,6 +3,8 @@ import type { FieldState } from '@angular/forms/signals';
 
 /**
  * Minimal FieldState contract required for aria-required resolution.
+ *
+ * @group ARIA Composition
  */
 export type AriaRequiredFieldState = Pick<FieldState<unknown>, 'required'>;
 
@@ -31,6 +33,7 @@ export type AriaRequiredFieldState = Pick<FieldState<unknown>, 'required'>;
  * ```
  *
  * @public
+ * @group ARIA Composition
  */
 export function createAriaRequiredSignal(
   fieldState: Signal<AriaRequiredFieldState | null>,

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
@@ -4,6 +4,8 @@ import { computed, type Signal } from '@angular/core';
  * Reactive reader for the current field's name. Accepts a plain getter or a
  * `Signal<string | null>`; both are invoked inside the resulting computed so
  * signal-based readers stay tracked.
+ *
+ * @group ARIA Composition
  */
 export type HintIdsFieldNameReader = () => string | null;
 
@@ -12,6 +14,8 @@ export type HintIdsFieldNameReader = () => string | null;
  *
  * Exposed so consumers composing custom wrappers can type their own
  * `aria-describedby` aggregators without re-deriving the shape.
+ *
+ * @group ARIA Composition
  */
 export type HintIdsSignal = Signal<readonly string[]>;
 
@@ -23,6 +27,8 @@ export type HintIdsSignal = Signal<readonly string[]>;
  * type-import the factory's inputs without using package-internal imports.
  * Production code passes its `NgxFieldIdentity` instance in
  * directly via structural assignability.
+ *
+ * @group ARIA Composition
  */
 export interface HintIdsIdentityLike {
   readonly hintIds: Signal<readonly string[]>;
@@ -41,6 +47,8 @@ export interface HintIdsIdentityLike {
  * type-import the factory's inputs without using package-internal imports.
  * Production code passes its `NgxSignalFormHintRegistry` instance
  * in directly via structural assignability.
+ *
+ * @group ARIA Composition
  */
 export interface HintIdsRegistryLike {
   readonly hints: Signal<
@@ -54,6 +62,8 @@ export interface HintIdsRegistryLike {
  * All three properties are optional — the factory must produce a stable
  * signal even when neither an identity service nor a registry is available,
  * matching the directive shell's "no wrapper context" branch.
+ *
+ * @group ARIA Composition
  */
 export interface CreateHintIdsSignalOptions {
   /**
@@ -104,6 +114,7 @@ export interface CreateHintIdsSignalOptions {
  * testable without `TestBed` and reusable from any injection context.
  *
  * @public
+ * @group ARIA Composition
  */
 export function createHintIdsSignal(
   options: CreateHintIdsSignalOptions = {},

--- a/packages/toolkit/core/utilities/create-field-name-resolver.ts
+++ b/packages/toolkit/core/utilities/create-field-name-resolver.ts
@@ -7,6 +7,7 @@ import { createDevWarnOnce } from './dev-warn-once';
  * over `contentChildren(NgxSignalFormControlSemanticsDirective)`.
  *
  * @public
+ * @group ARIA Composition
  */
 export type BoundControlElementReader = () => HTMLElement | null;
 
@@ -16,6 +17,7 @@ export type BoundControlElementReader = () => HTMLElement | null;
  * (Spartan's `BrnLabel`, for instance).
  *
  * @public
+ * @group ARIA Composition
  */
 export type LabelForReader = () => string | null;
 
@@ -23,6 +25,7 @@ export type LabelForReader = () => string | null;
  * Inputs for {@link createFieldNameResolver}.
  *
  * @public
+ * @group ARIA Composition
  */
 export interface CreateFieldNameResolverOptions {
   /**
@@ -79,6 +82,7 @@ export interface CreateFieldNameResolverOptions {
  * ```
  *
  * @public
+ * @group ARIA Composition
  */
 export function createFieldNameResolver(
   options: CreateFieldNameResolverOptions,

--- a/packages/toolkit/core/utilities/create-unique-id.ts
+++ b/packages/toolkit/core/utilities/create-unique-id.ts
@@ -89,6 +89,7 @@ const warnFallback = createDevWarnOnce();
  * ```
  *
  * @public
+ * @group Utility Functions
  */
 export function createUniqueId(prefix: string): string {
   // Probe the injection context *before* calling `inject()`. This isolates

--- a/packages/toolkit/core/utilities/humanize-field-path.ts
+++ b/packages/toolkit/core/utilities/humanize-field-path.ts
@@ -23,6 +23,7 @@ const ANGULAR_FORM_NAME_PREFIX = /^[^.]+\.form\d+\./u;
  * @returns Human-readable label; nested segments are joined with ` / `
  *
  * @public
+ * @group Utility Functions
  */
 export function humanizeFieldPath(fieldName: string): string {
   const strippedFieldName = fieldName

--- a/packages/toolkit/core/utilities/read-direct-errors.ts
+++ b/packages/toolkit/core/utilities/read-direct-errors.ts
@@ -10,6 +10,8 @@ function normalizeValidationErrors(errors: unknown): ValidationError[] {
  *
  * Unlike `errorSummary()`-based approaches, this only reads direct `errors()`
  * from the current field/group state.
+ *
+ * @group Utility Functions
  */
 export function readDirectErrors(state: unknown): ValidationError[] {
   if (!state || typeof state !== 'object') {

--- a/packages/toolkit/headless/README.md
+++ b/packages/toolkit/headless/README.md
@@ -210,7 +210,9 @@ Resolves field names and generates stable IDs for ARIA linking. Falls back to th
 
 Signals: `resolvedFieldName()` (nullable), `errorId()` (nullable), `warningId()` (nullable).
 
-## Reactive primitives
+## Reactive Primitives
+
+Factories that return plain signals for programmatic use — in services, host directives, or custom renderers that don't want a template directive.
 
 ### createErrorMessageSignal
 
@@ -254,9 +256,9 @@ Options of note:
 - `strategy` / `submittedStatus`: forwarded to `createErrorVisibility`. Omit to inherit from the form context.
 - `injector`: optional, for use outside an Angular injection context.
 
-## Utility functions
+### createErrorState / createCharacterCount / createFieldStateFlags
 
-For programmatic use without directives:
+For programmatic use without a directive:
 
 ```typescript
 // Error state without a directive
@@ -273,28 +275,23 @@ const count = createCharacterCount({ field: form.bio, maxLength: 500 });
 // Common field-state flags in one object
 const flags = createFieldStateFlags(form.email);
 // flags.isTouched(), flags.isDirty(), flags.isValid(), flags.isInvalid(), flags.isPending()
+```
 
-// Safe field state reading
-readFieldFlag(field(), 'invalid'); // boolean, null-safe
-readErrors(field()); // uses errorSummary() or errors()
-dedupeValidationErrors(errors); // remove duplicates by kind+message
+### createFieldOptionalitySummary / summarizeFieldOptionality
 
-// Human-readable field paths
-humanizeFieldPath('address.postalCode'); // 'Address / Postal code'
+Reach for these when a custom component needs to know whether a field is required/optional to render a marker or legend:
 
-// Unique ID generation
-createUniqueId('field'); // 'field-1', 'field-2', ...
-
-// Error-summary building blocks (what NgxHeadlessErrorSummary uses internally)
-toErrorSummaryEntry(error); // ValidationError → ErrorSummaryEntryData with focus()
-focusBoundControlFromError(error); // focus the control bound to an error
-
+```typescript
 // Required/optional leaf summary for a form tree (drives marking legends)
 const summary = summarizeFieldOptionality(formTree); // { hasRequired, hasOptional }
 const reactive = createFieldOptionalitySummary(() => this.formTree()); // computed signals
 ```
 
-## Custom-wrapper ARIA factories (re-exported from core)
+### createFieldsetAggregation / createErrorSummaryEntries
+
+The pure pipelines behind `NgxHeadlessFieldset` and `NgxHeadlessErrorSummary` — reach for these when building a custom grouped surface. No injection context required, but you supply pre-resolved `showErrors`/`showWarnings` signals from your own visibility seam call. See the source JSDoc for the option/result contracts.
+
+## ARIA Composition
 
 This entry point also re-exports the pure factories that
 [`docs/CUSTOM_WRAPPERS.md`](https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/CUSTOM_WRAPPERS.md)
@@ -309,8 +306,29 @@ teaches for hosts that own their own ARIA instead of using
 | `createHintIdsSignal(...)`         | Hint-id collection for the described-by chain                       |
 | `createAriaDescribedByBridge(...)` | Bridge for hosts whose described-by attribute another library owns  |
 | `createFieldNameResolver(...)`     | Field-name cascade (explicit → label `for` (opt-in) → control `id`) |
-| `createErrorRendererInputs(...)`   | Input set for driving a custom error renderer                       |
-| `toHintDescriptors(...)`           | Normalize projected hints for registry registration                 |
+
+## Utility Functions
+
+Plain, dependency-free helpers used internally by the directives and factories above — safe to call directly for one-off reads:
+
+```typescript
+// Safe field state reading
+readFieldFlag(field(), 'invalid'); // boolean, null-safe
+readErrors(field()); // uses errorSummary() or errors()
+readDirectErrors(field()); // only direct-field errors, not descendants
+dedupeValidationErrors(errors); // remove duplicates by kind+message
+
+// Human-readable field paths
+humanizeFieldPath('address.postalCode'); // 'Address / Postal code'
+
+// Unique ID generation
+createUniqueId('field'); // 'field-1', 'field-2', ...
+
+// Error-summary building blocks (what NgxHeadlessErrorSummary uses internally)
+toErrorSummaryEntry(error); // ValidationError → ErrorSummaryEntryData with focus()
+resolveFieldNameFromError(error); // ValidationError → human-readable field name
+focusBoundControlFromError(error); // focus the control bound to an error
+```
 
 ## Related documentation
 

--- a/packages/toolkit/headless/src/group-tags.spec.ts
+++ b/packages/toolkit/headless/src/group-tags.spec.ts
@@ -1,0 +1,365 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+// Mechanical verification for issue #360: every public export of the
+// `/headless` barrel must carry a `@group <Name>` JSDoc tag at its
+// *declaration* site, so a generated API reference (or a human skimming the
+// source) can bucket the ~70-export surface into the same use-case sections
+// documented in `headless/README.md` (Directives / Reactive Primitives /
+// ARIA Composition / Utility Functions). This reads the checked-in source of
+// truth directly — the same approach `scripts/packaging.spec.ts` uses for
+// re-export drift — rather than a built/generated doc artifact, so it works
+// without a TypeDoc (or similar) pipeline, which this repo does not have.
+//
+// The barrel is walked structurally (export declarations, import bindings,
+// `export *`), not hand-listed, so a future export that forgets its `@group`
+// tag fails here instead of silently shipping ungrouped.
+
+const toolkitDir = resolve(import.meta.dirname, '../..');
+const repoRoot = resolve(toolkitDir, '../..');
+
+const tsconfigBase = JSON.parse(
+  readFileSync(resolve(repoRoot, 'tsconfig.base.json'), 'utf8'),
+) as { compilerOptions: { paths: Record<string, string[]> } };
+
+/** Reads `lib.entryFile` out of an entry point's `ng-package.json`. */
+function readEntryFile(entryDir: string): string {
+  const ngPackageJson = JSON.parse(
+    readFileSync(resolve(entryDir, 'ng-package.json'), 'utf8'),
+  ) as { lib?: { entryFile?: string } };
+  const entryFile = ngPackageJson.lib?.entryFile;
+  if (!entryFile) {
+    throw new Error(`${entryDir}/ng-package.json is missing lib.entryFile`);
+  }
+  return resolve(entryDir, entryFile);
+}
+
+const headlessEntryFile = readEntryFile(resolve(toolkitDir, 'headless'));
+
+// The four use-case sections `headless/README.md` is organized into. A
+// `@group` tag whose value isn't one of these is almost certainly a typo
+// (e.g. `@group Directive` or `@group Reactive Primitive`) that would
+// silently fall outside every documented section — validated below, not
+// just presence-checked.
+const ALLOWED_GROUPS = [
+  'Directives',
+  'Reactive Primitives',
+  'ARIA Composition',
+  'Utility Functions',
+] as const;
+
+/**
+ * Thrown by {@link findDeclarationJsDoc} only for its own terminal "walked
+ * every statement in this file, no match" case. Distinguished from every
+ * other failure (an unmapped tsconfig path, an unresolvable relative
+ * specifier, a cycle) so the `export *` fallback below can swallow *this*
+ * case alone — a genuine resolver bug still surfaces instead of being
+ * folded into "try the next export *".
+ */
+class DeclarationNotFoundError extends Error {}
+
+/** Resolves an import/export module specifier to an absolute `.ts` file. */
+function resolveSpecifier(fromFile: string, specifier: string): string {
+  if (specifier.startsWith('.')) {
+    const base = resolve(dirname(fromFile), specifier);
+    for (const candidate of [`${base}.ts`, resolve(base, 'index.ts')]) {
+      if (existsSync(candidate)) return candidate;
+    }
+    throw new Error(
+      `${fromFile}: cannot resolve relative module '${specifier}'`,
+    );
+  }
+
+  const mapping = tsconfigBase.compilerOptions.paths[specifier];
+  if (!mapping || mapping.length === 0) {
+    throw new Error(
+      `${fromFile}: no tsconfig.base.json path mapping for '${specifier}'`,
+    );
+  }
+  return resolve(repoRoot, mapping[0]);
+}
+
+const sourceFileCache = new Map<string, ts.SourceFile>();
+
+function getSourceFile(filePath: string): ts.SourceFile {
+  const cached = sourceFileCache.get(filePath);
+  if (cached) return cached;
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  sourceFileCache.set(filePath, sourceFile);
+  return sourceFile;
+}
+
+/** Concatenated leading comment text (JSDoc block(s)) for a statement. */
+function getLeadingCommentText(
+  sourceFile: ts.SourceFile,
+  statement: ts.Statement,
+): string {
+  const ranges =
+    ts.getLeadingCommentRanges(sourceFile.text, statement.getFullStart()) ?? [];
+  return ranges
+    .map((range) => sourceFile.text.slice(range.pos, range.end))
+    .join('\n');
+}
+
+function isNamedDeclarationMatch(
+  statement: ts.Statement,
+  name: string,
+): boolean {
+  return (
+    (ts.isClassDeclaration(statement) ||
+      ts.isFunctionDeclaration(statement) ||
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement) ||
+      ts.isEnumDeclaration(statement)) &&
+    statement.name?.text === name
+  );
+}
+
+/**
+ * Finds where `name` is *declared* (following re-export and import chains
+ * across relative files and `@ngx-signal-forms/toolkit*` package specifiers)
+ * and returns its leading JSDoc comment text.
+ */
+function findDeclarationJsDoc(
+  filePath: string,
+  name: string,
+  visited: Set<string> = new Set(),
+): string {
+  const key = `${filePath}::${name}`;
+  if (visited.has(key)) {
+    throw new Error(`Cycle detected resolving '${name}' from ${filePath}`);
+  }
+  visited.add(key);
+
+  const sourceFile = getSourceFile(filePath);
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          if (element.name.text !== name) continue;
+          const internalName = (element.propertyName ?? element.name).text;
+
+          if (
+            statement.moduleSpecifier &&
+            ts.isStringLiteral(statement.moduleSpecifier)
+          ) {
+            const target = resolveSpecifier(
+              filePath,
+              statement.moduleSpecifier.text,
+            );
+            return findDeclarationJsDoc(target, internalName, visited);
+          }
+
+          // `export { name }` / `export { type name }` with no specifier:
+          // re-exports a name imported (or declared) elsewhere in this file.
+          return resolveLocalName(sourceFile, filePath, internalName, visited);
+        }
+        continue;
+      }
+
+      if (
+        statement.moduleSpecifier &&
+        ts.isStringLiteral(statement.moduleSpecifier)
+      ) {
+        // `export * from '...'` — try the target; a miss here just means
+        // the name lives in a different statement of this same file.
+        const target = resolveSpecifier(
+          filePath,
+          statement.moduleSpecifier.text,
+        );
+        try {
+          return findDeclarationJsDoc(target, name, visited);
+        } catch (error) {
+          // Only "the target module doesn't export this name" is an
+          // expected miss when probing multiple `export *` re-exports —
+          // anything else (unmapped path mapping, unresolvable specifier,
+          // a resolver cycle) is a real bug and must not be swallowed.
+          if (error instanceof DeclarationNotFoundError) continue;
+          throw error;
+        }
+      }
+      continue;
+    }
+
+    const modifiers = ts.canHaveModifiers(statement)
+      ? ts.getModifiers(statement)
+      : undefined;
+    const isExported = modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!isExported) continue;
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === name
+        ) {
+          return getLeadingCommentText(sourceFile, statement);
+        }
+      }
+      continue;
+    }
+
+    if (isNamedDeclarationMatch(statement, name)) {
+      return getLeadingCommentText(sourceFile, statement);
+    }
+  }
+
+  throw new DeclarationNotFoundError(
+    `Could not find declaration of '${name}' in ${filePath}`,
+  );
+}
+
+/**
+ * Resolves a name that is exported *without* a module specifier — either
+ * imported from elsewhere in the same file (the common case: `import {
+ * humanizeFieldPath } from '...'; export { humanizeFieldPath };`) or declared
+ * directly in it without its own `export` modifier on the declaration itself.
+ */
+function resolveLocalName(
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  name: string,
+  visited: Set<string>,
+): string {
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isImportDeclaration(statement) &&
+      statement.importClause?.namedBindings &&
+      ts.isNamedImports(statement.importClause.namedBindings) &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      for (const element of statement.importClause.namedBindings.elements) {
+        if (element.name.text !== name) continue;
+        const internalName = (element.propertyName ?? element.name).text;
+        const target = resolveSpecifier(
+          filePath,
+          statement.moduleSpecifier.text,
+        );
+        return findDeclarationJsDoc(target, internalName, visited);
+      }
+    }
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === name
+        ) {
+          return getLeadingCommentText(sourceFile, statement);
+        }
+      }
+    } else if (isNamedDeclarationMatch(statement, name)) {
+      return getLeadingCommentText(sourceFile, statement);
+    }
+  }
+
+  throw new Error(`Could not resolve local name '${name}' in ${filePath}`);
+}
+
+/** Every name the `/headless` barrel (`index.ts`) publicly exports. */
+function collectBarrelExportNames(entryFile: string): string[] {
+  const sourceFile = getSourceFile(entryFile);
+  const names: string[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          names.push(element.name.text);
+        }
+      }
+      continue;
+    }
+
+    const modifiers = ts.canHaveModifiers(statement)
+      ? ts.getModifiers(statement)
+      : undefined;
+    const isExported = modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!isExported) continue;
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name))
+          names.push(declaration.name.text);
+      }
+    } else if (
+      ts.isClassDeclaration(statement) ||
+      ts.isFunctionDeclaration(statement) ||
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement) ||
+      ts.isEnumDeclaration(statement)
+    ) {
+      if (statement.name) names.push(statement.name.text);
+    }
+  }
+
+  return names.toSorted();
+}
+
+const barrelExportNames = collectBarrelExportNames(headlessEntryFile);
+
+describe('@ngx-signal-forms/toolkit/headless — @group JSDoc coverage (issue #360)', () => {
+  it('found at least one export to check (barrel walk did not silently return empty)', () => {
+    expect(barrelExportNames.length).toBeGreaterThan(50);
+  });
+
+  it.each(barrelExportNames)(
+    '%s has a @group tag with a value from the documented taxonomy',
+    (name) => {
+      const jsDoc = findDeclarationJsDoc(headlessEntryFile, name);
+
+      // Anchored to an actual JSDoc tag *line* (`^\s*\*\s*@group\s+...$`,
+      // multiline) rather than a bare `@group` substring search — a
+      // free-text mention in prose or an `@example` code block (e.g. "see
+      // the @group tag on X") must NOT count as a real tag. `g` collects
+      // every tag line in the comment so a duplicate `@group` tag is
+      // visible instead of the first/last match winning silently.
+      const tagLineRegex = /^[ \t]*\*[ \t]*@group[ \t]+(.+?)[ \t]*$/gmu;
+      const matches = [...jsDoc.matchAll(tagLineRegex)];
+
+      if (matches.length === 0) {
+        throw new Error(
+          `Expected a @group tag in the JSDoc for '${name}':\n${jsDoc}`,
+        );
+      }
+      if (matches.length > 1) {
+        const values = matches.map((m) => m[1]).join(', ');
+        throw new Error(
+          `'${name}' has ${matches.length} @group tags in its JSDoc ` +
+            `(expected exactly 1): ${values}`,
+        );
+      }
+
+      // A trailing ` */` (single-line-comment-close on the same line as the
+      // tag) is the only thing the capture could still pick up beyond the
+      // group name itself — strip it before comparing so
+      // `@group Directives */` still validates as `Directives`.
+      const value = matches[0][1].replace(/\*\/\s*$/u, '').trim();
+
+      if (!(ALLOWED_GROUPS as readonly string[]).includes(value)) {
+        throw new Error(
+          `'${name}' has @group '${value}', which is not one of the ` +
+            `documented sections: ${ALLOWED_GROUPS.join(', ')}`,
+        );
+      }
+
+      expect(ALLOWED_GROUPS as readonly string[]).toContain(value);
+    },
+  );
+});

--- a/packages/toolkit/headless/src/index.ts
+++ b/packages/toolkit/headless/src/index.ts
@@ -141,6 +141,8 @@ export {
  * })
  * export class MyComponent {}
  * ```
+ *
+ * @group Directives
  */
 export const NgxHeadlessToolkit = [
   NgxHeadlessErrorState,

--- a/packages/toolkit/headless/src/lib/character-count-types.ts
+++ b/packages/toolkit/headless/src/lib/character-count-types.ts
@@ -19,20 +19,33 @@
  * - `null` / `undefined` — treated as length `0`
  *
  * Any other value type is treated as length `0`.
+ *
+ * Shared by the directive (`field: FieldTree<CharacterCountValue>`) and the
+ * factory (`CreateCharacterCountOptions.field`) alike; grouped with its
+ * three sibling exports from this module under the directive's section
+ * (its primary/canonical consumer) rather than split across two groups.
+ *
+ * @group Directives
  */
 export type CharacterCountValue = string | readonly string[] | null | undefined;
 
 /**
  * Character count limit state.
+ *
+ * @group Directives
  */
 export type CharacterCountLimitState = 'ok' | 'warning' | 'danger' | 'exceeded';
 
 /**
  * Default warning threshold percentage.
+ *
+ * @group Directives
  */
 export const DEFAULT_WARNING_THRESHOLD = 0.8;
 
 /**
  * Default danger threshold percentage.
+ *
+ * @group Directives
  */
 export const DEFAULT_DANGER_THRESHOLD = 0.95;

--- a/packages/toolkit/headless/src/lib/character-count.ts
+++ b/packages/toolkit/headless/src/lib/character-count.ts
@@ -24,6 +24,8 @@ export {
  * The directive requires a `maxLength` input, so the resolved numeric
  * signals are always non-nullable. `hasLimit` is retained for template
  * ergonomics and future extensibility.
+ *
+ * @group Directives
  */
 export interface CharacterCountStateSignals {
   /** Current value length */
@@ -93,6 +95,8 @@ export interface CharacterCountStateSignals {
  *   <!-- Display with 70%/90% thresholds -->
  * </div>
  * ```
+ *
+ * @group Directives
  */
 @Directive({
   selector: '[ngxHeadlessCharacterCount]',

--- a/packages/toolkit/headless/src/lib/create-error-message-signal.ts
+++ b/packages/toolkit/headless/src/lib/create-error-message-signal.ts
@@ -31,6 +31,7 @@ import { resolveErrorMessage } from './utilities';
  *   non-stripped `message` override.
  *
  * @public
+ * @group Reactive Primitives
  */
 export interface ResolvedFieldError {
   readonly kind: string;
@@ -48,6 +49,7 @@ export interface ResolvedFieldError {
  * - `'only'` — warnings only
  *
  * @public
+ * @group Reactive Primitives
  */
 export type IncludeWarningsOption = boolean | 'only';
 
@@ -55,6 +57,7 @@ export type IncludeWarningsOption = boolean | 'only';
  * Options for {@link createErrorMessageSignal}.
  *
  * @public
+ * @group Reactive Primitives
  */
 export interface CreateErrorMessageSignalOptions {
   /**
@@ -215,6 +218,7 @@ type FieldStateAccessor = () => FieldStateInput;
  * ```
  *
  * @public
+ * @group Reactive Primitives
  */
 export function createErrorMessageSignal(
   field: FieldStateAccessor,

--- a/packages/toolkit/headless/src/lib/error-state.ts
+++ b/packages/toolkit/headless/src/lib/error-state.ts
@@ -31,6 +31,8 @@ export type { ResolvedError };
  * Error state signals exposed by the headless directive.
  *
  * These signals provide all the state needed for custom error display implementations.
+ *
+ * @group Directives
  */
 export interface ErrorStateSignals {
   /** Whether to show errors based on the current strategy */
@@ -99,6 +101,8 @@ export interface ErrorStateSignals {
  * ```
  *
  * @template TValue The type of the field value
+ *
+ * @group Directives
  */
 @Directive({
   selector: '[ngxHeadlessErrorState]',

--- a/packages/toolkit/headless/src/lib/error-summary-utilities.ts
+++ b/packages/toolkit/headless/src/lib/error-summary-utilities.ts
@@ -24,6 +24,8 @@ import type { ValidationErrorWithFieldTree } from './field-state-utilities';
 
 /**
  * A resolved error-summary entry ready for rendering.
+ *
+ * @group Utility Functions
  */
 export interface ErrorSummaryEntryData {
   readonly kind: string;
@@ -97,6 +99,7 @@ function fieldIdentityKey(error: ValidationError): string {
  *   `humanizeFieldPath` when `undefined`.
  *
  * @public
+ * @group Utility Functions
  */
 export function resolveFieldNameFromError(
   error: ValidationError,
@@ -122,6 +125,7 @@ export function resolveFieldNameFromError(
  * Uses duck-typed access to `error.fieldTree().focusBoundControl()`.
  *
  * @public
+ * @group Utility Functions
  */
 export function focusBoundControlFromError(error: ValidationError): void {
   const e = error as ValidationErrorWithFieldTree;
@@ -144,6 +148,7 @@ export function focusBoundControlFromError(error: ValidationError): void {
  *   `humanizeFieldPath` when `undefined`
  *
  * @public
+ * @group Utility Functions
  */
 export function toErrorSummaryEntry(
   error: ValidationError,

--- a/packages/toolkit/headless/src/lib/error-summary.ts
+++ b/packages/toolkit/headless/src/lib/error-summary.ts
@@ -16,11 +16,15 @@ import {
 
 /**
  * A resolved error-summary entry with kind, message, and focus capability.
+ *
+ * @group Directives
  */
 export type ErrorSummaryEntry = ErrorSummaryEntryData;
 
 /**
  * Error summary signals exposed by the headless directive.
+ *
+ * @group Directives
  */
 export interface ErrorSummarySignals {
   /** Resolved blocking error entries ready for rendering */
@@ -95,6 +99,8 @@ export interface ErrorSummarySignals {
  *   </ul>
  * </div>
  * ```
+ *
+ * @group Directives
  */
 @Directive({
   selector: '[ngxHeadlessErrorSummary]',

--- a/packages/toolkit/headless/src/lib/field-name.ts
+++ b/packages/toolkit/headless/src/lib/field-name.ts
@@ -16,6 +16,8 @@ import {
 
 /**
  * Field name state signals exposed by the headless directive.
+ *
+ * @group Directives
  */
 export interface FieldNameStateSignals {
   /** Resolved field name from input or override; `null` when no name is resolvable. */
@@ -84,6 +86,8 @@ export interface FieldNameStateSignals {
  *   <label [for]="fieldName.resolvedFieldName()">Email</label>
  * </div>
  * ```
+ *
+ * @group Directives
  */
 @Directive({
   selector: '[ngxHeadlessFieldName]',

--- a/packages/toolkit/headless/src/lib/field-optionality.ts
+++ b/packages/toolkit/headless/src/lib/field-optionality.ts
@@ -9,6 +9,7 @@ import { isFieldStateInteractive } from '@ngx-signal-forms/toolkit/core';
  * no leaf fields — reports `false` for both.
  *
  * @public
+ * @group Reactive Primitives
  */
 export interface FieldOptionality {
   readonly hasRequired: boolean;
@@ -179,6 +180,7 @@ function readRequired(leaf: AnyFieldTree): boolean {
  *
  * @param tree A form `FieldTree` (typically a form root or a subtree).
  * @public
+ * @group Reactive Primitives
  */
 export function summarizeFieldOptionality(
   tree: AnyFieldTree,
@@ -223,6 +225,7 @@ export function summarizeFieldOptionality(
  * ```
  *
  * @public
+ * @group Reactive Primitives
  */
 export function createFieldOptionalitySummary(
   treeSource: () => AnyFieldTree | null | undefined,

--- a/packages/toolkit/headless/src/lib/field-state-utilities.ts
+++ b/packages/toolkit/headless/src/lib/field-state-utilities.ts
@@ -24,6 +24,8 @@ import {
  *
  * Angular Signal Forms exposes these as `Signal<boolean>` properties.
  * We define it locally for type-safe access via duck-typing.
+ *
+ * @group Utility Functions
  */
 export type BooleanStateKey =
   | 'invalid'
@@ -35,6 +37,8 @@ export type BooleanStateKey =
 /**
  * Type representing the shape of FieldState for reading errors.
  * Used for duck-typing access to error properties.
+ *
+ * @group Utility Functions
  */
 export type FieldStateLike = {
   invalid?: ErrorReadableState['invalid'];
@@ -67,6 +71,8 @@ function normalizeValidationErrors(errors: unknown): ValidationError[] {
  * const isInvalid = readFieldFlag(fieldState, 'invalid');
  * const isTouched = readFieldFlag(fieldState, 'touched');
  * ```
+ *
+ * @group Utility Functions
  */
 export function readFieldFlag(state: unknown, key: BooleanStateKey): boolean {
   if (!state || typeof state !== 'object') {
@@ -79,6 +85,8 @@ export function readFieldFlag(state: unknown, key: BooleanStateKey): boolean {
 
 /**
  * Computed boolean state flags from a reactive field state signal.
+ *
+ * @group Reactive Primitives
  */
 export interface FieldStateFlags {
   readonly isInvalid: Signal<boolean>;
@@ -98,6 +106,8 @@ export interface FieldStateFlags {
  *
  * @param fieldState - A signal/computed that returns the field state object
  * @returns Object with computed signals for each boolean flag
+ *
+ * @group Reactive Primitives
  */
 export function createFieldStateFlags(
   fieldState: () => unknown,
@@ -125,6 +135,8 @@ export function createFieldStateFlags(
  * const fieldState = addressField();
  * const allErrors = readErrors(fieldState); // Includes nested field errors
  * ```
+ *
+ * @group Utility Functions
  */
 export function readErrors(state: unknown): ValidationError[] {
   if (!state || typeof state !== 'object') {

--- a/packages/toolkit/headless/src/lib/fieldset.ts
+++ b/packages/toolkit/headless/src/lib/fieldset.ts
@@ -29,6 +29,8 @@ import {
 
 /**
  * Fieldset state signals exposed by the headless directive.
+ *
+ * @group Directives
  */
 export interface FieldsetStateSignals {
   /** Aggregated and deduplicated errors from all fields */
@@ -126,6 +128,8 @@ export interface FieldsetStateSignals {
  * registry → default) as `NgxHeadlessErrorState`.
  *
  * @template TFieldset The type of the fieldset field value
+ *
+ * @group Directives
  */
 @Directive({
   selector: '[ngxHeadlessFieldset]',

--- a/packages/toolkit/headless/src/lib/notification.ts
+++ b/packages/toolkit/headless/src/lib/notification.ts
@@ -15,6 +15,8 @@ import { resolveErrorMessage } from './utilities';
 
 /**
  * Resolved notification message with kind and human-facing message.
+ *
+ * @group Directives
  */
 export interface ResolvedNotificationMessage {
   readonly kind: string;
@@ -26,6 +28,8 @@ export interface ResolvedNotificationMessage {
  * styled component can render a complete grouped notification surface
  * (alert + status live regions, IDs, messages) using only these signals —
  * see the usage example below.
+ *
+ * @group Directives
  */
 export interface NotificationStateSignals {
   /** Whether any messages are present. */
@@ -85,6 +89,8 @@ export interface NotificationStateSignals {
  *   }
  * </div>
  * ```
+ *
+ * @group Directives
  */
 @Directive({
   selector: '[ngxHeadlessNotification]',

--- a/packages/toolkit/headless/src/lib/utilities.ts
+++ b/packages/toolkit/headless/src/lib/utilities.ts
@@ -64,6 +64,8 @@ export {
  * `NgxHeadlessErrorState` share one definition. Mirrors the
  * `CharacterCountValue` re-export above for the same reason: the type moved,
  * the public export path did not.
+ *
+ * @group Directives
  */
 export interface ResolvedError {
   readonly kind: string;
@@ -97,6 +99,8 @@ type ReactiveOrStatic<T> = T | ReadSignal<T>;
  * const unique = dedupeValidationErrors(errors);
  * // [{ kind: 'required', message: 'Required' }, { kind: 'email', message: 'Invalid email' }]
  * ```
+ *
+ * @group Utility Functions
  */
 export function dedupeValidationErrors(
   errors: readonly ValidationError[],
@@ -178,6 +182,8 @@ export function buildHeadlessErrorState(
 
 /**
  * Options for creating error state signals.
+ *
+ * @group Reactive Primitives
  */
 export interface CreateErrorStateOptions<TValue = unknown> {
   /** Form field FieldTree */
@@ -216,6 +222,8 @@ export interface CreateErrorStateOptions<TValue = unknown> {
 
 /**
  * Error state signals returned by createErrorState.
+ *
+ * @group Reactive Primitives
  */
 export interface ErrorStateResult {
   /** Whether to show errors */
@@ -296,6 +304,8 @@ export interface ErrorStateResult {
  *
  * @see {@link splitByKind} and {@link isWarningError} for the warning
  *   convention.
+ *
+ * @group Reactive Primitives
  */
 export function createErrorState<TValue = unknown>(
   options: Readonly<CreateErrorStateOptions<TValue>>,
@@ -354,6 +364,8 @@ function createErrorStateInternal<TValue = unknown>(
 
 /**
  * Options for creating character count signals.
+ *
+ * @group Reactive Primitives
  */
 export interface CreateCharacterCountOptions {
   /** Form field producing a {@link CharacterCountValue}. */
@@ -378,6 +390,8 @@ export interface CreateCharacterCountOptions {
 
 /**
  * Character count signals returned by createCharacterCount.
+ *
+ * @group Reactive Primitives
  */
 export interface CharacterCountResult {
   /** Current value length */
@@ -426,6 +440,8 @@ export interface CharacterCountResult {
  *   console.log(`State: ${charCount.limitState()}`);
  * });
  * ```
+ *
+ * @group Reactive Primitives
  */
 export function createCharacterCount(
   options: Readonly<CreateCharacterCountOptions>,
@@ -511,6 +527,8 @@ export function createCharacterCount(
  * owning the single `createErrorVisibility()`/`createShowErrorsComputed()`
  * seam call (ADR-0006) and threads the results in here; this factory only
  * combines them with the (visibility-independent) presence check.
+ *
+ * @group Reactive Primitives
  */
 export interface CreateFieldsetAggregationOptions {
   /** Reactive reader for the fieldset's own field state (from `field()()`). */
@@ -533,6 +551,8 @@ export interface CreateFieldsetAggregationOptions {
 
 /**
  * Fieldset error/warning aggregation result.
+ *
+ * @group Reactive Primitives
  */
 export interface FieldsetAggregationResult {
   /** Aggregated and deduplicated blocking errors. */
@@ -566,6 +586,8 @@ export interface FieldsetAggregationResult {
  * `createShowErrorsComputed()` call (ADR-0006's single seam).
  *
  * @remarks Does not require an injection context.
+ *
+ * @group Reactive Primitives
  */
 export function createFieldsetAggregation(
   options: Readonly<CreateFieldsetAggregationOptions>,
@@ -664,6 +686,8 @@ const STRIP_WARNING_PREFIX_OPTION = { stripWarningPrefix: true } as const;
  * input — mirrors {@link CreateFieldsetAggregationOptions}'s contract
  * (ADR-0005: factories take DI-resolved values as inputs, never `inject()`
  * themselves).
+ *
+ * @group Reactive Primitives
  */
 export interface CreateErrorSummaryEntriesOptions {
   /** Reactive reader for the root field state (from `formTree()()`). */
@@ -678,6 +702,8 @@ export interface CreateErrorSummaryEntriesOptions {
 
 /**
  * Error-summary entry-mapping result.
+ *
+ * @group Reactive Primitives
  */
 export interface ErrorSummaryEntriesResult {
   /** Resolved blocking error entries ready for rendering. */
@@ -706,6 +732,8 @@ export interface ErrorSummaryEntriesResult {
  * `createFieldsetAggregation`).
  *
  * @remarks Does not require an injection context.
+ *
+ * @group Reactive Primitives
  */
 export function createErrorSummaryEntries(
   options: Readonly<CreateErrorSummaryEntriesOptions>,


### PR DESCRIPTION
Docs-only discovery pass over the headless entry point. All 74 public exports of the barrel (as reshaped by #354) now carry exactly one `@group` JSDoc tag — **Directives**, **Reactive Primitives**, **ARIA Composition**, or **Utility Functions** — placed at the true declaration site, including the `/core`-sourced factories the barrel re-exports (their group names are entry-neutral, so root-barrel consumers read them correctly too). The headless README is reorganized into the same four use-case sections, content preserved; two stale rows naming APIs deleted in rc.12 (`createErrorRendererInputs`, `toHintDescriptors`) are dropped.

The tags are enforced mechanically: a new `group-tags.spec.ts` (following the `packaging.spec.ts` source-verification precedent) reads the entry file from `ng-package.json`, walks every export through re-export chains, `export *`, and tsconfig-path package imports down to the declaration, and asserts a `@group` tag whose value is in the allowed four-group set — a missing *or typo'd* group fails one test per export. Mutation-tested: stripping a tag or misspelling a group makes exactly the affected tests fail.

No export is added, removed, or renamed; every hunk outside the new spec is comment-only.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
