### PR TITLE
feat(demo): single-model wizard — per-step subtree validation on one form()

### DIFF
--- a/apps/demo-e2e/src/forms/05-advanced/single-model-wizard.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/single-model-wizard.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test } from '@playwright/test';
+import { SingleModelWizardPage } from '../../page-objects/single-model-wizard.page';
+
+/**
+ * Single-Model Wizard - E2E Tests
+ * Route: /advanced-scenarios/single-model-wizard
+ *
+ * One `form()` model spans every step. "Next" validates the active step's
+ * subtree directly via a shared `#validateStep` helper; the `ngx-wizard`'s
+ * `canNavigate` guard calls that same helper to gate progress-header
+ * navigation (a shared-component finding — see the README).
+ */
+test.describe('Advanced Scenarios - Single-Model Wizard', () => {
+  let wizard: SingleModelWizardPage;
+
+  test.beforeEach(async ({ page }) => {
+    wizard = new SingleModelWizardPage(page);
+    await wizard.goto();
+  });
+
+  test('should display the account step first', async () => {
+    await expect(wizard.stepHeading).toHaveText(/Step 1 of 3: Account/);
+    await expect(wizard.fullNameInput).toBeVisible();
+  });
+
+  test('blocks Next on an invalid step and surfaces touched errors', async () => {
+    await wizard.nextButton.click();
+
+    // Still on step 1 — navigation was blocked.
+    await expect(wizard.stepHeading).toHaveText(/Step 1 of 3: Account/);
+    await expect(wizard.errorAlerts.first()).toBeVisible();
+  });
+
+  test('advances to Shipping once the Account step is valid', async () => {
+    await wizard.fillAccountStep('Ada Lovelace', 'ada@acme.example');
+    await wizard.nextButton.click();
+
+    await expect(wizard.stepHeading).toHaveText(/Step 2 of 3: Shipping/);
+    // Focus should land on the new step's heading.
+    await expect(wizard.stepHeading).toBeFocused();
+  });
+
+  test("Next validates only the active step's subtree, not the sibling step", async () => {
+    await test.step("a blocked Next on Account never renders Shipping's fields at all", async () => {
+      await wizard.nextButton.click();
+
+      await expect(wizard.stepHeading).toHaveText(/Step 1 of 3: Account/);
+      await expect(wizard.errorAlerts.first()).toBeVisible();
+      // Only the active step's template is instantiated (NgTemplateOutlet
+      // in the shared wizard), so Shipping's own fields can't be showing
+      // errors — they aren't even in the DOM to check.
+      await expect(wizard.streetInput).toHaveCount(0);
+      await expect(wizard.postalCodeInput).toHaveCount(0);
+    });
+
+    await test.step('arriving on Shipping (untouched) shows zero errors, even though its fields are required', async () => {
+      await wizard.fillAccountStep('Ada Lovelace', 'ada@acme.example');
+      await wizard.nextButton.click();
+
+      await expect(wizard.stepHeading).toHaveText(/Step 2 of 3: Shipping/);
+      // markAsTouched() on leaving Account only cascaded within Account's
+      // own subtree — Shipping's required street/city/postalCode are
+      // untouched, so on-touch error display keeps them silent even
+      // though they are, technically, currently invalid (empty).
+      await expect(wizard.errorAlerts).toHaveCount(0);
+    });
+  });
+
+  test("runs the cross-step express-shipping rule against step 1's email", async () => {
+    await test.step('advance with a free-email address', async () => {
+      await wizard.fillAccountStep('Ada Lovelace', 'ada@gmail.com');
+      await wizard.nextButton.click();
+      await expect(wizard.stepHeading).toHaveText(/Step 2 of 3: Shipping/);
+    });
+
+    await test.step('checking express shipping surfaces the cross-step error', async () => {
+      await wizard.fillShippingStep('1 Infinite Loop', 'Cupertino', '95014');
+      await wizard.expressShippingCheckbox.check();
+      await wizard.expressShippingCheckbox.blur();
+
+      const error = wizard.page.locator('[role="alert"]', {
+        hasText: /work email address \(step 1\)/i,
+      });
+      await expect(error).toBeVisible();
+    });
+
+    await test.step('fixing the email on step 1 clears the error without touching step 2 again', async () => {
+      await wizard.previousButton.click();
+      await expect(wizard.stepHeading).toHaveText(/Step 1 of 3: Account/);
+
+      await wizard.emailInput.fill('ada@acme.example');
+      await wizard.nextButton.click();
+      await expect(wizard.stepHeading).toHaveText(/Step 2 of 3: Shipping/);
+
+      const error = wizard.page.locator('[role="alert"]', {
+        hasText: /work email address \(step 1\)/i,
+      });
+      await expect(error).toHaveCount(0);
+      await expect(wizard.expressShippingCheckbox).toBeChecked();
+    });
+  });
+
+  test('completes the full wizard and submits the whole form once', async () => {
+    await test.step('fill and advance through Account', async () => {
+      await wizard.fillAccountStep('Grace Hopper', 'grace@navy.example');
+      await wizard.nextButton.click();
+    });
+
+    await test.step('fill and advance through Shipping', async () => {
+      await wizard.fillShippingStep('1 Compiler Way', 'Arlington', '22202');
+      await wizard.nextButton.click();
+      await expect(wizard.stepHeading).toHaveText(/Step 3 of 3: Review/);
+      // Review has no fields of its own, but reaching it already required
+      // Account and Shipping to be valid — treated as completed so the
+      // progress bar reaches 100% on step 3 of 3 rather than maxing out
+      // at 2/3 (~67%).
+      await expect(wizard.progressFill).toHaveAttribute(
+        'style',
+        /width:\s*100%/,
+      );
+      await expect(wizard.progressFill).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    await test.step('review reflects the exact values entered on earlier steps', async () => {
+      await expect(wizard.orderSummary).toContainText('Grace Hopper');
+      await expect(wizard.orderSummary).toContainText('grace@navy.example');
+      await expect(wizard.orderSummary).toContainText('1 Compiler Way');
+    });
+
+    await test.step('confirm order runs the whole-form submit()', async () => {
+      await wizard.confirmOrderButton.click();
+      await expect(wizard.successMessage).toBeVisible();
+    });
+  });
+
+  test('per-subtree gating makes reaching Confirm with an invalid earlier step unreachable', async () => {
+    // See single-model-wizard.form.ts's `confirmOrder()` comment: submit()
+    // re-validating the WHOLE form is a safety net for exactly the state
+    // this test tries (and fails) to construct. This test pins that the
+    // safety net is currently unreachable through the UI, not merely
+    // untested — every forward transition (custom Next AND the shared
+    // wizard's progress-header clicks) re-validates the subtree of the
+    // step being left, so an invalid step can never be left forward, and
+    // Confirm only ever renders on Review, the last step.
+    await test.step('complete the wizard once, validly, reaching Review', async () => {
+      await wizard.fillAccountStep('Grace Hopper', 'grace@navy.example');
+      await wizard.nextButton.click();
+      await wizard.fillShippingStep('1 Compiler Way', 'Arlington', '22202');
+      await wizard.nextButton.click();
+      await expect(wizard.stepHeading).toHaveText(/Step 3 of 3: Review/);
+    });
+
+    await test.step('go back and invalidate Shipping without re-leaving it forward', async () => {
+      await wizard.previousButton.click(); // Review -> Shipping
+      await expect(wizard.stepHeading).toHaveText(/Step 2 of 3: Shipping/);
+      await wizard.postalCodeInput.fill('');
+    });
+
+    await test.step('Next re-validates the step being left and blocks forward progress', async () => {
+      await wizard.nextButton.click();
+
+      // Still on Shipping: the invalid subtree can never be left forward,
+      // so Review — and therefore the Confirm button, which only renders
+      // on Review — is unreachable from this state.
+      await expect(wizard.stepHeading).toHaveText(/Step 2 of 3: Shipping/);
+      await expect(wizard.errorAlerts.first()).toBeVisible();
+      await expect(wizard.confirmOrderButton).toHaveCount(0);
+    });
+
+    await test.step("the progress header can't be used to route around the block either", async () => {
+      // Review was never marked "visited" by the shared wizard (the
+      // custom Next/Previous buttons write `currentStep` directly and
+      // never call `goToStep()`), so its own header button is only ever
+      // enabled while Review is the CURRENT step (`completedSteps()`
+      // treats Review as completed once reached — see
+      // single-model-wizard.form.ts) or, once left, never again. From
+      // here (currently on Shipping, not Review), neither condition
+      // holds, so the button stays disabled — part of why the state is
+      // unreachable, not just coincidentally blocked once.
+      await expect(wizard.stepNavButton('Review')).toBeDisabled();
+    });
+  });
+});

--- a/apps/demo-e2e/src/page-objects/single-model-wizard.page.ts
+++ b/apps/demo-e2e/src/page-objects/single-model-wizard.page.ts
@@ -1,0 +1,93 @@
+import { DEMO_PATHS } from '@ngx-signal-forms/demo-shared';
+import { Locator, Page } from '@playwright/test';
+import { BaseFormPage } from './base-form.page';
+
+/**
+ * Page Object for "Advanced - Single-Model Wizard" demo
+ * Route: /advanced-scenarios/single-model-wizard
+ *
+ * A three-step wizard (Account → Shipping → Review) driven by ONE `form()`
+ * model. The custom Next button validates the active step directly via a
+ * shared `#validateStep` helper; the `ngx-wizard`'s `canNavigate` guard
+ * calls the same helper to gate progress-header clicks.
+ */
+export class SingleModelWizardPage extends BaseFormPage {
+  readonly fullNameInput: Locator;
+  readonly emailInput: Locator;
+  readonly streetInput: Locator;
+  readonly cityInput: Locator;
+  readonly postalCodeInput: Locator;
+  readonly expressShippingCheckbox: Locator;
+  readonly nextButton: Locator;
+  readonly previousButton: Locator;
+  readonly confirmOrderButton: Locator;
+  readonly stepHeading: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.fullNameInput = this.page.getByLabel('Full name');
+    this.emailInput = this.page.getByLabel('Email');
+    this.streetInput = this.page.getByLabel('Street address');
+    this.cityInput = this.page.getByLabel('City');
+    this.postalCodeInput = this.page.getByLabel('Postal code');
+    this.expressShippingCheckbox = this.page.getByLabel(/Express shipping/i);
+    this.nextButton = this.page.getByRole('button', { name: 'Next' });
+    this.previousButton = this.page.getByRole('button', { name: 'Previous' });
+    this.confirmOrderButton = this.page.getByRole('button', {
+      name: 'Confirm order',
+    });
+    // Scoped to the wizard's own step heading — the page also renders an
+    // unrelated `<h2>` for the "Demonstrated" example card.
+    this.stepHeading = this.page.locator('.single-model-wizard .step-heading');
+  }
+
+  async goto(): Promise<void> {
+    await this.gotoRoute(DEMO_PATHS.singleModelWizard);
+  }
+
+  async fillAccountStep(fullName: string, email: string): Promise<void> {
+    await this.fullNameInput.fill(fullName);
+    await this.emailInput.fill(email);
+  }
+
+  async fillShippingStep(
+    street: string,
+    city: string,
+    postalCode: string,
+  ): Promise<void> {
+    await this.streetInput.fill(street);
+    await this.cityInput.fill(city);
+    await this.postalCodeInput.fill(postalCode);
+  }
+
+  /** The always-visible running total in the status row. */
+  get orderTotal(): Locator {
+    return this.page.locator('.order-total');
+  }
+
+  /** The read-only order summary shown on the Review step. */
+  get orderSummary(): Locator {
+    return this.page.locator('.order-summary');
+  }
+
+  get successMessage(): Locator {
+    return this.page.locator('.success-message');
+  }
+
+  /** The shared `ngx-wizard`'s progress-bar fill (`completedSteps.length / steps.length`). */
+  get progressFill(): Locator {
+    return this.page.locator('.wizard-progress-fill');
+  }
+
+  /** The review step's "some details still need attention" alert. */
+  get reviewError(): Locator {
+    return this.page.locator('.review-error');
+  }
+
+  /** A progress-header step button, by its visible label. */
+  stepNavButton(label: 'Account' | 'Shipping' | 'Review'): Locator {
+    return this.page.locator('.wizard-progress .wizard-step-button', {
+      hasText: label,
+    });
+  }
+}

--- a/apps/demo/src/app/05-advanced/advanced-wizard/README.md
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/README.md
@@ -78,6 +78,8 @@ The most complex demo in the app: a three-step travel-booking wizard built on a 
 
 ## Related
 
+- [Single-Model Wizard](../single-model-wizard/README.md) — the single-`form()`
+  alternative to this demo's form-per-step architecture; read together for the contrast.
 - [Cross-Field Validation](../cross-field-validation/README.md) — the simpler cross-field primer.
 - [Submission Patterns](../submission-patterns/README.md) — declarative submission in a single-screen form.
 - [Global Configuration](../global-configuration/README.md) — app-level defaults the wizard also consumes.

--- a/apps/demo/src/app/05-advanced/single-model-wizard/README.md
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/README.md
@@ -1,0 +1,261 @@
+# Single-Model Wizard
+
+## Intent
+
+A three-step wizard (Account → Shipping → Review) built on **one shared `form()` model**,
+answering [docs/FAQ.md's condensed answer](../../../../../docs/FAQ.md#for-a-multi-step-wizard-how-do-i-validate-only-the-current-step-before-next-with-one-form-model)
+in full: how to gate "Next" on only the active step's subtree, run cross-step validation
+against a single model, and submit the whole thing once at the end. It reuses the shared
+`ngx-wizard` component **unmodified** — no fork, no new inputs.
+
+This demo is a sibling of [`advanced-wizard`](../advanced-wizard/README.md), not a
+replacement for it. Read both READMEs together; the contrast is the point.
+
+## Toolkit features showcased
+
+- One `form()` spanning every step; each step's template binds only its own slice
+  (`wizardForm.account…`, `wizardForm.shipping…`).
+- The shared `ngx-wizard`'s async-aware `canNavigate` input as the subtree-validation gate
+  (progress-header navigation, and — via a shared helper — the custom Next button; see the
+  "Shared component finding" section below) — see
+  [`components/wizard.ts`](../../shared/wizard/wizard.ts) and its
+  [README](../../shared/wizard/README.md).
+- Cross-step `validate(path, ctx => …)`: step 2's `expressShipping` reads step 1's `email`
+  via `ctx.valueOf(path.account.email)` — no store, no event, no manual sync.
+- Whole-form `submit()` (returns `Promise<boolean>`) on the final step, which re-validates
+  every field, not just the one on screen.
+- `focusFirstInvalid()` on both the per-step gate and the final submit failure path.
+
+## Form model
+
+```ts
+interface SingleModelWizardValue {
+  account: { fullName: string; email: string };
+  shipping: {
+    street: string;
+    city: string;
+    postalCode: string;
+    expressShipping: boolean;
+  };
+}
+```
+
+One `form(model, singleModelWizardSchema)` call. There is no per-step model, no
+`linkedSignal` bridge, and nothing to "commit" between steps — every step reads and writes
+the same signal directly.
+
+## Validation rules
+
+### Errors
+
+- Account — full name required; email required and must look like an email address.
+- Shipping — street, city, postal code required.
+- Cross-step — `expressShipping` (step 2) requires a non-free email domain on `account.email`
+  (step 1). Unchecking the box, or leaving it unchecked, needs no email at all.
+
+### Warnings
+
+- None.
+
+## How `canNavigate` gates a single-model wizard
+
+Bound as `[canNavigate]="guardStep"` on `<ngx-wizard>`. Per
+[`docs/FAQ.md`](../../../../../docs/FAQ.md#for-a-multi-step-wizard-how-do-i-validate-only-the-current-step-before-next-with-one-form-model),
+the guard validates the subtree of the step being **left**, not the one being entered:
+
+```ts
+protected readonly guardStep: WizardCanNavigate = (event) => {
+  if (event.toIndex <= event.fromIndex) return true; // always allow going back
+  return this.#validateStep(event.fromStep); // 'account' → wizardForm.account
+};
+
+#validateStep(stepId: string): boolean {
+  const stepField = this.#stepField(stepId);
+  if (!stepField) return true;
+
+  stepField().markAsTouched(); // cascades to every descendant field
+  if (stepField().invalid()) {
+    focusFirstInvalid(stepField);
+    return false;
+  }
+  return true;
+}
+```
+
+`markAsTouched()` cascading to descendants (Angular 22 Signal Forms) is what makes this
+work with one call: the whole step's errors surface at once, exactly like a normal
+single-screen form submit — just scoped to a subtree instead of the whole model.
+
+`#validateStep` is called from two places: `guardStep` (bound to `canNavigate`, gating
+progress-header clicks) and the custom Next button's `nextStep()` method (see the finding
+below for why Next can't drive through `canNavigate` directly). Both paths enforce the
+identical rule, so there's exactly one place that decides what "this step is valid enough
+to leave" means.
+
+The final step's Confirm button calls `submit(wizardForm, action)` directly — it isn't
+gated by `canNavigate` at all, because `submit()` performs its own whole-form validation
+and touches everything itself.
+
+## Shared component finding
+
+**The wizard's built-in Next button cannot be used to drive `canNavigate`-gated
+progression to a step that hasn't been visited yet — including the very first "Next"
+click of the whole wizard.**
+
+`WizardComponent.next()` calls `goToStep()`, which checks `canNavigateToStep()` **before**
+ever touching the `canNavigate` guard:
+
+```ts
+async goToStep(stepId: string): Promise<void> {
+  if (!this.canNavigateToStep(stepId)) {
+    return; // canNavigate is never even invoked
+  }
+  // ...only here does `canNavigate` get awaited
+}
+```
+
+`canNavigateToStep()` allows navigation to a step only if it's the current step, already
+**visited**, or already marked **completed**. On a fresh wizard, step 2 is none of those —
+so clicking the built-in "Next" button on step 1 is a no-op, silently, regardless of
+whether step 1 is valid. This isn't specific to a single-model form; it would affect any
+consumer trying to use the built-in Next button purely as a `canNavigate`-gated "validate
+then advance" control. `advanced-wizard` never hits this because it doesn't call
+`next()`/`goToStep()` for its own Next/Previous flow at all — it drives `currentStep`
+through its NgRx store directly (`[showNavigation]="false"` plus custom buttons calling
+`store.goToNextStep()`), which happens to sidestep the check without anyone having
+diagnosed it as one.
+
+**Resolution, without touching the shared component:** this demo also uses
+`[showNavigation]="false"` with custom buttons — the "Custom Navigation" pattern the
+wizard's own README already documents — but goes one step further than `advanced-wizard`:
+`nextStep()` calls the exact same `#validateStep()` helper the `canNavigate` guard uses,
+then writes `currentStep` directly (bypassing `goToStep()`/`canNavigateToStep()`
+entirely). The `canNavigate` guard stays bound and does real work for the progress
+header's own step-click navigation. Zero changes were made to
+[`shared/wizard/wizard.ts`](../../shared/wizard/wizard.ts).
+
+One consequence worth naming: because the custom Next/Previous buttons never call
+`goToStep()`, the wizard's own `#visitedSteps` set is never populated by this demo — so a
+header button is only ever enabled for the _current_ step or a step whose subtree is
+_presently_ valid (`completedSteps()`), never for "a step you visited a while ago,
+whatever state it's in now". That turns out to matter for the next section.
+
+If the shared component is ever revisited, the fix is narrow: `canNavigateToStep()`
+should not gate `next()`'s call into `goToStep()` — only header-click navigation needs
+the visited/completed check. That's a decision for the shared component's own owners, not
+something this demo should decide unilaterally.
+
+## Confirm is unreachable with an invalid earlier step
+
+A natural question: can you reach Review with Account or Shipping quietly broken (e.g.
+edited back into an invalid state after already passing it once), and have `submit()`
+fail at Confirm? Tested and confirmed **no** — this is not just untested, it's
+unreachable through the UI, by construction:
+
+- Every forward transition — the custom Next button (`nextStep()`) and the progress
+  header's own clicks (`goToStep()` → `canNavigate`) — re-validates the subtree of the
+  step **currently being left**, per `#validateStep()`. An invalid step can never be left
+  forward, by either path.
+- The Confirm button only renders once `isLastStep()` (Review). Reaching Review requires
+  leaving Shipping forward at least once _after_ it was last made invalid — which
+  `#validateStep()` blocks.
+- Cross-step validators (the express-shipping rule) live on the field whose value depends
+  on the other step (`shipping.expressShipping`), so editing `account.email` after the
+  fact reactively invalidates that field immediately — which also drops `'shipping'` out
+  of `completedSteps()` right away, disabling its own header button before you could even
+  attempt the workaround.
+
+Pinned by the "per-subtree gating makes reaching Confirm … unreachable" e2e test: it
+deliberately tries to construct the broken path (complete the wizard once, go back,
+invalidate Shipping, attempt to return to Review both via Next and via the progress
+header) and asserts every attempt is blocked.
+
+This does **not** mean `submit()`'s own whole-form validation in `confirmOrder()` is dead
+code — it's a safety net for exactly this state, kept as defense in depth in case the
+gating above is ever loosened. See that method's doc comment for the known UX nit if it
+ever does trigger: `focusFirstInvalid()` can't focus fields on Account/Shipping from
+Review, since those steps' `ng-template`s aren't rendered there — the `review-error`
+alert would be the only feedback. A "jump to the first invalid step" helper is a possible
+future improvement, not built here since the state it would help with isn't reachable
+today.
+
+## Strong suites (favor one model)
+
+- **Cross-step validation that reads another step's value while validating this step's
+  field** — one `validate()` call, no plumbing.
+- **Live cross-step values** — the running total in the status row and the Review step's
+  summary read the exact same signal every other step writes to; nothing is copied or
+  synced.
+- **A single submit at the end** — `submit()` runs once, against the whole model, and
+  there's exactly one source of truth to validate.
+
+## Weak suites (reach for `advanced-wizard`'s form-per-step instead)
+
+- **Steps that must be submittable and persisted independently of each other.** A single
+  model has no natural "save step 1 now, without step 2 existing yet" boundary.
+- **A draft that should survive navigating away and back.** `advanced-wizard`'s
+  `linkedSignal` + store draft/commit pattern gives every step its own recoverable state;
+  a single in-memory model here resets like any other unsaved form.
+- **Independently-typed or independently-versioned step schemas**, e.g. steps built by
+  different teams or loaded from different sources — a shared model couples them at the
+  type level.
+
+## Keyboard and screen-reader behavior on step change
+
+The shared `ngx-wizard` component does **not** manage focus itself — that's deliberately
+left to the consumer (see its README's "Validation with canNavigate" section). This demo
+follows the same recipe `advanced-wizard`'s `wizard-container.ts` uses — a `#pendingFocus`
+signal plus a named `afterRenderEffect()` that focuses a `tabindex="-1"` step heading once
+it renders — with one difference:
+
+- `advanced-wizard` sets `#pendingFocus` only inside its own custom `nextStep()` /
+  `previousStep()` methods, so navigating via the progress header's step buttons (which
+  call the wizard's `goToStep()` directly) does **not** move focus.
+- This demo instead watches the two-way-bound `currentStep` signal itself with a small
+  `effect()`, so focus moves to the new step's heading no matter which UI path triggered
+  the navigation — Next/Previous buttons, submit, or a progress-header step click alike.
+
+Each step heading is prefixed with its position ("Step 2 of 3: Shipping details"), so
+moving focus there both places the cursor sensibly **and** is the de facto step-change
+announcement for screen readers — there is no separate `aria-live` announcement, because
+focus movement onto content that states the new step number and name already conveys it.
+This is a consumer-side pattern, not a change to the shared component; verified with an
+axe-core scan (no new violations) and manual keyboard walkthrough (Tab order stays inside
+the active step, heading receives focus on every transition).
+
+## Key files
+
+- [single-model-wizard.model.ts](single-model-wizard.model.ts) — the one model, its initial
+  value, and step ids.
+- [single-model-wizard.validations.ts](single-model-wizard.validations.ts) — the single
+  schema, including the cross-step express-shipping rule.
+- [single-model-wizard.form.ts](single-model-wizard.form.ts) — the wizard: `form()`
+  creation, the `canNavigate` guard, focus management, and `submit()`.
+- [single-model-wizard.form.html](single-model-wizard.form.html) — step templates, each
+  binding only its own slice of `wizardForm`.
+
+## How to test
+
+1. Run the demo and navigate to `/advanced-scenarios/single-model-wizard`.
+2. Click **Next** on the empty Account step — confirm navigation is blocked, errors
+   appear, and focus lands on the first invalid field.
+3. Enter a personal email (e.g. `you@gmail.com`), advance to Shipping, and check
+   **Express shipping** — confirm the cross-step error naming step 1 appears.
+4. Go back to Account, change the email to a non-free domain, return to Shipping — confirm
+   the express-shipping error clears without touching that field again.
+5. Toggle Express shipping on/off and confirm the running total in the status row updates
+   immediately.
+6. Reach Review and confirm the summary matches steps 1–2 exactly, and the progress bar
+   above the steps reaches 100% (Review has no fields of its own, so it's treated as
+   completed once reached — otherwise the bar would max out at 2/3).
+7. Click **Confirm order** — confirm the success message appears and focus/announcement
+   behavior holds.
+
+## Related
+
+- [Advanced Wizard](../advanced-wizard/README.md) — the form-per-step + store
+  architecture; read together with this page for the full contrast.
+- [Shared wizard component](../../shared/wizard/README.md) — the `canNavigate` guard this
+  demo relies on.
+- [Cross-Field Validation](../cross-field-validation/README.md) — the single-screen
+  primer for `validate(path, ctx => …)`, without the wizard step-gating layer on top.

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.content.ts
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.content.ts
@@ -1,0 +1,62 @@
+export const SINGLE_MODEL_WIZARD_CONTENT = {
+  demonstrated: {
+    icon: '🧩',
+    title: 'Single-Model Wizard',
+    sections: [
+      {
+        title: 'One form(), three steps',
+        items: [
+          '• <strong>Shared model:</strong> One `form()` spans every step; each step template binds only its own slice (`wizardForm.account…`, `wizardForm.shipping…`)',
+          '• <strong>Subtree gating:</strong> A shared `#validateStep` helper marks the step being left as touched and checks its subtree\'s `valid()`/`invalid()` before allowing "Next"; the `ngx-wizard`\'s `canNavigate` guard calls the same helper to gate progress-header clicks',
+          "• <strong>Cross-step validation:</strong> Step 2's express-shipping checkbox reads step 1's email with `ctx.valueOf(path.account.email)` — no store, no event, no manual sync",
+        ],
+      },
+      {
+        title: 'Why this differs from advanced-wizard',
+        items: [
+          '• <strong>No per-step commit:</strong> There is nothing to "commit" — every step reads and writes the same model directly',
+          '• <strong>Live cross-step values:</strong> The running total and the review step update immediately from data entered on earlier steps',
+          '• <strong>Single submit():</strong> Confirming the order calls `submit()` once on the whole form, which re-validates every step, not just the one you are looking at',
+        ],
+      },
+    ],
+  },
+  learning: {
+    title: 'Wizard Patterns',
+    sections: [
+      {
+        title: '🧪 Try This',
+        items: [
+          '1. Click <strong>Next</strong> on the empty <strong>Account</strong> step → navigation is blocked, "Full name is required" and "Email is required" appear, and focus jumps to the first invalid field',
+          '2. Fill in a personal email like <code>you@gmail.com</code> and advance to <strong>Shipping</strong>',
+          '3. Fill the address fields and check <strong>Express shipping</strong> → "Express shipping requires a work email address (step 1)" appears, even though the field that is wrong lives on step 1',
+          '4. Go back to <strong>Account</strong>, change the email to <code>you@acme.example</code>, return to <strong>Shipping</strong> → the express-shipping error clears itself; no re-entry needed',
+          '5. Watch the running total in the status row update live as you check/uncheck express shipping — the same model is read from both steps',
+          '6. Reach <strong>Review</strong> and confirm the name, email, address and total shown there are the exact values from steps 1–2 — nothing was copied or committed',
+          '7. Click <strong>Confirm order</strong> → `submit()` marks the whole form touched and validates every field, not just the current step, before running the action',
+        ],
+      },
+      {
+        title: 'When one model wins',
+        items: [
+          "• Cross-step rules that read one step's value while validating another's field",
+          '• A single point-in-time submit at the end (no independent per-step persistence needed)',
+          '• Live derived values (totals, previews) that must reflect every step at once',
+        ],
+      },
+      {
+        title: 'When it does not',
+        items: [
+          '• Steps that must be submittable and persisted independently of each other',
+          '• A draft that should survive navigating away and back without a shared model to read from',
+          '• See <code>advanced-wizard</code> for the form-per-step + store architecture that covers those cases',
+        ],
+      },
+    ],
+    nextStep: {
+      text: 'See the form-per-step alternative in',
+      link: '/advanced-scenarios/advanced-wizard',
+      linkText: 'Advanced Wizard',
+    },
+  },
+} as const;

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.form.html
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.form.html
@@ -1,0 +1,211 @@
+<form [formRoot]="wizardForm" ngxSignalForm class="single-model-wizard">
+  <div class="status-row" aria-live="polite">
+    <span class="order-total">Running total: ${{ orderTotal() }}</span>
+  </div>
+
+  <ngx-wizard
+    [(currentStep)]="currentStep"
+    [completedSteps]="completedSteps()"
+    [canNavigate]="guardStep"
+    [showNavigation]="false"
+  >
+    <!-- Account step: bound to wizardForm.account -->
+    <ng-template
+      ngxWizardStep="account"
+      label="Account"
+      let-stepNumber="stepNumber"
+    >
+      <h2 #stepHeading tabindex="-1" class="step-heading">
+        Step {{ stepNumber }} of {{ stepCount }}: Account details
+      </h2>
+
+      <div class="step-fields">
+        <ngx-form-field-wrapper
+          [formField]="wizardForm.account.fullName"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="fullName">Full name</label>
+          <input
+            id="fullName"
+            type="text"
+            [formField]="wizardForm.account.fullName"
+          />
+        </ngx-form-field-wrapper>
+
+        <ngx-form-field-wrapper
+          [formField]="wizardForm.account.email"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            [formField]="wizardForm.account.email"
+          />
+          <ngx-form-field-hint>
+            A work email unlocks express shipping on the next step.
+          </ngx-form-field-hint>
+        </ngx-form-field-wrapper>
+      </div>
+    </ng-template>
+
+    <!-- Shipping step: bound to wizardForm.shipping, cross-step rule reads account.email -->
+    <ng-template
+      ngxWizardStep="shipping"
+      label="Shipping"
+      let-stepNumber="stepNumber"
+    >
+      <h2 #stepHeading tabindex="-1" class="step-heading">
+        Step {{ stepNumber }} of {{ stepCount }}: Shipping details
+      </h2>
+
+      <div class="step-fields">
+        <ngx-form-field-wrapper
+          [formField]="wizardForm.shipping.street"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="street">Street address</label>
+          <input
+            id="street"
+            type="text"
+            [formField]="wizardForm.shipping.street"
+          />
+        </ngx-form-field-wrapper>
+
+        <ngx-form-field-wrapper
+          [formField]="wizardForm.shipping.city"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="city">City</label>
+          <input id="city" type="text" [formField]="wizardForm.shipping.city" />
+        </ngx-form-field-wrapper>
+
+        <ngx-form-field-wrapper
+          [formField]="wizardForm.shipping.postalCode"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="postalCode">Postal code</label>
+          <input
+            id="postalCode"
+            type="text"
+            [formField]="wizardForm.shipping.postalCode"
+          />
+        </ngx-form-field-wrapper>
+
+        <ngx-form-field-wrapper
+          [formField]="wizardForm.shipping.expressShipping"
+          [appearance]="appearance()"
+          [orientation]="orientation()"
+        >
+          <label for="expressShipping">
+            Express shipping (+${{ expressShippingSurcharge }})
+          </label>
+          <input
+            id="expressShipping"
+            type="checkbox"
+            ngxSignalFormControl="checkbox"
+            [formField]="wizardForm.shipping.expressShipping"
+          />
+          <ngx-form-field-hint>
+            Requires a work email address, entered on step 1.
+          </ngx-form-field-hint>
+        </ngx-form-field-wrapper>
+      </div>
+    </ng-template>
+
+    <!-- Review step: read-only, live values pulled from the SAME model -->
+    <ng-template
+      ngxWizardStep="review"
+      label="Review"
+      let-stepNumber="stepNumber"
+    >
+      <h2 #stepHeading tabindex="-1" class="step-heading">
+        Step {{ stepNumber }} of {{ stepCount }}: Review your order
+      </h2>
+
+      @if (orderConfirmed()) {
+      <div
+        class="success-message"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        <p>Order confirmed! A confirmation email is on its way.</p>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          (click)="startNewOrder()"
+        >
+          Start a new order
+        </button>
+      </div>
+      } @else {
+      <dl class="order-summary">
+        <div>
+          <dt>Name</dt>
+          <dd>{{ wizardForm.account.fullName().value() || '—' }}</dd>
+        </div>
+        <div>
+          <dt>Email</dt>
+          <dd>{{ wizardForm.account.email().value() || '—' }}</dd>
+        </div>
+        <div>
+          <dt>Address</dt>
+          <dd>
+            {{ wizardForm.shipping.street().value() }}, {{
+            wizardForm.shipping.city().value() }} {{
+            wizardForm.shipping.postalCode().value() }}
+          </dd>
+        </div>
+        <div>
+          <dt>Shipping</dt>
+          <dd>
+            {{ wizardForm.shipping.expressShipping().value() ? 'Express' :
+            'Standard' }} — ${{ orderTotal() }}
+          </dd>
+        </div>
+      </dl>
+
+      @if (submitAttempted() && wizardForm().invalid()) {
+      <p class="review-error" role="alert">
+        Some details still need attention — check the earlier steps.
+      </p>
+      } }
+    </ng-template>
+  </ngx-wizard>
+
+  <!--
+    Custom navigation (ngx-wizard's `[showNavigation]="false"` +
+    "Custom Navigation" pattern from its own README). `nextStep()` calls
+    the SAME `#validateStep` the `canNavigate` guard above uses — see the
+    README's "Shared component finding" for why the built-in Next button
+    can't be used here.
+  -->
+  @if (!orderConfirmed()) {
+  <div class="wizard-navigation">
+    <button
+      type="button"
+      class="btn btn-secondary"
+      [disabled]="isFirstStep()"
+      (click)="previousStep()"
+    >
+      Previous
+    </button>
+
+    @if (!isLastStep()) {
+    <button type="button" class="btn btn-primary" (click)="nextStep()">
+      Next
+    </button>
+    } @else {
+    <button type="button" class="btn btn-success" (click)="confirmOrder()">
+      Confirm order
+    </button>
+    }
+  </div>
+  }
+</form>

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.form.scss
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.form.scss
@@ -1,0 +1,109 @@
+:host {
+  display: block;
+}
+
+.single-model-wizard {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+/* Reserved height prevents layout shift when the total changes. */
+.status-row {
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.step-heading {
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+
+  /* Focus lands here after every step change; keep the ring visible. */
+  &:focus-visible {
+    outline: 2px solid var(--color-primary, #3b82f6);
+    outline-offset: 2px;
+  }
+}
+
+.step-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.order-summary dt {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.order-summary dd {
+  margin: 0.125rem 0 0;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.review-error {
+  margin-top: 1rem;
+  color: #dc2626;
+}
+
+.success-message {
+  padding: 1rem;
+  background-color: #ecfdf5;
+  border: 1px solid #86efac;
+  border-radius: 0.75rem;
+  color: #166534;
+}
+
+.success-message p {
+  margin: 0 0 0.75rem;
+}
+
+.wizard-navigation {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1.5rem;
+}
+
+.btn {
+  padding: 0.5rem 1.5rem;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  border: none;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-primary {
+  background-color: var(--color-primary, #3b82f6);
+  color: white;
+}
+
+.btn-secondary {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.btn-success {
+  /* #22c55e (the shared --color-success token's usual fallback) is only
+     2.27:1 against white text — fails WCAG 2.2 AA's 4.5:1 minimum. Use a
+     darker green here instead of reusing that token's default. */
+  background-color: #166534;
+  color: white;
+}

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.form.ts
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.form.ts
@@ -1,0 +1,276 @@
+import {
+  afterRenderEffect,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  form,
+  FormField,
+  submit,
+  type FieldTree,
+} from '@angular/forms/signals';
+
+import {
+  type FormFieldAppearance,
+  type FormFieldOrientation,
+  focusFirstInvalid,
+  NgxSignalFormToolkit,
+} from '@ngx-signal-forms/toolkit';
+import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
+
+import {
+  type WizardCanNavigate,
+  WizardComponent,
+  WizardStepDirective,
+} from '../../shared/wizard';
+
+import {
+  BASE_SHIPPING_COST,
+  EXPRESS_SHIPPING_SURCHARGE,
+  INITIAL_SINGLE_MODEL_WIZARD_VALUE,
+  SINGLE_MODEL_WIZARD_STEP_COUNT,
+  type SingleModelWizardStepId,
+  type SingleModelWizardValue,
+} from './single-model-wizard.model';
+import { singleModelWizardSchema } from './single-model-wizard.validations';
+
+const STEP_ORDER: readonly SingleModelWizardStepId[] = [
+  'account',
+  'shipping',
+  'review',
+];
+
+/**
+ * Single-model wizard: one `form()` spans every step, and each step's
+ * template binds only its own slice (`wizardForm.account…`,
+ * `wizardForm.shipping…`). Contrast with `advanced-wizard`, which gives
+ * every step its own `form()` fed by a shared store — see this feature's
+ * README for when each shape earns its keep.
+ *
+ * Uses the shared `ngx-wizard` UNMODIFIED, with `[showNavigation]="false"`
+ * and custom Previous/Next/Confirm buttons — exactly the "Custom
+ * Navigation" pattern documented in its own README. That pattern turned
+ * out to be required, not optional, here: see the README's "Shared
+ * component finding" section for why the built-in nav buttons can't
+ * reach an unvisited step even when `canNavigate` would allow it.
+ */
+@Component({
+  selector: 'ngx-single-model-wizard',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+
+  imports: [
+    FormField,
+    NgxSignalFormToolkit,
+    NgxFormField,
+    WizardComponent,
+    WizardStepDirective,
+  ],
+  templateUrl: './single-model-wizard.form.html',
+  styleUrl: './single-model-wizard.form.scss',
+})
+export class SingleModelWizardComponent {
+  protected readonly appearance = signal<FormFieldAppearance>('outline');
+  protected readonly orientation = signal<FormFieldOrientation>('vertical');
+
+  readonly #model = signal<SingleModelWizardValue>(
+    INITIAL_SINGLE_MODEL_WIZARD_VALUE,
+  );
+
+  /** The one `form()` model spanning both editable steps. */
+  protected readonly wizardForm = form(this.#model, singleModelWizardSchema);
+  /** Surfaced for the page's live form-state debugger. */
+  readonly formTree: FieldTree<unknown> = this.wizardForm;
+
+  protected readonly currentStep = signal<SingleModelWizardStepId>('account');
+  protected readonly stepCount = SINGLE_MODEL_WIZARD_STEP_COUNT;
+  protected readonly expressShippingSurcharge = EXPRESS_SHIPPING_SURCHARGE;
+
+  protected readonly currentStepIndex = computed(() =>
+    STEP_ORDER.indexOf(this.currentStep()),
+  );
+  protected readonly isFirstStep = computed(
+    () => this.currentStepIndex() === 0,
+  );
+  protected readonly isLastStep = computed(
+    () => this.currentStepIndex() === STEP_ORDER.length - 1,
+  );
+
+  protected readonly orderConfirmed = signal(false);
+  protected readonly submitAttempted = signal(false);
+
+  /**
+   * Live cross-step value: the order total reacts to step 2's checkbox
+   * immediately, everywhere it's read (the review step below, or the
+   * status row) — no store round-trip or step-commit needed, because it's
+   * all one model.
+   */
+  protected readonly orderTotal = computed(() => {
+    const expressShipping = this.wizardForm.shipping.expressShipping().value();
+    return expressShipping
+      ? BASE_SHIPPING_COST + EXPRESS_SHIPPING_SURCHARGE
+      : BASE_SHIPPING_COST;
+  });
+
+  /**
+   * Steps whose subtree is currently valid — drives the progress header,
+   * including `ngx-wizard`'s progress bar
+   * (`completedSteps.length / steps.length`). Review has no fields of its
+   * own to validate — reaching it already required Account and Shipping to
+   * be valid, per `#validateStep` — so it's treated as completed once it's
+   * the active step, letting the progress bar reach 100% on step 3 of 3
+   * instead of maxing out at 2/3.
+   */
+  protected readonly completedSteps = computed(() => {
+    const steps: SingleModelWizardStepId[] = [];
+    if (!this.wizardForm.account().invalid()) steps.push('account');
+    if (!this.wizardForm.shipping().invalid()) steps.push('shipping');
+    if (this.currentStep() === 'review') steps.push('review');
+    return steps;
+  });
+
+  /**
+   * Tracks pending focus request for the active step heading. Set when
+   * `currentStep` changes, cleared once `afterRenderEffect` applies focus.
+   */
+  readonly #pendingFocus = signal(false);
+  #previousStepId: SingleModelWizardStepId | null = null;
+
+  protected readonly stepHeadingRef =
+    viewChild<ElementRef<HTMLHeadingElement>>('stepHeading');
+
+  // Named Angular effect fields are intentionally unread — Angular manages
+  // their lifecycle. Mirrors the pattern in advanced-wizard's
+  // wizard-container.ts.
+  // oxlint-disable-next-line no-unused-private-class-members -- EffectRef is intentionally kept as a named field to document the side effect.
+  readonly #trackStepChangeEffect = effect(() => {
+    const step = this.currentStep();
+    if (this.#previousStepId !== null && this.#previousStepId !== step) {
+      this.#pendingFocus.set(true);
+    }
+    this.#previousStepId = step;
+  });
+
+  // oxlint-disable-next-line no-unused-private-class-members -- EffectRef is intentionally kept as a named field to document the side effect.
+  readonly #focusHeadingEffect = afterRenderEffect(() => {
+    const heading = this.stepHeadingRef();
+    if (this.#pendingFocus() && heading) {
+      heading.nativeElement.focus();
+      this.#pendingFocus.set(false);
+    }
+  });
+
+  /**
+   * Gates PROGRESS-HEADER clicks — bound unmodified as `[canNavigate]` on
+   * `<ngx-wizard>`. Per docs/FAQ.md's single-model-wizard answer, it
+   * validates the subtree of the step being LEFT, not the one being
+   * entered, and only ever runs for forward moves.
+   *
+   * This is NOT what gates the Next button below — see the README's
+   * "Shared component finding" for why the built-in navigation had to move
+   * to custom buttons that call `#validateStep` directly instead.
+   */
+  protected readonly guardStep: WizardCanNavigate = (event) => {
+    if (event.toIndex <= event.fromIndex) {
+      return true; // always allow going back
+    }
+    return this.#validateStep(event.fromStep);
+  };
+
+  /**
+   * Marks the given step's subtree touched (cascades to every descendant
+   * field) and reports whether it's valid, focusing the first invalid
+   * field when it isn't. Shared by the header-click guard above and the
+   * custom Next button below, so both paths enforce the identical rule.
+   */
+  #validateStep(stepId: string): boolean {
+    const stepField = this.#stepField(stepId);
+    if (!stepField) {
+      return true;
+    }
+
+    stepField().markAsTouched();
+    if (stepField().invalid()) {
+      focusFirstInvalid(stepField);
+      return false;
+    }
+
+    return true;
+  }
+
+  #stepField(stepId: string): FieldTree<unknown> | null {
+    switch (stepId as SingleModelWizardStepId) {
+      case 'account':
+        return this.wizardForm.account;
+      case 'shipping':
+        return this.wizardForm.shipping;
+      default:
+        return null;
+    }
+  }
+
+  protected previousStep(): void {
+    const previousIndex = this.currentStepIndex() - 1;
+    if (previousIndex >= 0) {
+      this.currentStep.set(STEP_ORDER[previousIndex]);
+    }
+  }
+
+  protected nextStep(): void {
+    if (!this.#validateStep(this.currentStep())) {
+      return;
+    }
+
+    const nextIndex = this.currentStepIndex() + 1;
+    if (nextIndex < STEP_ORDER.length) {
+      this.currentStep.set(STEP_ORDER[nextIndex]);
+    }
+  }
+
+  /**
+   * Final step: whole-form `submit()`. It marks every field touched, runs
+   * every validator (including the cross-step one), and only runs the
+   * action if the whole model — not just the current slice — is valid.
+   *
+   * In THIS demo's current wiring, per-subtree gating (`#validateStep`,
+   * above) means every forward transition already re-validates the step
+   * being left, so reaching Review/Confirm with an invalid Account or
+   * Shipping subtree is unreachable through the UI (pinned by the
+   * "per-subtree gating makes reaching Confirm … unreachable" e2e test).
+   * `submit()`'s own validation is a safety net for that state anyway —
+   * defense in depth against a future gating change, not dead code.
+   *
+   * Known UX nit if that safety net ever DOES trigger: `focusFirstInvalid`
+   * walks the whole form's error summary, but Account/Shipping's fields
+   * live inside the wizard's lazily-rendered `ng-template` steps (only
+   * Review is in the DOM here) — so it has no bound control to focus on
+   * those steps and silently no-ops for them. The `review-error` alert
+   * below is the only feedback in that case. A "jump to the first invalid
+   * step, then focus" helper would close this gap; not built here since
+   * the state it addresses isn't currently reachable.
+   */
+  protected async confirmOrder(): Promise<void> {
+    this.submitAttempted.set(true);
+
+    const succeeded = await submit(this.wizardForm, async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 600));
+      this.orderConfirmed.set(true);
+    });
+
+    if (!succeeded) {
+      focusFirstInvalid(this.wizardForm);
+    }
+  }
+
+  protected startNewOrder(): void {
+    this.#model.set(INITIAL_SINGLE_MODEL_WIZARD_VALUE);
+    this.orderConfirmed.set(false);
+    this.submitAttempted.set(false);
+    this.currentStep.set('account');
+    this.#previousStepId = null;
+  }
+}

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.model.ts
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.model.ts
@@ -1,0 +1,42 @@
+/**
+ * Account details, gathered on step 1. Also feeds step 2's cross-step
+ * validation (a work email unlocks express shipping).
+ */
+export interface SingleModelWizardAccount {
+  fullName: string;
+  email: string;
+}
+
+/**
+ * Shipping details, gathered on step 2. `expressShipping` is only valid when
+ * step 1's email is a work address — a cross-step rule that a single shared
+ * `form()` model can express directly, with no synchronization between
+ * per-step forms required.
+ */
+export interface SingleModelWizardShipping {
+  street: string;
+  city: string;
+  postalCode: string;
+  expressShipping: boolean;
+}
+
+/** The single `form()` model spanning every step of the wizard. */
+export interface SingleModelWizardValue {
+  account: SingleModelWizardAccount;
+  shipping: SingleModelWizardShipping;
+}
+
+export const INITIAL_SINGLE_MODEL_WIZARD_VALUE: SingleModelWizardValue = {
+  account: { fullName: '', email: '' },
+  shipping: { street: '', city: '', postalCode: '', expressShipping: false },
+};
+
+/** Step identifiers, matching the `ngxWizardStep` values in the template. */
+export type SingleModelWizardStepId = 'account' | 'shipping' | 'review';
+
+export const SINGLE_MODEL_WIZARD_STEP_COUNT = 3;
+
+/** Base shipping cost, in whole currency units. */
+export const BASE_SHIPPING_COST = 25;
+/** Extra cost for express shipping, in whole currency units. */
+export const EXPRESS_SHIPPING_SURCHARGE = 15;

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.page.ts
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.page.ts
@@ -1,0 +1,59 @@
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
+import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
+
+import {
+  ExampleCardsComponent,
+  PageHeaderComponent,
+  SplitLayoutComponent,
+} from '../../ui';
+
+import { SINGLE_MODEL_WIZARD_CONTENT } from './single-model-wizard.content';
+import { SingleModelWizardComponent } from './single-model-wizard.form';
+
+@Component({
+  selector: 'ngx-single-model-wizard-page',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+  `,
+  imports: [
+    SingleModelWizardComponent,
+    ExampleCardsComponent,
+    PageHeaderComponent,
+    SplitLayoutComponent,
+    NgxSignalFormDebugger,
+  ],
+  template: `
+    <ngx-page-header
+      title="Single-Model Wizard"
+      subtitle="One form() model spanning every step, gated by the shared wizard's canNavigate guard"
+    />
+
+    <ngx-example-cards
+      [demonstrated]="content.demonstrated"
+      [learning]="content.learning"
+    >
+      <ngx-split-layout>
+        <ngx-single-model-wizard left />
+
+        @if (wizardRef(); as wizard) {
+          <div right>
+            <ngx-signal-form-debugger
+              [formTree]="wizard.formTree"
+              title="Whole-Wizard Form State"
+            />
+          </div>
+        }
+      </ngx-split-layout>
+    </ngx-example-cards>
+  `,
+})
+export class SingleModelWizardPageComponent {
+  protected readonly content = SINGLE_MODEL_WIZARD_CONTENT;
+  protected readonly wizardRef = viewChild(SingleModelWizardComponent);
+}

--- a/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.validations.ts
+++ b/apps/demo/src/app/05-advanced/single-model-wizard/single-model-wizard.validations.ts
@@ -1,0 +1,58 @@
+import { required, schema, validate } from '@angular/forms/signals';
+import type { SingleModelWizardValue } from './single-model-wizard.model';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Free/consumer email providers. Express shipping is reserved for accounts
+ * using a work email — a rule that reads step 1's `email` while validating
+ * step 2's `expressShipping` field.
+ */
+const FREE_EMAIL_DOMAINS = new Set([
+  'gmail.com',
+  'yahoo.com',
+  'hotmail.com',
+  'outlook.com',
+  'icloud.com',
+]);
+
+/**
+ * Single schema for the whole wizard model. Every rule — single-field and
+ * cross-step alike — is declared once, against the one shared `form()`
+ * model. There is no per-step schema to keep in sync.
+ */
+export const singleModelWizardSchema = schema<SingleModelWizardValue>(
+  (path) => {
+    required(path.account.fullName, { message: 'Full name is required' });
+    required(path.account.email, { message: 'Email is required' });
+    validate(path.account.email, (ctx) => {
+      const value = ctx.value();
+      if (!value || EMAIL_PATTERN.test(value)) return null;
+      return { kind: 'email', message: 'Enter a valid email address' };
+    });
+
+    required(path.shipping.street, { message: 'Street address is required' });
+    required(path.shipping.city, { message: 'City is required' });
+    required(path.shipping.postalCode, {
+      message: 'Postal code is required',
+    });
+
+    // Cross-step rule: express shipping (step 2) is gated on the email
+    // domain entered on step 1. Reading `ctx.valueOf(path.account.email)`
+    // is the whole trick — no store, no event, no manual sync.
+    validate(path.shipping.expressShipping, (ctx) => {
+      if (!ctx.value()) return null; // unchecked: nothing to validate
+
+      const email = ctx.valueOf(path.account.email);
+      const domain = email.split('@')[1]?.toLowerCase();
+
+      if (!domain || FREE_EMAIL_DOMAINS.has(domain)) {
+        return {
+          kind: 'expressShippingRequiresWorkEmail',
+          message: 'Express shipping requires a work email address (step 1)',
+        };
+      }
+      return null;
+    });
+  },
+);

--- a/apps/demo/src/app/app.routes.ts
+++ b/apps/demo/src/app/app.routes.ts
@@ -205,6 +205,14 @@ export const appRoutes: Routes = [
         title: getRouteTitle('/advanced-scenarios/advanced-wizard'),
       },
       {
+        path: 'single-model-wizard',
+        loadComponent: () =>
+          import('./05-advanced/single-model-wizard/single-model-wizard.page').then(
+            (m) => m.SingleModelWizardPageComponent,
+          ),
+        title: getRouteTitle('/advanced-scenarios/single-model-wizard'),
+      },
+      {
         path: 'async-validation',
         loadComponent: () =>
           import('./05-advanced/async-validation/async-validation.page').then(

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -355,11 +355,13 @@ protected readonly guardStep: WizardCanNavigate = (event) => {
 ```
 
 Run whole-form validation at the end by touching everything (`submit()` marks all fields touched
-internally) before the final action. Honest gap: the maintained `advanced-wizard` demo uses a
-_form-per-step_ + NgRx architecture rather than one shared model, so treat it as a reference for
-step orchestration, not for the single-model pattern above.
+internally) before the final action. The maintained `advanced-wizard` demo uses a _form-per-step_ +
+NgRx architecture rather than one shared model — treat it as a reference for step orchestration.
+`single-model-wizard` is the runnable reference for the single-model pattern above, including the
+cross-step rule and the `canNavigate` guard shown here.
 
 **See:** [demo: wizard component](../apps/demo/src/app/shared/wizard/README.md) ·
+[demo: single-model-wizard](../apps/demo/src/app/05-advanced/single-model-wizard/README.md) ·
 [demo: advanced-wizard](../apps/demo/src/app/05-advanced/advanced-wizard/README.md)
 
 ### How do I two-way sync my form model with an NgRx SignalStore without update loops?

--- a/packages/demo-shared/src/lib/routes.metadata.ts
+++ b/packages/demo-shared/src/lib/routes.metadata.ts
@@ -15,6 +15,7 @@ export const DEMO_PATHS = {
   globalConfiguration: '/advanced-scenarios/global-configuration',
   submissionPatterns: '/advanced-scenarios/submission-patterns',
   advancedWizard: '/advanced-scenarios/advanced-wizard',
+  singleModelWizard: '/advanced-scenarios/single-model-wizard',
   asyncValidation: '/advanced-scenarios/async-validation',
   fieldStatePatterns: '/advanced-scenarios/field-state-patterns',
   crossFieldValidation: '/advanced-scenarios/cross-field-validation',
@@ -144,6 +145,11 @@ export const DEMO_CATEGORIES = [
         path: '/advanced-scenarios/advanced-wizard',
         label: 'Advanced Wizard (@ngrx/signals + Zod)',
         hasControls: true,
+      },
+      {
+        path: '/advanced-scenarios/single-model-wizard',
+        label: 'Single-Model Wizard',
+        hasControls: false,
       },
       {
         path: '/advanced-scenarios/async-validation',


### PR DESCRIPTION
New `advanced-scenarios/single-model-wizard` page — the canonical shape reader tests kept asking for: **one `form()` model spanning all steps**, as a sibling to `advanced-wizard`'s form-per-step + NgRx draft/commit (different architectures, not two settings of one; the README's contrast section is the teaching value and `advanced-wizard` is not being replaced).

Mechanics: each step template binds only its slice; Next marks the active step's subtree touched (Angular 22 cascade) and gates on that subtree's validity with `focusFirstInvalid()`; a cross-step rule (express shipping requires a company email) reads `account.email` from the shipping step; the final step runs whole-form `submit()` (`Promise<boolean>`).

Two findings worth reviewer attention:

- **Shared-component finding, reported not patched**: `WizardComponent.next()` consults `canNavigateToStep()` (current/visited/completed only) *before* `canNavigate`, so its built-in Next is a silent no-op for any never-visited step — `advanced-wizard` never noticed because it bypasses `next()` via its store. This demo reuses the wizard unmodified through its documented custom-navigation pattern, keeps `canNavigate` genuinely exercised via header clicks, and records the finding (with a suggested fix) in the README.
- **Confirm-with-invalid-earlier-step is unreachable**, and that's now a pinned invariant: every forward path re-validates the subtree being left, and the cross-step rule reactively disables the Review header button the instant its dependency changes. An E2E test constructs the tampering attempt and asserts every route to Confirm is blocked; a code comment records that if the safety-net `submit()` failure were ever reached, `focusFirstInvalid()` would no-op for non-rendered steps (future "jump to first invalid step" idea noted, not built).

Focus lands on the step heading ("Step N of 3: …") on every step change, covering custom buttons *and* header clicks. Axe scans at four wizard states: 0 violations; one inherited low-contrast confirm-button color fixed locally. 7 E2E tests, 3× green; FAQ §339 now points at the runnable demo.

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
