### PR TITLE
docs(demo): describe implicit live-region semantics accurately

### DIFF
--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.content.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.content.ts
@@ -29,8 +29,8 @@ export const WARNING_SUPPORT_CONTENT = {
       {
         title: 'WCAG 2.2 Messaging',
         items: [
-          '<strong>Errors:</strong> <code>role="alert"</code> with <code>aria-live="assertive"</code>',
-          '<strong>Warnings:</strong> <code>role="status"</code> with <code>aria-live="polite"</code>',
+          '<strong>Errors:</strong> <code>role="alert"</code> (implicitly assertive; the toolkit renders no explicit <code>aria-live</code>)',
+          '<strong>Warnings:</strong> <code>role="status"</code> (implicitly polite; the toolkit renders no explicit <code>aria-live</code>)',
           'Immediate announcement for errors (blocking)',
           'Polite announcement for warnings (non-intrusive)',
         ],

--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.validations.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.validations.ts
@@ -21,8 +21,8 @@ import type { PasswordFormModel } from './warning-support.model';
  * non-blocking warning (see the `validate()` blocks below). The toolkit's error
  * components automatically:
  * - Separate warnings from blocking errors in the UI
- * - Display warnings with ARIA role="status" aria-live="polite" (non-intrusive)
- * - Display errors with ARIA role="alert" aria-live="assertive" (immediate)
+ * - Display warnings with ARIA role="status" (implicitly polite; non-intrusive)
+ * - Display errors with ARIA role="alert" (implicitly assertive; immediate)
  * - Style warnings differently (amber vs red)
  * - Allow form submission even with warnings present
  *


### PR DESCRIPTION
The Warning Support page promised DOM the toolkit deliberately does not produce: it claimed errors render `role="alert"` with `aria-live="assertive"` and warnings `role="status"` with `aria-live="polite"`. The toolkit relies on the roles' implicit live-region semantics and omits explicit `aria-live`/`aria-atomic` (the NVDA + Firefox double-announcement workaround documented in `form-field-error.ts`). The page copy and the schema doc comment now describe errors as implicitly assertive and warnings as implicitly polite, noting no explicit attribute is rendered.

A demo- and docs-wide grep for `aria-live`/`aria-atomic`/role claims found every other mention already accurate — including hand-rolled demo markup that legitimately renders its own explicit attributes. Warning Support E2E: 16/16 green; no spec asserted the changed text.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
