### PR TITLE
docs(demo): explain Standard Schema requiredness metadata bridging

### DIFF
--- a/apps/demo/src/app/05-advanced/zod-validation/zod-validation.content.ts
+++ b/apps/demo/src/app/05-advanced/zod-validation/zod-validation.content.ts
@@ -53,6 +53,15 @@ export const ZOD_VALIDATION_CONTENT = {
           '• Keeping this route small makes it a stable learning and regression baseline.',
         ],
       },
+      {
+        title: 'Required markers with Standard Schema',
+        items: [
+          '• <strong><code>validateStandardSchema()</code> maps issues, not requiredness:</strong> the Standard Schema contract gives no portable way to ask "is this field required?" The toolkit cannot safely read an object&apos;s keys from the schema alone, so it cannot enumerate required fields from a single root-level call.',
+          '• <strong>Per-field bridge:</strong> <code>requiredFromStandardSchema(path.field, schema)</code> closes that gap. It probes one field at a time and registers Angular&apos;s <code>REQUIRED</code> metadata — the signal that drives <code>aria-required</code> and the wrapper&apos;s required marker. This demo calls it once for each required field: first name, last name, email, password, account type, and country.',
+          '• <strong>What it does not catch:</strong> conditional or async requiredness is not inferred by this synchronous probe — only a field&apos;s unconditional base-schema requiredness is.',
+          '• <strong>Read more:</strong> <a href="https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/FAQ.md">FAQ</a> · <a href="https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/MIGRATING_BETA_TO_V1.md">beta-to-v1 migration guide</a>.',
+        ],
+      },
     ],
     nextStep: {
       text: 'Layer business policy on top of Zod next →',

--- a/apps/demo/src/app/05-advanced/zod-vest-validation/zod-vest-validation.content.ts
+++ b/apps/demo/src/app/05-advanced/zod-vest-validation/zod-vest-validation.content.ts
@@ -58,6 +58,15 @@ export const ZOD_VEST_VALIDATION_CONTENT = {
           '• Flows that want native Angular <code>submit()</code> while still teaching users through non-blocking warnings.',
         ],
       },
+      {
+        title: 'Required markers with Standard Schema',
+        items: [
+          '• <strong><code>validateStandardSchema()</code> maps issues, not requiredness:</strong> the Standard Schema contract gives no portable way to ask "is this field required?" The toolkit cannot safely read an object&apos;s keys from the schema alone, so it cannot enumerate required fields from a single root-level call.',
+          '• <strong>Per-field bridge:</strong> <code>requiredFromStandardSchema(path.field, schema)</code> closes that gap. It probes one field at a time and registers Angular&apos;s <code>REQUIRED</code> metadata — the signal that drives <code>aria-required</code> and the wrapper&apos;s required marker. This demo calls it once per unconditionally required Zod field: first name, last name, email, password, account type, and country.',
+          '• <strong>What it does not catch:</strong> conditional or async requiredness is not inferred by this synchronous probe. <strong>VAT number</strong> is a live example — it is only required for <code>Business</code> accounts in <code>DE</code>/<code>NL</code>/<code>BE</code>, so that rule lives in the Vest suite instead, not in a <code>requiredFromStandardSchema()</code> call.',
+          '• <strong>Read more:</strong> <a href="https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/FAQ.md">FAQ</a> · <a href="https://github.com/ngx-signal-forms/ngx-signal-forms/blob/main/docs/MIGRATING_BETA_TO_V1.md">beta-to-v1 migration guide</a>.',
+        ],
+      },
     ],
     nextStep: {
       text: 'Compare this with a pure Vest suite →',


### PR DESCRIPTION
Both Zod demo pages now carry a "Required markers with Standard Schema" learning card explaining what previously read as unexplained boilerplate: `validateStandardSchema()` maps validation issues but the Standard Schema contract exposes no portable requiredness metadata or safe root-level key enumeration, so `requiredFromStandardSchema(path.field, schema)` is the deliberate per-field bridge that powers `aria-required` and the wrapper required marker.

The copy explicitly scopes the synchronous probe — conditional/async requiredness is not inferred, and the Zod + Vest page uses its own VAT-number rule (required only for Business accounts in DE/NL/BE, enforced by Vest) as the live counterexample. Links out to the FAQ and the beta-to-v1 migration guide; nothing implies automatic discovery or a new root-level helper.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
