### PR TITLE
feat(demo): third-party widget adapter — FormValueControl around a legacy datepicker

### DIFF
--- a/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
+++ b/apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts
@@ -1019,4 +1019,130 @@ test.describe('Custom Signal Forms Controls', () => {
       });
     });
   });
+
+  // Regression coverage for issue #272: LegacyDatepickerAdapterComponent, a
+  // FormValueControl<Date | null> adapter around a self-contained fake
+  // "legacy" third-party datepicker widget. See
+  // apps/demo/src/app/shared/controls/legacy-datepicker-adapter.ts for the
+  // full design writeup this pins down.
+  test.describe('Legacy Datepicker Adapter', () => {
+    test('should render the widget with manual ARIA ownership and no wrapper-owned aria-invalid on load', async () => {
+      await expect(page.birthDateInput).toBeVisible();
+      await expect(page.birthDateInput).toHaveAttribute(
+        'aria-invalid',
+        'false',
+      );
+
+      // Manual ARIA mode: the adapter host (not the wrapper, and not the
+      // widget's internal input) carries the semantics marker, matching the
+      // `ngxSignalFormControlAria="manual"` declared in the template.
+      await expect(page.birthDateAdapterHost).toHaveAttribute(
+        'data-ngx-signal-form-control-aria-mode',
+        'manual',
+      );
+    });
+
+    test('should forward aria-describedby/aria-invalid onto the widget internal input, not the adapter host', async () => {
+      await test.step('Touch the field with unparseable text to trigger a parse error', async () => {
+        await page.birthDateInput.fill('not-a-date');
+        await page.birthDateInput.blur();
+      });
+
+      await test.step('Verify the described-by/invalid attributes land on the real input', async () => {
+        await expect(page.birthDateInput).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+        await expect(page.birthDateInput).toHaveAttribute(
+          'aria-describedby',
+          /birthDate-error/,
+        );
+      });
+
+      await test.step('Verify the error message renders as a parse error', async () => {
+        const error = page.getErrorById('birthDate');
+        await expect(error).toBeVisible();
+        await expect(error).toContainText(/not a date in yyyy-mm-dd format/i);
+      });
+    });
+
+    test('should surface an impossible calendar date as a parse error', async () => {
+      await page.birthDateInput.fill('2026-02-30');
+      await page.birthDateInput.blur();
+
+      const error = page.getErrorById('birthDate');
+      await expect(error).toBeVisible();
+      await expect(error).toContainText(/not a real calendar date/i);
+    });
+
+    test('should clear the parse error once the typed text becomes a real date', async () => {
+      await test.step('Trigger the parse error', async () => {
+        await page.birthDateInput.fill('garbage');
+        await page.birthDateInput.blur();
+        await expect(page.getErrorById('birthDate')).toBeVisible();
+      });
+
+      await test.step('Replace it with a real date', async () => {
+        await page.birthDateInput.fill('');
+        await page.birthDateInput.fill('1990-05-17');
+        await page.birthDateInput.blur();
+      });
+
+      await test.step('Verify the error clears and aria-invalid resets', async () => {
+        await expect(page.getErrorById('birthDate')).toHaveCount(0);
+        await expect(page.birthDateInput).toHaveAttribute(
+          'aria-invalid',
+          'false',
+        );
+      });
+    });
+
+    test('should not mark the field touched while focus moves within the widget, but does once focus truly leaves', async () => {
+      await test.step('Seed invalid text, then move focus from the input to the widget trigger button', async () => {
+        // Invalid text first: a false-positive touch (e.g. from a naive
+        // (blur) on the input, which the composite focusout +
+        // relatedTarget hook exists to avoid) must be observable as a
+        // rendered `parse` error below. An empty, valid field would pass
+        // this assertion even with a plain (blur) adapter.
+        await page.birthDateInput.fill('bad-date');
+        await page.birthDateInput.focus();
+        await page.birthDateTrigger.focus();
+      });
+
+      await test.step('Verify no error renders yet — the internal hop did not touch the field', async () => {
+        // aria-invalid mirrors the field's raw validity unconditionally
+        // (same convention as the rating controls elsewhere on this page),
+        // so it is not gated by touched and is not the discriminating
+        // signal here. The rendered error message is what the wrapper's
+        // 'on-touch' strategy actually gates.
+        await expect(page.getErrorById('birthDate')).toHaveCount(0);
+      });
+
+      await test.step('Verify leaving the whole widget does mark it touched', async () => {
+        await page.productNameInput.focus();
+
+        await expect(page.getErrorById('birthDate')).toBeVisible();
+        await expect(page.birthDateInput).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+      });
+    });
+
+    test('should round-trip a value picked from the popup calendar and clear it on reset', async () => {
+      await test.step('Pick a date from the popup', async () => {
+        await page.pickTodayInBirthDatePopup();
+      });
+
+      await test.step('Verify the text input reflects the picked date and the popup closed', async () => {
+        await expect(page.birthDatePopup).toBeHidden();
+        await expect(page.birthDateInput).not.toHaveValue('');
+      });
+
+      await test.step('Reset the form and verify the widget clears back to empty', async () => {
+        await page.getSubmitButton(/reset/i).click();
+        await expect(page.birthDateInput).toHaveValue('');
+      });
+    });
+  });
 });

--- a/apps/demo-e2e/src/page-objects/custom-controls.page.ts
+++ b/apps/demo-e2e/src/page-objects/custom-controls.page.ts
@@ -30,6 +30,12 @@ export class CustomControlsPage extends BaseFormPage {
   readonly wouldRecommendControl: Locator;
   readonly accessibilityAuditControl: Locator;
 
+  // Legacy datepicker adapter (FormValueControl<Date | null>)
+  readonly birthDateInput: Locator;
+  readonly birthDateTrigger: Locator;
+  readonly birthDatePopup: Locator;
+  readonly birthDateAdapterHost: Locator;
+
   constructor(page: Page) {
     super(page);
 
@@ -65,6 +71,16 @@ export class CustomControlsPage extends BaseFormPage {
     this.serviceRatingControl = this.form.locator('#serviceRating');
     this.wouldRecommendControl = this.form.locator('#wouldRecommend');
     this.accessibilityAuditControl = this.form.locator('#accessibilityAudit');
+
+    // Legacy datepicker adapter
+    this.birthDateInput = this.form.locator('#birthDate');
+    this.birthDateTrigger = this.form.getByRole('button', {
+      name: 'Choose date',
+    });
+    this.birthDatePopup = this.form.locator('.legacy-datepicker__popup');
+    this.birthDateAdapterHost = this.form.locator(
+      'ngx-legacy-datepicker-adapter',
+    );
   }
 
   /**
@@ -196,6 +212,15 @@ export class CustomControlsPage extends BaseFormPage {
     if (!(await this.shareReviewPubliclyCheckbox.isChecked())) {
       await this.shareReviewPubliclyCheckbox.click();
     }
+  }
+
+  /**
+   * Open the legacy datepicker popup and pick today's date (the widget's
+   * grid always renders the current month by default).
+   */
+  async pickTodayInBirthDatePopup(): Promise<void> {
+    await this.birthDateTrigger.click();
+    await this.birthDatePopup.locator('[aria-current="date"]').click();
   }
 
   /**

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md
@@ -12,6 +12,7 @@ Angular Signal Forms replaces the legacy `ControlValueAccessor` boilerplate with
 - `ngxSignalFormControl="checkbox"` — opt-in checkbox semantics for a standard checkbox.
 - `ngxSignalFormControl="slider"` — custom slider with `layout: 'custom'` and `ariaMode: 'manual'` so the control owns its own `aria-describedby` chain.
 - Component-scoped control presets inherited via `provideNgxSignalFormControlPresetsForComponent()`.
+- `LegacyDatepickerAdapterComponent` — a `FormValueControl<Date | null>` adapter wrapped around a self-contained fake third-party datepicker widget (`LegacyDatepickerComponent`), demonstrating `ngxSignalFormControlAria="manual"` plus Angular's `transformedValue()` for the parse/format boundary. See [docs/CUSTOM_CONTROLS.md](../../../../../../docs/CUSTOM_CONTROLS.md#adapting-an-existing-third-party-widget).
 
 ## Form model
 
@@ -44,7 +45,10 @@ Angular Signal Forms replaces the legacy `ControlValueAccessor` boilerplate with
 - [custom-controls.form.ts](custom-controls.form.ts) — consuming form and wrapper bindings.
 - [custom-controls.html](custom-controls.html) — template with the three control semantics paths.
 - [custom-controls.validations.ts](custom-controls.validations.ts) — schema rules.
+- [custom-controls.legacy-datepicker.spec.ts](custom-controls.legacy-datepicker.spec.ts) — unit coverage for the third-party widget adapter (value round-trip, `parse` errors, composite touched hook, programmatic reset).
 - `apps/demo/src/app/shared/controls/rating-control` — reusable star rating implementation.
+- `apps/demo/src/app/shared/controls/legacy-datepicker-widget` — the fake, self-contained "legacy" third-party datepicker widget (its own value/change API; no Signal Forms awareness).
+- `apps/demo/src/app/shared/controls/legacy-datepicker-adapter` — the `FormValueControl<Date | null>` adapter that bridges the widget above; see its class-level doc comment for the full design writeup.
 
 ## How to test
 
@@ -54,6 +58,8 @@ Angular Signal Forms replaces the legacy `ControlValueAccessor` boilerplate with
 4. Blur the share-review checkbox without checking it and verify the wrapper error appears via explicit checkbox semantics.
 5. Blur the accessibility-audit slider empty and confirm it keeps its own `aria-describedby` chain while still rendering wrapper errors.
 6. Toggle the email-updates switch to observe the inline-row preset applied at the app level.
+7. Type `not-a-date` into Date of Birth and tab out — a `parse` error renders; replace it with a real date to clear it.
+8. Click the 📅 button, pick a day from the popup, then click Reset — confirm the text field clears, proving the value round-trips through the adapter in both directions.
 
 ## Related
 

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.content.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.content.ts
@@ -32,6 +32,15 @@ export const CUSTOM_CONTROLS_CONTENT: ExampleCardConfig = {
         ],
       },
       {
+        title: 'Adapting a third-party widget',
+        items: [
+          'LegacyDatepickerAdapterComponent implements <code>FormValueControl&lt;Date | null&gt;</code> around a self-contained fake "legacy" datepicker with its own value/change API — no toolkit or Signal Forms knowledge in the widget itself',
+          "<code>transformedValue()</code> owns the parse/format boundary between the widget's raw text and the field's <code>Date | null</code>, and reports a <code>kind: 'parse'</code> error automatically when the text is not a real YYYY-MM-DD date",
+          "Touched is reported on <code>(focusout)</code> with a relatedTarget containment check — not a plain <code>(blur)</code> — because focus moves across the widget's input, trigger button, and popup day buttons before the user is actually done",
+          'The widget owns its own internal <code>&lt;input&gt;</code>, so the wrapper stays <code>appearance="plain"</code> and the adapter forwards <code>aria-describedby</code>/<code>aria-invalid</code>/<code>aria-required</code> down onto that input via the widget\'s own passthrough inputs',
+        ],
+      },
+      {
         title: 'Wrapper Integration',
         items: [
           'Auto-derives field names for simple projected controls and supports explicit fieldName for nested custom controls',
@@ -60,6 +69,8 @@ export const CUSTOM_CONTROLS_CONTENT: ExampleCardConfig = {
           '5. <strong>Share this review publicly:</strong> tick the checkbox → its required error clears',
           '6. <strong>Accessibility Audit:</strong> its error renders <strong>above</strong> the stars (errorPlacement="top") — like every rating control on this page, it wires <code>aria-describedby</code> itself (manual ARIA); rate 1+ stars to clear it',
           '7. Fill <strong>Product Name</strong> and the remaining ratings → the footer flips to "✓ All fields valid"',
+          '8. <strong>Date of Birth:</strong> type <code>not-a-date</code> and tab out → a <code>parse</code> error appears; replace it with <code>2026-02-30</code> → a different parse error ("not a real calendar date"); type a real date like <code>1990-05-17</code> → the error clears',
+          '9. Click the 📅 button next to Date of Birth, pick a day → the text field updates and the popup closes; click <strong>Reset</strong> → the text field clears back to empty, proving the value change flows back through the adapter in both directions',
         ],
       },
       {

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.form.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.form.ts
@@ -22,6 +22,7 @@ import {
 } from '@ngx-signal-forms/toolkit';
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
 import {
+  LegacyDatepickerAdapterComponent,
   RatingControlComponent,
   SwitchControlComponent,
 } from '../../shared/controls';
@@ -61,6 +62,7 @@ import { customControlsSchema } from './custom-controls.validations';
     FormField,
     NgxSignalFormToolkit,
     NgxFormField,
+    LegacyDatepickerAdapterComponent,
     RatingControlComponent,
     SwitchControlComponent,
   ],
@@ -179,6 +181,17 @@ export class CustomControlsFormComponent {
       'accessibilityAudit',
       ['accessibilityAudit-hint'],
     );
+
+  /**
+   * `LegacyDatepickerAdapterComponent` also runs in manual ARIA mode (its
+   * internal widget owns the real `<input>`), so it needs the same
+   * explicit described-by chain as the rating controls above.
+   */
+  protected readonly birthDateDescribedBy = this.#buildRatingDescribedBy(
+    this.reviewForm.birthDate,
+    'birthDate',
+    ['birthDate-hint'],
+  );
 
   /**
    * Reset form to initial values.

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.html
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.html
@@ -143,6 +143,33 @@
       </ngx-form-field-hint>
     </ngx-form-field-wrapper>
 
+    <!-- Date of Birth - FormValueControl adapter around a self-contained
+         fake "legacy" third-party datepicker widget. The widget owns its
+         internal <input>, so ARIA stays manual and the wrapper stays
+         plain — see LegacyDatepickerAdapterComponent for the full adapter
+         boundary writeup (value round-trip, touched hook, ARIA forwarding,
+         parse errors). -->
+    <ngx-form-field-wrapper
+      appearance="plain"
+      [orientation]="orientation()"
+      [formField]="reviewForm.birthDate"
+      fieldName="birthDate"
+    >
+      <label id="birthDate-label" for="birthDate">
+        Date of Birth (legacy widget, optional)
+      </label>
+      <ngx-legacy-datepicker-adapter
+        [controlId]="'birthDate'"
+        [labelledBy]="'birthDate-label'"
+        ngxSignalFormControlAria="manual"
+        [describedBy]="birthDateDescribedBy()"
+        [formField]="reviewForm.birthDate"
+      />
+      <ngx-form-field-hint id="birthDate-hint">
+        Type a date as YYYY-MM-DD, or use the 📅 button to pick one.
+      </ngx-form-field-hint>
+    </ngx-form-field-wrapper>
+
     <!-- Feedback - Stacked textarea for comparison -->
     <ngx-form-field-wrapper
       [appearance]="appearance()"

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.legacy-datepicker.spec.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.legacy-datepicker.spec.ts
@@ -1,0 +1,207 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideNgxSignalFormsConfig } from '@ngx-signal-forms/toolkit';
+import { render, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { CustomControlsFormComponent } from './custom-controls.form';
+
+/**
+ * Focused coverage for `LegacyDatepickerAdapterComponent` (issue #272), run
+ * through the "Date of Birth" field on the custom-controls demo form.
+ *
+ * The widget's own popup calendar relies on `<dialog>.showModal()`, which
+ * jsdom does not implement (and jsdom's tab-order computation across the
+ * widget's popup buttons is unreliable), so this spec drives touched state
+ * with a direct `.blur()` rather than `userEvent.tab()`. The popup's
+ * day-picking path — and real focus traversal through the widget — is
+ * covered in
+ * `apps/demo-e2e/src/forms/04-form-field-wrapper/custom-controls.spec.ts`
+ * under a real browser.
+ */
+describe('LegacyDatepickerAdapterComponent (custom-controls demo)', () => {
+  async function setup() {
+    return render(CustomControlsFormComponent, {
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNgxSignalFormsConfig({
+          defaultErrorStrategy: 'on-touch',
+          autoAria: true,
+        }),
+      ],
+    });
+  }
+
+  /**
+   * Leaves the widget entirely (relatedTarget outside the host), the same
+   * "exit" signal `onHostFocusOut` listens for — see the adapter's class doc.
+   */
+  function leaveWidget(dateInput: HTMLInputElement): void {
+    dateInput.blur();
+  }
+
+  it('round-trips a valid typed date into the field value', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+
+    await user.type(dateInput, '2020-05-17');
+    leaveWidget(dateInput);
+
+    // No parse error for a well-formed, real calendar date.
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/is not a (?:date|real calendar date)/i),
+      ).not.toBeInTheDocument();
+    });
+    expect(dateInput).toHaveValue('2020-05-17');
+  });
+
+  it('surfaces unparseable typed input as a `parse` error', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+
+    await user.type(dateInput, 'not-a-date');
+    leaveWidget(dateInput);
+
+    expect(
+      await screen.findByText(/is not a date in yyyy-mm-dd format/i),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(dateInput.getAttribute('aria-invalid')).toBe('true');
+    });
+  });
+
+  it('surfaces an impossible calendar date (e.g. Feb 30) as a `parse` error', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+
+    await user.type(dateInput, '2026-02-30');
+    leaveWidget(dateInput);
+
+    expect(
+      await screen.findByText(/is not a real calendar date/i),
+    ).toBeInTheDocument();
+  });
+
+  it('clears the parse error once the text becomes a valid date', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+
+    await user.type(dateInput, 'garbage');
+    leaveWidget(dateInput);
+    await screen.findByText(/is not a date in yyyy-mm-dd format/i);
+
+    await user.clear(dateInput);
+    await user.type(dateInput, '1999-12-31');
+    leaveWidget(dateInput);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/is not a date in yyyy-mm-dd format/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not mark the field touched while focus stays inside the widget, but does once focus truly leaves', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+    const triggerButton = screen.getByRole('button', { name: /choose date/i });
+    const productNameInput = screen.getByLabelText(/product name/i);
+
+    // Seed genuinely invalid text first, so a false-positive touch (e.g.
+    // from a plain (blur) on the input, which is exactly what this
+    // composite `focusout` + relatedTarget hook exists to avoid) would be
+    // observable as a rendered `parse` error below. Testing this with an
+    // empty, valid field would pass even with a naive (blur) adapter.
+    await user.type(dateInput, 'bad-date');
+
+    // Moving focus from the text input to the widget's own trigger button
+    // is an internal transition, not an exit.
+    dateInput.focus();
+    triggerButton.focus();
+
+    // aria-invalid mirrors the field's raw validity unconditionally (same
+    // convention as RatingControlComponent elsewhere on this page) — it is
+    // not gated by touched, so it is not the discriminating signal here.
+    // The rendered error message is what the wrapper's 'on-touch' strategy
+    // actually gates, so that is what proves (or disproves) a false-positive
+    // touch from the internal input -> trigger hop above.
+    expect(
+      screen.queryByText(/is not a date in yyyy-mm-dd format/i),
+    ).not.toBeInTheDocument();
+
+    // Now actually leave the whole widget — this must fire `touch`.
+    productNameInput.focus();
+
+    expect(
+      await screen.findByText(/is not a date in yyyy-mm-dd format/i),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(dateInput.getAttribute('aria-invalid')).toBe('true');
+    });
+  });
+
+  it('clears an empty field back to no value without a parse error', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+
+    await user.type(dateInput, '2020-05-17');
+    leaveWidget(dateInput);
+    await user.click(dateInput);
+    await user.clear(dateInput);
+    leaveWidget(dateInput);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/is not a (?:date|real calendar date)/i),
+      ).not.toBeInTheDocument();
+    });
+    expect(dateInput).toHaveValue('');
+  });
+
+  it('formats an externally-reset model value back onto the widget', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const dateInput = screen.getByLabelText(
+      /date of birth/i,
+    ) as HTMLInputElement;
+
+    await user.type(dateInput, '2020-05-17');
+    leaveWidget(dateInput);
+    expect(dateInput).toHaveValue('2020-05-17');
+
+    // Programmatic reset (mirrors the demo's own Reset button, which calls
+    // `reviewForm().reset()`): the widget's displayed text must follow the
+    // model back to empty via `transformedValue`'s `format`.
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    await user.click(resetButton);
+
+    await waitFor(() => {
+      expect(dateInput).toHaveValue('');
+    });
+  });
+});

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.model.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.model.ts
@@ -26,6 +26,14 @@ export interface CustomControlsModel {
 
   /** Optional feedback text */
   feedback: string;
+
+  /**
+   * Date of birth, edited through a `FormValueControl<Date | null>` adapter
+   * wrapped around a self-contained fake "legacy" datepicker widget (its
+   * own value/change API, not a native input). Optional — see
+   * `LegacyDatepickerAdapterComponent` for the adapter boundary itself.
+   */
+  birthDate: Date | null;
 }
 
 /**
@@ -40,4 +48,5 @@ export const initialCustomControlsModel: CustomControlsModel = {
   shareReviewPublicly: false,
   accessibilityAudit: 0,
   feedback: '',
+  birthDate: null,
 };

--- a/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.validations.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/custom-controls/custom-controls.validations.ts
@@ -46,4 +46,9 @@ export const customControlsSchema = schema<CustomControlsModel>((path) => {
   min(path.accessibilityAudit, 1, {
     message: 'Accessibility audit must be at least 1 star',
   });
+
+  // Date of birth is optional and has no schema-level rule here — its only
+  // validation is the `parse` error the LegacyDatepickerAdapterComponent
+  // reports automatically (via `transformedValue`) when the underlying
+  // legacy widget's typed text isn't a real YYYY-MM-DD date.
 });

--- a/apps/demo/src/app/shared/controls/index.ts
+++ b/apps/demo/src/app/shared/controls/index.ts
@@ -1,2 +1,4 @@
+export { LegacyDatepickerAdapterComponent } from './legacy-datepicker-adapter';
+export { LegacyDatepickerComponent } from './legacy-datepicker-widget';
 export { RatingControlComponent } from './rating-control';
 export { SwitchControlComponent } from './switch-control';

--- a/apps/demo/src/app/shared/controls/legacy-datepicker-adapter.ts
+++ b/apps/demo/src/app/shared/controls/legacy-datepicker-adapter.ts
@@ -1,0 +1,199 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  input,
+  model,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  transformedValue,
+  type FormValueControl,
+  type ParseResult,
+  type ValidationError,
+} from '@angular/forms/signals';
+import { LegacyDatepickerComponent } from './legacy-datepicker-widget';
+
+/**
+ * Parses the legacy widget's raw text into a `Date`, or reports a `parse`
+ * error when the text is non-blank but malformed or not a real calendar
+ * date (e.g. `2026-02-30`). Blank/whitespace-only text is treated as "no
+ * value" — `{ value: null }`, no error — matching the widget's cleared
+ * state rather than flagging an empty field as unparseable.
+ *
+ * `kind: 'parse'` is the same built-in Angular Signal Forms error kind used
+ * by `transformedValue`'s own reference example (see
+ * `@angular/forms/signals` `NumberInput` doc example) and by the toolkit's
+ * `resolveErrorMessage` — it renders through the wrapper's normal error
+ * surface with no extra wiring.
+ */
+function parseLegacyDate(raw: string): ParseResult<Date | null> {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return { value: null };
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(trimmed);
+  if (!match) {
+    return {
+      error: {
+        kind: 'parse',
+        message: `"${trimmed}" is not a date in YYYY-MM-DD format`,
+      },
+    };
+  }
+
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(year, month - 1, day);
+
+  const isRealCalendarDate =
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day;
+
+  if (!isRealCalendarDate) {
+    return {
+      error: {
+        kind: 'parse',
+        message: `"${trimmed}" is not a real calendar date`,
+      },
+    };
+  }
+
+  return { value: date };
+}
+
+function formatLegacyDate(value: Date | null): string {
+  if (value === null) return '';
+  return [
+    value.getFullYear().toString().padStart(4, '0'),
+    (value.getMonth() + 1).toString().padStart(2, '0'),
+    value.getDate().toString().padStart(2, '0'),
+  ].join('-');
+}
+
+/**
+ * Adapter that bridges `LegacyDatepickerComponent` — a self-contained stand-in
+ * for a third-party datepicker with its own value/change API — to Angular
+ * Signal Forms' `FormValueControl<Date | null>` contract.
+ *
+ * ## Value round-trip and type mismatch (Date vs raw string)
+ *
+ * The widget's own API works in raw strings (`rawValue` / `rawValueChange`).
+ * `transformedValue()` owns the parse/format boundary: `parse` turns the
+ * widget's text into a `Date | null` (or a `parse` validation error), and
+ * `format` turns an external `Date | null` model change — including a
+ * programmatic `form().reset()` — back into the text the widget displays.
+ * Because `transformedValue` is called inside a component bound via
+ * `[formField]`, parse errors are reported to the nearest field
+ * automatically; no manual `errors` wiring is needed.
+ *
+ * ## Touched propagation without a single native blur
+ *
+ * The widget spans three focusable elements (its text input, its calendar
+ * trigger button, and the day buttons inside its popup `<dialog>`). A plain
+ * `(blur)` on the internal input would mark the field touched — and could
+ * flash a validation error — every time focus moves from the input to the
+ * trigger button, even though the user is still interacting with the same
+ * logical control. Instead this adapter listens for `(focusout)` on its own
+ * host and only emits `touch` when the newly focused element
+ * (`event.relatedTarget`) is *not* contained anywhere inside the host. That
+ * fires exactly once, when focus truly leaves the whole widget — whether
+ * from the input, the trigger, or a day button in the popup (native `dialog`
+ * elements stay in the same DOM subtree even while promoted to the top
+ * layer, so `contains()` still sees them).
+ *
+ * ## Where ARIA lands
+ *
+ * The widget renders its own internal `<input>` — the adapter's host element
+ * is not the interactive control. So the wrapper's `aria-describedby` /
+ * `aria-invalid` / `aria-required` are forwarded down onto that internal
+ * input via the widget's own `ariaDescribedBy` / `ariaInvalid` /
+ * `ariaRequired` passthrough inputs, not set on the adapter's host. This
+ * only works because the fake widget was built with those passthrough
+ * inputs; a real third-party widget must expose an equivalent escape hatch
+ * (or you fall back to whatever ARIA surface it does own) — see
+ * `docs/CUSTOM_CONTROLS.md`.
+ */
+@Component({
+  selector: 'ngx-legacy-datepicker-adapter',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LegacyDatepickerComponent],
+  host: {
+    '(focusout)': 'onHostFocusOut($event)',
+  },
+  template: `
+    <ngx-legacy-datepicker
+      #widget
+      [widgetId]="controlId()"
+      [(rawValue)]="rawValue"
+      [widgetDisabled]="disabled()"
+      [labelledBy]="labelledBy()"
+      [ariaDescribedBy]="describedBy()"
+      [ariaInvalid]="invalid()"
+      [ariaRequired]="required()"
+    />
+  `,
+})
+export class LegacyDatepickerAdapterComponent implements FormValueControl<Date | null> {
+  readonly #host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  // Native `#private` fields on a `viewChild()` query miscompile under this
+  // workspace's dev toolchain (see apps/demo/src/app/app.ts) — use
+  // `protected` instead.
+  protected readonly widget = viewChild.required(LegacyDatepickerComponent);
+
+  /** Id forwarded to the widget's internal, real `<input>` element. */
+  readonly controlId = input.required<string>();
+
+  /** aria-labelledby source for the label projected outside this control. */
+  readonly labelledBy = input<string | null>(null);
+
+  /**
+   * Explicit aria-describedby chain — this control runs in
+   * `ngxSignalFormControlAria="manual"` mode, so the parent form computes
+   * hint/error id chains and passes them in, mirroring the rating-control
+   * pattern used elsewhere on this page.
+   */
+  readonly describedBy = input<string | null>(null);
+
+  readonly disabled = input(false);
+  readonly invalid = input(false);
+  readonly required = input(false);
+  readonly errors = input<readonly ValidationError[]>([]);
+
+  /** Required by `FormValueControl<Date | null>`. */
+  readonly value = model<Date | null>(null);
+
+  /** Emitted when focus truly leaves the whole widget — see class doc. */
+  readonly touch = output();
+
+  /**
+   * Bridges the widget's raw-string value/change API to `value` (a
+   * `Date | null`), reporting parse errors to the bound field automatically.
+   */
+  protected readonly rawValue = transformedValue(this.value, {
+    parse: parseLegacyDate,
+    format: formatLegacyDate,
+  });
+
+  focus(): void {
+    this.widget().focusInput();
+  }
+
+  protected onHostFocusOut(event: FocusEvent): void {
+    const related = event.relatedTarget;
+    const relatedNode = related instanceof Node ? related : null;
+    if (
+      relatedNode === null ||
+      !this.#host.nativeElement.contains(relatedNode)
+    ) {
+      this.touch.emit();
+    }
+  }
+}

--- a/apps/demo/src/app/shared/controls/legacy-datepicker-widget.ts
+++ b/apps/demo/src/app/shared/controls/legacy-datepicker-widget.ts
@@ -1,0 +1,398 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  input,
+  model,
+  signal,
+  viewChild,
+} from '@angular/core';
+
+/**
+ * A tiny, self-contained stand-in for a "legacy" third-party datepicker
+ * widget.
+ *
+ * This component deliberately does **not** know anything about Angular
+ * Signal Forms. It owns its own value/change API (`rawValue` /
+ * `rawValueChange`), its own popup calendar, and its own internal `<input>`
+ * — exactly the shape you'd get from an npm-installed date-picker library.
+ * `LegacyDatepickerAdapterComponent` (in the same directory) is the piece
+ * that bridges this widget to `FormValueControl<Date | null>`.
+ *
+ * Two things make this widget a realistic "hard case" for a Signal Forms
+ * adapter:
+ *
+ * - Its value is a free-typed string (`YYYY-MM-DD` or garbage — the widget
+ *   does not validate), not a `Date`. The adapter owns the parse/format
+ *   boundary.
+ * - Interacting with it moves focus across more than one element (the text
+ *   input, the calendar-trigger button, and the day buttons inside the
+ *   popup dialog). A plain `(blur)` on the internal input would fire every
+ *   time focus hops between those elements, long before the user is done
+ *   with the widget as a whole.
+ *
+ * (Its selector carries the repo's mandatory `ngx` prefix only because this
+ * file lives inside this workspace's lint rules — imagine it published as
+ * `<legacy-datepicker>` from an unrelated npm package.)
+ */
+@Component({
+  selector: 'ngx-legacy-datepicker',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'legacy-datepicker',
+  },
+  styles: `
+    :host {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    /*
+     * Colors below are explicit (not opacity tricks) and chosen for
+     * conforming contrast in both themes:
+     *  - #6b7280 (gray-500) on white / #1f2937 (gray-800) borders: ~4.8:1 /
+     *    ~5.8:1 — clears the >=3:1 WCAG 1.4.11 non-text UI boundary minimum.
+     *  - #4b5563 (gray-600) muted day text on white: ~7.6:1 — clears the
+     *    >=4.5:1 WCAG 1.4.3 normal-text minimum (an opacity-based mute would
+     *    have silently dropped below that floor).
+     *  - #9ca3af (gray-400) muted day text / border on the dark popup
+     *    surface (#1f2937): ~5.8:1 — same floors, dark-theme pairing.
+     */
+    .legacy-datepicker__input {
+      inline-size: 11rem;
+      padding: 0.375rem 0.5rem;
+      border: 1px solid #6b7280;
+      border-radius: 0.25rem;
+      background-color: #ffffff;
+      color: #111827;
+      font: inherit;
+    }
+
+    .legacy-datepicker__input[aria-invalid='true'] {
+      border-color: #db1818;
+    }
+
+    .legacy-datepicker__input:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+
+    .legacy-datepicker__trigger {
+      padding: 0.375rem 0.5rem;
+      border: 1px solid #6b7280;
+      border-radius: 0.25rem;
+      background: transparent;
+      color: #111827;
+      cursor: pointer;
+      font-size: 1rem;
+      line-height: 1;
+    }
+
+    .legacy-datepicker__trigger:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+
+    .legacy-datepicker__popup {
+      padding: 0.75rem;
+      border: 1px solid #6b7280;
+      border-radius: 0.5rem;
+      background-color: #ffffff;
+      color: #111827;
+    }
+
+    .legacy-datepicker__popup-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      margin-block-end: 0.5rem;
+      font-weight: 600;
+    }
+
+    .legacy-datepicker__grid {
+      display: grid;
+      grid-template-columns: repeat(7, 2rem);
+      gap: 0.125rem;
+    }
+
+    .legacy-datepicker__day {
+      inline-size: 2rem;
+      block-size: 2rem;
+      border: 1px solid transparent;
+      border-radius: 0.25rem;
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+    }
+
+    /* Explicit color, not opacity: opacity multiplies the already-passing
+       base text contrast down below the WCAG 1.4.3 floor (~2.8:1 at 0.4). */
+    .legacy-datepicker__day--outside {
+      color: #4b5563;
+    }
+
+    .legacy-datepicker__day[aria-current='date'] {
+      border-color: #007bc7;
+    }
+
+    .legacy-datepicker__day[aria-pressed='true'] {
+      background-color: #007bc7;
+      color: #fff;
+    }
+
+    :host-context(.dark) {
+      .legacy-datepicker__input,
+      .legacy-datepicker__trigger,
+      .legacy-datepicker__popup {
+        border-color: #9ca3af;
+        background-color: #1f2937;
+        color: #f3f4f6;
+      }
+
+      .legacy-datepicker__input[aria-invalid='true'] {
+        border-color: #fca5a5;
+      }
+
+      .legacy-datepicker__day--outside {
+        color: #9ca3af;
+      }
+    }
+  `,
+  template: `
+    <input
+      #input
+      type="text"
+      class="legacy-datepicker__input"
+      [id]="widgetId()"
+      [value]="rawValue()"
+      (input)="onTextInput($event)"
+      [disabled]="widgetDisabled()"
+      [attr.aria-labelledby]="labelledBy()"
+      [attr.aria-describedby]="ariaDescribedBy()"
+      [attr.aria-invalid]="ariaInvalid() ? 'true' : 'false'"
+      [attr.aria-required]="ariaRequired() ? 'true' : null"
+      placeholder="YYYY-MM-DD"
+      autocomplete="off"
+    />
+    <button
+      #trigger
+      type="button"
+      class="legacy-datepicker__trigger"
+      [disabled]="widgetDisabled()"
+      (click)="openPopup()"
+      aria-label="Choose date"
+      aria-haspopup="dialog"
+    >
+      📅
+    </button>
+
+    <dialog
+      #dialog
+      class="legacy-datepicker__popup"
+      [attr.aria-label]="'Choose date'"
+      (close)="onDialogClose()"
+      (click)="onDialogClick($event)"
+    >
+      <div class="legacy-datepicker__popup-header">
+        <button
+          type="button"
+          (click)="previousMonth()"
+          aria-label="Previous month"
+        >
+          ‹
+        </button>
+        <span [id]="widgetId() + '-caption'">{{ monthLabel() }}</span>
+        <button type="button" (click)="nextMonth()" aria-label="Next month">
+          ›
+        </button>
+      </div>
+      <div
+        class="legacy-datepicker__grid"
+        role="group"
+        [attr.aria-labelledby]="widgetId() + '-caption'"
+      >
+        @for (day of visibleDays(); track day.iso) {
+          <button
+            type="button"
+            class="legacy-datepicker__day"
+            [class.legacy-datepicker__day--outside]="!day.inCurrentMonth"
+            [attr.aria-current]="day.isToday ? 'date' : null"
+            [attr.aria-pressed]="day.isSelected"
+            [attr.aria-label]="day.label"
+            (click)="pickDay(day.iso)"
+          >
+            {{ day.dayNumber }}
+          </button>
+        }
+      </div>
+    </dialog>
+  `,
+})
+export class LegacyDatepickerComponent {
+  /** Id placed on the widget's real, focusable `<input>` element. */
+  readonly widgetId = input.required<string>();
+
+  /**
+   * The widget's own value/change API: a free-typed raw string, not a
+   * `Date`. Two-way bound (`[(rawValue)]`) by whatever wraps this widget.
+   */
+  readonly rawValue = model('');
+
+  readonly widgetDisabled = input(false);
+
+  /** Passthrough ARIA the widget applies to its internal `<input>`. */
+  readonly labelledBy = input<string | null>(null);
+  readonly ariaDescribedBy = input<string | null>(null);
+  readonly ariaInvalid = input(false);
+  readonly ariaRequired = input(false);
+
+  // Native `#private` fields on a `viewChild()` query miscompile under this
+  // workspace's dev toolchain (see apps/demo/src/app/app.ts) — use
+  // `protected` instead.
+  protected readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('input');
+  protected readonly triggerEl =
+    viewChild<ElementRef<HTMLButtonElement>>('trigger');
+  protected readonly dialogEl =
+    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+
+  protected readonly viewMonth = signal(startOfMonth(new Date()));
+
+  protected readonly monthLabel = computed(() =>
+    this.viewMonth().toLocaleDateString(undefined, {
+      month: 'long',
+      year: 'numeric',
+    }),
+  );
+
+  protected readonly visibleDays = computed(() => {
+    const month = this.viewMonth();
+    const selectedIso = /^\d{4}-\d{2}-\d{2}$/u.test(this.rawValue())
+      ? this.rawValue()
+      : null;
+    const today = new Date();
+    const todayIso = toIso(today);
+
+    const firstOfMonth = startOfMonth(month);
+    const gridStart = new Date(firstOfMonth);
+    gridStart.setDate(gridStart.getDate() - firstOfMonth.getDay());
+
+    return Array.from({ length: 42 }, (_, index) => {
+      const date = new Date(gridStart);
+      date.setDate(gridStart.getDate() + index);
+      const iso = toIso(date);
+
+      return {
+        iso,
+        dayNumber: date.getDate(),
+        inCurrentMonth: date.getMonth() === month.getMonth(),
+        isToday: iso === todayIso,
+        isSelected: iso === selectedIso,
+        label: date.toLocaleDateString(undefined, {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric',
+          year: 'numeric',
+        }),
+      };
+    });
+  });
+
+  /**
+   * A real third-party widget would expose *something* to programmatically
+   * focus its interactive element — this is that "something". It is
+   * deliberately not named `focus()`: the widget was not written against
+   * the `FormValueControl` contract, and the adapter is what reconciles the
+   * naming difference.
+   */
+  focusInput(): void {
+    this.inputEl()?.nativeElement.focus();
+  }
+
+  protected onTextInput(event: Event): void {
+    const target = event.target;
+    if (target instanceof HTMLInputElement) {
+      this.rawValue.set(target.value);
+    }
+  }
+
+  protected openPopup(): void {
+    if (this.widgetDisabled()) return;
+    // `fromIso` returns null for anything that isn't a real calendar date —
+    // including regex-shaped-but-impossible text like "2026-02-30", which
+    // would otherwise roll forward into March (both via `new Date(iso)`'s
+    // UTC parsing and via naive y/m/d construction that doesn't validate
+    // the round-trip). Falling back to today keeps the popup's month in
+    // sync with what the adapter actually accepts — text the adapter
+    // rejects as a `parse` error never silently redirects the calendar.
+    const typedDate = fromIso(this.rawValue());
+    this.viewMonth.set(startOfMonth(typedDate ?? new Date()));
+    this.dialogEl()?.nativeElement.showModal();
+  }
+
+  protected onDialogClose(): void {
+    this.triggerEl()?.nativeElement.focus();
+  }
+
+  /** Closing on backdrop click: only when the click lands on the dialog itself. */
+  protected onDialogClick(event: MouseEvent): void {
+    if (event.target === this.dialogEl()?.nativeElement) {
+      this.dialogEl()?.nativeElement.close();
+    }
+  }
+
+  protected previousMonth(): void {
+    const month = this.viewMonth();
+    this.viewMonth.set(new Date(month.getFullYear(), month.getMonth() - 1, 1));
+  }
+
+  protected nextMonth(): void {
+    const month = this.viewMonth();
+    this.viewMonth.set(new Date(month.getFullYear(), month.getMonth() + 1, 1));
+  }
+
+  protected pickDay(iso: string): void {
+    this.rawValue.set(iso);
+    this.dialogEl()?.nativeElement.close();
+  }
+}
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+/**
+ * Parses a "YYYY-MM-DD" string as a local-time `Date` (never UTC — see the
+ * `openPopup()` call site for why UTC parsing is wrong here), returning
+ * `null` for anything that isn't shaped like a date OR isn't a *real*
+ * calendar date. `new Date(year, month - 1, day)` never throws — it happily
+ * rolls "2026-02-30" forward into March — so the round-trip is checked
+ * explicitly (mirrors the `isRealCalendarDate` check in the adapter's
+ * `parseLegacyDate`).
+ */
+function fromIso(iso: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(iso);
+  if (!match) return null;
+
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(year, month - 1, day);
+
+  const isRealCalendarDate =
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day;
+
+  return isRealCalendarDate ? date : null;
+}
+
+function toIso(date: Date): string {
+  const y = date.getFullYear().toString().padStart(4, '0');
+  const m = (date.getMonth() + 1).toString().padStart(2, '0');
+  const d = date.getDate().toString().padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}

--- a/docs/CUSTOM_CONTROLS.md
+++ b/docs/CUSTOM_CONTROLS.md
@@ -582,6 +582,127 @@ Usage with toolkit:
 </form>
 ```
 
+## Adapting an Existing Third-Party Widget
+
+Everything above builds a control **from scratch**. This section is the
+other case: you already have a widget — a datepicker, a rich-text editor, a
+combobox — with its own value/change API, and you need a thin
+`FormValueControl<T>` adapter around it rather than a new control.
+
+**Runnable reference:** the custom-controls demo's "Date of Birth" field —
+`apps/demo/src/app/shared/controls/legacy-datepicker-adapter.ts`, wrapping a
+self-contained fake "legacy" datepicker widget
+(`legacy-datepicker-widget.ts`) that has no Signal Forms awareness at all.
+See that adapter's class-level doc comment for the full design writeup; this
+section summarizes the four decisions it makes.
+
+### 1. Value round-trip and type mismatch
+
+The widget almost never speaks your model's type. Ours exposes a raw string
+(`YYYY-MM-DD`, or garbage while the user is mid-typo); the field needs
+`Date | null`. Use Angular Signal Forms' `transformedValue()` to own that
+boundary in one place:
+
+```typescript
+protected readonly rawValue = transformedValue(this.value, {
+  parse: (raw: string): ParseResult<Date | null> => {
+    /* raw text -> Date | null, or { error: { kind: 'parse', message } } */
+  },
+  format: (value: Date | null): string => {
+    /* Date | null -> raw text */
+  },
+});
+```
+
+`parse` runs on every widget change event; `format` runs whenever `value`
+changes from outside — including a programmatic `form().reset()` — so the
+widget always redisplays what the model actually holds.
+
+### 2. Touched propagation without a single native blur
+
+Third-party widgets are often composites: a text input plus a trigger
+button plus a popup with its own focusable elements (segments, calendar
+days, list options). A plain `(blur)` on the widget's internal input fires
+every time focus hops between those pieces — long before the user is done
+with the widget as a whole.
+
+Listen for `(focusout)` on the **adapter's own host** instead, and only
+treat it as "the user left the control" when the newly focused element
+(`event.relatedTarget`) is not contained anywhere inside that host:
+
+```typescript
+protected onHostFocusOut(event: FocusEvent): void {
+  const related = event.relatedTarget;
+  const relatedNode = related instanceof Node ? related : null;
+  if (relatedNode === null || !this.#host.nativeElement.contains(relatedNode)) {
+    this.touch.emit();
+  }
+}
+```
+
+This fires exactly once, whichever internal element focus was on when it
+finally left — including out of a native `<dialog>` popup, which stays in
+the same DOM subtree (so `contains()` still sees it) even while promoted to
+the browser's top layer.
+
+### 3. Where ARIA lands
+
+If the widget renders its own internal `<input>`, that input — not the
+adapter's host element — is the thing screen readers care about. Pair the
+adapter with `ngxSignalFormControlAria="manual"` and `appearance="plain"` so
+the wrapper still supplies the label, hint, and error content, and forward
+`aria-describedby` / `aria-invalid` / `aria-required` down onto the widget's
+real input through whatever passthrough inputs the widget exposes:
+
+```html
+<ngx-form-field-wrapper
+  appearance="plain"
+  [formField]="form.birthDate"
+  fieldName="birthDate"
+>
+  <label id="birthDate-label" for="birthDate">Date of birth</label>
+  <ngx-legacy-datepicker-adapter
+    [controlId]="'birthDate'"
+    [labelledBy]="'birthDate-label'"
+    ngxSignalFormControlAria="manual"
+    [describedBy]="birthDateDescribedBy()"
+    [formField]="form.birthDate"
+  />
+</ngx-form-field-wrapper>
+```
+
+Because the adapter's host is not the focusable element, `id` cannot live on
+that host — use `fieldName` on the wrapper (as above) instead of an `id`
+attribute, and forward the same identifier into the widget as its internal
+input's real `id`. This is the same "control can't expose an id" pattern
+from [Field identity: `id` and `fieldName`](#field-identity-id-and-fieldname)
+above, applied to a composite host. If the real widget you're wrapping
+doesn't expose an ARIA passthrough at all, you don't get this choice — fall
+back to whatever ARIA surface it does own, or treat the gap as a defect to
+raise with the widget's maintainers.
+
+### 4. Parse/invalid-input path
+
+Report unparseable or partial input as a `kind: 'parse'` validation error —
+the same built-in kind `transformedValue`'s own reference example uses, and
+one the toolkit's `resolveErrorMessage` already renders through the normal
+error surface with no extra wiring:
+
+```typescript
+if (!isRealCalendarDate) {
+  return {
+    error: {
+      kind: 'parse',
+      message: `"${trimmed}" is not a real calendar date`,
+    },
+  };
+}
+```
+
+Because `transformedValue` is called inside the component bound via
+`[formField]`, that error is reported to the nearest field automatically —
+no manual `errors` input wiring required.
+
 ## Related
 
 - [Angular Signal Forms API](https://angular.dev/api/forms/signals)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -264,18 +264,22 @@ canonical rather than re-deriving tokens.
 
 Write a thin adapter that implements `FormValueControl<Date | null>` on your datepicker host:
 expose `value = model<Date | null>(null)` and sync it to/from the third-party widget's own
-value/change events, add a `focus()` method (needed for `focusFirstInvalid()` and error-summary
+value/change events (Angular's `transformedValue()` is the built-in tool for that parse/format
+boundary — see below), add a `focus()` method (needed for `focusFirstInvalid()` and error-summary
 navigation), and optional `touch`/`disabled`/`invalid`. Bind it with the standard
 `[formField]="form.birthDate"`. Because the widget owns its own visuals and ARIA, pair it with
 `ngxSignalFormControlAria="manual"` and `appearance="plain"` so the toolkit supplies label/hint/
 error content and field-identity IDs without clashing. Handle any type mismatch (e.g. `Date` vs
-ISO string) inside the adapter's read/write path. There is no runnable datepicker demo yet — the
-adapter pattern generalizes from the `FormValueControl` examples in custom-controls; the Material
-app's README also notes date-picker ARIA gotchas.
+ISO string) inside the adapter's read/write path, and surface unparseable input as a
+`kind: 'parse'` error. Widgets with internal popups or multiple focusable pieces (a calendar grid,
+segmented input) need a composite-aware touched hook — `(focusout)` with a `relatedTarget`
+containment check — instead of a plain `(blur)`.
 
-**See:** [docs/CUSTOM_CONTROLS.md](./CUSTOM_CONTROLS.md) ·
-[demo: custom-controls](../apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md) ·
-[demo-material README](../apps/demo-material/README.md)
+**See:** [docs/CUSTOM_CONTROLS.md § Adapting an Existing Third-Party Widget](./CUSTOM_CONTROLS.md#adapting-an-existing-third-party-widget) ·
+runnable demo: the "Date of Birth" field in
+[demo: custom-controls](../apps/demo/src/app/04-form-field-wrapper/custom-controls/README.md)
+(`apps/demo/src/app/shared/controls/legacy-datepicker-adapter.ts`) · the Material app's README also
+notes date-picker ARIA gotchas.
 
 ---
 


### PR DESCRIPTION
Adds the case `docs/CUSTOM_CONTROLS.md` was missing: adapting an **existing widget that owns its own value/change API**, as opposed to building markup from scratch. The custom-controls demo gains a Date of Birth field composed of two pieces:

- `LegacyDatepickerComponent` — a small self-contained fake "legacy" widget (text input + `<dialog>` calendar popup) with a string `rawValue`/`rawValueChange` API and zero Signal Forms awareness. Deliberately built in-repo: the lesson is the adapter boundary, not a calendar dependency.
- `LegacyDatepickerAdapterComponent` — a `FormValueControl<Date | null>` adapter answering the three questions scratch-built examples never hit:
  - **Value round-trip** via Angular's `transformedValue()` (widget text ⇄ `Date | null`, including programmatic reset), which also yields `kind: 'parse'` errors for free — covering both malformed text and impossible dates like `2026-02-30`.
  - **Touched without a native blur**: host `focusout` gated by `relatedTarget` containment, so focus hops between the widget's input, trigger, and popup day buttons don't mark the field touched — only truly leaving the composite does. The unit and E2E negative tests are discriminating (invalid text seeded first, so a naive `(blur)` adapter would visibly fail them).
  - **ARIA placement**: the adapter opts into `ngxSignalFormControlAria="manual"` and forwards `aria-describedby`/`aria-invalid`/`aria-required` onto the widget's internal input — the wrapper's `fieldName` keeps the toolkit's id chain intact even though the adapter host isn't the focusable element.

The widget passes WCAG 2.2 AA in both themes (borders ≥3:1, day text ≥4.5:1, `:host-context(.dark)` styles matching the rating-control precedent, dark-mode error border) and the route's axe scan reports 0 violations. A UTC-parse timezone bug in the popup's month derivation was caught in review and fixed with a local-safe constructor.

7 unit specs + 6 E2E tests; FAQ §"third-party datepicker" now points at the runnable demo. No toolkit changes were needed — `transformedValue()`, manual ARIA mode, and wrapper `fieldName` were sufficient, which is itself a finding worth recording.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
