### PR TITLE
refactor(demo): let ngxSignalFormControl own the rating control's semantics marker

### DIFF
--- a/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
+++ b/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
@@ -384,6 +384,16 @@ test.describe('Custom Signal Forms Controls', () => {
         }
       });
 
+      // The component no longer hand-authors this marker in its host
+      // metadata (#369); it reaches the DOM only via the
+      // ngxSignalFormControl directive applied at the call sites.
+      await test.step('Verify the rating control host carries the semantics marker', async () => {
+        await expect(page.ratingControl).toHaveAttribute(
+          'data-ngx-signal-form-control',
+          '',
+        );
+      });
+
       await test.step('Verify the rating control starts with its hint-only described-by chain', async () => {
         await expect(page.ratingControl).toHaveAttribute(
           'aria-describedby',

--- a/apps/demo/src/app/shared/controls/rating-control.ts
+++ b/apps/demo/src/app/shared/controls/rating-control.ts
@@ -48,7 +48,6 @@ import { NgxFieldIdentity } from '@ngx-signal-forms/toolkit';
   changeDetection: ChangeDetectionStrategy.OnPush,
 
   host: {
-    'data-ngx-signal-form-control': '',
     role: 'slider',
     '[attr.tabindex]': 'disabled() ? -1 : 0',
     '[attr.aria-labelledby]': 'resolvedLabelledBy()',


### PR DESCRIPTION
The demo's custom star-rating control hand-authored `data-ngx-signal-form-control` in its host metadata while every call site already applies `ngxSignalFormControl="slider"` — the public directive that owns that marker and the resolved `kind`/`layout`/`aria-mode` attributes. The duplicate is removed; the directive is now the single semantics declaration, and the rendered output is unchanged (verified against the directive source and the custom-controls E2E suite, 27/27 twice).

The existing suite asserted the resolved attributes on the wrapper but never the bare marker on the control host, so one focused `test.step` now pins exactly the attribute that used to be hand-authored. Everything the control intentionally owns — `role="slider"`, value ARIA, keyboard interaction, described-by composition, manual ARIA mode — is untouched.

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
