### PR TITLE
test(demo-e2e): cover Server Integration resource and server-error flows

### DIFF
--- a/apps/demo-e2e/src/forms/05-advanced/server-integration.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/server-integration.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from '@playwright/test';
+import { ServerIntegrationPage } from '../../page-objects/server-integration.page';
+
+/**
+ * Advanced Scenarios - Server Integration - E2E Tests
+ * Route: /advanced-scenarios/server-integration
+ *
+ * Covers the "edit record" flow: `resource()` prefill, a Save that can be
+ * rejected by the fake server (a `taken@example.com` email trips both a
+ * form-level banner and a field error via a native `TreeValidationResult`),
+ * editing to clear the server error, a successful save that re-baselines the
+ * form as pristine, and a reload that restores the last-saved record.
+ *
+ * Determinism note: `ProfileApiService` (server-integration.api.ts) is a
+ * plain in-memory fake gated by a real `setTimeout(400ms)` — it does not go
+ * through `HttpClient`/MSW, so there is no request to gate with `page.route`.
+ * Racing that real 400ms window against page-load/bootstrap time is exactly
+ * the kind of flake this suite avoids elsewhere with `page.route` gating: a
+ * contended dev server can push Angular's bootstrap itself past 400ms, so the
+ * loading state can resolve — and vanish — before it is ever observed.
+ *
+ * Playwright's Clock API cannot fix this: pausing time from before
+ * navigation (the only way to guarantee the 400ms `setTimeout` never fires
+ * early) also freezes the timers Angular's own zoneless change-detection
+ * scheduler needs, so the page never renders past the app shell at all —
+ * verified directly (with the clock paused pre-navigation, neither the
+ * loading indicator nor the form ever mounted, even after `fastForward`).
+ * Instead, `ServerIntegrationPage.holdPrefillTimer()` installs an init
+ * script that intercepts only the one `setTimeout` call requesting exactly
+ * 400ms and holds it unfired until the test explicitly releases it — every
+ * other timer (Angular's own scheduling included) passes through untouched.
+ * See that method's doc comment for the full mechanism. That test therefore
+ * runs on its own, outside the shared `beforeEach`, so the hold can be
+ * installed before `goto()`.
+ */
+test.describe('Advanced Scenarios - Server Integration', () => {
+  test('shows a loading indicator before the profile resource resolves, then prefills pristine', async ({
+    page,
+  }) => {
+    const serverIntegration = new ServerIntegrationPage(page);
+    await serverIntegration.holdPrefillTimer();
+    await serverIntegration.goto();
+
+    // The prefill's `setTimeout` is held, so this can never race — the
+    // indicator is guaranteed to still be mounted regardless of how long
+    // bootstrap took.
+    await expect(serverIntegration.loadingIndicator).toBeVisible();
+
+    await serverIntegration.releasePrefillTimer();
+
+    await expect(serverIntegration.loadingIndicator).toBeHidden();
+    await expect(serverIntegration.nameInput).toHaveValue('Grace Hopper');
+    await expect(serverIntegration.emailInput).toHaveValue('grace@example.com');
+    await expect(serverIntegration.debugLine('dirty', false)).toBeVisible();
+    await expect(serverIntegration.debugLine('touched', false)).toBeVisible();
+  });
+});
+
+test.describe('Advanced Scenarios - Server Integration (loaded)', () => {
+  let serverIntegration: ServerIntegrationPage;
+
+  test.beforeEach(async ({ page }) => {
+    serverIntegration = new ServerIntegrationPage(page);
+    await serverIntegration.goto();
+    await expect(serverIntegration.loadingIndicator).toBeHidden();
+  });
+
+  test('disables Save when Name is cleared', async () => {
+    await expect(serverIntegration.saveButton).toBeEnabled();
+
+    await serverIntegration.nameInput.fill('');
+
+    await expect(serverIntegration.saveButton).toBeDisabled();
+    await expect(serverIntegration.debugLine('invalid', true)).toBeVisible();
+  });
+
+  test('rejects a taken email with a form banner and a field error, and clears both once Email is edited', async () => {
+    await test.step('submitting taken@example.com surfaces the banner and the field error', async () => {
+      await serverIntegration.emailInput.fill('taken@example.com');
+      await serverIntegration.save();
+
+      await expect(serverIntegration.saveButton).toHaveText('Saving…');
+      await expect(serverIntegration.saveButton).toBeDisabled();
+
+      await expect(serverIntegration.formBanner).toBeVisible();
+      await expect(serverIntegration.formBanner).toContainText(
+        'Please fix the errors below.',
+      );
+      await expect(serverIntegration.emailFieldError).toBeVisible();
+      await expect(serverIntegration.emailInput).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      );
+    });
+
+    await test.step('editing Email clears the field error and the root submission error', async () => {
+      await serverIntegration.emailInput.fill('grace.fixed@example.com');
+
+      await expect(serverIntegration.emailFieldError).toHaveCount(0);
+      await expect(serverIntegration.formBanner).toHaveCount(0);
+      await expect(serverIntegration.emailInput).not.toHaveAttribute(
+        'aria-invalid',
+        'true',
+      );
+    });
+  });
+
+  test('a successful save resets dirty/touched, and reloading restores the saved values', async () => {
+    await test.step('saving valid changes shows the success state and re-baselines pristine', async () => {
+      await serverIntegration.nameInput.fill('Grace M. Hopper');
+      await serverIntegration.emailInput.fill('grace.hopper@navy.mil');
+      await serverIntegration.save();
+
+      await expect(serverIntegration.saveButton).toHaveText('Saving…');
+      await expect(serverIntegration.successBanner).toBeVisible();
+      await expect(serverIntegration.saveButton).toHaveText('Save profile');
+
+      await expect(serverIntegration.debugLine('dirty', false)).toBeVisible();
+      await expect(serverIntegration.debugLine('touched', false)).toBeVisible();
+      // The fields keep showing what was typed — reset(value) re-baselines,
+      // it does not blank the form.
+      await expect(serverIntegration.nameInput).toHaveValue('Grace M. Hopper');
+      await expect(serverIntegration.emailInput).toHaveValue(
+        'grace.hopper@navy.mil',
+      );
+    });
+
+    await test.step('reload from server restores the just-saved record and settles pristine', async () => {
+      // Dirty the form with an unsaved edit first — otherwise the fields
+      // already showing the saved values would make the assertions below
+      // pass even if Reload were a no-op.
+      await serverIntegration.nameInput.fill('Unsaved Local Edit');
+      await expect(serverIntegration.debugLine('dirty', true)).toBeVisible();
+
+      await serverIntegration.reload();
+
+      await expect(serverIntegration.reloadButton).toHaveText('Reloading…');
+      await expect(serverIntegration.reloadButton).toHaveText(
+        'Reload from server',
+      );
+
+      // The unsaved edit is gone; the last *saved* values come back.
+      await expect(serverIntegration.nameInput).toHaveValue('Grace M. Hopper');
+      await expect(serverIntegration.emailInput).toHaveValue(
+        'grace.hopper@navy.mil',
+      );
+      await expect(serverIntegration.debugLine('dirty', false)).toBeVisible();
+      await expect(serverIntegration.debugLine('touched', false)).toBeVisible();
+    });
+  });
+});

--- a/apps/demo-e2e/src/page-objects/server-integration.page.ts
+++ b/apps/demo-e2e/src/page-objects/server-integration.page.ts
@@ -1,0 +1,164 @@
+import { DEMO_PATHS } from '@ngx-signal-forms/demo-shared';
+import { Locator, Page } from '@playwright/test';
+import {
+  ROLE_ALERT_SELECTOR,
+  ROLE_STATUS_SELECTOR,
+} from '../fixtures/aria-selectors';
+import { BaseFormPage } from './base-form.page';
+
+/**
+ * `ProfileApiService#loadProfile()` (server-integration.api.ts) delays its
+ * resolution by exactly this many milliseconds via a plain `setTimeout` —
+ * not `HttpClient`/MSW, so there is nothing for `page.route` to gate. Kept
+ * in sync with `SIMULATED_LATENCY_MS` in that file; only used to identify
+ * the specific `setTimeout` call to hold in {@link ServerIntegrationPage.holdPrefillTimer}.
+ */
+const PREFILL_DELAY_MS = 400;
+
+/**
+ * Global hook name installed by {@link ServerIntegrationPage.holdPrefillTimer}
+ * for {@link ServerIntegrationPage.releasePrefillTimer} to call.
+ */
+const RELEASE_HOOK = '__ngxE2EReleasePrefillTimer';
+
+/**
+ * Page Object for "Advanced - Server Integration" demo
+ * Route: /advanced-scenarios/server-integration
+ *
+ * Prefills from a fake `resource()`-backed API, submits an edit, and maps
+ * server-side field/form errors back onto the form via a native
+ * `TreeValidationResult`.
+ */
+export class ServerIntegrationPage extends BaseFormPage {
+  readonly nameInput: Locator;
+  readonly emailInput: Locator;
+  readonly saveButton: Locator;
+  readonly resetButton: Locator;
+  readonly reloadButton: Locator;
+  readonly loadingIndicator: Locator;
+  readonly successBanner: Locator;
+  readonly formBanner: Locator;
+  readonly emailFieldError: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.nameInput = this.page.getByRole('textbox', { name: 'Name' });
+    this.emailInput = this.page.getByRole('textbox', { name: 'Email' });
+    this.saveButton = this.page.getByRole('button', {
+      name: /^(Save profile|Saving…)$/,
+    });
+    this.resetButton = this.page.getByRole('button', { name: 'Reset' });
+    this.reloadButton = this.page.getByRole('button', {
+      name: /^(Reload from server|Reloading…)$/,
+    });
+    this.loadingIndicator = this.page.locator(ROLE_STATUS_SELECTOR, {
+      hasText: 'Loading profile from server',
+    });
+    this.successBanner = this.page.locator(ROLE_STATUS_SELECTOR, {
+      hasText: 'Profile saved',
+    });
+    this.formBanner = this.page.locator(ROLE_ALERT_SELECTOR, {
+      hasText: 'Could not save profile',
+    });
+    this.emailFieldError = this.page.locator(ROLE_ALERT_SELECTOR, {
+      hasText: 'This email is already taken.',
+    });
+  }
+
+  async goto(): Promise<void> {
+    await this.gotoRoute(DEMO_PATHS.serverIntegration);
+  }
+
+  /**
+   * Deterministically holds the profile prefill open before the resource
+   * resolves — the same "gate on a manually-resolved promise" pattern this
+   * suite uses elsewhere via `page.route`, adapted for a demo with no
+   * network call to gate.
+   *
+   * `ProfileApiService` isn't backed by `HttpClient`/MSW, so there is no
+   * request to intercept, and Playwright's Clock API is not an option
+   * either: freezing time from before navigation (the only way to guarantee
+   * the 400ms `setTimeout` never fires early) also freezes the timers
+   * Angular's own zoneless change-detection scheduler depends on, so the
+   * page never renders past the shell at all (verified: with the clock
+   * paused pre-navigation, neither the loading indicator nor the form ever
+   * mounts, even after `fastForward`).
+   *
+   * Instead, an init script installed before any app code runs intercepts
+   * exactly one `setTimeout` call requesting {@link PREFILL_DELAY_MS} — the
+   * one `delay()` call the prefill's `resource()` loader makes — and holds
+   * it unfired. The interception is **one-shot**: the moment that first
+   * matching call is captured, `window.setTimeout` is restored to the
+   * native implementation immediately (not merely after release), so it
+   * cannot also swallow the *later* 400ms `setTimeout` calls the Save/Reload
+   * actions make on this same page (`SIMULATED_LATENCY_MS` is shared across
+   * all three). Every other `setTimeout`/`setInterval` call — including
+   * Angular's own scheduling — passes through untouched throughout. The
+   * held timer only ever fires once {@link releasePrefillTimer} calls it
+   * explicitly, so the loading indicator is guaranteed to still be mounted
+   * no matter how long bootstrap itself takes.
+   *
+   * Must be called before {@link goto}.
+   */
+  async holdPrefillTimer(): Promise<void> {
+    await this.page.addInitScript(
+      ({ delayMs, releaseHookName }) => {
+        const originalSetTimeout = window.setTimeout.bind(window);
+        let held: { handler: TimerHandler; args: unknown[] } | undefined;
+
+        (window as unknown as Record<string, () => void>)[releaseHookName] =
+          () => {
+            if (held) {
+              originalSetTimeout(held.handler, 0, ...held.args);
+              held = undefined;
+            }
+          };
+
+        window.setTimeout = ((
+          handler: TimerHandler,
+          timeout?: number,
+          ...args: unknown[]
+        ) => {
+          if (timeout === delayMs && !held) {
+            held = { handler, args };
+            // One-shot: restore the native setTimeout immediately so no
+            // later 400ms call (e.g. Save/Reload, which share the same
+            // simulated latency) is ever intercepted.
+            window.setTimeout = originalSetTimeout;
+            return 0 as unknown as ReturnType<typeof window.setTimeout>;
+          }
+          return originalSetTimeout(handler, timeout, ...args);
+        }) as typeof window.setTimeout;
+      },
+      { delayMs: PREFILL_DELAY_MS, releaseHookName: RELEASE_HOOK },
+    );
+  }
+
+  /** Releases the `setTimeout` held by {@link holdPrefillTimer}, letting the prefill resolve. */
+  async releasePrefillTimer(): Promise<void> {
+    await this.page.evaluate((releaseHookName) => {
+      (window as unknown as Record<string, () => void>)[releaseHookName]();
+    }, RELEASE_HOOK);
+  }
+
+  /**
+   * The `invalid()`/`submitting()`/`dirty()`/`touched()` debug readout
+   * rendered by the form itself (public DOM). Scoped to `this.form` because
+   * the split-layout right pane also mounts `NgxSignalFormDebugger`, which
+   * echoes the same `dirty()`/`touched()` text inside a `<code>` block.
+   */
+  debugLine(
+    signalName: 'invalid' | 'submitting' | 'dirty' | 'touched',
+    value: boolean,
+  ): Locator {
+    return this.form.getByText(`${signalName}(): ${value}`, { exact: true });
+  }
+
+  async save(): Promise<void> {
+    await this.saveButton.click();
+  }
+
+  async reload(): Promise<void> {
+    await this.reloadButton.click();
+  }
+}


### PR DESCRIPTION
Adds the dedicated Server Integration E2E suite (`server-integration.spec.ts` + `ServerIntegrationPage`): the loading indicator before the resource resolves, the Grace Hopper prefill settling pristine, client-invalid Save gating, the `taken@example.com` conflict raising both the form-level banner and the Email field error, an edit clearing both, a successful save resetting dirty/touched while retaining values, and Reload discarding an unsaved local edit to restore the last saved values pristine. All assertions use public DOM surfaces only.

Two things worth a reviewer's attention:

- **The loading-indicator determinism mechanism.** The demo's API is a plain in-memory fake gated by `setTimeout(400)` (not MSW/HTTP, contrary to the issue brief — noted as drift), so `page.route` gating can't help, and Playwright's Clock API turned out unusable: pausing before navigation stalls Angular's zoneless change-detection scheduler entirely (verified empirically), while pausing after navigation leaves the race open because the clock auto-ticks until paused. The suite instead installs an init-script that holds only the prefill's 400ms `setTimeout` un-fired until the test releases it — every other timer passes through — so the indicator is guaranteed observable regardless of bootstrap speed. Stress-verified: the previous approach flaked ~1-in-4 under 4-worker contention; the hold ran clean across repeated targeted stress runs.
- **Reload is proven to do something.** The test dirties Name with an unsaved edit before clicking Reload, then asserts the edit is discarded and the last-saved values return pristine — it fails if Reload were a no-op.

Verified 4/4 across 3 consecutive runs plus `--repeat-each=3` (12/12) and a targeted `--repeat-each=6` on the loading-indicator test.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
