### PR TITLE
fix(demo): align showcase forms with the current Signal Forms contract

### DIFF
--- a/apps/demo-e2e/src/forms/02-toolkit-core/aria-attributes.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/aria-attributes.spec.ts
@@ -110,32 +110,30 @@ test.describe('Accessibility - ARIA Attributes', () => {
     await test.step('Verify additive aria-describedby behavior', async () => {
       const ratingInput = page.locator('#overallRating');
 
-      /// Verify initial aria-describedby contains only the hint
-      const initialDescribedBy = ratingInput;
-      await expect(initialDescribedBy).toHaveAttribute(
-        'aria-describedby',
-        'rating-hint',
-      );
+      await expect(page.locator('#rating-hint')).toBeVisible();
+      await expect(ratingInput).not.toHaveAttribute('aria-describedby');
 
       /// Trigger validation error by entering invalid value and blurring
       await ratingInput.fill('0');
       await ratingInput.blur();
 
-      /// After error, aria-describedby should contain BOTH hint and error ID
-      const updatedDescribedBy =
-        await ratingInput.getAttribute('aria-describedby');
-      expect(updatedDescribedBy).toContain('rating-hint');
-      expect(updatedDescribedBy).toContain('overallRating-error');
+      /// After error, auto-ARIA adds the error id. The hint stays visible
+      /// without an author-owned aria-describedby on the control.
+      await expect(ratingInput).toHaveAttribute(
+        'aria-describedby',
+        /overallRating-error/,
+      );
+      await expect(page.locator('#rating-hint')).toBeVisible();
 
-      /// Fix the value and verify error ID is removed but hint remains
+      /// Fix the value and verify the error id is removed
       await ratingInput.fill('4');
       await ratingInput.blur();
 
-      const finalDescribedBy = ratingInput;
-      await expect(finalDescribedBy).toHaveAttribute(
+      await expect(ratingInput).not.toHaveAttribute(
         'aria-describedby',
-        'rating-hint',
+        /overallRating-error/,
       );
+      await expect(page.locator('#rating-hint')).toBeVisible();
     });
   });
 
@@ -155,22 +153,22 @@ test.describe('Accessibility - ARIA Attributes', () => {
       const improvementTextarea = page.locator('#improvementSuggestions');
       await expect(improvementTextarea).toBeVisible({ timeout: 3000 });
 
-      /// Verify initial aria-describedby contains both hint and counter
-      const initialDescribedBy =
-        await improvementTextarea.getAttribute('aria-describedby');
-      expect(initialDescribedBy).toContain('improvement-hint');
-      expect(initialDescribedBy).toContain('improvement-counter');
+      await expect(page.locator('#improvement-hint')).toBeVisible();
+      await expect(page.locator('#improvement-counter')).toBeVisible();
+      await expect(improvementTextarea).not.toHaveAttribute('aria-describedby');
 
       /// Trigger validation error by blurring empty required field
       await improvementTextarea.focus();
       await improvementTextarea.blur();
 
-      /// After error, aria-describedby should contain hint, counter, AND error ID
-      const updatedDescribedBy =
-        await improvementTextarea.getAttribute('aria-describedby');
-      expect(updatedDescribedBy).toContain('improvement-hint');
-      expect(updatedDescribedBy).toContain('improvement-counter');
-      expect(updatedDescribedBy).toContain('improvementSuggestions-error');
+      /// After error, auto-ARIA links the error container. Hint and counter
+      /// stay in the DOM with stable ids.
+      await expect(improvementTextarea).toHaveAttribute(
+        'aria-describedby',
+        /improvementSuggestions-error/,
+      );
+      await expect(page.locator('#improvement-hint')).toBeVisible();
+      await expect(page.locator('#improvement-counter')).toBeVisible();
     });
   });
 });

--- a/apps/demo-e2e/src/forms/02-toolkit-core/aria-strategy-integration.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/aria-strategy-integration.spec.ts
@@ -58,10 +58,11 @@ test.describe('ARIA Strategy Integration', () => {
       await ratingInput.focus();
       await ratingInput.fill('0');
 
-      /// aria-describedby should only contain hint, NOT error ID
-      await expect(ratingInput).toHaveAttribute(
+      /// On this wrapper-free page, auto-ARIA does not stamp author hint
+      /// ids. Before blur it must not link the error container either.
+      await expect(ratingInput).not.toHaveAttribute(
         'aria-describedby',
-        'rating-hint',
+        /overallRating-error/,
       );
     });
   });
@@ -76,10 +77,13 @@ test.describe('ARIA Strategy Integration', () => {
       await ratingInput.fill('0');
       await ratingInput.blur();
 
-      /// aria-describedby should contain both hint AND error ID
-      const describedBy = await ratingInput.getAttribute('aria-describedby');
-      expect(describedBy).toContain('rating-hint');
-      expect(describedBy).toContain('overallRating-error');
+      /// After blur, auto-ARIA links the error container. Hint ids stay in
+      /// the DOM; they are not preserved author aria-describedby values.
+      await expect(page.locator('#rating-hint')).toBeVisible();
+      await expect(ratingInput).toHaveAttribute(
+        'aria-describedby',
+        /overallRating-error/,
+      );
     });
   });
 

--- a/apps/demo-e2e/src/forms/02-toolkit-core/error-display-modes.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/error-display-modes.spec.ts
@@ -118,6 +118,45 @@ test.describe('Error Display Modes', () => {
     });
   });
 
+  test('does not set author-owned aria-describedby on toolkit-managed native inputs', async () => {
+    const controlIds = [
+      'name',
+      'email',
+      'company',
+      'productUsed',
+      'overallRating',
+      'detailedFeedback',
+    ];
+
+    for (const id of controlIds) {
+      await expect(formPage.page.locator(`#${id}`)).not.toHaveAttribute(
+        'aria-describedby',
+      );
+    }
+
+    await expect(formPage.page.locator('#name-hint')).toBeVisible();
+    await expect(formPage.page.locator('#detailed-hint')).toBeVisible();
+    await expect(formPage.page.locator('#detailed-counter')).toBeVisible();
+  });
+
+  test('shows an in-page status message on valid submit and does not call window.alert', async () => {
+    const dialogs: string[] = [];
+    formPage.page.on('dialog', (dialog) => {
+      dialogs.push(dialog.message());
+      void dialog.dismiss();
+    });
+
+    await formPage.fillValidData();
+    await formPage.submit();
+
+    await expect(
+      formPage.page.getByRole('status').filter({
+        hasText: /thank you for your feedback/i,
+      }),
+    ).toBeVisible();
+    expect(dialogs).toEqual([]);
+  });
+
   test('valid data should not show errors in any mode', async () => {
     await test.step('Fill with valid data across all modes', async () => {
       const modes = ['immediate', 'onTouch', 'onSubmit'] as const;

--- a/apps/demo-e2e/src/forms/02-toolkit-core/error-display-modes.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/error-display-modes.spec.ts
@@ -137,6 +137,14 @@ test.describe('Error Display Modes', () => {
     await expect(formPage.page.locator('#name-hint')).toBeVisible();
     await expect(formPage.page.locator('#detailed-hint')).toBeVisible();
     await expect(formPage.page.locator('#detailed-counter')).toBeVisible();
+
+    await formPage.ratingInput.fill('2');
+    await formPage.ratingInput.blur();
+    const improvement = formPage.page.locator('#improvementSuggestions');
+    await expect(improvement).toBeVisible();
+    await expect(improvement).not.toHaveAttribute('aria-describedby');
+    await expect(formPage.page.locator('#improvement-hint')).toBeVisible();
+    await expect(formPage.page.locator('#improvement-counter')).toBeVisible();
   });
 
   test('shows an in-page status message on valid submit and does not call window.alert', async () => {

--- a/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
@@ -220,6 +220,26 @@ test.describe('Warning Support Demo', () => {
     });
   });
 
+  test.describe('Form host contract', () => {
+    test('uses formRoot without a host submit handler', async ({
+      page: playwrightPage,
+    }) => {
+      const form = playwrightPage.locator('ngx-warning-support-form form');
+      await expect(form).toBeVisible();
+      await expect(form).toHaveAttribute('novalidate', '');
+      await expect(form).not.toHaveAttribute('ng-reflect-ng-submit');
+
+      const hasComponentSubmitHandler = await form.evaluate((element) => {
+        const host = element.closest('ngx-warning-support-form');
+        return Boolean(
+          host &&
+          'handleSubmit' in (host as unknown as Record<string, unknown>),
+        );
+      });
+      expect(hasComponentSubmitHandler).toBe(false);
+    });
+  });
+
   test.describe('Form Submission', () => {
     test('should show success message after valid submission (no warnings)', async () => {
       await page.usernameInput.fill('testuser123');

--- a/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
@@ -221,13 +221,12 @@ test.describe('Warning Support Demo', () => {
   });
 
   test.describe('Form host contract', () => {
-    test('uses formRoot without a host submit handler', async ({
+    test('uses a formRoot host with native novalidate', async ({
       page: playwrightPage,
     }) => {
       const form = playwrightPage.locator('ngx-warning-support-form form');
       await expect(form).toBeVisible();
       await expect(form).toHaveAttribute('novalidate', '');
-      await expect(form).not.toHaveAttribute('ng-reflect-ng-submit');
     });
   });
 

--- a/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
+++ b/apps/demo-e2e/src/forms/02-toolkit-core/warning-support.spec.ts
@@ -228,15 +228,6 @@ test.describe('Warning Support Demo', () => {
       await expect(form).toBeVisible();
       await expect(form).toHaveAttribute('novalidate', '');
       await expect(form).not.toHaveAttribute('ng-reflect-ng-submit');
-
-      const hasComponentSubmitHandler = await form.evaluate((element) => {
-        const host = element.closest('ngx-warning-support-form');
-        return Boolean(
-          host &&
-          'handleSubmit' in (host as unknown as Record<string, unknown>),
-        );
-      });
-      expect(hasComponentSubmitHandler).toBe(false);
     });
   });
 

--- a/apps/demo-e2e/src/forms/05-advanced/advanced-wizard.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/advanced-wizard.spec.ts
@@ -91,6 +91,12 @@ test.describe('Advanced Wizard Demo', () => {
       await expect(
         page.getByRole('heading', { name: 'Trip Details', exact: true }),
       ).toBeFocused();
+
+      const countryInput = page.locator('#dest-country-0');
+      await expect(countryInput).toBeVisible();
+      await expect(
+        page.locator('form.trip-step').locator('#dest-country-0'),
+      ).toBeVisible();
     });
 
     // ----------------------------------------------------------------

--- a/apps/demo-e2e/src/forms/05-advanced/i18n.spec.ts
+++ b/apps/demo-e2e/src/forms/05-advanced/i18n.spec.ts
@@ -17,6 +17,11 @@ test.describe('Advanced - i18n: Runtime Language Switch', () => {
     await expect(page.emailInput).toBeVisible();
   });
 
+  test('shows Form State & Validation bound to the live i18n form tree', async () => {
+    await expect(page.page.locator('ngx-split-layout')).toBeVisible();
+    await expect(page.page.locator('ngx-signal-form-debugger')).toBeVisible();
+  });
+
   test('should switch the required error text on a runtime language change', async () => {
     await test.step('Touch full name to trigger the required error in English', async () => {
       await page.fullNameInput.focus();

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.content.spec.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.content.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { YOUR_FIRST_FORM_CONTENT } from './your-first-form.content';
+
+describe('Your First Form educational copy', () => {
+  it('quotes live schema messages and does not claim native required', () => {
+    const items = [
+      ...YOUR_FIRST_FORM_CONTENT.demonstrated.sections.flatMap(
+        (section) => section.items,
+      ),
+      ...YOUR_FIRST_FORM_CONTENT.learning.sections.flatMap(
+        (section) => section.items,
+      ),
+    ].join('\n');
+
+    expect(items).toContain('Name must be at least 2 characters');
+    expect(items).toContain('Please enter a valid email address');
+    expect(items).toMatch(/Signal Forms owns requiredness|owns requiredness/i);
+    expect(items).not.toMatch(
+      /Keep semantic control attributes such as <code>type<\/code>, <code>required<\/code>/,
+    );
+  });
+});

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.content.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.content.ts
@@ -36,7 +36,8 @@ export const YOUR_FIRST_FORM_CONTENT = {
       {
         title: 'Validation ownership',
         items: [
-          '<strong>Native HTML still matters:</strong> Keep semantic control attributes such as <code>type</code>, <code>required</code>, and <code>autocomplete</code>',
+          '<strong>Native HTML still matters:</strong> Keep semantic control attributes such as <code>type</code> and <code>autocomplete</code>',
+          '<strong>Signal Forms owns requiredness:</strong> Required rules live in the schema. Do not add HTML <code>required</code> — it fights Signal Forms / toolkit error timing',
           '<strong>Signal Forms owns displayed state:</strong> Error visibility follows field state and the selected strategy, not browser submit-time validation UI',
           '<strong>Toolkit owns presentation:</strong> <code>aria-invalid</code>, <code>aria-describedby</code>, and reusable error rendering come from Signal Forms state',
         ],
@@ -58,10 +59,10 @@ export const YOUR_FIRST_FORM_CONTENT = {
       {
         title: '🧪 Try This (On Touch Strategy)',
         items: [
-          '1. Click the Name field → Tab away → See error appear',
-          '2. Type "A" → Error: "min 2 characters"',
+          '1. Click the Name field → Tab away → See error appear: "Name is required"',
+          '2. Type "A" → Error: "Name must be at least 2 characters"',
           '3. Type "Ab" → Error disappears',
-          '4. Test Email: Enter "test" → Leave field → Invalid email error',
+          '4. Test Email: Enter "test" → Leave field → "Please enter a valid email address"',
           '5. Submit empty form → All errors show at once',
         ],
       },

--- a/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.form.ts
+++ b/apps/demo/src/app/01-getting-started/your-first-form/your-first-form.form.ts
@@ -32,6 +32,7 @@ import { contactFormSchema } from './your-first-form.validations';
         <input
           id="contact-name"
           type="text"
+          autocomplete="name"
           [formField]="contactForm.name"
           class="form-input"
           placeholder="Your name"
@@ -50,6 +51,7 @@ import { contactFormSchema } from './your-first-form.validations';
         <input
           id="contact-email"
           type="email"
+          autocomplete="email"
           [formField]="contactForm.email"
           class="form-input"
           placeholder="you@example.com"

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.content.spec.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.content.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { ERROR_DISPLAY_MODES_CONTENT } from './error-display-modes.content';
+import * as errorDisplayModesBarrel from './index';
+
+function flattenItems(
+  content: typeof ERROR_DISPLAY_MODES_CONTENT,
+): readonly string[] {
+  return [
+    ...content.demonstrated.sections.flatMap((section) => section.items),
+    ...content.learning.sections.flatMap((section) => section.items),
+  ];
+}
+
+describe('Error Display Modes educational copy', () => {
+  it('quotes live improvement messages and does not call the rating control stars or claim cross-field validation', () => {
+    const items = flattenItems(ERROR_DISPLAY_MODES_CONTENT).join('\n');
+
+    expect(items).toContain('Please help us understand what could be improved');
+    expect(items).toContain(
+      'Please provide at least 10 characters of feedback',
+    );
+    expect(items).not.toMatch(/stars/i);
+    expect(items).not.toMatch(/cross-field validation/i);
+  });
+
+  it('does not export the unused productFeedbackValidationSuite', () => {
+    expect(errorDisplayModesBarrel).not.toHaveProperty(
+      'productFeedbackValidationSuite',
+    );
+  });
+});

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.content.spec.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.content.spec.ts
@@ -19,8 +19,8 @@ describe('Error Display Modes educational copy', () => {
     expect(items).toContain(
       'Please provide at least 10 characters of feedback',
     );
-    expect(items).not.toMatch(/stars/i);
-    expect(items).not.toMatch(/cross-field validation/i);
+    expect(items).not.toMatch(/stars/iu);
+    expect(items).not.toMatch(/cross-field validation/iu);
   });
 
   it('does not export the unused productFeedbackValidationSuite', () => {

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.content.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.content.ts
@@ -14,7 +14,7 @@ export const ERROR_DISPLAY_MODES_CONTENT = {
           '<strong>Email:</strong> Required, valid email format',
           '<strong>Company:</strong> Optional, max 100 characters',
           '<strong>Product Used:</strong> Required selection',
-          '<strong>Rating:</strong> Required, 1-5 stars',
+          '<strong>Rating:</strong> Required number, 1-5',
           '<strong>Improvement Suggestions:</strong> Required if rating ≤ 3, min 10 chars, max 500',
           '<strong>Detailed Feedback:</strong> Optional, max 1000 characters',
         ],
@@ -33,7 +33,6 @@ export const ERROR_DISPLAY_MODES_CONTENT = {
         items: [
           'Conditional validation (improvement suggestions for low ratings)',
           'Character counting with live feedback',
-          'Cross-field validation',
           'Dynamic field visibility',
         ],
       },
@@ -53,8 +52,8 @@ export const ERROR_DISPLAY_MODES_CONTENT = {
       {
         title: '🎯 Conditional Validation Test',
         items: [
-          '1. Set rating to 3 or below → Improvement field becomes required',
-          '2. Type less than 10 characters → Error: "at least 10 characters"',
+          '1. Set rating to 3 or below → Improvement field becomes required: "Please help us understand what could be improved"',
+          '2. Type less than 10 characters → Error: "Please provide at least 10 characters of feedback"',
           '3. Type 500+ characters → Character count turns red',
           '4. Set rating to 4 or 5 → Improvement field becomes optional',
         ],

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.form.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.form.ts
@@ -176,7 +176,6 @@ export class ErrorDisplayHelpersComponent {
             type="text"
             autocomplete="name"
             [formField]="productForm.name"
-            aria-describedby="name-hint"
             placeholder="Your full name"
           />
           <div class="form-hint" id="name-hint">
@@ -198,7 +197,6 @@ export class ErrorDisplayHelpersComponent {
             autocomplete="email"
             [formField]="productForm.email"
             placeholder="your.email@company.com"
-            aria-describedby="email-hint"
           />
           <div class="form-hint" id="email-hint">
             For follow-up questions (we respect your privacy)
@@ -219,7 +217,6 @@ export class ErrorDisplayHelpersComponent {
             autocomplete="organization"
             [formField]="productForm.company"
             placeholder="Your company (optional)"
-            aria-describedby="company-hint"
           />
           <div class="form-hint" id="company-hint">
             Helps us understand your use case
@@ -248,7 +245,6 @@ export class ErrorDisplayHelpersComponent {
             class="form-input"
             id="productUsed"
             [formField]="productForm.productUsed"
-            aria-describedby="product-hint"
           >
             <option value="">Select a product...</option>
             <option value="Web App">Web Application</option>
@@ -274,8 +270,7 @@ export class ErrorDisplayHelpersComponent {
             id="overallRating"
             type="number"
             [formField]="productForm.overallRating"
-            placeholder="Rate 1-5 stars"
-            aria-describedby="rating-hint"
+            placeholder="Rate 1-5"
           />
           <div class="form-hint" id="rating-hint">1 = Poor, 5 = Excellent</div>
           <ngx-form-field-error
@@ -296,7 +291,6 @@ export class ErrorDisplayHelpersComponent {
               rows="4"
               [formField]="productForm.improvementSuggestions"
               placeholder="Please help us understand what went wrong..."
-              aria-describedby="improvement-hint improvement-counter"
             ></textarea>
             <div class="mt-1 flex items-center justify-between">
               <div class="form-hint" id="improvement-hint">
@@ -329,7 +323,6 @@ export class ErrorDisplayHelpersComponent {
             rows="4"
             [formField]="productForm.detailedFeedback"
             placeholder="Share your detailed experience..."
-            aria-describedby="detailed-hint detailed-counter"
           ></textarea>
           <div class="mt-1 flex items-center justify-between">
             <div class="form-hint" id="detailed-hint">
@@ -392,6 +385,16 @@ export class ErrorDisplayHelpersComponent {
         </div>
       </fieldset>
 
+      @if (successMessage()) {
+        <div
+          class="mb-4 rounded-lg bg-green-50 p-4 text-green-800 dark:bg-green-900/20 dark:text-green-200"
+          role="status"
+          aria-live="polite"
+        >
+          {{ successMessage() }}
+        </div>
+      }
+
       <!-- Submit Section -->
       <div class="form-actions">
         @if (showSubmissionError()) {
@@ -441,13 +444,14 @@ export class ErrorDisplayModesFormComponent {
   readonly errorDisplayMode = input.required<ResolvedErrorDisplayStrategy>();
 
   readonly #model = signal({ ...INITIAL_MODEL });
+  protected readonly successMessage = signal('');
 
   /** Form instance using Signal Forms */
   readonly productForm = form(this.#model, productFeedbackSchema, {
     submission: {
       action: async () => {
         this.#submissionAttempted.set(true);
-        alert('Thank you for your feedback!');
+        this.successMessage.set('Thank you for your feedback!');
       },
       onInvalid: createOnInvalidHandler({
         afterInvalid: () => {

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.validations.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/error-display-modes.validations.ts
@@ -83,18 +83,3 @@ export const productFeedbackSchema = schema<ProductFeedbackModel>((path) => {
     message: 'Detailed feedback cannot exceed 1000 characters',
   });
 });
-
-export const productFeedbackValidationSuite = schema<ProductFeedbackModel>(
-  (path) => {
-    required(path.name, { message: 'Name is required' });
-    minLength(path.name, 2, { message: 'Name must be at least 2 characters' });
-
-    required(path.email, { message: 'Email is required' });
-    email(path.email, { message: 'Please enter a valid email address' });
-
-    required(path.detailedFeedback, { message: 'Feedback is required' });
-    minLength(path.detailedFeedback, 10, {
-      message: 'Feedback must be at least 10 characters',
-    });
-  },
-);

--- a/apps/demo/src/app/02-toolkit-core/error-display-modes/index.ts
+++ b/apps/demo/src/app/02-toolkit-core/error-display-modes/index.ts
@@ -1,6 +1,5 @@
 export { ErrorDisplayModesFormComponent } from './error-display-modes.form';
 export { ErrorDisplayModesPageComponent } from './error-display-modes.page';
-export { productFeedbackValidationSuite } from './error-display-modes.validations';
 export type { ProductFeedbackModel } from './error-display-modes.validations';
 
 // Re-export the reusable UI component for convenience

--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.content.spec.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.content.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { WARNING_SUPPORT_CONTENT } from './warning-support.content';
+
+describe('Warning Support educational copy', () => {
+  it('quotes the live warning strings', () => {
+    const items = WARNING_SUPPORT_CONTENT.learning.sections
+      .flatMap((section) => section.items)
+      .join('\n');
+
+    expect(items).toContain('Consider using 6+ characters for better security');
+    expect(items).toContain(
+      'Consider using 12+ characters for better security',
+    );
+    expect(items).toContain(
+      'Consider mixing uppercase, lowercase, numbers, and special characters',
+    );
+  });
+});

--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.content.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.content.ts
@@ -44,9 +44,9 @@ export const WARNING_SUPPORT_CONTENT = {
         title: '🧪 Try This',
         items: [
           '1. Leave fields empty → Submit → See blocking errors prevent submission',
-          '2. Enter username "abc" (3 chars) → Warning appears: "Consider 6+ characters"',
-          '3. Enter password "Short123" (8 chars) → Warning: "Consider 12+ characters"',
-          '4. Enter password "alllowercase" → Warning: "Mix uppercase, numbers, special chars"',
+          '2. Enter username "abc" (3 chars) → Warning appears: "Consider using 6+ characters for better security"',
+          '3. Enter password "Short123" (8 chars) → Warning: "Consider using 12+ characters for better security"',
+          '4. Enter password "alllowercase" → Warning: "Consider mixing uppercase, lowercase, numbers, and special characters"',
           "5. Submit with warnings present → Submission succeeds! Warnings don't block.",
         ],
       },

--- a/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.form.ts
+++ b/apps/demo/src/app/02-toolkit-core/warning-support/warning-support.form.ts
@@ -4,14 +4,15 @@ import {
   input,
   signal,
 } from '@angular/core';
-import { FormField } from '@angular/forms/signals';
+import { form, FormField } from '@angular/forms/signals';
 import {
+  createOnInvalidHandler,
+  hasOnlyWarnings,
   NgxSignalFormToolkit,
-  submitWithWarnings,
   type ResolvedErrorDisplayStrategy,
 } from '@ngx-signal-forms/toolkit';
 import { NgxFormField } from '@ngx-signal-forms/toolkit/form-field';
-import { createPasswordForm } from './warning-support.validations';
+import { passwordFormSchema } from './warning-support.validations';
 
 @Component({
   selector: 'ngx-warning-support-form',
@@ -32,7 +33,12 @@ import { createPasswordForm } from './warning-support.validations';
       </div>
     }
 
-    <form class="form-container" novalidate (submit)="handleSubmit($event)">
+    <form
+      [formRoot]="passwordForm"
+      ngxSignalForm
+      [errorStrategy]="errorDisplayMode()"
+      class="form-container"
+    >
       <ngx-form-field-wrapper
         [formField]="passwordForm.username"
         [strategy]="errorDisplayMode()"
@@ -77,8 +83,12 @@ import { createPasswordForm } from './warning-support.validations';
 
       <div class="form-actions">
         <button type="button" (click)="reset()">Reset</button>
-        <button type="submit" class="btn-primary" [disabled]="isSubmitting()">
-          @if (isSubmitting()) {
+        <button
+          type="submit"
+          class="btn-primary"
+          [disabled]="passwordForm().submitting()"
+        >
+          @if (passwordForm().submitting()) {
             Creating Account...
           } @else {
             Create Account
@@ -101,46 +111,42 @@ export class WarningsSupportFormComponent {
     password: '',
   });
 
-  readonly passwordForm = createPasswordForm(this.#formModel);
-  protected readonly isSubmitting = signal(false);
-  protected readonly successMessage = signal('');
+  readonly #onInvalid = createOnInvalidHandler();
+
   /**
-   * Form submission using submitWithWarnings() from the toolkit.
-   *
-   * **WCAG Compliant Behavior:**
-   * - Warnings do NOT block submission (only blocking errors do)
-   * - All fields are marked as touched to show feedback
-   * - Blocking errors prevent submission
+   * Native `[formRoot]` submit treats every ValidationError as blocking, so
+   * `ignoreValidators: 'all'` plus `hasOnlyWarnings()` preserve the warning
+   * bypass. Calling `submitWithWarnings()` from `submission.action` would
+   * no-op while `submitting()` is true.
    */
-  protected handleSubmit(event: SubmitEvent): void {
-    event.preventDefault();
+  readonly passwordForm = form(this.#formModel, passwordFormSchema, {
+    submission: {
+      ignoreValidators: 'all',
+      action: async () => {
+        if (!hasOnlyWarnings(this.passwordForm().errorSummary())) {
+          this.#onInvalid(this.passwordForm);
+          return;
+        }
 
-    if (this.isSubmitting()) {
-      return;
-    }
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1000);
+        });
 
-    this.isSubmitting.set(true);
+        this.successMessage.set(
+          '✓ Account created successfully! Notice how warnings did not block submission.',
+        );
 
-    void submitWithWarnings(this.passwordForm, async () => {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 1000);
-      });
+        setTimeout(() => {
+          this.successMessage.set('');
+        }, 5000);
+      },
+    },
+  });
 
-      this.successMessage.set(
-        '✓ Account created successfully! Notice how warnings did not block submission.',
-      );
-
-      setTimeout(() => {
-        this.successMessage.set('');
-      }, 5000);
-    }).finally(() => {
-      this.isSubmitting.set(false);
-    });
-  }
+  protected readonly successMessage = signal('');
 
   protected reset(): void {
     this.passwordForm().reset();
-    this.isSubmitting.set(false);
     this.#formModel.set({
       username: '',
       email: '',

--- a/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.content.spec.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.content.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { COMPLEX_FORMS_CONTENT } from './complex-forms.content';
+
+describe('Complex Forms educational copy', () => {
+  it('does not invent boilerplate percentages or line counts', () => {
+    const items = [
+      ...COMPLEX_FORMS_CONTENT.demonstrated.sections.flatMap(
+        (section) => section.items,
+      ),
+      ...COMPLEX_FORMS_CONTENT.learning.sections.flatMap(
+        (section) => section.items,
+      ),
+    ].join('\n');
+
+    expect(items).not.toMatch(/67%/);
+    expect(items).not.toMatch(/33%/);
+    expect(items).not.toMatch(/320 lines/);
+    expect(items).not.toMatch(/280 lines/);
+    expect(items).toMatch(/contacts/i);
+  });
+});

--- a/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.content.ts
+++ b/apps/demo/src/app/04-form-field-wrapper/complex-forms/complex-forms.content.ts
@@ -16,7 +16,7 @@ export const COMPLEX_FORMS_CONTENT = {
           '• <strong>Dynamic arrays:</strong> Add/remove items with reactive updates',
           '• <strong>Automatic layout:</strong> Label + input + error container',
           '• <strong>Type safety:</strong> Full TypeScript inference',
-          '• <strong>Maximum reduction:</strong> 67% less boilerplate',
+          '• <strong>Less boilerplate:</strong> Labels, errors, and layout come from the wrapper instead of per-field markup',
         ],
       },
       {
@@ -65,8 +65,7 @@ export const COMPLEX_FORMS_CONTENT = {
       {
         title: 'Code Reduction Benefits',
         items: [
-          '• <strong>Without wrapper:</strong> ~320 lines (manual labels/errors/layout)',
-          '• <strong>With wrapper:</strong> ~280 lines (33% less boilerplate)',
+          '• <strong>Wrapper-owned chrome:</strong> Labels, errors, and layout stay consistent without hand-wiring each field',
           '• <strong>Zero manual ARIA:</strong> Automatic accessibility',
           '• <strong>Consistent UX:</strong> Unified error display and stable control-family layouts',
         ],

--- a/apps/demo/src/app/05-advanced/advanced-wizard/components/trip-step.ts
+++ b/apps/demo/src/app/05-advanced/advanced-wizard/components/trip-step.ts
@@ -26,7 +26,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
 
   imports: [FormField, NgxSignalFormToolkit, NgxFormField],
   template: `
-    <div class="trip-step">
+    <form [formRoot]="tripForm" class="trip-step">
       <h2 #stepHeading class="mb-4 text-xl font-semibold" tabindex="-1">
         Trip Details
       </h2>
@@ -373,7 +373,7 @@ import { WizardStepInterface } from '../wizard-step.interface';
           + Add Another Destination
         </button>
       }
-    </div>
+    </form>
   `,
   styles: `
     .trip-step {

--- a/apps/demo/src/app/05-advanced/i18n/i18n.page.ts
+++ b/apps/demo/src/app/05-advanced/i18n/i18n.page.ts
@@ -3,11 +3,13 @@ import {
   Component,
   computed,
   signal,
+  viewChild,
 } from '@angular/core';
 import {
   type ResolvedErrorDisplayStrategy,
   type FormFieldAppearance,
 } from '@ngx-signal-forms/toolkit';
+import { NgxSignalFormDebugger } from '@ngx-signal-forms/debugger';
 import {
   AppearanceToggleComponent,
   DisplayControlsCardComponent,
@@ -16,6 +18,7 @@ import {
   NgxPageControlsDirective,
   OrientationToggleComponent,
   PageHeaderComponent,
+  SplitLayoutComponent,
 } from '../../ui';
 import { APPEARANCE_LABELS } from '../../ui/appearance-toggle';
 import {
@@ -50,6 +53,8 @@ import { I18nDemoComponent } from './i18n.form';
     DisplayControlsSectionComponent,
     NgxPageControlsDirective,
     PageHeaderComponent,
+    SplitLayoutComponent,
+    NgxSignalFormDebugger,
   ],
   template: `
     <ng-template ngxPageControls>
@@ -92,11 +97,20 @@ import { I18nDemoComponent } from './i18n.form';
       [demonstrated]="content.demonstrated"
       [learning]="content.learning"
     >
-      <ngx-i18n-demo
-        [errorDisplayMode]="errorDisplayMode()"
-        [appearance]="selectedAppearance()"
-        [orientation]="selectedOrientation()"
-      />
+      <ngx-split-layout>
+        <ngx-i18n-demo
+          [errorDisplayMode]="errorDisplayMode()"
+          [appearance]="selectedAppearance()"
+          [orientation]="selectedOrientation()"
+          left
+        />
+
+        @if (formRef(); as form) {
+          <div right>
+            <ngx-signal-form-debugger [formTree]="form.demoForm" />
+          </div>
+        }
+      </ngx-split-layout>
     </ngx-example-cards>
   `,
 })
@@ -124,4 +138,5 @@ export class I18nDemoPage {
     },
   ]);
   protected readonly content = I18N_DEMO_CONTENT;
+  protected readonly formRef = viewChild(I18nDemoComponent);
 }

--- a/apps/demo/src/app/ui/example-cards/example-cards.html
+++ b/apps/demo/src/app/ui/example-cards/example-cards.html
@@ -60,7 +60,7 @@
     <div class="text-xs text-gray-600 dark:text-gray-400">
       {{ learning().nextStep.text }}
       <a
-        [href]="learning().nextStep.link"
+        [routerLink]="learning().nextStep.link"
         class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
       >
         {{ learning().nextStep.linkText }}

--- a/apps/demo/src/app/ui/example-cards/example-cards.spec.ts
+++ b/apps/demo/src/app/ui/example-cards/example-cards.spec.ts
@@ -1,7 +1,6 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { Component } from '@angular/core';
-import { provideRouter, RouterLink } from '@angular/router';
-import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { render, screen } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
 import { ExampleCardsComponent } from './example-cards';
@@ -52,13 +51,12 @@ describe('ExampleCardsComponent', () => {
   });
 
   it('routes in-app next-step links through Angular routerLink', async () => {
-    const { fixture } = await render(ExampleCardsComponent, {
+    await render(ExampleCardsComponent, {
       inputs: { demonstrated, learning },
       providers: [provideZonelessChangeDetection(), provideRouter([])],
     });
 
     const nextStep = screen.getByRole('link', { name: /warning support/i });
-    expect(fixture.debugElement.query(By.directive(RouterLink))).not.toBeNull();
     expect(nextStep.getAttribute('href')).toBe('/toolkit-core/warning-support');
   });
 });

--- a/apps/demo/src/app/ui/example-cards/example-cards.spec.ts
+++ b/apps/demo/src/app/ui/example-cards/example-cards.spec.ts
@@ -1,0 +1,64 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { Component } from '@angular/core';
+import { provideRouter, RouterLink } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { render, screen } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { ExampleCardsComponent } from './example-cards';
+
+const demonstrated = {
+  icon: '🎯',
+  title: 'Overview',
+  sections: [{ title: 'Fields', items: ['Name'] }],
+};
+
+const learning = {
+  title: 'Try it',
+  sections: [{ title: 'Steps', items: ['Blur the name field'] }],
+  nextStep: {
+    text: 'Continue →',
+    link: '/toolkit-core/warning-support',
+    linkText: 'Warning Support',
+  },
+};
+
+@Component({
+  selector: 'ngx-example-cards-harness',
+  imports: [ExampleCardsComponent],
+  template: `
+    <ngx-example-cards [demonstrated]="demonstrated" [learning]="learning" />
+    <ngx-example-cards [demonstrated]="demonstrated" [learning]="learning" />
+  `,
+})
+class ExampleCardsHarness {
+  protected readonly demonstrated = demonstrated;
+  protected readonly learning = learning;
+}
+
+describe('ExampleCardsComponent', () => {
+  it('uses deterministic unique demonstrated heading ids', async () => {
+    const { fixture } = await render(ExampleCardsHarness, {
+      providers: [provideZonelessChangeDetection(), provideRouter([])],
+    });
+
+    const headings = fixture.nativeElement.querySelectorAll(
+      'h2[id^="example-cards-demonstrated"]',
+    ) as NodeListOf<HTMLHeadingElement>;
+
+    expect(headings).toHaveLength(2);
+    expect(headings[0].id).not.toBe(headings[1].id);
+    expect(headings[0].id).toMatch(/^example-cards-demonstrated/);
+    expect(headings[1].id).toMatch(/^example-cards-demonstrated/);
+  });
+
+  it('routes in-app next-step links through Angular routerLink', async () => {
+    const { fixture } = await render(ExampleCardsComponent, {
+      inputs: { demonstrated, learning },
+      providers: [provideZonelessChangeDetection(), provideRouter([])],
+    });
+
+    const nextStep = screen.getByRole('link', { name: /warning support/i });
+    expect(fixture.debugElement.query(By.directive(RouterLink))).not.toBeNull();
+    expect(nextStep.getAttribute('href')).toBe('/toolkit-core/warning-support');
+  });
+});

--- a/apps/demo/src/app/ui/example-cards/example-cards.ts
+++ b/apps/demo/src/app/ui/example-cards/example-cards.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { CardComponent } from '../card/card';
 
 type DemonstratedCardConfig = {
@@ -33,7 +34,7 @@ type LearningCardConfig = {
   selector: 'ngx-example-cards',
   changeDetection: ChangeDetectionStrategy.OnPush,
 
-  imports: [CardComponent],
+  imports: [CardComponent, RouterLink],
   templateUrl: './example-cards.html',
   styleUrl: './example-cards.scss',
 })
@@ -41,7 +42,7 @@ export class ExampleCardsComponent {
   demonstrated = input.required<DemonstratedCardConfig>();
   learning = input.required<LearningCardConfig>();
 
-  protected readonly demonstratedHeadingId = `demonstrated-${Math.random()
-    .toString(36)
-    .slice(2, 15)}`;
+  static #nextDemonstratedHeadingId = 0;
+
+  protected readonly demonstratedHeadingId = `example-cards-demonstrated-${++ExampleCardsComponent.#nextDemonstratedHeadingId}`;
 }

--- a/packages/demo-shared/src/lib/routes.metadata.spec.ts
+++ b/packages/demo-shared/src/lib/routes.metadata.spec.ts
@@ -19,7 +19,7 @@ describe('routes.metadata', () => {
     expect(getRouteTitle('/not-a-demo-route')).toBe('NgxSignalForms Toolkit');
   });
 
-  it('advertises display controls for every page that registers ngxPageControls', () => {
+  it('advertises expected display controls for representative routes', () => {
     const advertised = Object.fromEntries(
       DEMO_CATEGORIES.flatMap((category) =>
         category.links.map((link) => [link.path, link.hasControls]),

--- a/packages/demo-shared/src/lib/routes.metadata.spec.ts
+++ b/packages/demo-shared/src/lib/routes.metadata.spec.ts
@@ -18,4 +18,17 @@ describe('routes.metadata', () => {
   it('falls back to the default title for unknown routes', () => {
     expect(getRouteTitle('/not-a-demo-route')).toBe('NgxSignalForms Toolkit');
   });
+
+  it('advertises display controls for every page that registers ngxPageControls', () => {
+    const advertised = Object.fromEntries(
+      DEMO_CATEGORIES.flatMap((category) =>
+        category.links.map((link) => [link.path, link.hasControls]),
+      ),
+    );
+
+    expect(advertised[DEMO_PATHS.fieldsetAppearance]).toBe(true);
+    expect(advertised[DEMO_PATHS.storeBinding]).toBe(true);
+    expect(advertised[DEMO_PATHS.errorMessageSignal]).toBe(false);
+    expect(advertised[DEMO_PATHS.singleModelWizard]).toBe(false);
+  });
 });

--- a/packages/demo-shared/src/lib/routes.metadata.ts
+++ b/packages/demo-shared/src/lib/routes.metadata.ts
@@ -86,7 +86,7 @@ export const DEMO_CATEGORIES = [
       {
         path: '/form-field-wrapper/fieldset-appearance',
         label: 'Fieldset Appearance',
-        hasControls: false,
+        hasControls: true,
       },
       {
         path: '/form-field-wrapper/custom-controls',
@@ -175,6 +175,7 @@ export const DEMO_CATEGORIES = [
       {
         path: '/advanced-scenarios/store-binding',
         label: 'Store Binding (@ngrx/signals two-way)',
+        hasControls: true,
       },
       {
         path: '/advanced-scenarios/server-integration',


### PR DESCRIPTION
The demo now shows the current Angular 22.1 form contract instead of leftover submit hosts and stale try-this copy.

Warning Support submits through `form[formRoot]` and still accepts warning-only values. Native `[formRoot]` submit treats every `ValidationError` as blocking, so the action uses `ignoreValidators: 'all'` plus `hasOnlyWarnings()` rather than nesting `submitWithWarnings()` (that helper no-ops while `submitting()` is true). The wizard trip step destination fields live in `form[formRoot]="tripForm"`. Error Display Modes drops author `aria-describedby` on toolkit-managed native inputs, keeps hint/counter ids, and shows success in an in-page `role="status"` instead of `window.alert`. Educational cards quote the live schema strings. Example-card next steps use Angular `routerLink`. The i18n page shows Form State & Validation in the split layout. Nav “Has display controls” badges now match pages that register `ngxPageControls`.

Toolkit public behavior is unchanged. Review the Warning Support submit path first, then the Error Display Modes ARIA/success banner, then copy and nav metadata.

Refs #393, #394, #395, #396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline success messaging after valid form submissions instead of browser alerts.
  - Added clearer warning feedback and improved password guidance.
  - Added form debugging to the internationalization demo.
  - Enabled navigation controls for additional demo pages.
  - Improved autocomplete behavior for name and email fields.

- **Improvements**
  - Updated validation guidance and error examples across tutorials.
  - Improved wizard navigation and form accessibility.
  - Refined complex-form and feedback-demo explanations.

- **Tests**
  - Expanded automated coverage for form behavior, navigation, accessibility, and educational content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->