### PR TITLE
feat(core): let third-party wrappers own field identity via a host directive

### DIFF
--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -373,6 +373,28 @@ createErrorVisibility(options: CreateErrorVisibilityOptions): ControlVisibilityS
 NgxFieldIdentity        // resolves/tracks a control's field identity
 NgxControlPresetRegistry // resolves control-semantics preset defaults
 
+// Element-scoped field identity for a third-party wrapper. Selectorless —
+// compose it on your wrapper's HOST via hostDirectives, which is what puts
+// NgxFieldIdentity on the element injector your contained controls resolve
+// through. Use it when the field's name is NOT the bound control's `id`
+// (a widget that generates its own inner id; a role="group" cluster).
+// See docs/CUSTOM_WRAPPERS.md and ADR-0011.
+@Directive({ providers: [NgxFieldIdentity] })
+class NgxFieldIdentityProvider {
+  readonly fieldName: InputSignal<string | null | undefined>;
+  // string    -> the resolved name (trimmed); all generated ids derive from it
+  // null      -> bound but unresolvable yet; ARIA wiring is skipped, and it does
+  //              NOT fall back to the control's `id`
+  // unbound   -> publishes nothing, for a component that drives the injected
+  //              NgxFieldIdentity itself. Providing an identity still claims the
+  //              naming channel, so a provider nobody drives logs a dev warning.
+}
+// Usage:
+//   hostDirectives: [{ directive: NgxFieldIdentityProvider, inputs: ['fieldName'] }]
+// It publishes the field-NAME channel only. Hints and display timing keep
+// resolving through the two registries below — identity shadows them per
+// channel, not by presence (ADR-0010).
+
 // Third-party wrapper hint-registry contract (link projected hints into
 // aria-describedby without auto-ARIA querying the DOM). See docs/CUSTOM_WRAPPERS.md.
 const NGX_SIGNAL_FORM_HINT_REGISTRY: InjectionToken<NgxSignalFormHintRegistry>;
@@ -382,8 +404,10 @@ interface NgxSignalFormHintRegistry { readonly hints: Signal<readonly NgxSignalF
 // Wrapper-less standalone error surfaces (e.g. a sibling <ngx-form-field-error>
 // with its own strategy/warningStrategy overrides) publish their resolved
 // visibility here so auto-ARIA's aria-describedby mirrors what is actually
-// rendered. Wrapped fields publish through NgxFieldIdentity instead. See
-// docs/CUSTOM_CONTROLS.md for the worked example.
+// rendered. Auto-ARIA reads this whenever no NgxFieldIdentity has PUBLISHED a
+// strategy for the channel — including when an identity exists but owns only
+// the field name. The error and warning channels fall back independently
+// (ADR-0007, ADR-0010). See docs/CUSTOM_CONTROLS.md for the worked example.
 const NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY: InjectionToken<NgxSignalFormFieldVisibilityRegistry>;
 interface NgxSignalFormFieldVisibilityDescriptor {
   readonly fieldName: string;

--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -385,15 +385,19 @@ class NgxFieldIdentityProvider {
   // string    -> the resolved name (trimmed); all generated ids derive from it
   // null      -> bound but unresolvable yet; ARIA wiring is skipped, and it does
   //              NOT fall back to the control's `id`
-  // unbound   -> publishes nothing, for a component that drives the injected
-  //              NgxFieldIdentity itself. Providing an identity still claims the
-  //              naming channel, so a provider nobody drives logs a dev warning.
+  // unbound   -> publishes nothing, leaving the name to the composing component.
+  //              Providing an identity still claims the naming channel, so a
+  //              provider nobody drives logs a dev warning.
 }
 // Usage:
 //   hostDirectives: [{ directive: NgxFieldIdentityProvider, inputs: ['fieldName'] }]
 // It publishes the field-NAME channel only. Hints and display timing keep
 // resolving through the two registries below — identity shadows them per
 // channel, not by presence (ADR-0010).
+// NgxFormFieldWrapper composes this same directive rather than providing
+// NgxFieldIdentity itself, so the built-in wrapper runs on the public seam.
+// One `fieldName` attribute feeds both a component's own input and its
+// exposed host-directive input, so composing it costs consumers nothing.
 
 // Third-party wrapper hint-registry contract (link projected hints into
 // aria-describedby without auto-ARIA querying the DOM). See docs/CUSTOM_WRAPPERS.md.

--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -396,8 +396,10 @@ class NgxFieldIdentityProvider {
 // channel, not by presence (ADR-0010).
 // NgxFormFieldWrapper composes this same directive rather than providing
 // NgxFieldIdentity itself, so the built-in wrapper runs on the public seam.
-// One `fieldName` attribute feeds both a component's own input and its
-// exposed host-directive input, so composing it costs consumers nothing.
+// If your component declares its own input under the SAME public name (as the
+// wrapper does), Angular feeds one attribute to both it and the exposed
+// host-directive input — consumers bind `fieldName` once. Declare a different
+// name and you are asking for two bindings.
 
 // Third-party wrapper hint-registry contract (link projected hints into
 // aria-describedby without auto-ARIA querying the DOM). See docs/CUSTOM_WRAPPERS.md.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,9 +116,13 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   through — instead registers its already-rendered
   `errorContainerVisible()`/`warningContainerVisible()` booleans into
   `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY`, keyed by field name and
-  provided per-form by `NgxSignalForm`. Auto-aria prefers `NgxFieldIdentity`
-  when present and falls back to the registry; without either, it sees only
-  the ambient form context. Any new surface that gates a message region must
+  provided per-form by `NgxSignalForm`. Auto-aria resolves these **per
+  channel**, on the published value: a strategy the identity has actually
+  published wins, otherwise the registry entry does, otherwise it sees only
+  the ambient form context. It never branches on whether `NgxFieldIdentity`
+  is injectable — an identity that owns only the field name must leave both
+  strategy channels to the registry, and the error and warning channels fall
+  back independently of one another (ADR-0010). Any new surface that gates a message region must
   feed its decision through one of these two channels, or it will produce a
   dangling id (axe `aria-valid-attr-value`) or an unreferenced one
   (WCAG 1.3.1).
@@ -127,6 +131,18 @@ ngx-signal-forms — an Angular toolkit for working with Signal Forms.
   _different_ contracts — direct `errors()` vs aggregated `errorSummary()`
   reads, the deliberate `focus-first-invalid` policy asymmetry — merging is the
   bug, and those are marked in place as intentional.
+
+- **A field's name is owned by whoever provides its identity.** Auto-aria
+  derives a field name from the bound control's `id` unless an ancestor
+  provides an `NgxFieldIdentity`, in which case that service owns the name
+  outright — a `null` there means "not resolvable yet" and skips ARIA wiring,
+  it does not revert to the `id`. Wrappers get an identity by composing
+  `NgxFieldIdentityProvider` as a host directive, the built-in
+  `NgxFormFieldWrapper` included, so the public seam and the internal one are
+  the same seam. The provider publishes the name channel only; the wrapper
+  additionally drives the control element, visibility, hints, and resolved
+  strategies in-package, because none of those can travel through an input.
+  See ADR-0011.
 
 - **`packages/toolkit/core` is not a public entry point.** It is a
   build-time-only secondary entry that sibling entries compile against;

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -580,10 +580,10 @@ for you. Note that `hintIds` is `readonly string[] | null`, where `null` means
 "this identity never published hints" — see
 [ADR-0010](decisions/0010-field-identity-shadows-registries-per-channel.md).
 
-> `NgxFormFieldWrapper` does not compose this directive; it provides and
-> drives `NgxFieldIdentity` directly. Angular gives a component no way to bind
-> its own host directive's inputs, and the wrapper's name is only known after
-> its render-phase DOM read — see
+> `NgxFormFieldWrapper` composes this same directive rather than providing
+> `NgxFieldIdentity` itself, so the built-in wrapper runs on the seam you do.
+> It still writes the identity directly for what an input cannot carry — the
+> `id`-derived name tier, and every non-name channel — see
 > [ADR-0011](decisions/0011-field-identity-provider-host-directive.md).
 
 ### `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` — declaring display timing

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -489,65 +489,113 @@ Each factory is independently usable. Common partial compositions:
 The contract each factory advertises is `fieldState in → ARIA out`. Pick the
 ones you need.
 
-## Element-scoped identity vs. form-scoped visibility registration
+## Which seam publishes what
 
-Two DI-visible mechanisms feed `NgxSignalFormAutoAria` a field's resolved
-strategy/visibility state so it doesn't have to recompute — and possibly
-disagree with — the cascade already resolved elsewhere. They are **not**
-two equally-available options for a wrapper author to pick between: one is
-an internal implementation detail of the toolkit's own built-in wrapper,
-the other is the actual public integration path for third-party wrappers
-and standalone surfaces.
+`NgxSignalFormAutoAria` needs three things it cannot work out on its own: what
+the field is **called**, when its error/warning regions are **visible**, and
+which **hint** elements describe it. Each of those is a separate channel with
+its own seam, and you pick per channel — they compose, they are not
+alternatives:
 
-| Surface                                                      | Mechanism                                                         | Who drives it                                                                     |
-| ------------------------------------------------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `NgxFormFieldWrapper` (the toolkit's own built-in wrapper)   | `NgxFieldIdentity` — element-scoped, internal write API           | The toolkit itself, from `form-field-wrapper.ts`'s `afterEveryRender` write phase |
-| Your custom wrapper, or any standalone error/warning surface | `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` — form-scoped, public | You — this is the supported integration seam                                      |
+| Channel                            | Seam                                        | Use it when                                               |
+| ---------------------------------- | ------------------------------------------- | --------------------------------------------------------- |
+| **Field name**                     | `NgxFieldIdentityProvider` (host directive) | The field's name is not the bound control's `id`          |
+| **Error / warning display timing** | `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` | You resolve strategy yourself and render your own regions |
+| **Hint IDs**                       | `NGX_SIGNAL_FORM_HINT_REGISTRY`             | You render hint elements auto-aria should reference       |
 
-`NgxSignalFormAutoAria` prefers a present `NgxFieldIdentity` (confirmed in
-`auto-aria.ts`: the registry lookup is skipped whenever `NgxFieldIdentity`
-is injected) and falls back to the visibility registry otherwise — so the
-two are mutually exclusive per field, not layered, but that fallback is
-what makes the registry path work for anyone who isn't `NgxFormFieldWrapper`
-itself.
+Resolution is **per channel**: providing a field identity does not disturb the
+registries, and publishing to a registry does not disturb the identity. A
+wrapper that only needs the field-name fix takes only that seam and keeps
+everything else working ([ADR-0010](decisions/0010-field-identity-shadows-registries-per-channel.md)).
 
-### `NgxFieldIdentity` — the built-in wrapper's internal mechanism
+### `NgxFieldIdentityProvider` — declaring the field's name
 
-`NgxFieldIdentity` (`providedIn: null`, exported from
-`@ngx-signal-forms/toolkit`) is the centralized, per-wrapper-instance
-service `NgxFormFieldWrapper` provides at its own component level and
-drives from its `afterEveryRender` write phase — field-name resolution
-output, the bound control's element/visibility, and the wrapper's resolved
-error/warning display strategies all flow through it.
+By default auto-aria derives the field name from the bound control's `id`
+attribute, which forces the name and the DOM `id` to be the same string. Two
+common shapes can't satisfy that: a third-party widget that generates its own
+inner input `id`, and a `role="group"` cluster whose name belongs to the group
+rather than to any one control. In both cases the ids auto-aria generates
+(`{fieldName}-error`, `{fieldName}-warning`) disagree with what you rendered,
+leaving `aria-describedby` pointing at nothing.
 
-Its **resolved read signals** (`fieldName`, `controlId`, `errorId`,
-`warningId`, `hintIds`, `describedBy`, `isControlVisible`,
-`resolvedErrorStrategy`, `resolvedWarningStrategy`,
-`resolveControlElement()`) are public — read them if you've injected an
-ancestor-provided `NgxFieldIdentity` and want the same resolved state
-`NgxSignalFormAutoAria` sees. Its **writer methods**
-(`setFieldName`, `setControlElement`, `setControlVisible`, `setHintIds`,
-`setResolvedStrategies`) are explicitly tagged `@internal` in
-`field-identity.ts` — _"must not be called from outside this package —
-consumers read the resolved signals, they do not drive them."_ A custom
-wrapper must **not** provide its own `NgxFieldIdentity` instance and call
-those setters; that is not a supported contract today.
+Compose the provider onto your wrapper's host to declare the name yourself:
 
-> **Open design question (pre-v1):** promoting `NgxFieldIdentity`'s writers
-> into a supported surface third-party wrappers can drive themselves —
-> instead of routing through the registry below — is a real possibility
-> under consideration before the API freezes at 1.0. No commitment either
-> way yet; this document describes the contract as it exists today, not a
-> roadmap promise.
+```typescript
+import { Component, input } from '@angular/core';
+import {
+  NgxFieldIdentityProvider,
+  NgxFormFieldError,
+} from '@ngx-signal-forms/toolkit';
 
-### `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` — the public integration path
+@Component({
+  selector: 'my-field',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+  imports: [NgxFormFieldError],
+  template: `
+    <ng-content />
+    <ngx-form-field-error [formField]="field()" [fieldName]="name()" />
+  `,
+})
+export class MyField {
+  readonly field = input.required<unknown>();
+  readonly name = input.required<string>();
+}
+```
 
-This is the seam to use for your own wrapper or any standalone error/warning
-surface. It's provided by `NgxSignalForm` at the `[ngxSignalForm]` host, so
-it's reachable from anywhere inside that form, and `NgxSignalFormAutoAria`
-falls back to reading it whenever no `NgxFieldIdentity` is present in the
-injector chain — which is always true for a custom wrapper unless it
-happens to sit _inside_ the toolkit's own `NgxFormFieldWrapper`:
+```html
+<my-field
+  fieldName="emailAddress"
+  [field]="form.emailAddress"
+  name="emailAddress"
+>
+  <label for="p-inputtext-42">Email</label>
+  <input id="p-inputtext-42" [formField]="form.emailAddress" />
+</my-field>
+<!-- aria-describedby="emailAddress-error", not "p-inputtext-42-error" -->
+```
+
+Three things worth knowing:
+
+- **It has no selector.** Placement on the host element is load-bearing — that
+  is the element injector your contained controls resolve through — and a
+  selector would invite putting it somewhere that silently does nothing.
+- **Providing an identity claims the naming channel for the whole subtree.**
+  Binding `null` means "not resolvable yet" and skips ARIA wiring; it does not
+  fall back to the control's `id`. If nothing ever publishes a name, a
+  dev-mode warning says so.
+- **It publishes the name and nothing else.** Strategy deliberately has no
+  channel here: the visibility registry publishes the _observed_ boolean that
+  already gates a rendered region, so it cannot drift from the DOM the way a
+  separately-declared strategy could.
+
+`NgxFieldIdentity`'s **resolved read signals** (`fieldName`, `controlId`,
+`errorId`, `warningId`, `hintIds`, `describedBy`, `isControlVisible`,
+`resolvedErrorStrategy`, `resolvedWarningStrategy`, `resolveControlElement()`)
+are public — inject an ancestor-provided instance and read the same resolved
+state auto-aria sees. Its **writer methods** stay `@internal` and are stripped
+from the published type definitions; `NgxFieldIdentityProvider` drives them
+for you. Note that `hintIds` is `readonly string[] | null`, where `null` means
+"this identity never published hints" — see
+[ADR-0010](decisions/0010-field-identity-shadows-registries-per-channel.md).
+
+> `NgxFormFieldWrapper` does not compose this directive; it provides and
+> drives `NgxFieldIdentity` directly. Angular gives a component no way to bind
+> its own host directive's inputs, and the wrapper's name is only known after
+> its render-phase DOM read — see
+> [ADR-0011](decisions/0011-field-identity-provider-host-directive.md).
+
+### `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` — declaring display timing
+
+This is the seam for display timing, in your own wrapper or in any standalone
+error/warning surface. It's provided by `NgxSignalForm` at the
+`[ngxSignalForm]` host, so it's reachable from anywhere inside that form.
+`NgxSignalFormAutoAria` reads it for a field whenever no identity has
+published a strategy for that channel — including when an identity exists but
+owns only the field name, which is exactly the `NgxFieldIdentityProvider` case
+above. The error and warning channels fall back independently of one another
+([ADR-0007](decisions/0007-warning-display-timing-cascade.md)):
 
 ```typescript
 import { effect, inject } from '@angular/core';

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -535,21 +535,21 @@ import {
   imports: [NgxFormFieldError],
   template: `
     <ng-content />
-    <ngx-form-field-error [formField]="field()" [fieldName]="name()" />
+    <ngx-form-field-error [formField]="field()" [fieldName]="fieldName()" />
   `,
 })
 export class MyField {
   readonly field = input.required<unknown>();
-  readonly name = input.required<string>();
+  // Declare `fieldName` on your component too, with the same public name the
+  // host directive exposes. Angular feeds one attribute to both, so consumers
+  // bind it once and you can still read it for your own template. This is
+  // exactly what `NgxFormFieldWrapper` does.
+  readonly fieldName = input.required<string>();
 }
 ```
 
 ```html
-<my-field
-  fieldName="emailAddress"
-  [field]="form.emailAddress"
-  name="emailAddress"
->
+<my-field fieldName="emailAddress" [field]="form.emailAddress">
   <label for="p-inputtext-42">Email</label>
   <input id="p-inputtext-42" [formField]="form.emailAddress" />
 </my-field>

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -1609,10 +1609,10 @@ Resolution is now **per channel**: a channel belongs to the identity only when
 the identity has published a value for it. See
 [ADR-0010](./decisions/0010-field-identity-shadows-registries-per-channel.md).
 
-**Breaking change:** `NgxFieldIdentity.hintIds` and the structural type
-`HintIdsIdentityLike` (re-exported from both the `core` and `headless`
-barrels) widen from `Signal<readonly string[]>` to
-`Signal<readonly string[] | null>`. The two empty-ish states now mean
+**Breaking change:** `NgxFieldIdentity.hintIds` (from the root entry point)
+and the structural type `HintIdsIdentityLike` (from
+`@ngx-signal-forms/toolkit/headless`) widen from `Signal<readonly string[]>`
+to `Signal<readonly string[] | null>`. The two empty-ish states now mean
 different things:
 
 | Value  | Meaning                                                            |

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -1713,9 +1713,12 @@ reporting "visible" preserves prior behavior rather than stripping ARIA on a
 guess. If you assert visibility in tests, those assertions need a real
 browser — jsdom implements neither `checkVisibility()` nor layout.
 
-See [ADR-0011](./decisions/0011-field-identity-provider-host-directive.md),
-including why `NgxFormFieldWrapper` does not itself compose the directive
-(Angular gives a component no way to bind its own host directive's inputs).
+`NgxFormFieldWrapper` composes this same directive rather than providing
+`NgxFieldIdentity` itself, so the built-in wrapper runs on the seam a
+third-party wrapper uses. Nothing changes for its consumers: Angular feeds one
+`fieldName` attribute to both the wrapper's own input and the exposed
+host-directive input. See
+[ADR-0011](./decisions/0011-field-identity-provider-host-directive.md).
 
 **Files:** `packages/toolkit/core/directives/field-identity-provider.ts`,
 `packages/toolkit/core/directives/auto-aria.ts`,

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -57,6 +57,7 @@ releases will not include any of the renames below.
 - **BREAKING: `canSubmitWithWarnings()` now reads `errorSummary()`** — child-path blocking errors now correctly disable submission (see [§5c](#5c-cansubmitwithwarnings-now-aggregates-descendant-errors))
 - **BREAKING: `injectFieldControl()` validates the resolved value against the runtime `FieldTree` contract** — an id resolving to a non-`FieldTree` property now throws instead of silently returning an unsound cast (see [§5d](#5d-injectfieldcontrol-validates-the-resolved-fieldtree))
 - **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§8](#8-headless-audit-fixes-v100))
+- **New: `NgxFieldIdentityProvider`** — host directive letting a third-party wrapper declare a field name that differs from the bound control's `id`; also fixes stale `aria-invalid` on controls with no layout box, for every wrapper (see [§15](#15-new-api-ngxfieldidentityprovider--third-party-wrappers-can-own-field-naming-387))
 - **BREAKING: `NgxFieldIdentity.hintIds` is now `Signal<readonly string[] | null>`** — `null` means the hint channel was never published (fall back to the hint registry), `[]` means published-and-empty; identity now shadows the fallback registries per channel rather than by mere presence (see [§14](#14-ngxfieldidentityhintids-is-nullable--identity-shadows-the-registries-per-channel-387))
 - **BREAKING: `CharacterCountResult` members are now typed `Signal<T>`** (was the looser `ReadSignal<T>` alias); a new `hasLimit` member was added — compile-time tightening only, no runtime change
 - **Bug fix** — error summary no longer drops a second field's error when two different fields share the same kind + message-less default; `NgxHeadlessNotification` no longer leaks the internal `warn:` prefix; `createErrorMessageSignal`'s ID fallback strips Angular's internal `{appId}.form{n}.` prefix; required `Date`/`File`/`Map`-valued leaves no longer vanish from field-optionality summaries
@@ -1643,3 +1644,79 @@ one another, per [ADR-0007](./decisions/0007-warning-display-timing-cascade.md).
 **Files:** `packages/toolkit/core/services/field-identity.ts`,
 `packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts`,
 `packages/toolkit/core/directives/auto-aria.ts`.
+
+## 15. New API: `NgxFieldIdentityProvider` — third-party wrappers can own field naming (#387)
+
+**Root cause:** `NgxSignalFormAutoAria` derives a field name from the bound
+control's `id` attribute unless an ancestor provides an `NgxFieldIdentity`,
+and only the built-in wrapper ever did. A custom wrapper therefore could not
+use a field name that differed from the control's DOM `id` — which breaks for
+a third-party widget that generates its own inner input id, and for a
+`role="group"` cluster whose name belongs to the group rather than to any one
+control. The generated `{fieldName}-error` id then disagreed with what the
+wrapper rendered, leaving a dangling `aria-describedby` (axe
+`aria-valid-attr-value`) and error text unreachable by assistive technology.
+
+**New API:** compose `NgxFieldIdentityProvider` onto your wrapper's host with
+`hostDirectives`. It is selectorless on purpose — host placement is
+load-bearing.
+
+```typescript
+import { NgxFieldIdentityProvider } from '@ngx-signal-forms/toolkit';
+
+@Component({
+  selector: 'my-field',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+  /* ... */
+})
+export class MyField {}
+```
+
+```html
+<my-field fieldName="emailAddress">
+  <input id="p-inputtext-42" [formField]="form.emailAddress" />
+</my-field>
+<!-- aria-describedby="emailAddress-error", not "p-inputtext-42-error" -->
+```
+
+It publishes the **field-name channel only**. Hints and display timing keep
+resolving through `NGX_SIGNAL_FORM_HINT_REGISTRY` and
+`NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY`, and composing the directive does
+not disturb them (see [§14](#14-ngxfieldidentityhintids-is-nullable--identity-shadows-the-registries-per-channel-387)).
+The `set*` writers on `NgxFieldIdentity` stay `@internal` and stay stripped
+from the published type definitions.
+
+Binding `null` means "not resolvable yet" and skips ARIA wiring; it does not
+fall back to the control's `id`, because a wrapper that declares its own
+naming has said the `id` is not the name. Leaving the input unbound _and_
+never driving the injected identity logs a dev-mode warning.
+
+**Behavior fix (no API change): `aria-invalid` no longer goes stale on a
+control with no layout box.** The gate that removes `aria-invalid` from a
+hidden control used to read a flag only the built-in wrapper published, so a
+custom wrapper inside a collapsed `<details>`, an inactive tab, or a
+non-current wizard step kept a stale attribute — with `'manual'` ARIA mode as
+the only escape. `NgxSignalFormAutoAria` now probes its own host element, so
+the fix applies to every wrapper. In a multi-control cluster each control now
+tracks its own layout state rather than the cluster's first control's.
+
+**Behavior change on a public function: `isElementCssVisible()`.** On runtimes
+without `Element.checkVisibility()` it now reports `true` instead of guessing
+from `offsetParent`. The old fallback was wrong in both directions — a false
+positive for collapsed `<details>` and `content-visibility: hidden` (the very
+cases it existed for), and a false negative for `position: fixed` elements and
+for any environment with no layout engine. `checkVisibility()` is Baseline
+2024, so the fallback is only reached on genuinely old runtimes, where
+reporting "visible" preserves prior behavior rather than stripping ARIA on a
+guess. If you assert visibility in tests, those assertions need a real
+browser — jsdom implements neither `checkVisibility()` nor layout.
+
+See [ADR-0011](./decisions/0011-field-identity-provider-host-directive.md),
+including why `NgxFormFieldWrapper` does not itself compose the directive
+(Angular gives a component no way to bind its own host directive's inputs).
+
+**Files:** `packages/toolkit/core/directives/field-identity-provider.ts`,
+`packages/toolkit/core/directives/auto-aria.ts`,
+`packages/toolkit/core/services/field-identity.ts`.

--- a/docs/MIGRATING_BETA_TO_V1.md
+++ b/docs/MIGRATING_BETA_TO_V1.md
@@ -57,6 +57,7 @@ releases will not include any of the renames below.
 - **BREAKING: `canSubmitWithWarnings()` now reads `errorSummary()`** — child-path blocking errors now correctly disable submission (see [§5c](#5c-cansubmitwithwarnings-now-aggregates-descendant-errors))
 - **BREAKING: `injectFieldControl()` validates the resolved value against the runtime `FieldTree` contract** — an id resolving to a non-`FieldTree` property now throws instead of silently returning an unsound cast (see [§5d](#5d-injectfieldcontrol-validates-the-resolved-fieldtree))
 - **BREAKING: `ErrorSummarySignals` gained `shouldShowWarnings`** — implementers of the interface must add this member (see [§8](#8-headless-audit-fixes-v100))
+- **BREAKING: `NgxFieldIdentity.hintIds` is now `Signal<readonly string[] | null>`** — `null` means the hint channel was never published (fall back to the hint registry), `[]` means published-and-empty; identity now shadows the fallback registries per channel rather than by mere presence (see [§14](#14-ngxfieldidentityhintids-is-nullable--identity-shadows-the-registries-per-channel-387))
 - **BREAKING: `CharacterCountResult` members are now typed `Signal<T>`** (was the looser `ReadSignal<T>` alias); a new `hasLimit` member was added — compile-time tightening only, no runtime change
 - **Bug fix** — error summary no longer drops a second field's error when two different fields share the same kind + message-less default; `NgxHeadlessNotification` no longer leaks the internal `warn:` prefix; `createErrorMessageSignal`'s ID fallback strips Angular's internal `{appId}.form{n}.` prefix; required `Date`/`File`/`Map`-valued leaves no longer vanish from field-optionality summaries
 - **BREAKING: `NgxFormFieldCharacterCount`'s `colorThresholds` input removed** — warning/danger color breakpoints are now CSS-only via `--ngx-form-field-char-count-warning-threshold` / `-danger-threshold` (default `80`/`95`); `[liveAnnounce]` wording stays fixed at those defaults regardless of a CSS override (see [§13](#13-ngxformfieldcharactercount-colorthresholds-removed--thresholds-are-css-only-355))
@@ -1589,3 +1590,56 @@ Restyling the color threshold is a pure presentation change; the
 announcement timing stays exactly where it was.
 
 **Files:** `packages/toolkit/assistive/character-count.ts`.
+
+## 14. `NgxFieldIdentity.hintIds` is nullable — identity shadows the registries per channel (#387)
+
+**Root cause:** `NgxSignalFormAutoAria` and `createHintIdsSignal` both decided
+whether to use an `NgxFieldIdentity` or a fallback registry by asking whether
+the identity service was _injectable_, not whether it had published anything.
+That was indistinguishable from correct while `NgxFormFieldWrapper` was the
+only thing that ever provided one, because it drives every channel on every
+render. It stops being correct as soon as a partially-driven identity exists —
+a wrapper that adopts the identity only to fix its field naming would, by the
+mere act of providing it, switch its own hints and its own field-level
+`strategy`/`warningStrategy` overrides off the registries and onto the ambient
+form context.
+
+Resolution is now **per channel**: a channel belongs to the identity only when
+the identity has published a value for it. See
+[ADR-0010](./decisions/0010-field-identity-shadows-registries-per-channel.md).
+
+**Breaking change:** `NgxFieldIdentity.hintIds` and the structural type
+`HintIdsIdentityLike` (re-exported from both the `core` and `headless`
+barrels) widen from `Signal<readonly string[]>` to
+`Signal<readonly string[] | null>`. The two empty-ish states now mean
+different things:
+
+| Value  | Meaning                                                            |
+| ------ | ------------------------------------------------------------------ |
+| `null` | Channel never published — consumers fall back to the hint registry |
+| `[]`   | Published, and this field genuinely has no hints — authoritative   |
+
+```typescript
+// before — `[]` was both "nothing published yet" and "no hints"
+const ids: readonly string[] = identity.hintIds();
+
+// after — decide which of the two you mean
+const ids = identity.hintIds() ?? [];
+```
+
+**Who is affected:** only code that reads `identity.hintIds()` **directly**.
+`createHintIdsSignal` coalesces internally and still returns a non-null
+`Signal<readonly string[]>`, so every wrapper that composes ARIA through the
+published factories — which is the documented path, and all of this repo's
+demo wrappers — needs no change at all.
+
+`NgxFieldIdentity.describedBy` is unchanged (`string | null`); it treats the
+unpublished state as "no IDs". `resolvedErrorStrategy` and
+`resolvedWarningStrategy` needed no type change — they were already `null`
+until published — but consumers must now test that **value** rather than the
+presence of the service. The two strategy channels fall back independently of
+one another, per [ADR-0007](./decisions/0007-warning-display-timing-cascade.md).
+
+**Files:** `packages/toolkit/core/services/field-identity.ts`,
+`packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts`,
+`packages/toolkit/core/directives/auto-aria.ts`.

--- a/docs/decisions/0010-field-identity-shadows-registries-per-channel.md
+++ b/docs/decisions/0010-field-identity-shadows-registries-per-channel.md
@@ -46,7 +46,7 @@ The `set*` writers stay `@internal` and stay stripped from the published `.d.ts`
 
 ## Consequences
 
-- **Breaking, on a public read surface.** `NgxFieldIdentity.hintIds` and the structural type `HintIdsIdentityLike` (re-exported from both the `core` and `headless` barrels) widen to `readonly string[] | null`. Anything reading `identity.hintIds()` directly must handle `null`. `createHintIdsSignal` still _returns_ a non-null `Signal<readonly string[]>` — it coalesces internally — so consumers who go through the factory are unaffected, which is every wrapper in this repo.
+- **Breaking, on a public read surface.** `NgxFieldIdentity.hintIds` widens to `readonly string[] | null`. `NgxFieldIdentity` is published from the root entry point; the structural type `HintIdsIdentityLike` widens with it and is published from `@ngx-signal-forms/toolkit/headless` only — the `core` barrel it also lives in is a build-time-only source barrel that `strip-internal-exports.mjs` removes from the published `exports` map. Anything reading `identity.hintIds()` directly must handle `null`. `createHintIdsSignal` still _returns_ a non-null `Signal<readonly string[]>` — it coalesces internally — so consumers who go through the factory are unaffected, which is every wrapper in this repo.
 - `NgxFieldIdentity.describedBy` treats the unpublished state as "no IDs", so it stays `string | null` and its behavior is unchanged.
 - `setHintIds([])` is now a meaningful claim rather than a no-op: it is how a driver says "I own this channel and there is nothing in it".
 - `NgxFormFieldWrapper` behavior is unchanged. It publishes every channel on every render, so it takes the same branch it always did.

--- a/docs/decisions/0010-field-identity-shadows-registries-per-channel.md
+++ b/docs/decisions/0010-field-identity-shadows-registries-per-channel.md
@@ -36,7 +36,7 @@ They stop being the same statement the moment anything else provides an identity
 Each channel therefore needs a state that means "never published", distinct from every legitimate resolved value:
 
 - `resolvedErrorStrategy` and `resolvedWarningStrategy` already had one — they are `null` until `setResolvedStrategies` runs. No type change; the call sites changed from testing the service to testing the value.
-- `hintIds` did not. It was `readonly string[]`, initialised to `[]`, which conflated "nobody published hints" with "this field genuinely has no hints". It is now `readonly string[] | null`:
+- `hintIds` did not. It was `readonly string[]`, initialized to `[]`, which conflated "nobody published hints" with "this field genuinely has no hints". It is now `readonly string[] | null`:
   - `null` — unpublished. Consumers fall through to the hint registry exactly as they would with no identity at all.
   - `[]` — published, and this field has no hints. Authoritative; the registry is not consulted.
 
@@ -47,9 +47,9 @@ The `set*` writers stay `@internal` and stay stripped from the published `.d.ts`
 ## Consequences
 
 - **Breaking, on a public read surface.** `NgxFieldIdentity.hintIds` and the structural type `HintIdsIdentityLike` (re-exported from both the `core` and `headless` barrels) widen to `readonly string[] | null`. Anything reading `identity.hintIds()` directly must handle `null`. `createHintIdsSignal` still _returns_ a non-null `Signal<readonly string[]>` — it coalesces internally — so consumers who go through the factory are unaffected, which is every wrapper in this repo.
-- `NgxFieldIdentity.describedBy` treats the unpublished state as "no IDs", so it stays `string | null` and its behaviour is unchanged.
+- `NgxFieldIdentity.describedBy` treats the unpublished state as "no IDs", so it stays `string | null` and its behavior is unchanged.
 - `setHintIds([])` is now a meaningful claim rather than a no-op: it is how a driver says "I own this channel and there is nothing in it".
-- `NgxFormFieldWrapper` behaviour is unchanged. It publishes every channel on every render, so it takes the same branch it always did.
+- `NgxFormFieldWrapper` behavior is unchanged. It publishes every channel on every render, so it takes the same branch it always did.
 - This is a prerequisite for shipping any public way to provide an identity. Without it, the facade would be a foot-gun on arrival.
 
 ## Alternatives Considered

--- a/docs/decisions/0010-field-identity-shadows-registries-per-channel.md
+++ b/docs/decisions/0010-field-identity-shadows-registries-per-channel.md
@@ -1,0 +1,67 @@
+# ADR-0010: Field Identity Shadows the Fallback Registries Per Channel
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-17
+
+## Context
+
+Issue [#387](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/387) asked whether `NgxFieldIdentity`'s `set*` writers should become the supported surface for third-party wrapper authors. Answering it exposed a defect one layer down.
+
+`NgxFieldIdentity` carries several independent channels: the resolved field name, the bound control's element and layout visibility, the hint IDs correlated to the field, and the wrapper's resolved error and warning display strategies. Two of those channels have a registry-based public equivalent that any surface inside a form can publish to:
+
+| Channel                        | Fallback registry                                  |
+| ------------------------------ | -------------------------------------------------- |
+| hint IDs                       | `NGX_SIGNAL_FORM_HINT_REGISTRY`                    |
+| error / warning display timing | `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY`        |
+| field name                     | — (no equivalent; derived from the control's `id`) |
+
+Both consumers of those fallbacks tested for the **presence of the service**, not for a published value:
+
+- `createHintIdsSignal` returned `identity.hintIds()` whenever an identity was passed, before consulting the registry at all.
+- `NgxSignalFormAutoAria` skipped the visibility-registry lookup entirely whenever `NgxFieldIdentity` was injectable.
+
+That was invisible in practice because `NgxFormFieldWrapper` was the only thing that ever provided an identity, and it drives every channel on every render. There was no such thing as a partially-driven identity, so "the service exists" and "this channel is published" were the same statement.
+
+They stop being the same statement the moment anything else provides an identity — which is exactly what #387 set out to allow. A third-party wrapper that adopts `NgxFieldIdentity` to fix its field naming would, by the mere act of providing it, switch its own hints and its own field-level strategy overrides off the registries and onto the ambient form context. Adopting the new capability would silently cost adopters two working ones.
+
+## Decision
+
+**Resolution is per channel. A channel is owned by the identity only when the identity has published a value for it. Consumers must never branch on whether `NgxFieldIdentity` is injectable.**
+
+Each channel therefore needs a state that means "never published", distinct from every legitimate resolved value:
+
+- `resolvedErrorStrategy` and `resolvedWarningStrategy` already had one — they are `null` until `setResolvedStrategies` runs. No type change; the call sites changed from testing the service to testing the value.
+- `hintIds` did not. It was `readonly string[]`, initialised to `[]`, which conflated "nobody published hints" with "this field genuinely has no hints". It is now `readonly string[] | null`:
+  - `null` — unpublished. Consumers fall through to the hint registry exactly as they would with no identity at all.
+  - `[]` — published, and this field has no hints. Authoritative; the registry is not consulted.
+
+The error and warning channels resolve **independently of each other**, per [ADR-0007](0007-warning-display-timing-cascade.md). An identity that publishes an error strategy but not a warning strategy leaves warnings to the registry. Deciding both from one test would reintroduce the cross-channel coupling ADR-0007 removed.
+
+The `set*` writers stay `@internal` and stay stripped from the published `.d.ts`. This ADR is about how _readers_ resolve, not about who is allowed to write.
+
+## Consequences
+
+- **Breaking, on a public read surface.** `NgxFieldIdentity.hintIds` and the structural type `HintIdsIdentityLike` (re-exported from both the `core` and `headless` barrels) widen to `readonly string[] | null`. Anything reading `identity.hintIds()` directly must handle `null`. `createHintIdsSignal` still _returns_ a non-null `Signal<readonly string[]>` — it coalesces internally — so consumers who go through the factory are unaffected, which is every wrapper in this repo.
+- `NgxFieldIdentity.describedBy` treats the unpublished state as "no IDs", so it stays `string | null` and its behaviour is unchanged.
+- `setHintIds([])` is now a meaningful claim rather than a no-op: it is how a driver says "I own this channel and there is nothing in it".
+- `NgxFormFieldWrapper` behaviour is unchanged. It publishes every channel on every render, so it takes the same branch it always did.
+- This is a prerequisite for shipping any public way to provide an identity. Without it, the facade would be a foot-gun on arrival.
+
+## Alternatives Considered
+
+**Keep presence-based shadowing and require drivers to publish every channel.** Rejected. It makes the cheapest useful case — a wrapper that only wants to fix its field name — the most expensive one, forcing authors to re-derive strategy and hint state they have no reason to own. It also fails silently: forget a channel and you get subtly wrong ARIA, not an error.
+
+**Use a separate "published" boolean per channel.** Rejected as redundant. Two of the three channels already encode it in their value, and a parallel set of flags is one more thing that can disagree with the data it describes.
+
+**Make `hintIds` stay `readonly string[]` and add `hasPublishedHints`.** Rejected for the same reason, and because it leaves the misleading `[]` default in place for anyone who reads only the array.
+
+## Related
+
+- [ADR-0007](0007-warning-display-timing-cascade.md) — the independence of the error and warning cascades, which this ADR must preserve per channel.
+- [ADR-0005](0005-aria-primitives-as-factories.md) — why `createHintIdsSignal` is a pure factory that consumers thread DI-resolved values into, which is what makes the coalescing possible in one place.
+- Issue [#387](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/387).

--- a/docs/decisions/0011-field-identity-provider-host-directive.md
+++ b/docs/decisions/0011-field-identity-provider-host-directive.md
@@ -1,0 +1,90 @@
+# ADR-0011: Field Identity Is Provided by a Host Directive, Not by Promoted Writers
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-17
+
+## Context
+
+Issue [#387](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/387) asked whether `NgxFieldIdentity`'s five `set*` writers should become the supported surface for third-party wrapper authors. Two capability gaps motivated the question.
+
+**Field naming.** `NgxSignalFormAutoAria` derives a field name from the bound control's `id` attribute unless an ancestor provides an `NgxFieldIdentity`, and only `NgxFormFieldWrapper` ever did. A custom wrapper therefore could not use a field name that differed from the control's DOM `id`. That breaks for a third-party widget that generates its own inner input id, and for a `role="group"` cluster whose name belongs to the group rather than to any single control. The generated `{fieldName}-error` id then disagrees with what the wrapper rendered — a dangling `aria-describedby`, which axe reports as `aria-valid-attr-value` and which leaves the error text unreachable by assistive technology. `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` cannot rescue this: its lookup is keyed on the same DOM-derived name.
+
+**Stale `aria-invalid`.** The gate that removes `aria-invalid` from a control with no layout box read the wrapper-published `NgxFieldIdentity.isControlVisible`, so it only ever fired for the built-in wrapper. A custom wrapper inside a collapsed `<details>`, an inactive tab, or a non-current wizard step kept a stale `aria-invalid` on a hidden control. The only escape was `NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` — forfeiting all of auto-aria to fix one attribute.
+
+The build had already answered the literal question. `strip-internal-members.mjs` removes `@internal` members from the published `.d.ts`, so the writers are not public today and promoting them would be new API, not a status-quo confirmation.
+
+## Decision
+
+### 1. Ship a selectorless host directive, not promoted writers
+
+`NgxFieldIdentityProvider` is a `@Directive` with `providers: [NgxFieldIdentity]` and one input, composed onto a wrapper's host via `hostDirectives`. It drives the `@internal` writers itself. No writer becomes public.
+
+A wrapper author does not actually want the writers — they want an `NgxFieldIdentity` **provided at their own host and already driven**, because auto-aria finds one by walking up the element injector. The directive is that, and it is strictly better than the writers as a contract: one declarative input instead of a five-call, ordering-sensitive protocol, with the "name before element" invariant enforced by the toolkit rather than by consumer discipline. It is also the composition pattern already used across the package.
+
+**No selector.** Placement on the host element is load-bearing — that is the element injector descendants resolve through — and a selector invites putting it somewhere that silently does nothing. Verified against Angular 22.1: `hostDirectives` resolves the directive definition directly and never consults its selector.
+
+**The field-name channel is claimed by provision, not by publication.** Unlike hints and strategy (ADR-0010), providing an identity hands it the naming channel outright: a binding of `null` means "not resolvable yet" and skips ARIA wiring rather than reverting to the control's `id`. A wrapper that declares its own naming has already said the control's `id` is not the name, so falling back to it during a transient unresolved window would emit ids that are wrong rather than absent. Because that makes an un-driven provider harmful rather than inert, a dev-mode diagnostic fires when nothing publishes a name.
+
+### 2. The input is optional, not required
+
+`input<string | null | undefined>(undefined)`, not `input.required`.
+
+A required input on a host directive must be re-exposed by the composing component (`NG2019`, `HOST_DIRECTIVE_MISSING_REQUIRED_BINDING`), and once exposed, every consumer template must bind it (`NG8008`) — attributed to the host directive's class, and firing even with `strictTemplates: false`. Making the input required would therefore make `[fieldName]` mandatory on every wrapper that composes this directive, in every downstream template. `required` buys nothing here anyway: `null` is a legal bound value, so the only thing lost is the unbound-vs-null distinction, which we use for a different purpose.
+
+### 3. `NgxFormFieldWrapper` does **not** compose the directive
+
+This deviates from the plan recorded on the issue, which called for the built-in wrapper to refactor onto the new surface to dogfood it. Angular does not permit it.
+
+A component cannot bind its own host directive's inputs — the only way in is to expose the input to _its_ consumers, which for `NgxFormFieldWrapper` would make `[fieldName]` mandatory on every `<ngx-form-field-wrapper>` in existence. And it could not use the input even if it were bindable: the wrapper's name is DOM-derived in its `afterEveryRender` write phase, strictly after inputs are set.
+
+Composing the directive with its input left unbound would work mechanically, but it would only be reusing a one-line `providers` array while adding a false-positive dev warning and a provider-resolution risk to the most-used component in the package. That is indirection, not dogfooding. The wrapper keeps `providers: [NgxFieldIdentity]` and drives it directly, as an in-package consumer of an in-package service.
+
+The third-party path is instead proven by test fixtures that are genuine custom wrappers, including an axe scan of one inside collapsible markup.
+
+### 4. Auto-aria probes its own host element for the `aria-invalid` gate
+
+Auto-aria no longer reads a wrapper-published visibility flag. It probes its own host element in the `earlyRead` phase of the `afterEveryRender` it already runs.
+
+The probe belongs in a render read phase, not an `effect()`: effects flush strictly before render hooks in the same change-detection cycle, so an effect-based probe reads pre-layout geometry. The initial pre-layout snapshot seeds `true` so ARIA is never stripped on the strength of a probe that ran before the element was laid out.
+
+This closes the gap for every wrapper, built-in or not. It is also more correct for a multi-control cluster, where the wrapper published one control's visibility for all of them and each control should track its own.
+
+Note this is **staleness prevention, not a conformance requirement**. Nothing in WCAG or ARIA mandates removing state from an unrendered element — an unrendered element is not in the accessibility tree at all. The value is that the attribute is correct at the moment the container reopens.
+
+### 5. `isElementCssVisible` fails open instead of guessing from `offsetParent`
+
+The old fallback for runtimes without `Element.checkVisibility()` was `offsetParent !== null`. That is wrong in both directions, and browser-verified in `field-identity.visibility.browser.spec.ts`:
+
+- **False positive** for a collapsed `<details>` and for `content-visibility: hidden` — the headline cases this probe exists for. The fallback reported those controls visible, so on any runtime taking that branch the staleness fix silently did nothing.
+- **False negative** for `position: fixed` elements, for `<body>`/`<html>`, and for every environment with no layout engine — jsdom, and any non-rendering host. There it would strip correct ARIA from controls the user can plainly see.
+
+`checkVisibility()` is Baseline 2024, so the fallback is reached only on genuinely old runtimes. Reporting `true` there keeps the pre-existing behaviour instead of stripping ARIA on a guess. The call also now passes `visibilityProperty` and `opacityProperty` alongside the historic `checkVisibilityCSS` alias; browsers ignore dictionary members they do not know.
+
+## Consequences
+
+- New public API: `NgxFieldIdentityProvider`, exported from the package root barrel. A root re-export is required because `/core` is stripped from the published `exports` map.
+- `NgxFieldIdentity`'s published `.d.ts` is unchanged — still no `set*` members after `post-build`.
+- `aria-invalid` behaviour changes for multi-control clusters: each control now tracks its own layout state rather than the cluster's first control's. Asserted deliberately rather than incidentally.
+- `isElementCssVisible` changes behaviour on runtimes without `checkVisibility()`, from "guess from `offsetParent`" to "report visible". It is exported publicly, so this is a behaviour change on a public function.
+- Visibility semantics are now only assertable in browser specs. The jsdom specs pin the fail-open contract instead, which is all jsdom can honestly answer.
+
+## Alternatives Considered
+
+**Promote the five `set*` writers.** Rejected. It publishes an ordering-sensitive imperative protocol, forces `strip-internal-members.mjs` to carve out exceptions, and hands consumers channels (strategy) where the registry's observed booleans are strictly safer.
+
+**Expose only `setFieldName`.** Rejected for the same protocol reasons, and because the consumer still has to provide and wire the service themselves — the part the directive actually removes.
+
+**Give the directive a `controlElement` input, or invert DI so auto-aria registers itself upward.** Rejected as unnecessary. Nothing reads the shared control element, and the only reader of the cached visibility flag now self-probes. Inversion stays additive if a future consumer needs it.
+
+**Replace auto-aria's imperative writes with `host: { '[attr.aria-describedby]': '…' }`.** Rejected. A host binding owns the attribute outright, and auto-aria merges consumer-authored `aria-describedby` ids with generated ones. Manual ARIA mode also needs read-then-passthrough, which a host binding cannot express. The imperative read/write phase is what buys that merge.
+
+## Related
+
+- [ADR-0010](0010-field-identity-shadows-registries-per-channel.md) — per-channel resolution, the prerequisite that keeps this directive from disabling the registries.
+- [ADR-0007](0007-warning-display-timing-cascade.md) — independence of the error and warning cascades.
+- Issue [#387](https://github.com/ngx-signal-forms/ngx-signal-forms/issues/387).

--- a/docs/decisions/0011-field-identity-provider-host-directive.md
+++ b/docs/decisions/0011-field-identity-provider-host-directive.md
@@ -63,14 +63,14 @@ The old fallback for runtimes without `Element.checkVisibility()` was `offsetPar
 - **False positive** for a collapsed `<details>` and for `content-visibility: hidden` — the headline cases this probe exists for. The fallback reported those controls visible, so on any runtime taking that branch the staleness fix silently did nothing.
 - **False negative** for `position: fixed` elements, for `<body>`/`<html>`, and for every environment with no layout engine — jsdom, and any non-rendering host. There it would strip correct ARIA from controls the user can plainly see.
 
-`checkVisibility()` is Baseline 2024, so the fallback is reached only on genuinely old runtimes. Reporting `true` there keeps the pre-existing behaviour instead of stripping ARIA on a guess. The call also now passes `visibilityProperty` and `opacityProperty` alongside the historic `checkVisibilityCSS` alias; browsers ignore dictionary members they do not know.
+`checkVisibility()` is Baseline 2024, so the fallback is reached only on genuinely old runtimes. Reporting `true` there keeps the pre-existing behavior instead of stripping ARIA on a guess. The call also passes `visibilityProperty`, the modern name for the historic `checkVisibilityCSS` alias, so both spellings are covered. `opacityProperty` is deliberately NOT passed: an `opacity: 0` control is still laid out, focusable, and interactive — it is the standard custom-checkbox pattern, and treating it as hidden would strip `aria-invalid` from a control the user is operating.
 
 ## Consequences
 
 - New public API: `NgxFieldIdentityProvider`, exported from the package root barrel. A root re-export is required because `/core` is stripped from the published `exports` map.
 - `NgxFieldIdentity`'s published `.d.ts` is unchanged — still no `set*` members after `post-build`.
-- `aria-invalid` behaviour changes for multi-control clusters: each control now tracks its own layout state rather than the cluster's first control's. Asserted deliberately rather than incidentally.
-- `isElementCssVisible` changes behaviour on runtimes without `checkVisibility()`, from "guess from `offsetParent`" to "report visible". It is exported publicly, so this is a behaviour change on a public function.
+- `aria-invalid` behavior changes for multi-control clusters: each control now tracks its own layout state rather than the cluster's first control's. Asserted deliberately rather than incidentally.
+- `isElementCssVisible` changes behavior on runtimes without `checkVisibility()`, from "guess from `offsetParent`" to "report visible". It is exported publicly, so this is a behavior change on a public function.
 - Visibility semantics are now only assertable in browser specs. The jsdom specs pin the fail-open contract instead, which is all jsdom can honestly answer.
 
 ## Alternatives Considered

--- a/docs/decisions/0011-field-identity-provider-host-directive.md
+++ b/docs/decisions/0011-field-identity-provider-host-directive.md
@@ -34,17 +34,25 @@ A wrapper author does not actually want the writers — they want an `NgxFieldId
 
 `input<string | null | undefined>(undefined)`, not `input.required`.
 
-A required input on a host directive must be re-exposed by the composing component (`NG2019`, `HOST_DIRECTIVE_MISSING_REQUIRED_BINDING`), and once exposed, every consumer template must bind it (`NG8008`) — attributed to the host directive's class, and firing even with `strictTemplates: false`. Making the input required would therefore make `[fieldName]` mandatory on every wrapper that composes this directive, in every downstream template. `required` buys nothing here anyway: `null` is a legal bound value, so the only thing lost is the unbound-vs-null distinction, which we use for a different purpose.
+A required host-directive input must be re-exposed by the composing component (`NG2019`, `HOST_DIRECTIVE_MISSING_REQUIRED_BINDING`), and once exposed, every consumer template must bind it (`NG8008`) — attributed to the host directive's class, and firing even with `strictTemplates: false`.
 
-### 3. `NgxFormFieldWrapper` does **not** compose the directive
+Note what this does _not_ mean. Angular feeds one `fieldName` attribute to both a component's own input and its exposed host-directive input, so composing this directive never asks consumers for an extra binding. The problem is narrower: a wrapper's own `fieldName` is normally _optional_. `NgxFormFieldWrapper`'s is, because tier 2 of the name cascade reads the bound control's `id` and that is the usual source. Requiring the input here would promote that optional input to mandatory and break every field relying on the `id` fallback.
 
-This deviates from the plan recorded on the issue, which called for the built-in wrapper to refactor onto the new surface to dogfood it. Angular does not permit it.
+`required` buys little anyway: `null` is a legal bound value, so the only thing lost is the unbound-vs-null distinction, which §3 puts to work.
 
-A component cannot bind its own host directive's inputs — the only way in is to expose the input to _its_ consumers, which for `NgxFormFieldWrapper` would make `[fieldName]` mandatory on every `<ngx-form-field-wrapper>` in existence. And it could not use the input even if it were bindable: the wrapper's name is DOM-derived in its `afterEveryRender` write phase, strictly after inputs are set.
+### 3. `NgxFormFieldWrapper` composes the directive
 
-Composing the directive with its input left unbound would work mechanically, but it would only be reusing a one-line `providers` array while adding a false-positive dev warning and a provider-resolution risk to the most-used component in the package. That is indirection, not dogfooding. The wrapper keeps `providers: [NgxFieldIdentity]` and drives it directly, as an in-package consumer of an in-package service.
+The built-in wrapper drops `NgxFieldIdentity` from its own `providers` and composes `NgxFieldIdentityProvider` on its host with the `fieldName` input exposed. The public seam and the built-in one are then the same seam, which is the only way to keep the third-party path honest.
 
-The third-party path is instead proven by test fixtures that are genuine custom wrappers, including an axe scan of one inside collapsible markup.
+This costs consumers nothing. Angular feeds a single `fieldName` attribute to both the wrapper's own input and the exposed host-directive input, and a component composing the directive resolves `NgxFieldIdentity` from the directive's `providers` — no duplicate provider, no second instance. Every existing wrapper spec passed unchanged across the refactor.
+
+The wrapper still drives the identity itself, because the input cannot carry everything:
+
+- **Tier 1 of the name cascade** — an explicitly bound `fieldName` — now travels through the directive.
+- **Tier 2** — the bound control's `id` — cannot. It is only known in the wrapper's `afterEveryRender` write phase, strictly after inputs are set. The directive stays inert (its input is unbound) and the wrapper writes the resolved name itself.
+- **Every non-name channel** — control element, visibility, hints, resolved strategies — has no channel on the directive at all and stays with the wrapper.
+
+The two writers do not contend. Effects flush before render hooks, so within a tick the directive publishes first and the wrapper's write phase follows with the fully-resolved cascade, which subsumes it.
 
 ### 4. Auto-aria probes its own host element for the `aria-invalid` gate
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -8,6 +8,7 @@ immediately preceding version to that release.
 | -------------- | -------------- | ---------------------------------- |
 | `v1.0.0-rc.10` | `v1.0.0-rc.11` | [Upgrade guide](./v1.0.0-rc.11.md) |
 | `v1.0.0-rc.11` | `v1.0.0-rc.12` | [Upgrade guide](./v1.0.0-rc.12.md) |
+| `v1.0.0-rc.12` | `v1.0.0-rc.13` | [Upgrade guide](./v1.0.0-rc.13.md) |
 
 Each guide starts with an `Upgrade from v<previous-version>` section:
 

--- a/docs/migrations/v1.0.0-rc.13.md
+++ b/docs/migrations/v1.0.0-rc.13.md
@@ -113,6 +113,8 @@ No other consumer migration is required.
   reverting to the control's `id`. Leaving the input unbound _and_ never
   driving the injected identity logs a dev-mode warning.
 
-  See [`docs/CUSTOM_WRAPPERS.md`](../CUSTOM_WRAPPERS.md) and
-  [ADR-0011](../decisions/0011-field-identity-provider-host-directive.md),
-  including why `NgxFormFieldWrapper` does not itself compose the directive.
+  `NgxFormFieldWrapper` now composes this same directive instead of providing
+  `NgxFieldIdentity` itself. This is internal wiring — one `fieldName`
+  attribute still feeds the wrapper, so no template changes. See
+  [`docs/CUSTOM_WRAPPERS.md`](../CUSTOM_WRAPPERS.md) and
+  [ADR-0011](../decisions/0011-field-identity-provider-host-directive.md).

--- a/docs/migrations/v1.0.0-rc.13.md
+++ b/docs/migrations/v1.0.0-rc.13.md
@@ -10,8 +10,8 @@ identity, adds `NgxFieldIdentityProvider` to do it, and fixes stale
 
 - **`NgxFieldIdentity.hintIds` is now `Signal<readonly string[] | null>`**
   (was `Signal<readonly string[]>`), and the structural type
-  `HintIdsIdentityLike` — re-exported from `@ngx-signal-forms/toolkit` and
-  `@ngx-signal-forms/toolkit/headless` — widens with it. The two empty-ish
+  `HintIdsIdentityLike` — published from `@ngx-signal-forms/toolkit/headless`
+  — widens with it. The two empty-ish
   states now mean different things:
 
   | Value  | Meaning                                                            |

--- a/docs/migrations/v1.0.0-rc.13.md
+++ b/docs/migrations/v1.0.0-rc.13.md
@@ -1,0 +1,118 @@
+# Migration to v1.0.0-rc.13
+
+## Upgrade from v1.0.0-rc.12
+
+This release makes a third-party form-field wrapper able to own its own field
+identity, adds `NgxFieldIdentityProvider` to do it, and fixes stale
+`aria-invalid` on controls with no layout box. One public read type widens.
+
+### Required changes
+
+- **`NgxFieldIdentity.hintIds` is now `Signal<readonly string[] | null>`**
+  (was `Signal<readonly string[]>`), and the structural type
+  `HintIdsIdentityLike` — re-exported from `@ngx-signal-forms/toolkit` and
+  `@ngx-signal-forms/toolkit/headless` — widens with it. The two empty-ish
+  states now mean different things:
+
+  | Value  | Meaning                                                            |
+  | ------ | ------------------------------------------------------------------ |
+  | `null` | Channel never published — consumers fall back to the hint registry |
+  | `[]`   | Published, and this field genuinely has no hints — authoritative   |
+
+  ```ts
+  // before
+  const ids: readonly string[] = identity.hintIds();
+
+  // after — decide which of the two empty states you mean
+  const ids = identity.hintIds() ?? [];
+  ```
+
+  **Only code that reads `identity.hintIds()` directly is affected.**
+  `createHintIdsSignal` coalesces internally and still returns a non-null
+  `Signal<readonly string[]>`, so a wrapper that composes ARIA through the
+  published factories — the documented path — needs no change.
+
+  `NgxFieldIdentity.describedBy` is unchanged (`string | null`).
+
+- **If you assert control visibility in tests, those assertions now need a
+  real browser.** `isElementCssVisible()` no longer falls back to
+  `offsetParent` when `Element.checkVisibility()` is missing; it reports
+  `true`. jsdom implements neither `checkVisibility()` nor layout, so a jsdom
+  test can no longer observe "hidden". See the behavior change below for why.
+
+No other consumer migration is required.
+
+### Behavior changes
+
+- **Field identity now shadows the fallback registries per channel, not by
+  presence.** `NgxSignalFormAutoAria` and `createHintIdsSignal` used to switch
+  wholesale onto an `NgxFieldIdentity` whenever one was injectable. They now
+  test whether that identity has actually _published_ the channel, and fall
+  back to `NGX_SIGNAL_FORM_HINT_REGISTRY` /
+  `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` otherwise. The error and warning
+  strategy channels fall back independently of one another. `NgxFormFieldWrapper`
+  publishes every channel on every render, so its behavior is unchanged. See
+  [ADR-0010](../decisions/0010-field-identity-shadows-registries-per-channel.md).
+
+- **`aria-invalid` no longer goes stale on a control with no layout box.** The
+  gate that removes it read a flag only the built-in wrapper published, so a
+  custom wrapper inside a collapsed `<details>`, an inactive tab, or a
+  non-current wizard step kept a stale attribute — with `'manual'` ARIA mode as
+  the only escape. `NgxSignalFormAutoAria` now probes its own host element, so
+  the fix applies to every wrapper. In a selection cluster the group element
+  now tracks its own layout state rather than inheriting whichever single
+  control the wrapper resolved, so hiding one option no longer strips
+  `aria-invalid` from a visible group.
+
+- **`isElementCssVisible()` fails open on runtimes without
+  `Element.checkVisibility()`.** The old `offsetParent !== null` fallback was
+  wrong in both directions: a false positive for a collapsed `<details>` and
+  for `content-visibility: hidden` — the very cases it existed for — and a
+  false negative for `position: fixed` elements and for any environment with
+  no layout engine. `checkVisibility()` is Baseline 2024, so the fallback is
+  reached only on genuinely old runtimes, where reporting "visible" preserves
+  prior behavior instead of stripping ARIA on a guess. The call passes
+  `visibilityProperty` (and its historic `checkVisibilityCSS` alias) but
+  deliberately **not** `opacityProperty`: an `opacity: 0` control is still
+  laid out, focusable, and interactive — the standard custom-checkbox pattern.
+
+### Additions
+
+- **`NgxFieldIdentityProvider`** — a selectorless directive that provides
+  `NgxFieldIdentity` on its host and publishes a field name into it. Compose
+  it via `hostDirectives` when your field's name is not the bound control's
+  `id`: a third-party widget that generates its own inner input id, or a
+  `role="group"` cluster whose name belongs to the group.
+
+  ```ts
+  import { NgxFieldIdentityProvider } from '@ngx-signal-forms/toolkit';
+
+  @Component({
+    selector: 'my-field',
+    hostDirectives: [
+      { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+    ],
+    /* ... */
+  })
+  export class MyField {}
+  ```
+
+  ```html
+  <my-field fieldName="emailAddress">
+    <input id="p-inputtext-42" [formField]="form.emailAddress" />
+  </my-field>
+  <!-- aria-describedby="emailAddress-error", not "p-inputtext-42-error" -->
+  ```
+
+  It publishes the field-name channel only; hints and display timing keep
+  resolving through their registries. `NgxFieldIdentity`'s `set*` writers stay
+  `@internal` and stay stripped from the published type definitions — the
+  directive drives them for you.
+
+  Binding `null` means "not resolvable yet" and skips ARIA wiring rather than
+  reverting to the control's `id`. Leaving the input unbound _and_ never
+  driving the injected identity logs a dev-mode warning.
+
+  See [`docs/CUSTOM_WRAPPERS.md`](../CUSTOM_WRAPPERS.md) and
+  [ADR-0011](../decisions/0011-field-identity-provider-host-directive.md),
+  including why `NgxFormFieldWrapper` does not itself compose the directive.

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -481,16 +481,23 @@ Building blocks for custom wrappers and headless UIs that want to join the
 | `resolveFieldNameFromCandidates(...candidates)` | Pick the first non-blank field name from a precedence chain (explicit → host id → context)  |
 | `generateErrorId(fieldName, kind?)`             | Derive `{fieldName}-error` (container) or `{fieldName}-error-{kind}` (per-error) element id |
 | `generateWarningId(fieldName)`                  | Derive the `{fieldName}-warning` element id used for `aria-describedby`                     |
-| `isElementCssVisible(element)`                  | CSS-visibility test (`Element.checkVisibility()` with `offsetParent` fallback)              |
+| `isElementCssVisible(element)`                  | CSS-visibility test via `Element.checkVisibility()`; reports `true` on runtimes without it  |
 
 ### Field identity service
 
 `NgxFieldIdentity` is the element-scoped service that consolidates the three
 load-bearing accessibility primitives every assistive/headless surface depends
 on: **field-name resolution**, **control visibility**, and **stable error /
-warning ID generation**. The canonical `ngx-form-field-wrapper` provides and
-drives it; custom controls and third-party wrappers can provide it themselves
-to get identical behavior without re-deriving the rules.
+warning ID generation**. Both the canonical `ngx-form-field-wrapper` and any
+third-party wrapper get one the same way — by composing
+[`NgxFieldIdentityProvider`](../../docs/CUSTOM_WRAPPERS.md) as a host
+directive.
+
+Its channels publish **independently**. Merely providing an identity claims
+nothing but the field name: hint ids and the error / warning display
+strategies keep resolving through `NGX_SIGNAL_FORM_HINT_REGISTRY` and
+`NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY` until this service actually
+publishes them (ADR-0010).
 
 | Member                      | Description                                                                                                                 |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -498,7 +505,7 @@ to get identical behavior without re-deriving the rules.
 | `controlId()`               | The bound control element's `id` attribute, or `null`                                                                       |
 | `errorId()`                 | Stable `{fieldName}-error` id, or `null` when no name is resolved                                                           |
 | `warningId()`               | Stable `{fieldName}-warning` id, or `null` when no name is resolved                                                         |
-| `hintIds()`                 | Hint ids contributed by the surrounding registry for this field                                                             |
+| `hintIds()`                 | Hint ids for this field, or `null` when the hint channel was never published (consumers fall back to the hint registry)     |
 | `describedBy()`             | Aggregated `aria-describedby` chain from `hintIds()`, or `null`                                                             |
 | `isControlVisible()`        | Callable signal: no-arg returns the cached, reactive visibility flag                                                        |
 | `isControlVisible(element)` | Same member with an element argument: ad-hoc, non-reactive `isElementCssVisible(element)` probe                             |
@@ -514,9 +521,10 @@ names:
   an **opt-in** middle step. Omit `labelFor` and the two paths emit the same
   name byte-for-byte.
 
-The `set*` writer methods are tagged `@internal`: the surrounding
-`ngx-form-field-wrapper` **drives** the identity, and consumers **read** the
-resolved signals — they do not drive them. A post-build step
+The `set*` writer methods are tagged `@internal`: a wrapper **drives** the
+identity — through `NgxFieldIdentityProvider` for the field name, and directly
+in-package for the rest — and consumers **read** the resolved signals. A
+post-build step
 (`scripts/strip-internal-members.mjs`) removes `@internal`-tagged class
 members from the published `.d.ts`, so the writers do not appear there — this
 is a compile-time barrier, not just a naming convention. (`tsconfig.lib.json`
@@ -524,10 +532,22 @@ does not enable TypeScript's own `stripInternal`: that flag breaks
 ng-packagr's multi-entry-point `.d.ts` bundling for this package, dropping
 unrelated public symbols along with the tagged ones — see #289.)
 
-Building a wrapper of your own? Don't reach for the writers — compose the pure
-ARIA factories (`createAriaDescribedBySignal`, `createAriaInvalidSignal`, …)
-instead. That is the supported seam, and it is what
-[`CUSTOM_WRAPPERS.md`](../../docs/CUSTOM_WRAPPERS.md) documents.
+Building a wrapper of your own? Don't reach for the writers. Compose
+`NgxFieldIdentityProvider` when your field's name is not the bound control's
+`id`, and compose the pure ARIA factories (`createAriaDescribedBySignal`,
+`createAriaInvalidSignal`, …) for the rest. Those are the supported seams, and
+they are what [`CUSTOM_WRAPPERS.md`](../../docs/CUSTOM_WRAPPERS.md)
+documents — the built-in wrapper runs on the same ones.
+
+```typescript
+@Component({
+  selector: 'my-field',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+})
+export class MyField {}
+```
 
 #### Custom control example
 

--- a/packages/toolkit/core/directives/auto-aria.channel-fallback.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.channel-fallback.spec.ts
@@ -1,0 +1,242 @@
+import {
+  Component,
+  Directive,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import {
+  FormField,
+  form,
+  minLength,
+  schema,
+  validate,
+} from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldError } from '../../assistive/form-field-error';
+import { NgxSignalFormToolkit } from '../../index';
+import { NgxFieldIdentity } from '../services/field-identity';
+import { NGX_SIGNAL_FORM_HINT_REGISTRY } from '../tokens';
+import type {
+  ResolvedErrorDisplayStrategy,
+  ResolvedWarningDisplayStrategy,
+} from '../types';
+
+/**
+ * An identity that owns exactly one channel — the field name — and leaves
+ * hints and both strategy cascades unpublished.
+ *
+ * This is the shape a third-party wrapper takes: it knows what its field is
+ * called, and nothing else. Before per-channel resolution, merely providing
+ * `NgxFieldIdentity` was enough to switch auto-aria off every fallback
+ * registry, so a wrapper that adopted the identity to fix its field naming
+ * silently lost hint correlation and field-level strategy overrides at the
+ * same time. Each test below pins one of those channels.
+ */
+@Directive({
+  selector: '[ngxTestPartialIdentity]',
+  providers: [NgxFieldIdentity],
+})
+class PartialIdentityHost {
+  readonly ngxTestPartialIdentity = input.required<string>();
+  readonly #identity = inject(NgxFieldIdentity);
+
+  constructor() {
+    effect(() => this.#identity.setFieldName(this.ngxTestPartialIdentity()));
+  }
+}
+
+function createPasswordForm() {
+  const model = signal({ password: 'abc' });
+  return form(
+    model,
+    schema((path) => {
+      minLength(path.password, 4, { message: 'At least 4 characters' });
+      validate(path.password, (ctx) => {
+        const value = ctx.value();
+        if (value.length > 0 && value.length < 8) {
+          return { kind: 'warn:weak', message: 'Consider 8+ characters' };
+        }
+        return null;
+      });
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Strategy channels
+// ---------------------------------------------------------------------------
+
+@Component({
+  selector: 'ngx-test-partial-identity-strategies',
+  imports: [
+    PartialIdentityHost,
+    NgxFormFieldError,
+    FormField,
+    NgxSignalFormToolkit,
+  ],
+  template: `
+    <form [formRoot]="pwForm" ngxSignalForm [errorStrategy]="errorStrategy()">
+      <div ngxTestPartialIdentity="password">
+        <label for="password">Password</label>
+        <input id="password" type="password" [formField]="pwForm.password" />
+      </div>
+      <ngx-form-field-error
+        [formField]="pwForm.password"
+        fieldName="password"
+        [strategy]="fieldStrategy()"
+        [warningStrategy]="fieldWarningStrategy()"
+      />
+    </form>
+  `,
+})
+class PartialIdentityStrategyHost {
+  readonly errorStrategy = input.required<ResolvedErrorDisplayStrategy>();
+  readonly fieldStrategy = input.required<ResolvedErrorDisplayStrategy>();
+  readonly fieldWarningStrategy =
+    input.required<ResolvedWarningDisplayStrategy>();
+
+  readonly pwForm = createPasswordForm();
+}
+
+async function renderStrategyHost(inputs: {
+  errorStrategy: ResolvedErrorDisplayStrategy;
+  fieldStrategy: ResolvedErrorDisplayStrategy;
+  fieldWarningStrategy: ResolvedWarningDisplayStrategy;
+}) {
+  const { container } = await render(PartialIdentityStrategyHost, { inputs });
+  return {
+    container,
+    describedBy:
+      container
+        .querySelector('input#password')
+        ?.getAttribute('aria-describedby') ?? '',
+  };
+}
+
+describe('auto-aria: a partially-driven identity does not claim the strategy channels', () => {
+  it('still honours a registry-published error strategy the ambient form context contradicts', async () => {
+    // The form gates errors until submit; the standalone error component
+    // overrides *its* blocking channel to 'immediate' and renders. An
+    // identity is present but published no error strategy, so the registry
+    // must still win — otherwise auto-aria falls back to the ambient
+    // 'on-submit' context and never references the region that is on screen
+    // (WCAG 1.3.1).
+    const { container, describedBy } = await renderStrategyHost({
+      errorStrategy: 'on-submit',
+      fieldStrategy: 'immediate',
+      fieldWarningStrategy: 'on-submit',
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'At least 4 characters',
+    );
+    expect(describedBy).toContain('password-error');
+    expect(describedBy).not.toContain('password-warning');
+  });
+
+  it('still honours a registry-published warning strategy the ambient form context contradicts', async () => {
+    const { container, describedBy } = await renderStrategyHost({
+      errorStrategy: 'on-submit',
+      fieldStrategy: 'on-submit',
+      fieldWarningStrategy: 'immediate',
+    });
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      'Consider 8+ characters',
+    );
+    expect(describedBy).toContain('password-warning');
+    expect(describedBy).not.toContain('password-error');
+  });
+
+  it('does not reference regions the registry-published strategies suppress', async () => {
+    // The mirror case: the form says "show immediately", the standalone
+    // component overrides both channels to 'on-submit', nothing renders. A
+    // dangling reference here is an axe `aria-valid-attr-value` violation.
+    const { container, describedBy } = await renderStrategyHost({
+      errorStrategy: 'immediate',
+      fieldStrategy: 'on-submit',
+      fieldWarningStrategy: 'on-submit',
+    });
+
+    expect(
+      container.querySelector('[role="alert"]')?.textContent?.trim() ?? '',
+    ).toBe('');
+    expect(
+      container.querySelector('[role="status"]')?.textContent?.trim() ?? '',
+    ).toBe('');
+    expect(describedBy).not.toContain('password-error');
+    expect(describedBy).not.toContain('password-warning');
+  });
+
+  it('resolves the two strategy channels independently (ADR-0007)', async () => {
+    // One channel published by the registry, the other suppressed — the
+    // channels must not be decided together.
+    const { describedBy } = await renderStrategyHost({
+      errorStrategy: 'on-submit',
+      fieldStrategy: 'immediate',
+      fieldWarningStrategy: 'immediate',
+    });
+
+    // A blocking error suppresses the warning region in the default
+    // renderer, so only the error id may appear.
+    expect(describedBy).toContain('password-error');
+    expect(describedBy).not.toContain('password-warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hint channel
+// ---------------------------------------------------------------------------
+
+/**
+ * The custom-wrapper shape for hints: the host owns field naming through a
+ * partially-driven identity *and* publishes its own hints through the
+ * registry, which is the documented third-party seam. Both must work at once.
+ */
+@Component({
+  selector: 'ngx-test-partial-identity-hints',
+  imports: [PartialIdentityHost, FormField, NgxSignalFormToolkit],
+  providers: [
+    {
+      provide: NGX_SIGNAL_FORM_HINT_REGISTRY,
+      useFactory: () => ({
+        hints: computed(() => [
+          { id: 'password-hint', fieldName: 'password' },
+          { id: 'other-field-hint', fieldName: 'username' },
+        ]),
+      }),
+    },
+  ],
+  template: `
+    <form [formRoot]="pwForm" ngxSignalForm>
+      <div ngxTestPartialIdentity="password">
+        <label for="password">Password</label>
+        <input id="password" type="password" [formField]="pwForm.password" />
+        <p id="password-hint">Use at least 8 characters</p>
+      </div>
+    </form>
+  `,
+})
+class PartialIdentityHintHost {
+  readonly pwForm = createPasswordForm();
+}
+
+describe('auto-aria: a partially-driven identity does not claim the hint channel', () => {
+  it('still correlates registry hints when the identity published none', async () => {
+    const { container } = await render(PartialIdentityHintHost);
+
+    const describedBy =
+      container
+        .querySelector('input#password')
+        ?.getAttribute('aria-describedby') ?? '';
+
+    expect(describedBy.split(' ')).toContain('password-hint');
+    // The identity resolved the field name, so the registry filter still
+    // scopes correctly — a hint for another field must not leak in.
+    expect(describedBy).not.toContain('other-field-hint');
+  });
+});

--- a/packages/toolkit/core/directives/auto-aria.control-visibility.browser.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.control-visibility.browser.spec.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import { NgxFormFieldError } from '../../assistive/form-field-error';
 import { NgxFormFieldWrapper } from '../../form-field/form-field-wrapper';
 import { NgxSignalFormToolkit } from '../../index';
+import { isElementCssVisible } from '../services/field-identity';
 import { NgxFieldIdentityProvider } from './field-identity-provider';
 
 /**
@@ -111,7 +112,7 @@ describe('auto-aria — aria-invalid on a control with no layout box (custom wra
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(control?.checkVisibility()).toBe(false);
+    expect(isElementCssVisible(control!)).toBe(false);
     expect(control?.getAttribute('aria-invalid')).toBeNull();
   });
 
@@ -260,7 +261,7 @@ describe('auto-aria — aria-invalid on a selection cluster', () => {
     // The wrapper used to publish the *first* resolved control's visibility
     // for the whole cluster, so hiding that radio stripped `aria-invalid`
     // off a group the user can plainly see.
-    expect(group?.checkVisibility()).toBe(true);
+    expect(isElementCssVisible(group!)).toBe(true);
     expect(group?.getAttribute('aria-invalid')).toBe('true');
   });
 

--- a/packages/toolkit/core/directives/auto-aria.control-visibility.browser.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.control-visibility.browser.spec.ts
@@ -1,5 +1,11 @@
 import { Component, input, signal } from '@angular/core';
-import { FormField, form, minLength, schema } from '@angular/forms/signals';
+import {
+  FormField,
+  form,
+  minLength,
+  required,
+  schema,
+} from '@angular/forms/signals';
 import { render } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
 import { NgxFormFieldError } from '../../assistive/form-field-error';
@@ -95,9 +101,9 @@ describe('auto-aria — aria-invalid on a control with no layout box (custom wra
     const { fixture } = await render(CollapsibleCustomHost, {
       inputs: { open: true },
     });
-    const control = fixture.nativeElement.querySelector<HTMLElement>(
-      'input#widget-generated-7',
-    );
+    const control = (
+      fixture.nativeElement as HTMLElement
+    ).querySelector<HTMLElement>('input#widget-generated-7');
     expect(control?.getAttribute('aria-invalid')).toBe('true');
 
     fixture.componentRef.setInput('open', false);
@@ -113,9 +119,9 @@ describe('auto-aria — aria-invalid on a control with no layout box (custom wra
     const { fixture } = await render(CollapsibleCustomHost, {
       inputs: { open: false },
     });
-    const control = fixture.nativeElement.querySelector<HTMLElement>(
-      'input#widget-generated-7',
-    );
+    const control = (
+      fixture.nativeElement as HTMLElement
+    ).querySelector<HTMLElement>('input#widget-generated-7');
 
     fixture.componentRef.setInput('open', true);
     await fixture.whenStable();
@@ -158,8 +164,9 @@ describe('auto-aria — aria-invalid on a control with no layout box (built-in w
     const { fixture } = await render(CollapsibleBuiltinHost, {
       inputs: { open: true },
     });
-    const control =
-      fixture.nativeElement.querySelector<HTMLElement>('input#email');
+    const control = (
+      fixture.nativeElement as HTMLElement
+    ).querySelector<HTMLElement>('input#email');
     expect(control?.getAttribute('aria-invalid')).toBe('true');
 
     fixture.componentRef.setInput('open', false);
@@ -168,5 +175,104 @@ describe('auto-aria — aria-invalid on a control with no layout box (built-in w
     await fixture.whenStable();
 
     expect(control?.getAttribute('aria-invalid')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selection cluster — the one shape where self-probing changes behavior
+// ---------------------------------------------------------------------------
+
+@Component({
+  selector: 'ngx-test-cluster-visibility-host',
+  imports: [NgxFormFieldWrapper, FormField, NgxSignalFormToolkit],
+  template: `
+    <form [formRoot]="deliveryForm" ngxSignalForm>
+      <details [open]="open()">
+        <summary>Delivery</summary>
+        <ngx-form-field-wrapper
+          [formField]="deliveryForm.deliveryMethod"
+          fieldName="deliveryMethod"
+          strategy="immediate"
+        >
+          <div>
+            <label>
+              <input
+                id="delivery-standard"
+                type="radio"
+                [formField]="deliveryForm.deliveryMethod"
+                value="standard"
+                [style.display]="hideFirstOption() ? 'none' : null"
+              />
+              Standard
+            </label>
+            <label>
+              <input
+                id="delivery-express"
+                type="radio"
+                [formField]="deliveryForm.deliveryMethod"
+                value="express"
+              />
+              Express
+            </label>
+          </div>
+        </ngx-form-field-wrapper>
+      </details>
+    </form>
+  `,
+})
+class ClusterVisibilityHost {
+  readonly open = input.required<boolean>();
+  readonly hideFirstOption = input.required<boolean>();
+
+  readonly #model = signal({ deliveryMethod: '' });
+  readonly deliveryForm = form(
+    this.#model,
+    schema((path) => {
+      required(path.deliveryMethod, { message: 'Pick a delivery method' });
+    }),
+  );
+}
+
+/**
+ * A selection cluster has exactly one auto-aria instance, on the wrapper host
+ * that carries the group role — the individual radios are excluded by the
+ * directive's selector. Self-probing therefore moves the visibility source
+ * from "whichever single control the wrapper resolved" to "the element that
+ * actually carries `aria-invalid`". That is a deliberate behavior change, so
+ * both halves of it are asserted rather than left to the general suite.
+ */
+describe('auto-aria — aria-invalid on a selection cluster', () => {
+  async function renderCluster(open: boolean, hideFirstOption: boolean) {
+    const { fixture } = await render(ClusterVisibilityHost, {
+      inputs: { open, hideFirstOption },
+    });
+    return {
+      fixture,
+      group: (fixture.nativeElement as HTMLElement).querySelector<HTMLElement>(
+        'ngx-form-field-wrapper',
+      ),
+    };
+  }
+
+  it('keeps the group aria-invalid when one option is hidden but the group is not', async () => {
+    const { group } = await renderCluster(true, true);
+
+    // The wrapper used to publish the *first* resolved control's visibility
+    // for the whole cluster, so hiding that radio stripped `aria-invalid`
+    // off a group the user can plainly see.
+    expect(group?.checkVisibility()).toBe(true);
+    expect(group?.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('removes the group aria-invalid when the whole cluster loses its layout box', async () => {
+    const { fixture, group } = await renderCluster(true, false);
+    expect(group?.getAttribute('aria-invalid')).toBe('true');
+
+    fixture.componentRef.setInput('open', false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(group?.getAttribute('aria-invalid')).toBeNull();
   });
 });

--- a/packages/toolkit/core/directives/auto-aria.control-visibility.browser.spec.ts
+++ b/packages/toolkit/core/directives/auto-aria.control-visibility.browser.spec.ts
@@ -1,0 +1,172 @@
+import { Component, input, signal } from '@angular/core';
+import { FormField, form, minLength, schema } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldError } from '../../assistive/form-field-error';
+import { NgxFormFieldWrapper } from '../../form-field/form-field-wrapper';
+import { NgxSignalFormToolkit } from '../../index';
+import { NgxFieldIdentityProvider } from './field-identity-provider';
+
+/**
+ * `aria-invalid` must not go stale on a control that has no layout box.
+ *
+ * A control inside a collapsed `<details>`, an inactive tab panel, or a
+ * non-current wizard step is not in the accessibility tree, so leaving
+ * `aria-invalid="true"` on it means the attribute is wrong the instant the
+ * container reopens with a different validation state. `NgxSignalFormAutoAria`
+ * therefore probes its own host element each read phase and removes the
+ * attribute while the control is not laid out.
+ *
+ * Browser-only by necessity: jsdom implements neither `checkVisibility()` nor
+ * a real `offsetParent`, so the probe always reports "visible" there and every
+ * assertion below would pass vacuously.
+ */
+
+function createForm() {
+  const model = signal({ email: 'no' });
+  return form(
+    model,
+    schema((path) => {
+      minLength(path.email, 5, { message: 'At least 5 characters' });
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom wrapper (the case with no workaround before this change)
+// ---------------------------------------------------------------------------
+
+@Component({
+  selector: 'ngx-test-collapsible-custom-wrapper',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+  imports: [NgxFormFieldError],
+  template: `
+    <ng-content />
+    <ngx-form-field-error
+      [formField]="errorField()"
+      fieldName="email"
+      strategy="immediate"
+    />
+  `,
+})
+class CollapsibleCustomWrapper {
+  readonly errorField = input.required<unknown>();
+}
+
+@Component({
+  selector: 'ngx-test-collapsible-custom-host',
+  imports: [CollapsibleCustomWrapper, FormField, NgxSignalFormToolkit],
+  template: `
+    <form [formRoot]="emailForm" ngxSignalForm>
+      <details [open]="open()">
+        <summary>Contact details</summary>
+        <ngx-test-collapsible-custom-wrapper
+          fieldName="email"
+          [errorField]="emailForm.email"
+        >
+          <label for="widget-generated-7">Email</label>
+          <input id="widget-generated-7" [formField]="emailForm.email" />
+        </ngx-test-collapsible-custom-wrapper>
+      </details>
+    </form>
+  `,
+})
+class CollapsibleCustomHost {
+  readonly open = input.required<boolean>();
+  readonly emailForm = createForm();
+}
+
+describe('auto-aria — aria-invalid on a control with no layout box (custom wrapper)', () => {
+  it('sets aria-invalid while the control is laid out', async () => {
+    const { container } = await render(CollapsibleCustomHost, {
+      inputs: { open: true },
+    });
+
+    expect(
+      container
+        .querySelector('input#widget-generated-7')
+        ?.getAttribute('aria-invalid'),
+    ).toBe('true');
+  });
+
+  it('removes aria-invalid rather than leaving it stale when collapsed', async () => {
+    const { fixture } = await render(CollapsibleCustomHost, {
+      inputs: { open: true },
+    });
+    const control = fixture.nativeElement.querySelector<HTMLElement>(
+      'input#widget-generated-7',
+    );
+    expect(control?.getAttribute('aria-invalid')).toBe('true');
+
+    fixture.componentRef.setInput('open', false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(control?.checkVisibility()).toBe(false);
+    expect(control?.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('restores aria-invalid when the container reopens', async () => {
+    const { fixture } = await render(CollapsibleCustomHost, {
+      inputs: { open: false },
+    });
+    const control = fixture.nativeElement.querySelector<HTMLElement>(
+      'input#widget-generated-7',
+    );
+
+    fixture.componentRef.setInput('open', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(control?.getAttribute('aria-invalid')).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Built-in wrapper (previously the only shape the fix covered)
+// ---------------------------------------------------------------------------
+
+@Component({
+  selector: 'ngx-test-collapsible-builtin-host',
+  imports: [NgxFormFieldWrapper, FormField, NgxSignalFormToolkit],
+  template: `
+    <form [formRoot]="emailForm" ngxSignalForm>
+      <details [open]="open()">
+        <summary>Contact details</summary>
+        <ngx-form-field-wrapper
+          [formField]="emailForm.email"
+          strategy="immediate"
+        >
+          <label for="email">Email</label>
+          <input id="email" [formField]="emailForm.email" />
+        </ngx-form-field-wrapper>
+      </details>
+    </form>
+  `,
+})
+class CollapsibleBuiltinHost {
+  readonly open = input.required<boolean>();
+  readonly emailForm = createForm();
+}
+
+describe('auto-aria — aria-invalid on a control with no layout box (built-in wrapper)', () => {
+  it('keeps the pre-existing behavior after auto-aria took over the probe', async () => {
+    const { fixture } = await render(CollapsibleBuiltinHost, {
+      inputs: { open: true },
+    });
+    const control =
+      fixture.nativeElement.querySelector<HTMLElement>('input#email');
+    expect(control?.getAttribute('aria-invalid')).toBe('true');
+
+    fixture.componentRef.setInput('open', false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(control?.getAttribute('aria-invalid')).toBeNull();
+  });
+});

--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -206,13 +206,14 @@ export class NgxSignalFormAutoAria {
    *
    * Note what this deliberately does *not* check: whether
    * {@link #fieldIdentity} exists. An identity that is merely injectable
-   * claims nothing — only a *published* strategy does, and that is tested
-   * per channel at the two call sites below. Gating on service presence
-   * instead would mean any partially-driven identity (a third-party wrapper
-   * that owns only the field name, say) silently switched both strategy
-   * channels off the registry and onto the ambient form context, dropping
-   * the field-level overrides a standalone `<ngx-form-field-error>` had
-   * published. See ADR-0010.
+   * claims nothing. Only a *published* strategy does, and the two call sites
+   * below test for that per channel.
+   *
+   * Gating on service presence instead would break any partially-driven
+   * identity — a third-party wrapper that owns only the field name, say. It
+   * would switch both strategy channels off the registry and onto the ambient
+   * form context, dropping the field-level overrides a standalone
+   * `<ngx-form-field-error>` had published. See ADR-0010.
    */
   readonly #registryVisibilityEntry = computed(() => {
     const fieldName = this.#domSnapshot().fieldName;
@@ -243,13 +244,17 @@ export class NgxSignalFormAutoAria {
    * identity happens to be injectable — see `#registryVisibilityEntry`.
    */
   readonly #visibilityByStrategy = computed(() => {
-    if (this.#fieldIdentity?.resolvedErrorStrategy() != null) {
-      return this.#ownVisibilityByStrategy();
+    const publishedErrorStrategy =
+      this.#fieldIdentity?.resolvedErrorStrategy() ?? null;
+
+    if (publishedErrorStrategy === null) {
+      const registryEntry = this.#registryVisibilityEntry();
+      if (registryEntry) return registryEntry.errorContainerVisible();
     }
 
-    const registryEntry = this.#registryVisibilityEntry();
-    if (registryEntry) return registryEntry.errorContainerVisible();
-
+    // `#ownVisibilityByStrategy` already reads the published strategy and
+    // falls back to the ambient form context when it is null, so it covers
+    // both remaining branches.
     return this.#ownVisibilityByStrategy();
   });
 

--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -186,17 +186,20 @@ export class NgxSignalFormAutoAria {
   #previousTickWasManualAriaMode: boolean | null = null;
 
   /**
-   * The wrapper-less fallback channel's entry for the currently bound
-   * control's field name, or `undefined` when there is none to fall back
-   * to. Deliberately skipped whenever {@link #fieldIdentity} is present —
-   * the wrapper fast-path already accounts for the wrapper's own
-   * field-level overrides, and preferring it keeps existing wrapped-field
-   * behavior unchanged. Only consulted for the wrapper-less case, where a
-   * sibling `<ngx-form-field-error>` has no other way to reach auto-aria.
+   * The fallback channel's entry for the currently bound control's field
+   * name, or `undefined` when there is none to fall back to.
+   *
+   * Note what this deliberately does *not* check: whether
+   * {@link #fieldIdentity} exists. An identity that is merely injectable
+   * claims nothing — only a *published* strategy does, and that is tested
+   * per channel at the two call sites below. Gating on service presence
+   * instead would mean any partially-driven identity (a third-party wrapper
+   * that owns only the field name, say) silently switched both strategy
+   * channels off the registry and onto the ambient form context, dropping
+   * the field-level overrides a standalone `<ngx-form-field-error>` had
+   * published. See ADR-0010.
    */
   readonly #registryVisibilityEntry = computed(() => {
-    if (this.#fieldIdentity) return undefined;
-
     const fieldName = this.#domSnapshot().fieldName;
     if (!fieldName) return undefined;
 
@@ -213,15 +216,22 @@ export class NgxSignalFormAutoAria {
    * `[ngxSignalForm]` context (strategy + submittedStatus) via DI, matching
    * the same cascade as the form-field wrapper and headless error-state.
    *
-   * When an owning `NgxFormFieldWrapper` has published its own resolved
-   * strategy, that wins: it already accounts for the wrapper's field-level
-   * `strategy` input, which the ambient form context cannot see. Absent a
-   * wrapper, a registry entry — published by a standalone
-   * `<ngx-form-field-error>` — wins instead: its `errorContainerVisible` is
-   * the exact boolean already gating that component's own live region, so
-   * reusing it here can't drift from what is actually rendered.
+   * When an owning wrapper has **published an error strategy** on the
+   * identity, that wins: it already accounts for the wrapper's field-level
+   * `strategy` input, which the ambient form context cannot see. Otherwise a
+   * registry entry — published by a standalone `<ngx-form-field-error>` —
+   * wins: its `errorContainerVisible` is the exact boolean already gating
+   * that component's own live region, so reusing it here can't drift from
+   * what is actually rendered.
+   *
+   * The precedence test is on the published *value*, not on whether an
+   * identity happens to be injectable — see `#registryVisibilityEntry`.
    */
   readonly #visibilityByStrategy = computed(() => {
+    if (this.#fieldIdentity?.resolvedErrorStrategy() != null) {
+      return this.#ownVisibilityByStrategy();
+    }
+
     const registryEntry = this.#registryVisibilityEntry();
     if (registryEntry) return registryEntry.errorContainerVisible();
 
@@ -254,14 +264,25 @@ export class NgxSignalFormAutoAria {
    * visible warning that `aria-describedby` never references, leaving the
    * advisory text unavailable to assistive technology (WCAG 1.3.1).
    *
-   * Same registry fallback as {@link #visibilityByStrategy}: absent a
-   * wrapper, a standalone error component's published
+   * Same per-channel fallback as {@link #visibilityByStrategy}, resolved
+   * **independently of the error channel**: ADR-0007 establishes the two
+   * cascades as separate, so an identity that publishes an error strategy
+   * but not a warning strategy must still let the registry own warnings.
+   * Absent a published warning strategy, a standalone error component's
    * `warningContainerVisible` wins over recomputing the cascade from the
    * ambient form context.
    */
   readonly #warningVisibilityByStrategy = computed(() => {
-    const registryEntry = this.#registryVisibilityEntry();
-    if (registryEntry) return registryEntry.warningContainerVisible();
+    // A wrapper's published strategy already resolved its field-level
+    // `warningStrategy` input, so it takes precedence over both the registry
+    // and the ambient form context.
+    const publishedWarningStrategy =
+      this.#fieldIdentity?.resolvedWarningStrategy() ?? null;
+
+    if (publishedWarningStrategy === null) {
+      const registryEntry = this.#registryVisibilityEntry();
+      if (registryEntry) return registryEntry.warningContainerVisible();
+    }
 
     const fieldState = this.#resolveFieldState();
     if (!fieldState) return false;
@@ -269,10 +290,7 @@ export class NgxSignalFormAutoAria {
     return shouldShowWarnings(
       fieldState.errors().some(isWarningError),
       fieldState.touched(),
-      // A wrapper's published strategy already resolved its field-level
-      // `warningStrategy` input, so it takes precedence over the ambient
-      // form context.
-      this.#fieldIdentity?.resolvedWarningStrategy() ??
+      publishedWarningStrategy ??
         resolveWarningStrategyFromContext(
           undefined,
           this.#formContext,

--- a/packages/toolkit/core/directives/auto-aria.ts
+++ b/packages/toolkit/core/directives/auto-aria.ts
@@ -32,7 +32,10 @@ import { createErrorVisibility } from '../utilities/create-error-visibility';
 import { createAriaDescribedBySignal } from '../utilities/aria/create-aria-described-by-signal';
 import { createHintIdsSignal } from '../utilities/aria/create-hint-ids-signal';
 import { isBlockingError, isWarningError } from '../utilities/warning-error';
-import { NgxFieldIdentity } from '../services/field-identity';
+import {
+  isElementCssVisible,
+  NgxFieldIdentity,
+} from '../services/field-identity';
 
 interface AutoAriaDomSnapshot {
   readonly fieldName: string | null;
@@ -40,6 +43,15 @@ interface AutoAriaDomSnapshot {
   readonly ariaInvalid: string | null;
   readonly ariaRequired: string | null;
   readonly role: string | null;
+  /**
+   * Whether *this* control had a CSS layout box as of the last read phase.
+   *
+   * Probed from the directive's own host element rather than read off a
+   * wrapper-published flag, so it works for any wrapper (or none) and so each
+   * control in a multi-control cluster tracks its own layout state instead of
+   * inheriting the cluster's first control's.
+   */
+  readonly isControlVisible: boolean;
 }
 
 const INITIAL_DOM_SNAPSHOT: AutoAriaDomSnapshot = {
@@ -48,6 +60,9 @@ const INITIAL_DOM_SNAPSHOT: AutoAriaDomSnapshot = {
   ariaInvalid: null,
   ariaRequired: null,
   role: null,
+  // Assume laid out until a real read phase says otherwise, so ARIA is never
+  // stripped on the strength of a pre-layout probe.
+  isControlVisible: true,
 };
 
 /**
@@ -332,10 +347,28 @@ export class NgxSignalFormAutoAria {
     return this.#shouldShowBy('warning');
   });
 
+  /**
+   * Whether this control is currently laid out, sourced from the directive's
+   * own read phase.
+   *
+   * Deliberately *not* the owning wrapper's published
+   * `NgxFieldIdentity.isControlVisible`. Reading that flag made the
+   * `aria-invalid` staleness fix conditional on there being a built-in
+   * wrapper: a custom wrapper inside a collapsed `<details>`, an inactive
+   * tab, or a non-current wizard step kept a stale `aria-invalid` on a hidden
+   * control, and the only escape was `NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` —
+   * forfeiting all of auto-aria to fix one attribute. It is also more correct
+   * for a multi-control cluster, where the wrapper publishes one control's
+   * visibility for all of them.
+   */
+  readonly #isControlVisible = computed(
+    () => this.#domSnapshot().isControlVisible,
+  );
+
   readonly #factoryAriaInvalid = createAriaInvalidSignal(
     this.#fieldStateSignal,
     this.#visibilityByStrategy,
-    this.#fieldIdentity?.isControlVisible,
+    this.#isControlVisible,
   );
 
   /**
@@ -512,7 +545,13 @@ export class NgxSignalFormAutoAria {
     return preserved.length > 0 ? preserved.join(' ') : null;
   }
 
-  #readDomSnapshot(): AutoAriaDomSnapshot {
+  /**
+   * @param isControlVisible The layout probe's result. Passed in rather than
+   *   taken here so the constructor's pre-layout seed can assume `true`,
+   *   while the `earlyRead` phase — the only point at which a layout read is
+   *   both meaningful and cheap — supplies the real value.
+   */
+  #readDomSnapshot(isControlVisible: boolean): AutoAriaDomSnapshot {
     // When the identity service is present (wrapper context), prefer its
     // field name over the element's id attribute. This ensures auto-aria and
     // the wrapper always agree on which name drives ID generation.
@@ -532,6 +571,7 @@ export class NgxSignalFormAutoAria {
       // DOM by the time `afterEveryRender` runs, so this reflects the
       // current render's role, not a stale one.
       role: this.#element.nativeElement.getAttribute('role'),
+      isControlVisible,
     };
   }
 
@@ -548,19 +588,25 @@ export class NgxSignalFormAutoAria {
   }
 
   constructor() {
-    this.#domSnapshot.set(this.#readDomSnapshot());
-
-    // Visibility tracking lives entirely in `NgxFieldIdentity` — auto-aria
-    // reads `isControlVisible()` directly in the `ariaInvalid` computed,
-    // so no afterEveryRender wiring is needed here.
+    // Seed with `isControlVisible: true`. The element exists by now but has
+    // not been through layout, and `checkVisibility()` on a not-yet-laid-out
+    // element reports `false` — probing here would strip `aria-invalid` on
+    // the first tick and put it back on the next.
+    this.#domSnapshot.set(this.#readDomSnapshot(true));
 
     // Single afterEveryRender with proper phased callbacks:
-    // - earlyRead: read DOM attributes before any writes (prevents layout thrashing)
+    // - earlyRead: read DOM attributes and probe layout before any writes
+    //   (prevents layout thrashing)
     // - write: update the snapshot signal and write managed ARIA attributes to the DOM
     afterEveryRender(
       {
         earlyRead: () => {
-          return this.#readDomSnapshot();
+          // The layout probe belongs here, not in an `effect()`. Effects
+          // flush strictly before render hooks in the same change-detection
+          // cycle, so an effect-based probe would read pre-layout geometry.
+          return this.#readDomSnapshot(
+            isElementCssVisible(this.#element.nativeElement),
+          );
         },
         write: (snapshot) => {
           const current = this.#domSnapshot();
@@ -573,7 +619,8 @@ export class NgxSignalFormAutoAria {
             current.describedBy !== snapshot.describedBy ||
             current.ariaInvalid !== snapshot.ariaInvalid ||
             current.ariaRequired !== snapshot.ariaRequired ||
-            current.role !== snapshot.role
+            current.role !== snapshot.role ||
+            current.isControlVisible !== snapshot.isControlVisible
           ) {
             this.#domSnapshot.set(snapshot);
           }

--- a/packages/toolkit/core/directives/field-identity-provider.a11y.browser.spec.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.a11y.browser.spec.ts
@@ -1,0 +1,106 @@
+import { ApplicationRef, Component, input, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormField, form, minLength, schema } from '@angular/forms/signals';
+import { expectNoA11yViolations } from '@ngx-signal-forms/toolkit/testing';
+import { render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { NgxFormFieldError } from '../../assistive/form-field-error';
+import { NgxSignalFormToolkit } from '../../index';
+import { NgxFieldIdentityProvider } from './field-identity-provider';
+
+/**
+ * WCAG 2.2 AA conformance gate for a third-party wrapper that owns its own
+ * field identity — the shape `NgxFieldIdentityProvider` exists to support.
+ *
+ * Two things are under test that a jsdom spec cannot reach:
+ *
+ * 1. The control's DOM `id` is widget-generated and differs from the field
+ *    name, so every `aria-describedby` target is one this wrapper rendered
+ *    from the *declared* name. A mismatch is an axe `aria-valid-attr-value`
+ *    failure (dangling id reference).
+ * 2. The wrapper sits inside a collapsible container. Collapsing it must not
+ *    leave ARIA state behind on a control that has no layout box.
+ */
+@Component({
+  selector: 'ngx-test-a11y-identity-wrapper',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+  imports: [NgxFormFieldError],
+  template: `
+    <ng-content />
+    <ngx-form-field-error
+      [formField]="errorField()"
+      fieldName="emailAddress"
+      strategy="immediate"
+    />
+  `,
+})
+class A11yIdentityWrapper {
+  readonly errorField = input.required<unknown>();
+}
+
+@Component({
+  selector: 'ngx-test-a11y-identity-host',
+  imports: [A11yIdentityWrapper, FormField, NgxSignalFormToolkit],
+  template: `
+    <form [formRoot]="emailForm" ngxSignalForm>
+      <details [open]="open()">
+        <summary>Contact details</summary>
+        <ngx-test-a11y-identity-wrapper
+          fieldName="emailAddress"
+          [errorField]="emailForm.emailAddress"
+        >
+          <label for="widget-generated-7">Email address</label>
+          <input id="widget-generated-7" [formField]="emailForm.emailAddress" />
+        </ngx-test-a11y-identity-wrapper>
+      </details>
+    </form>
+  `,
+})
+class A11yIdentityHost {
+  readonly open = input.required<boolean>();
+  readonly #model = signal({ emailAddress: 'no' });
+  readonly emailForm = form(
+    this.#model,
+    schema((path) => {
+      minLength(path.emailAddress, 5, { message: 'At least 5 characters' });
+    }),
+  );
+}
+
+describe('NgxFieldIdentityProvider — WCAG 2.2 AA conformance', () => {
+  it('has no violations when the declared field name differs from the control id', async () => {
+    const { container } = await render(A11yIdentityHost, {
+      inputs: { open: true },
+    });
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const describedBy =
+      container
+        .querySelector('input#widget-generated-7')
+        ?.getAttribute('aria-describedby') ?? '';
+    expect(describedBy).toContain('emailAddress-error');
+
+    await expectNoA11yViolations(container);
+  });
+
+  it('has no violations once the container collapses around the control', async () => {
+    const { container, fixture } = await render(A11yIdentityHost, {
+      inputs: { open: true },
+    });
+
+    fixture.componentRef.setInput('open', false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(
+      container
+        .querySelector('input#widget-generated-7')
+        ?.getAttribute('aria-invalid'),
+    ).toBeNull();
+
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/toolkit/core/directives/field-identity-provider.spec.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.spec.ts
@@ -20,6 +20,14 @@ import { NgxFieldIdentityProvider } from './field-identity-provider';
  * wrapper rendered, producing a dangling `aria-describedby` (axe
  * `aria-valid-attr-value`).
  */
+/**
+ * Mirrors the worked example in `docs/CUSTOM_WRAPPERS.md` exactly, so the
+ * documented pattern is compiled and executed rather than only asserted in
+ * prose. Note the component declares its own `fieldName` input under the
+ * *same public name* the host directive exposes: Angular feeds one attribute
+ * to both, so consumers bind it once and the component can still read it for
+ * its own template.
+ */
 @Component({
   selector: 'ngx-test-custom-wrapper',
   hostDirectives: [
@@ -29,15 +37,15 @@ import { NgxFieldIdentityProvider } from './field-identity-provider';
   template: `
     <ng-content />
     <ngx-form-field-error
-      [formField]="errorField()"
-      [fieldName]="errorFieldName()"
+      [formField]="field()"
+      [fieldName]="fieldName()"
       strategy="immediate"
     />
   `,
 })
 class CustomWrapper {
-  readonly errorField = input.required<unknown>();
-  readonly errorFieldName = input.required<string>();
+  readonly field = input.required<unknown>();
+  readonly fieldName = input.required<string>();
 }
 
 @Component({
@@ -47,8 +55,7 @@ class CustomWrapper {
     <form [formRoot]="loginForm" ngxSignalForm>
       <ngx-test-custom-wrapper
         fieldName="emailAddress"
-        [errorField]="loginForm.emailAddress"
-        errorFieldName="emailAddress"
+        [field]="loginForm.emailAddress"
       >
         <label for="p-inputtext-42">Email</label>
         <input id="p-inputtext-42" [formField]="loginForm.emailAddress" />
@@ -106,14 +113,14 @@ describe('NgxFieldIdentityProvider', () => {
       template: `
         <ng-content />
         <ngx-form-field-error
-          [formField]="errorField()"
+          [formField]="field()"
           fieldName="username"
           strategy="immediate"
         />
       `,
     })
     class InertWrapper {
-      readonly errorField = input.required<unknown>();
+      readonly field = input.required<unknown>();
     }
 
     @Component({
@@ -121,7 +128,7 @@ describe('NgxFieldIdentityProvider', () => {
       imports: [InertWrapper, FormField, NgxSignalFormToolkit],
       template: `
         <form [formRoot]="userForm" ngxSignalForm>
-          <ngx-test-inert-wrapper [errorField]="userForm.username">
+          <ngx-test-inert-wrapper [field]="userForm.username">
             <label for="username">Username</label>
             <input id="username" [formField]="userForm.username" />
           </ngx-test-inert-wrapper>

--- a/packages/toolkit/core/directives/field-identity-provider.spec.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.spec.ts
@@ -1,0 +1,208 @@
+import { Component, input, signal } from '@angular/core';
+import { FormField, form, minLength, schema } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { describe, expect, it, vi } from 'vitest';
+import { NgxFormFieldError } from '../../assistive/form-field-error';
+import { NgxSignalFormToolkit } from '../../index';
+import { NgxFieldIdentityProvider } from './field-identity-provider';
+
+/**
+ * The scenario this directive exists for: the control's DOM `id` is not the
+ * field's name.
+ *
+ * `NgxSignalFormAutoAria` derives a field name from the bound control's `id`
+ * unless an ancestor provides an `NgxFieldIdentity`. A third-party widget
+ * that generates its own inner input id — or a `role="group"` cluster whose
+ * name belongs to the group rather than to any one control — cannot satisfy
+ * that. The generated `${fieldName}-error` id then disagrees with what the
+ * wrapper rendered, producing a dangling `aria-describedby` (axe
+ * `aria-valid-attr-value`).
+ */
+@Component({
+  selector: 'ngx-test-custom-wrapper',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+  imports: [NgxFormFieldError],
+  template: `
+    <ng-content />
+    <ngx-form-field-error
+      [formField]="errorField()"
+      [fieldName]="errorFieldName()"
+      strategy="immediate"
+    />
+  `,
+})
+class CustomWrapper {
+  readonly errorField = input.required<unknown>();
+  readonly errorFieldName = input.required<string>();
+}
+
+@Component({
+  selector: 'ngx-test-custom-wrapper-host',
+  imports: [CustomWrapper, FormField, NgxSignalFormToolkit],
+  template: `
+    <form [formRoot]="loginForm" ngxSignalForm>
+      <ngx-test-custom-wrapper
+        fieldName="emailAddress"
+        [errorField]="loginForm.emailAddress"
+        errorFieldName="emailAddress"
+      >
+        <label for="p-inputtext-42">Email</label>
+        <input id="p-inputtext-42" [formField]="loginForm.emailAddress" />
+      </ngx-test-custom-wrapper>
+    </form>
+  `,
+})
+class CustomWrapperHost {
+  readonly #model = signal({ emailAddress: 'no' });
+  readonly loginForm = form(
+    this.#model,
+    schema((path) => {
+      minLength(path.emailAddress, 5, { message: 'At least 5 characters' });
+    }),
+  );
+}
+
+describe('NgxFieldIdentityProvider', () => {
+  it('makes auto-aria use the declared field name rather than the control id', async () => {
+    const { container } = await render(CustomWrapperHost);
+
+    const input = container.querySelector('input#p-inputtext-42');
+    const describedBy = input?.getAttribute('aria-describedby') ?? '';
+
+    expect(describedBy).toContain('emailAddress-error');
+    expect(describedBy).not.toContain('p-inputtext-42-error');
+  });
+
+  it('resolves aria-describedby to an element the wrapper actually rendered', async () => {
+    const { container } = await render(CustomWrapperHost);
+
+    const describedBy =
+      container
+        .querySelector('input#p-inputtext-42')
+        ?.getAttribute('aria-describedby') ?? '';
+
+    // Every referenced id must exist in the document, or the reference is
+    // dangling — the exact axe `aria-valid-attr-value` failure this
+    // directive removes.
+    for (const id of describedBy.split(' ').filter(Boolean)) {
+      expect(container.querySelector(`#${CSS.escape(id)}`)).not.toBeNull();
+    }
+    expect(describedBy).not.toBe('');
+  });
+
+  it('warns, and skips ARIA wiring, when nothing publishes a name', async () => {
+    // Providing an identity claims the naming channel for the whole subtree.
+    // A provider nobody drives is therefore not a harmless no-op: it
+    // suppresses the DOM-`id` derivation that would otherwise have worked,
+    // so the misconfiguration has to be observable.
+    @Component({
+      selector: 'ngx-test-inert-wrapper',
+      hostDirectives: [NgxFieldIdentityProvider],
+      imports: [NgxFormFieldError],
+      template: `
+        <ng-content />
+        <ngx-form-field-error
+          [formField]="errorField()"
+          fieldName="username"
+          strategy="immediate"
+        />
+      `,
+    })
+    class InertWrapper {
+      readonly errorField = input.required<unknown>();
+    }
+
+    @Component({
+      selector: 'ngx-test-inert-host',
+      imports: [InertWrapper, FormField, NgxSignalFormToolkit],
+      template: `
+        <form [formRoot]="userForm" ngxSignalForm>
+          <ngx-test-inert-wrapper [errorField]="userForm.username">
+            <label for="username">Username</label>
+            <input id="username" [formField]="userForm.username" />
+          </ngx-test-inert-wrapper>
+        </form>
+      `,
+    })
+    class InertHost {
+      readonly #model = signal({ username: 'no' });
+      readonly userForm = form(
+        this.#model,
+        schema((path) => {
+          minLength(path.username, 5, { message: 'At least 5 characters' });
+        }),
+      );
+    }
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const { container } = await render(InertHost);
+
+      const describedBy =
+        container
+          .querySelector('input#username')
+          ?.getAttribute('aria-describedby') ?? '';
+
+      expect(describedBy).not.toContain('username-error');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('NgxFieldIdentityProvider'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('clears the name when the bound value goes null, without falling back to the control id', async () => {
+    @Component({
+      selector: 'ngx-test-nullable-wrapper',
+      hostDirectives: [
+        { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+      ],
+      template: `<ng-content />`,
+    })
+    class NullableWrapper {}
+
+    @Component({
+      selector: 'ngx-test-nullable-host',
+      imports: [NullableWrapper, FormField, NgxSignalFormToolkit],
+      template: `
+        <form [formRoot]="userForm" ngxSignalForm>
+          <ngx-test-nullable-wrapper [fieldName]="name()">
+            <input id="username" [formField]="userForm.username" />
+          </ngx-test-nullable-wrapper>
+        </form>
+      `,
+    })
+    class NullableHost {
+      readonly name = input.required<string | null>();
+      readonly #model = signal({ username: 'no' });
+      readonly userForm = form(
+        this.#model,
+        schema((path) => {
+          minLength(path.username, 5, { message: 'At least 5 characters' });
+        }),
+      );
+    }
+
+    const { fixture } = await render(NullableHost, {
+      inputs: { name: 'account' },
+    });
+    const control = fixture.nativeElement.querySelector('input#username');
+
+    // A resolved name drives ARIA; an explicit null means "not resolvable
+    // yet", which must skip ARIA wiring rather than silently reverting to
+    // the control's `id`.
+    expect(control?.getAttribute('aria-invalid')).not.toBeNull();
+
+    fixture.componentRef.setInput('name', null);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const describedBy = control?.getAttribute('aria-describedby') ?? '';
+    expect(describedBy).not.toContain('username-error');
+    expect(describedBy).not.toContain('account-error');
+  });
+});

--- a/packages/toolkit/core/directives/field-identity-provider.spec.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.spec.ts
@@ -3,7 +3,9 @@ import { FormField, form, minLength, schema } from '@angular/forms/signals';
 import { render } from '@testing-library/angular';
 import { describe, expect, it, vi } from 'vitest';
 import { NgxFormFieldError } from '../../assistive/form-field-error';
+import { NgxFormFieldWrapper } from '../../form-field/form-field-wrapper';
 import { NgxSignalFormToolkit } from '../../index';
+import { NgxFieldIdentity } from '../services/field-identity';
 import { NgxFieldIdentityProvider } from './field-identity-provider';
 
 /**
@@ -204,5 +206,83 @@ describe('NgxFieldIdentityProvider', () => {
     const describedBy = control?.getAttribute('aria-describedby') ?? '';
     expect(describedBy).not.toContain('username-error');
     expect(describedBy).not.toContain('account-error');
+  });
+});
+
+describe('NgxFieldIdentityProvider — composed by NgxFormFieldWrapper', () => {
+  @Component({
+    selector: 'ngx-test-builtin-wrapper-host',
+    imports: [NgxFormFieldWrapper, FormField, NgxSignalFormToolkit],
+    template: `
+      <form [formRoot]="userForm" ngxSignalForm>
+        <ngx-form-field-wrapper
+          [formField]="userForm.username"
+          [fieldName]="explicitName()"
+          strategy="immediate"
+        >
+          <label for="username-control">Username</label>
+          <input id="username-control" [formField]="userForm.username" />
+        </ngx-form-field-wrapper>
+      </form>
+    `,
+  })
+  class BuiltinWrapperHost {
+    readonly explicitName = input.required<string | undefined>();
+    readonly #model = signal({ username: 'no' });
+    readonly userForm = form(
+      this.#model,
+      schema((path) => {
+        minLength(path.username, 5, { message: 'At least 5 characters' });
+      }),
+    );
+  }
+
+  it('provides the identity through the directive, not a duplicate providers entry', async () => {
+    const { fixture } = await render(BuiltinWrapperHost, {
+      inputs: { explicitName: 'account' },
+    });
+
+    const wrapperEl = (
+      fixture.nativeElement as HTMLElement
+    ).querySelector<HTMLElement>('ngx-form-field-wrapper');
+    const wrapperNode = fixture.debugElement.query(
+      (candidate) => candidate.nativeElement === wrapperEl,
+    );
+
+    // The directive must be on the wrapper's own host — that is the element
+    // injector the projected control resolves `NgxFieldIdentity` through.
+    expect(wrapperNode.injector.get(NgxFieldIdentityProvider)).toBeTruthy();
+    expect(wrapperNode.injector.get(NgxFieldIdentity).fieldName()).toBe(
+      'account',
+    );
+  });
+
+  it('routes a consumer-bound fieldName through the directive (cascade tier 1)', async () => {
+    const { fixture } = await render(BuiltinWrapperHost, {
+      inputs: { explicitName: 'account' },
+    });
+
+    const describedBy = (fixture.nativeElement as HTMLElement)
+      .querySelector('input#username-control')
+      ?.getAttribute('aria-describedby');
+
+    // The declared name wins over the control's `id`, and one `fieldName`
+    // attribute feeds both the wrapper's own input and the host directive's.
+    expect(describedBy).toContain('account-error');
+    expect(describedBy).not.toContain('username-control-error');
+  });
+
+  it('still derives the name from the control id when nothing is bound (cascade tier 2)', async () => {
+    // The directive stays inert here — a DOM-derived name is only known in the
+    // wrapper's render write phase, so it can never arrive through an input.
+    const { fixture } = await render(BuiltinWrapperHost, {
+      inputs: { explicitName: undefined },
+    });
+
+    const describedBy = (fixture.nativeElement as HTMLElement)
+      .querySelector('input#username-control')
+      ?.getAttribute('aria-describedby');
+
+    expect(describedBy).toContain('username-control-error');
   });
 });

--- a/packages/toolkit/core/directives/field-identity-provider.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.ts
@@ -1,0 +1,153 @@
+import {
+  afterNextRender,
+  Directive,
+  effect,
+  inject,
+  input,
+} from '@angular/core';
+import { NgxFieldIdentity } from '../services/field-identity';
+import { devWarnOnce, type WarnOnceRef } from '../utilities/dev-warn-once';
+
+/**
+ * Provides an {@link NgxFieldIdentity} on its host element and publishes a
+ * field name into it — the supported way for a third-party wrapper to own
+ * field identity for the controls it contains.
+ *
+ * ## What it is for
+ *
+ * `NgxSignalFormAutoAria` derives a field name from the bound control's `id`
+ * attribute unless an ancestor provides an `NgxFieldIdentity`. That is a hard
+ * constraint for a custom wrapper: it forces the field name and the control's
+ * DOM `id` to be the same string. Two common shapes cannot satisfy it —
+ *
+ * - a third-party widget that generates its own inner input `id` and exposes
+ *   no override, and
+ * - a `role="group"` cluster (radios, checkboxes) whose name belongs to the
+ *   group rather than to any single control.
+ *
+ * In both cases the ids auto-aria generates (`{fieldName}-error`,
+ * `{fieldName}-warning`) disagree with what the wrapper actually rendered,
+ * leaving `aria-describedby` pointing at nothing — an axe
+ * `aria-valid-attr-value` failure, and error text that assistive technology
+ * never reaches.
+ *
+ * ## How to use it
+ *
+ * Compose it onto your wrapper's host with `hostDirectives`. It has no
+ * selector on purpose: placement on the host element is load-bearing (that is
+ * the element injector descendants resolve through), and a selector would
+ * invite putting it somewhere that silently does nothing.
+ *
+ * ```typescript
+ * @Component({
+ *   selector: 'my-field',
+ *   hostDirectives: [
+ *     { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+ *   ],
+ *   template: `
+ *     <ng-content />
+ *     <ngx-form-field-error [formField]="field()" [fieldName]="name()" />
+ *   `,
+ * })
+ * export class MyField { }
+ * ```
+ *
+ * ```html
+ * <my-field fieldName="emailAddress" [field]="form.emailAddress">
+ *   <label for="p-inputtext-42">Email</label>
+ *   <input id="p-inputtext-42" [formField]="form.emailAddress" />
+ * </my-field>
+ * <!-- aria-describedby="emailAddress-error", not "p-inputtext-42-error" -->
+ * ```
+ *
+ * ## What it does not do
+ *
+ * It publishes the **field-name channel only**. Hint IDs and the error /
+ * warning display strategies keep resolving through
+ * `NGX_SIGNAL_FORM_HINT_REGISTRY` and
+ * `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY`, which stay the supported seams
+ * for those. Composing this directive does not disturb them: identity shadows
+ * the registries per channel, not by presence (ADR-0010).
+ *
+ * Strategy deliberately has no channel here. The registry publishes the
+ * *observed* boolean that already gates a rendered region, so it cannot drift
+ * from the DOM the way a separately-declared strategy could.
+ *
+ * The `set*` writers on `NgxFieldIdentity` remain `@internal` and are stripped
+ * from the published type definitions. This directive is the public surface;
+ * it drives them on your behalf.
+ *
+ * @public
+ * @group ARIA Composition
+ */
+@Directive({
+  providers: [NgxFieldIdentity],
+})
+export class NgxFieldIdentityProvider {
+  /**
+   * The field's name — the string every generated id is derived from
+   * (`{fieldName}-error`, `{fieldName}-warning`), and what a projected
+   * `<ngx-form-field-error [fieldName]="…">` must be given to match.
+   *
+   * Three states, all meaningful:
+   *
+   * - a non-empty string — the resolved name. Whitespace is trimmed.
+   * - `null` — bound, but not resolvable yet. ARIA wiring is skipped for this
+   *   field until a name appears; it does **not** revert to deriving one from
+   *   the control's `id`, because a wrapper that declares its own naming has
+   *   said the control's `id` is not the name.
+   * - unbound — this directive publishes nothing, leaving the identity's name
+   *   for the composing component to drive itself. This is what lets a
+   *   component compose the directive purely to *provision* the identity:
+   *   Angular gives a component no way to bind its own host directive's
+   *   inputs, and `NgxFormFieldWrapper`'s name is only known after its
+   *   render-phase DOM read. Note that providing an identity at all hands it
+   *   the naming channel, so leaving the input unbound *and* never driving
+   *   the identity means the contained controls get no ARIA wiring — a
+   *   dev-mode diagnostic calls that out.
+   *
+   * Not `input.required`, deliberately. A required input on a host directive
+   * must be re-exposed by the composing component (`NG2019`), and once
+   * exposed every consumer template must bind it (`NG8008`) — which would
+   * make `[fieldName]` mandatory on every wrapper that composes this.
+   */
+  readonly fieldName = input<string | null | undefined>(undefined);
+
+  readonly #identity = inject(NgxFieldIdentity);
+  readonly #warnedUnclaimed: WarnOnceRef = { current: false };
+
+  constructor() {
+    // An effect, not `afterEveryRender`: publishing a name needs no layout
+    // information, and effects flush before render hooks in the same change
+    // detection cycle, so the name is already current by the time auto-aria's
+    // `earlyRead` reads it. A render-phase write would land one tick late.
+    effect(() => {
+      const name = this.fieldName();
+      if (name === undefined) {
+        return;
+      }
+      this.#identity.setFieldName(name);
+    });
+
+    // Providing an identity claims the naming channel for this subtree, so a
+    // provider nobody drives is not a no-op — it suppresses the DOM-`id`
+    // derivation that would otherwise have worked. Checked after the first
+    // render so a composing component that drives the identity from its own
+    // render-phase write (as `NgxFormFieldWrapper` does) has already run.
+    afterNextRender(() => {
+      if (this.fieldName() !== undefined || this.#identity.fieldName()) {
+        return;
+      }
+      devWarnOnce(
+        this.#warnedUnclaimed,
+        'warn',
+        '[ngx-signal-forms] NgxFieldIdentityProvider: no field name was ' +
+          'published. Providing a field identity takes over field naming for ' +
+          'this subtree, so ARIA wiring is skipped until a name arrives — ' +
+          "the bound control's `id` is no longer used as a fallback. Expose " +
+          'the `fieldName` input via `hostDirectives` and bind it, or drive ' +
+          'the injected `NgxFieldIdentity` yourself.',
+      );
+    });
+  }
+}

--- a/packages/toolkit/core/directives/field-identity-provider.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.ts
@@ -77,6 +77,12 @@ import { devWarnOnce, type WarnOnceRef } from '../utilities/dev-warn-once';
  * from the published type definitions. This directive is the public surface;
  * it drives them on your behalf.
  *
+ * `NgxFormFieldWrapper` composes this directive too, rather than providing
+ * `NgxFieldIdentity` itself — so the seam a third-party wrapper uses is the
+ * same one the built-in wrapper runs on. Angular feeds a single `fieldName`
+ * attribute to both a component's own input and its exposed host-directive
+ * input, so composing it costs consumers nothing.
+ *
  * @public
  * @group ARIA Composition
  */
@@ -97,19 +103,20 @@ export class NgxFieldIdentityProvider {
    *   the control's `id`, because a wrapper that declares its own naming has
    *   said the control's `id` is not the name.
    * - unbound — this directive publishes nothing, leaving the identity's name
-   *   for the composing component to drive itself. This is what lets a
-   *   component compose the directive purely to *provision* the identity:
-   *   Angular gives a component no way to bind its own host directive's
-   *   inputs, and `NgxFormFieldWrapper`'s name is only known after its
-   *   render-phase DOM read. Note that providing an identity at all hands it
-   *   the naming channel, so leaving the input unbound *and* never driving
-   *   the identity means the contained controls get no ARIA wiring — a
-   *   dev-mode diagnostic calls that out.
+   *   to the composing component. That is what lets a wrapper resolve a name
+   *   from somewhere an input cannot reach. `NgxFormFieldWrapper` relies on
+   *   it: tier 2 of its cascade reads the bound control's `id`, which is only
+   *   known in its render write phase, long after inputs are set. Note that
+   *   providing an identity at all hands it the naming channel, so leaving
+   *   the input unbound *and* never driving the identity means the contained
+   *   controls get no ARIA wiring — a dev-mode diagnostic calls that out.
    *
-   * Not `input.required`, deliberately. A required input on a host directive
-   * must be re-exposed by the composing component (`NG2019`), and once
-   * exposed every consumer template must bind it (`NG8008`) — which would
-   * make `[fieldName]` mandatory on every wrapper that composes this.
+   * Not `input.required`, deliberately. Exposing a required host-directive
+   * input makes it mandatory in every consumer template (`NG8008`, chained
+   * from `NG2019` if it is not re-exposed at all). A wrapper's own
+   * `fieldName` is normally optional — `NgxFormFieldWrapper`'s certainly is,
+   * because the control's `id` is the usual source — so requiring it here
+   * would break every field that relies on that fallback.
    */
   readonly fieldName = input<string | null | undefined>(undefined);
 

--- a/packages/toolkit/core/directives/field-identity-provider.ts
+++ b/packages/toolkit/core/directives/field-identity-provider.ts
@@ -103,13 +103,14 @@ export class NgxFieldIdentityProvider {
    *   the control's `id`, because a wrapper that declares its own naming has
    *   said the control's `id` is not the name.
    * - unbound — this directive publishes nothing, leaving the identity's name
-   *   to the composing component. That is what lets a wrapper resolve a name
-   *   from somewhere an input cannot reach. `NgxFormFieldWrapper` relies on
-   *   it: tier 2 of its cascade reads the bound control's `id`, which is only
-   *   known in its render write phase, long after inputs are set. Note that
-   *   providing an identity at all hands it the naming channel, so leaving
-   *   the input unbound *and* never driving the identity means the contained
-   *   controls get no ARIA wiring — a dev-mode diagnostic calls that out.
+   *   to the composing component. That branch exists for **package-internal**
+   *   composers, which can reach the `@internal` writers: `NgxFormFieldWrapper`
+   *   relies on it, because tier 2 of its cascade reads the bound control's
+   *   `id`, which is only known in its render write phase, long after inputs
+   *   are set. Third-party wrappers cannot take this branch usefully — the
+   *   writers are stripped from the published type definitions — so for them
+   *   an unbound input means no ARIA wiring at all, and a dev-mode diagnostic
+   *   says so.
    *
    * Not `input.required`, deliberately. Exposing a required host-directive
    * input makes it mandatory in every consumer template (`NG8008`, chained
@@ -152,8 +153,8 @@ export class NgxFieldIdentityProvider {
           'published. Providing a field identity takes over field naming for ' +
           'this subtree, so ARIA wiring is skipped until a name arrives — ' +
           "the bound control's `id` is no longer used as a fallback. Expose " +
-          'the `fieldName` input via `hostDirectives` and bind it, or drive ' +
-          'the injected `NgxFieldIdentity` yourself.',
+          'the `fieldName` input via `hostDirectives` and bind it, or drop ' +
+          "this directive if the control's `id` is already the field name.",
       );
     });
   }

--- a/packages/toolkit/core/index.ts
+++ b/packages/toolkit/core/index.ts
@@ -22,6 +22,7 @@ export * from './services/field-visibility-registry';
 
 // Directives
 export * from './directives/auto-aria';
+export * from './directives/field-identity-provider';
 export * from './directives/control-semantics';
 export {
   NgxSignalForm,

--- a/packages/toolkit/core/services/field-identity.spec.ts
+++ b/packages/toolkit/core/services/field-identity.spec.ts
@@ -290,36 +290,33 @@ describe('NgxFieldIdentity', () => {
         expect(svc.isControlVisible()).toBe(false);
       });
 
-      it('returns false for an element with display:none', () => {
+      // The real hidden/visible answers need a layout engine and live in
+      // `field-identity.visibility.browser.spec.ts`. What jsdom *can* pin is
+      // the fail-open contract for runtimes with no `checkVisibility()`.
+      it('reports visible in an environment without checkVisibility()', () => {
         const svc = createService();
         const el = document.createElement('input');
         el.style.display = 'none';
         document.body.append(el);
         try {
-          expect(svc.isControlVisible(el)).toBe(false);
+          expect(svc.isControlVisible(el)).toBe(true);
         } finally {
           el.remove();
         }
       });
 
-      it('returns false for a detached element', () => {
-        const svc = createService();
-        const el = document.createElement('input');
-        expect(svc.isControlVisible(el)).toBe(false);
-      });
-
       it('element-arg does not mutate the cached no-arg value', () => {
         const svc = createService();
-        const hidden = document.createElement('input');
-        hidden.style.display = 'none';
-        document.body.append(hidden);
+        svc.setControlVisible(false);
+        const probed = document.createElement('input');
+        document.body.append(probed);
         try {
-          expect(svc.isControlVisible(hidden)).toBe(false);
           // Probing an element must not flip the cached flag, which is
           // driven exclusively by `setControlVisible`.
-          expect(svc.isControlVisible()).toBe(true);
+          expect(svc.isControlVisible(probed)).toBe(true);
+          expect(svc.isControlVisible()).toBe(false);
         } finally {
-          hidden.remove();
+          probed.remove();
         }
       });
 
@@ -383,23 +380,34 @@ describe('NgxFieldIdentity', () => {
   });
 
   describe('isElementCssVisible helper', () => {
-    // jsdom does not compute layout, so `offsetParent` is unreliable for
-    // attached elements. We assert only the negative cases here; the
-    // positive path is exercised in browser specs where layout is real.
-    it('returns false for an element with display:none', () => {
+    // jsdom implements no `checkVisibility()` and computes no layout, so the
+    // only contract assertable here is the fail-open one. Every real
+    // hidden/visible case lives in `field-identity.visibility.browser.spec.ts`.
+    it('fails open when the runtime has no checkVisibility()', () => {
+      expect(
+        (
+          document.createElement('input') as HTMLElement & {
+            checkVisibility?: unknown;
+          }
+        ).checkVisibility,
+      ).toBeUndefined();
+
       const el = document.createElement('input');
       el.style.display = 'none';
       document.body.append(el);
       try {
-        expect(isElementCssVisible(el)).toBe(false);
+        // Guessing "hidden" from `offsetParent` here would strip correct ARIA
+        // from every control in any layout-less environment — and it is a
+        // false positive for collapsed `<details>` anyway, the very case the
+        // probe exists for.
+        expect(isElementCssVisible(el)).toBe(true);
       } finally {
         el.remove();
       }
     });
 
-    it('returns false for a detached element', () => {
-      const el = document.createElement('input');
-      expect(isElementCssVisible(el)).toBe(false);
+    it('fails open for a detached element', () => {
+      expect(isElementCssVisible(document.createElement('input'))).toBe(true);
     });
   });
 

--- a/packages/toolkit/core/services/field-identity.spec.ts
+++ b/packages/toolkit/core/services/field-identity.spec.ts
@@ -26,10 +26,29 @@ describe('NgxFieldIdentity', () => {
       expect(svc.warningId()).toBeNull();
     });
 
-    it('exposes empty hintIds and null describedBy by default', () => {
+    it('reports the hint channel as unpublished, with a null describedBy, by default', () => {
       const svc = createService();
+      // `null`, not `[]` — an identity nobody has driven yet must not look
+      // like one that published "this field has no hints", or consumers
+      // would stop falling back to the hint registry. See ADR-0010.
+      expect(svc.hintIds()).toBeNull();
+      expect(svc.describedBy()).toBeNull();
+    });
+
+    it('distinguishes a published-but-empty hint list from the unpublished default', () => {
+      const svc = createService();
+      expect(svc.hintIds()).toBeNull();
+
+      svc.setHintIds([]);
+
       expect(svc.hintIds()).toEqual([]);
       expect(svc.describedBy()).toBeNull();
+    });
+
+    it('leaves the strategy channels unpublished by default', () => {
+      const svc = createService();
+      expect(svc.resolvedErrorStrategy()).toBeNull();
+      expect(svc.resolvedWarningStrategy()).toBeNull();
     });
 
     it('reports control visible by default', () => {

--- a/packages/toolkit/core/services/field-identity.ts
+++ b/packages/toolkit/core/services/field-identity.ts
@@ -77,7 +77,17 @@ export interface ControlVisibilitySignal extends Signal<boolean> {
  *
  * Provided at the `NgxFormFieldWrapper` level via `providers: [NgxFieldIdentity]`.
  * `NgxSignalFormAutoAria` and hint directives inject it optionally, falling
- * back to their current behavior when absent.
+ * back to their registry-driven behavior when absent.
+ *
+ * **Channels publish independently.** An identity does not have to drive
+ * every channel, and merely *existing* claims nothing. Each of the hint,
+ * error-strategy, and warning-strategy channels advertises "unpublished" as
+ * a distinct `null` state, and consumers fall back to
+ * `NGX_SIGNAL_FORM_HINT_REGISTRY` / `NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY`
+ * per channel — never by testing whether this service is injectable. This is
+ * what lets a partially-driven identity (one that only owns the field name,
+ * say) coexist with the registries instead of silently disabling them.
+ * See ADR-0010.
  *
  * Element-scoped: `providedIn: null` makes it a contract violation to
  * provide this service at the root injector. Each wrapper gets a fresh
@@ -94,7 +104,7 @@ export class NgxFieldIdentity {
   readonly #fieldName = signal<string | null>(null);
   readonly #controlElement = signal<HTMLElement | null>(null);
   readonly #controlId = signal<string | null>(null);
-  readonly #hintIds = signal<readonly string[]>([]);
+  readonly #hintIds = signal<readonly string[] | null>(null);
   readonly #isControlVisible = signal(true);
   readonly #resolvedErrorStrategy = signal<ResolvedErrorDisplayStrategy | null>(
     null,
@@ -132,6 +142,12 @@ export class NgxFieldIdentity {
   /**
    * Hint IDs contributed by the surrounding hint registry, filtered for
    * this field. Updated by `NgxFormFieldWrapper` when `hintDescriptors` changes.
+   *
+   * `null` means this identity has **never published** the hint channel —
+   * consumers must fall back to `NGX_SIGNAL_FORM_HINT_REGISTRY` exactly as
+   * they would with no identity present at all. An empty array means the
+   * channel *was* published and this field genuinely has no hints, which is
+   * authoritative and suppresses the fallback. See ADR-0010.
    */
   readonly hintIds = this.#hintIds.asReadonly();
 
@@ -225,7 +241,7 @@ export class NgxFieldIdentity {
    */
   readonly describedBy = computed<string | null>(() => {
     const ids = this.#hintIds();
-    return ids.length > 0 ? ids.join(' ') : null;
+    return ids !== null && ids.length > 0 ? ids.join(' ') : null;
   });
 
   /**
@@ -309,16 +325,22 @@ export class NgxFieldIdentity {
   }
 
   /**
-   * Updates the hint IDs visible to this field's identity. Idempotent —
-   * shallow array equality short-circuits the write so consumers don't
-   * re-run their describedBy computeds when the list is structurally
-   * unchanged.
+   * Publishes the hint IDs visible to this field's identity, claiming the
+   * hint channel. Idempotent — shallow array equality short-circuits the
+   * write so consumers don't re-run their describedBy computeds when the
+   * list is structurally unchanged.
+   *
+   * The first call flips {@link hintIds} off its unpublished `null` default,
+   * which is what stops consumers falling back to the hint registry. Passing
+   * `[]` is therefore a meaningful claim ("no hints for this field"), not a
+   * no-op.
    *
    * @internal
    */
   setHintIds(ids: readonly string[]): void {
     const current = this.#hintIds();
     if (
+      current !== null &&
       current.length === ids.length &&
       current.every((id, index) => id === ids[index])
     ) {

--- a/packages/toolkit/core/services/field-identity.ts
+++ b/packages/toolkit/core/services/field-identity.ts
@@ -13,29 +13,54 @@ import type {
 /**
  * Resolve whether an element is visible from a CSS perspective.
  *
- * Prefers `Element.checkVisibility()` (Chromium 105+, Firefox 125+,
- * Safari 17.4+) so `display: none`, `hidden`, and ancestor-collapse all
- * register as "not visible". Falls back to `offsetParent` on older
- * runtimes — sufficient to detect `display: none` in detached subtrees,
- * which is the common collapsed-fieldset case the issue calls out.
+ * Uses `Element.checkVisibility()` — Baseline 2024, and the only API that
+ * answers the question correctly. Its default behaviour already reports
+ * `false` for `display: none`, `display: contents`, the `hidden` attribute,
+ * `content-visibility: hidden`, and a collapsed `<details>` (whose
+ * `::details-content` is `content-visibility: hidden`). The options below add
+ * `visibility: hidden` and `opacity: 0`; browsers ignore dictionary members
+ * they do not know, so passing all three is safe on every runtime that has
+ * the method at all. `checkVisibilityCSS` is the historic alias for
+ * `visibilityProperty` and is kept for runtimes between Chromium 105 and 121.
+ *
+ * **When the method is unavailable, this reports `true`.** That is a
+ * deliberate fail-open, not an oversight. The obvious fallback,
+ * `offsetParent !== null`, is wrong in both directions: it is a false
+ * *positive* for a collapsed `<details>` and for `content-visibility: hidden`
+ * — the exact cases this function exists to catch — and a false *negative*
+ * for `position: fixed` elements, for `<body>`/`<html>`, and for every
+ * environment with no layout engine at all (jsdom, and any non-rendering
+ * host). Guessing "hidden" there would strip correct ARIA state from visible
+ * controls, which is strictly worse than leaving state in place on a control
+ * the user cannot see anyway.
  *
  * Exposed publicly (re-exported from `@ngx-signal-forms/toolkit`) so custom
  * controls and third-party wrappers can apply the exact same visibility test
- * the canonical wrapper uses internally, keeping the native-binding and
- * CSS-fallback ARIA paths in lockstep.
+ * the toolkit uses internally, keeping the native-binding and CSS-fallback
+ * ARIA paths in lockstep.
  *
  * @public
  */
 export function isElementCssVisible(el: HTMLElement): boolean {
   const checkVisibility = (
     el as HTMLElement & {
-      checkVisibility?: (options?: { checkVisibilityCSS?: boolean }) => boolean;
+      checkVisibility?: (options?: {
+        checkVisibilityCSS?: boolean;
+        visibilityProperty?: boolean;
+        opacityProperty?: boolean;
+      }) => boolean;
     }
   ).checkVisibility;
-  if (typeof checkVisibility === 'function') {
-    return checkVisibility.call(el, { checkVisibilityCSS: true });
+
+  if (typeof checkVisibility !== 'function') {
+    return true;
   }
-  return el.offsetParent !== null;
+
+  return checkVisibility.call(el, {
+    checkVisibilityCSS: true,
+    visibilityProperty: true,
+    opacityProperty: true,
+  });
 }
 
 /**

--- a/packages/toolkit/core/services/field-identity.ts
+++ b/packages/toolkit/core/services/field-identity.ts
@@ -14,14 +14,20 @@ import type {
  * Resolve whether an element is visible from a CSS perspective.
  *
  * Uses `Element.checkVisibility()` — Baseline 2024, and the only API that
- * answers the question correctly. Its default behaviour already reports
+ * answers the question correctly. Its default behavior already reports
  * `false` for `display: none`, `display: contents`, the `hidden` attribute,
  * `content-visibility: hidden`, and a collapsed `<details>` (whose
- * `::details-content` is `content-visibility: hidden`). The options below add
- * `visibility: hidden` and `opacity: 0`; browsers ignore dictionary members
- * they do not know, so passing all three is safe on every runtime that has
- * the method at all. `checkVisibilityCSS` is the historic alias for
- * `visibilityProperty` and is kept for runtimes between Chromium 105 and 121.
+ * `::details-content` is `content-visibility: hidden`). `visibilityProperty`
+ * adds `visibility: hidden`, which removes an element from the accessibility
+ * tree just as thoroughly. `checkVisibilityCSS` is the historic alias for the
+ * same option, kept for runtimes between Chromium 105 and 121; browsers
+ * ignore dictionary members they do not know, so passing both is safe.
+ *
+ * **`opacityProperty` is deliberately not passed.** An `opacity: 0` control
+ * is still laid out, still focusable, and still interactive — it is the
+ * standard custom-checkbox and custom-radio pattern, where a real input sits
+ * transparently over a styled box. Treating those as hidden would strip
+ * `aria-invalid` from controls a keyboard user is actively operating.
  *
  * **When the method is unavailable, this reports `true`.** That is a
  * deliberate fail-open, not an oversight. The obvious fallback,
@@ -47,7 +53,6 @@ export function isElementCssVisible(el: HTMLElement): boolean {
       checkVisibility?: (options?: {
         checkVisibilityCSS?: boolean;
         visibilityProperty?: boolean;
-        opacityProperty?: boolean;
       }) => boolean;
     }
   ).checkVisibility;
@@ -59,7 +64,6 @@ export function isElementCssVisible(el: HTMLElement): boolean {
   return checkVisibility.call(el, {
     checkVisibilityCSS: true,
     visibilityProperty: true,
-    opacityProperty: true,
   });
 }
 
@@ -209,9 +213,15 @@ export class NgxFieldIdentity {
    * the viewport.
    *
    * Driven by the wrapper, which calls `setControlVisible` from its
-   * `afterEveryRender` write phase using `Element.checkVisibility()`
-   * (with an `offsetParent` fallback). Defaults to `true` so consumers
-   * never strip ARIA attributes pre-visibility-eval.
+   * `afterEveryRender` write phase via {@link isElementCssVisible}. Defaults
+   * to `true` so consumers never strip ARIA attributes pre-visibility-eval.
+   *
+   * Nothing inside the toolkit reads this any more: `NgxSignalFormAutoAria`
+   * probes its own host element instead, so its `aria-invalid` gate works for
+   * every wrapper rather than only the built-in one, and each control in a
+   * cluster tracks its own layout state (ADR-0011). The channel stays because
+   * it is a published read surface — a consumer holding an ancestor identity
+   * can still read the wrapper's view of its bound control.
    *
    * This member is a {@link ControlVisibilitySignal}: a real `Signal<boolean>`
    * (reactive, threadable into `computed()`) that additionally accepts an
@@ -335,8 +345,8 @@ export class NgxFieldIdentity {
   /**
    * Updates the cached visibility of the bound control. Idempotent.
    *
-   * The wrapper drives this from its `afterEveryRender` write phase using
-   * `Element.checkVisibility()` (or `offsetParent` fallback). Polling the
+   * The wrapper drives this from its `afterEveryRender` write phase via
+   * {@link isElementCssVisible}. Polling the
    * visibility on each render rather than via `IntersectionObserver`
    * avoids both the spurious "scroll = hidden" semantics IO has and the
    * teardown/leak surface of long-lived observers.

--- a/packages/toolkit/core/services/field-identity.visibility.browser.spec.ts
+++ b/packages/toolkit/core/services/field-identity.visibility.browser.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isElementCssVisible } from './field-identity';
+
+/**
+ * The real semantics of {@link isElementCssVisible}, which need a layout
+ * engine and a runtime that implements `Element.checkVisibility()`. jsdom has
+ * neither, so its sibling spec can only pin the fail-open contract.
+ *
+ * The collapsed-`<details>` case is the one that matters most: it is the
+ * headline scenario for the `aria-invalid` staleness fix, and it is precisely
+ * where the old `offsetParent !== null` fallback gave the wrong answer — a
+ * collapsed `<details>` still reports an `offsetParent`, so the fallback
+ * called a hidden control visible.
+ */
+describe('isElementCssVisible — real layout semantics', () => {
+  const created: HTMLElement[] = [];
+
+  function mount(html: string, selector: string): HTMLElement {
+    const holder = document.createElement('div');
+    holder.innerHTML = html;
+    document.body.append(holder);
+    created.push(holder);
+    const el = holder.querySelector<HTMLElement>(selector);
+    if (!el) throw new Error(`no element matched ${selector}`);
+    return el;
+  }
+
+  afterEach(() => {
+    for (const el of created.splice(0)) {
+      el.remove();
+    }
+  });
+
+  it('reports a laid-out control visible', () => {
+    expect(isElementCssVisible(mount('<input id="a" />', '#a'))).toBe(true);
+  });
+
+  it('reports display:none hidden', () => {
+    expect(
+      isElementCssVisible(mount('<input id="a" style="display:none" />', '#a')),
+    ).toBe(false);
+  });
+
+  it('reports a [hidden] control hidden', () => {
+    expect(isElementCssVisible(mount('<input id="a" hidden />', '#a'))).toBe(
+      false,
+    );
+  });
+
+  it('reports a control inside a collapsed <details> hidden', () => {
+    const el = mount(
+      '<details><summary>More</summary><input id="a" /></details>',
+      '#a',
+    );
+
+    // The old `offsetParent` fallback returned a truthy parent here, calling
+    // a hidden control visible — the exact false positive that made the
+    // staleness fix silently ineffective on runtimes taking that branch.
+    expect(el.offsetParent).not.toBeNull();
+    expect(isElementCssVisible(el)).toBe(false);
+  });
+
+  it('reports a control inside an open <details> visible', () => {
+    expect(
+      isElementCssVisible(
+        mount(
+          '<details open><summary>More</summary><input id="a" /></details>',
+          '#a',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('reports visibility:hidden and opacity:0 hidden', () => {
+    expect(
+      isElementCssVisible(
+        mount('<input id="a" style="visibility:hidden" />', '#a'),
+      ),
+    ).toBe(false);
+    expect(
+      isElementCssVisible(mount('<input id="a" style="opacity:0" />', '#a')),
+    ).toBe(false);
+  });
+
+  it('reports a position:fixed control visible', () => {
+    // `offsetParent` is null for fixed-position elements — a false negative
+    // that would have stripped ARIA from a control the user can plainly see.
+    const el = mount(
+      '<input id="a" style="position:fixed;top:0;left:0" />',
+      '#a',
+    );
+
+    expect(el.offsetParent).toBeNull();
+    expect(isElementCssVisible(el)).toBe(true);
+  });
+});

--- a/packages/toolkit/core/services/field-identity.visibility.browser.spec.ts
+++ b/packages/toolkit/core/services/field-identity.visibility.browser.spec.ts
@@ -48,16 +48,14 @@ describe('isElementCssVisible — real layout semantics', () => {
   });
 
   it('reports a control inside a collapsed <details> hidden', () => {
-    const el = mount(
-      '<details><summary>More</summary><input id="a" /></details>',
-      '#a',
-    );
-
-    // The old `offsetParent` fallback returned a truthy parent here, calling
-    // a hidden control visible — the exact false positive that made the
-    // staleness fix silently ineffective on runtimes taking that branch.
-    expect(el.offsetParent).not.toBeNull();
-    expect(isElementCssVisible(el)).toBe(false);
+    expect(
+      isElementCssVisible(
+        mount(
+          '<details><summary>More</summary><input id="a" /></details>',
+          '#a',
+        ),
+      ),
+    ).toBe(false);
   });
 
   it('reports a control inside an open <details> visible', () => {
@@ -96,8 +94,51 @@ describe('isElementCssVisible — real layout semantics', () => {
   });
 
   it('reports a position:fixed control visible', () => {
-    // `offsetParent` is null for fixed-position elements — a false negative
-    // that would have stripped ARIA from a control the user can plainly see.
+    expect(
+      isElementCssVisible(
+        mount('<input id="a" style="position:fixed;top:0;left:0" />', '#a'),
+      ),
+    ).toBe(true);
+  });
+});
+
+/**
+ * Evidence for ADR-0011 §5, kept separate from the contract tests above.
+ *
+ * These assert the behaviour of `offsetParent`, not of `isElementCssVisible`.
+ * They exist so the claim "the old fallback was wrong in both directions" is
+ * demonstrated rather than asserted in prose. A failure here means the
+ * rationale changed, not that the visibility contract broke — read it as a
+ * prompt to revisit the ADR, not as a regression in the helper.
+ */
+describe('why the offsetParent fallback was removed (rationale, not contract)', () => {
+  const created: HTMLElement[] = [];
+
+  function mount(html: string, selector: string): HTMLElement {
+    const holder = document.createElement('div');
+    holder.innerHTML = html;
+    document.body.append(holder);
+    created.push(holder);
+    const el = holder.querySelector<HTMLElement>(selector);
+    if (!el) throw new Error(`no element matched ${selector}`);
+    return el;
+  }
+
+  afterEach(() => {
+    for (const el of created.splice(0)) el.remove();
+  });
+
+  it('was a false positive: a collapsed <details> still reports an offsetParent', () => {
+    const el = mount(
+      '<details><summary>More</summary><input id="a" /></details>',
+      '#a',
+    );
+
+    expect(el.offsetParent).not.toBeNull();
+    expect(isElementCssVisible(el)).toBe(false);
+  });
+
+  it('was a false negative: a visible position:fixed control has no offsetParent', () => {
     const el = mount(
       '<input id="a" style="position:fixed;top:0;left:0" />',
       '#a',

--- a/packages/toolkit/core/services/field-identity.visibility.browser.spec.ts
+++ b/packages/toolkit/core/services/field-identity.visibility.browser.spec.ts
@@ -71,15 +71,28 @@ describe('isElementCssVisible — real layout semantics', () => {
     ).toBe(true);
   });
 
-  it('reports visibility:hidden and opacity:0 hidden', () => {
+  it('reports visibility:hidden hidden', () => {
     expect(
       isElementCssVisible(
         mount('<input id="a" style="visibility:hidden" />', '#a'),
       ),
     ).toBe(false);
-    expect(
-      isElementCssVisible(mount('<input id="a" style="opacity:0" />', '#a')),
-    ).toBe(false);
+  });
+
+  it('reports an opacity:0 control VISIBLE', () => {
+    // The standard custom-checkbox / custom-radio pattern: a real input sits
+    // transparently over a styled box. It is laid out, focusable, and being
+    // operated by the user — stripping its `aria-invalid` would be an a11y
+    // regression, so `opacityProperty` is deliberately not passed to
+    // `checkVisibility()`.
+    const el = mount(
+      '<input id="a" type="checkbox" style="opacity:0" />',
+      '#a',
+    );
+
+    expect(isElementCssVisible(el)).toBe(true);
+    el.focus();
+    expect(document.activeElement).toBe(el);
   });
 
   it('reports a position:fixed control visible', () => {

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.spec.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.spec.ts
@@ -14,7 +14,7 @@ import { createHintIdsSignal } from './create-hint-ids-signal';
  * matches the production signature without spinning up a TestBed.
  */
 function createStubIdentity(
-  hintIds: Signal<readonly string[]>,
+  hintIds: Signal<readonly string[] | null>,
 ): NgxFieldIdentity {
   return { hintIds } as unknown as NgxFieldIdentity;
 }
@@ -63,6 +63,60 @@ describe('createHintIdsSignal – identity-service path', () => {
     });
 
     expect(result()).toEqual(['from-identity']);
+  });
+
+  it('falls through to the registry when the identity has published no hints', () => {
+    const identityHintIds = signal<readonly string[] | null>(null);
+    const registryHints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'from-registry', fieldName: 'email' },
+    ]);
+
+    const result = createHintIdsSignal({
+      identity: createStubIdentity(identityHintIds),
+      registry: createStubRegistry(registryHints),
+      fieldName: () => 'email',
+    });
+
+    expect(result()).toEqual(['from-registry']);
+  });
+
+  it('treats a published-but-empty hint list as authoritative, not as a fallback trigger', () => {
+    const identityHintIds = signal<readonly string[] | null>([]);
+    const registryHints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'from-registry', fieldName: 'email' },
+    ]);
+
+    const result = createHintIdsSignal({
+      identity: createStubIdentity(identityHintIds),
+      registry: createStubRegistry(registryHints),
+      fieldName: () => 'email',
+    });
+
+    expect(result()).toEqual([]);
+  });
+
+  it('stops falling back the moment the identity publishes its channel', () => {
+    const identityHintIds = signal<readonly string[] | null>(null);
+    const registryHints = signal<readonly NgxSignalFormHintDescriptor[]>([
+      { id: 'from-registry', fieldName: null },
+    ]);
+
+    const result = createHintIdsSignal({
+      identity: createStubIdentity(identityHintIds),
+      registry: createStubRegistry(registryHints),
+    });
+    expect(result()).toEqual(['from-registry']);
+
+    identityHintIds.set(['from-identity']);
+    expect(result()).toEqual(['from-identity']);
+  });
+
+  it('returns an empty list when an unpublished identity has no registry to fall back to', () => {
+    const result = createHintIdsSignal({
+      identity: createStubIdentity(signal<readonly string[] | null>(null)),
+    });
+
+    expect(result()).toEqual([]);
   });
 });
 

--- a/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
+++ b/packages/toolkit/core/utilities/aria/create-hint-ids-signal.ts
@@ -23,6 +23,14 @@ export type HintIdsSignal = Signal<readonly string[]>;
  * Minimal structural surface the factory needs from a field-identity
  * service: a reactive, pre-filtered list of hint IDs for the current field.
  *
+ * `hintIds` is nullable, and the two empty-ish states mean different things:
+ *
+ * - `null` — this identity has **never published** the hint channel. The
+ *   factory falls through to the registry exactly as if no identity were
+ *   present at all.
+ * - `[]` — this identity published the channel and there are genuinely no
+ *   hints. Authoritative; the registry is not consulted.
+ *
  * Exposed as a public option type so consumers building bespoke wrappers can
  * type-import the factory's inputs without using package-internal imports.
  * Production code passes its `NgxFieldIdentity` instance in
@@ -31,7 +39,7 @@ export type HintIdsSignal = Signal<readonly string[]>;
  * @group ARIA Composition
  */
 export interface HintIdsIdentityLike {
-  readonly hintIds: Signal<readonly string[]>;
+  readonly hintIds: Signal<readonly string[] | null>;
 }
 
 /**
@@ -68,26 +76,28 @@ export interface HintIdsRegistryLike {
 export interface CreateHintIdsSignalOptions {
   /**
    * Optional shared field-identity-like service (typically provided by a
-   * form field wrapper). When present, its pre-filtered `hintIds()` signal
-   * is used as-is and no registry filtering is performed.
+   * form field wrapper). When it has **published** the hint channel — its
+   * `hintIds()` returns a non-null array — that pre-filtered list is used
+   * as-is and no registry filtering is performed. While it returns `null`
+   * the channel is unclaimed and the registry fallback applies.
    */
   readonly identity?: HintIdsIdentityLike | null;
 
   /**
    * Optional hint-registry-like source exposing the un-filtered hint
-   * descriptors. Used as a fallback when
-   * {@link CreateHintIdsSignalOptions.identity} is absent. Hints are
-   * filtered to those whose `fieldName` is `null` (unscoped — applies to
-   * any field) or matches the resolved field name from
-   * {@link CreateHintIdsSignalOptions.fieldName}.
+   * descriptors. Used as a fallback whenever
+   * {@link CreateHintIdsSignalOptions.identity} is absent *or* has not
+   * published the hint channel. Hints are filtered to those whose
+   * `fieldName` is `null` (unscoped — applies to any field) or matches the
+   * resolved field name from {@link CreateHintIdsSignalOptions.fieldName}.
    */
   readonly registry?: HintIdsRegistryLike | null;
 
   /**
    * Optional reader for the resolved field name. Only consulted on the
-   * registry-fallback path; ignored when an identity service is present.
-   * When omitted, the registry is read with a `null` field name, so only
-   * hints whose own `fieldName` is `null` are kept.
+   * registry-fallback path; ignored once an identity service has published
+   * the hint channel. When omitted, the registry is read with a `null`
+   * field name, so only hints whose own `fieldName` is `null` are kept.
    */
   readonly fieldName?: HintIdsFieldNameReader;
 }
@@ -96,12 +106,13 @@ export interface CreateHintIdsSignalOptions {
  * Pure-signal factory that produces the `aria-describedby` hint-ID list for
  * a single field.
  *
- * Mirrors the resolution order previously inlined in
- * `NgxSignalFormAutoAria.#hintIds`:
+ * Resolution is **per channel**, not per service: an identity that exists
+ * but has not published its hints does not suppress the registry. Order:
  *
- * 1. If an identity service is provided, return its pre-filtered
- *    `hintIds()` signal verbatim — the wrapper has already correlated
- *    hints to this field.
+ * 1. If an identity service has published the hint channel (`hintIds()` is
+ *    non-null), return that pre-filtered list verbatim — the wrapper has
+ *    already correlated hints to this field. A published empty array is
+ *    authoritative and stops resolution here.
  * 2. Otherwise, if a registry is provided, return the registry's hints
  *    filtered to those whose `fieldName` is `null` (unscoped) or matches
  *    the reader-supplied current field name. Empty-string `fieldName` is
@@ -122,8 +133,9 @@ export function createHintIdsSignal(
   const { identity, registry, fieldName } = options;
 
   return computed((): readonly string[] => {
-    if (identity) {
-      return identity.hintIds();
+    const publishedHintIds = identity ? identity.hintIds() : null;
+    if (publishedHintIds !== null) {
+      return publishedHintIds;
     }
 
     if (!registry) {

--- a/packages/toolkit/form-field/form-field-wrapper.ts
+++ b/packages/toolkit/form-field/form-field-wrapper.ts
@@ -44,6 +44,7 @@ import {
   FORM_FIELD_ORIENTATION_VALUES,
   NGX_SIGNAL_FORM_HINT_REGISTRY,
   NgxFieldIdentity,
+  NgxFieldIdentityProvider,
   devWarnOnce,
   isElementCssVisible,
   type WarnOnceRef,
@@ -181,8 +182,20 @@ import { resolveUnionInput } from './utilities/resolve-union-input';
   selector: 'ngx-form-field-wrapper',
 
   imports: [NgComponentOutlet, NgxFormFieldError],
+  // `NgxFieldIdentity` is provided by the host directive, not listed here.
+  // Composing the public surface rather than duplicating it keeps one
+  // provisioning site, and means the `fieldName` input a consumer already
+  // binds reaches the identity through exactly the seam a third-party wrapper
+  // uses. Angular feeds one `fieldName` attribute to both this component's own
+  // input and the exposed host-directive input, so nothing changes for
+  // consumers. Tier 2 of the name cascade (the bound control's `id`) cannot
+  // travel through an input at all — it is only known in the render write
+  // phase below — so this component still drives the identity itself for that
+  // tier and for every non-name channel. See ADR-0011.
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
   providers: [
-    NgxFieldIdentity,
     {
       provide: NGX_SIGNAL_FORM_FIELD_CONTEXT,
       useFactory: () => {

--- a/packages/toolkit/index.ts
+++ b/packages/toolkit/index.ts
@@ -26,6 +26,7 @@ export {
   NGX_SIGNAL_FORMS_CONFIG,
   NgxControlPresetRegistry,
   NgxFieldIdentity,
+  NgxFieldIdentityProvider,
   NgxSignalFormAutoAria,
   NgxSignalFormControlSemanticsDirective,
   NgxSignalForm,


### PR DESCRIPTION
Closes #387.

Third-party wrappers can now own field identity, and `aria-invalid` no longer goes stale on controls with no layout box. Implements both agent briefs from the issue, with three verified deviations documented below.

## The two gaps this closes

**Field naming.** `NgxSignalFormAutoAria` derives a field name from the bound control's `id` unless an ancestor provides an `NgxFieldIdentity` — and only the built-in wrapper did. A custom wrapper therefore could not name a field anything other than its control's DOM `id`. That breaks for a third-party widget generating its own inner input id, and for a `role="group"` cluster whose name belongs to the group. The generated `{fieldName}-error` then disagreed with what the wrapper rendered: a dangling `aria-describedby`, which axe reports as `aria-valid-attr-value` and which leaves error text unreachable by assistive technology.

**Stale `aria-invalid`.** The gate that removes `aria-invalid` from a hidden control read a flag only the built-in wrapper published. A custom wrapper inside a collapsed `<details>`, an inactive tab, or a non-current wizard step kept a stale attribute, with `NGX_SIGNAL_FORM_ARIA_MODE: 'manual'` — forfeiting all of auto-aria — as the only escape.

## What changed

**`e57cc65a` — per-channel resolution (BREAKING).** Auto-aria and `createHintIdsSignal` used to switch onto an identity whenever one was *injectable*. That looked correct only because `NgxFormFieldWrapper` was the sole provider and drives every channel each render. Anything else providing an identity — the point of this issue — would silently switch its own hints and field-level strategy overrides off the registries. Each channel now resolves on its published *value*, and the error and warning channels fall back independently per ADR-0007. `hintIds` widens to `readonly string[] | null` (`null` = unpublished, `[]` = published-and-empty). This is a prerequisite: shipping the facade without it would ship a foot-gun.

**`80fbda06` — `NgxFieldIdentityProvider`.** A selectorless directive composed via `hostDirectives`. It provides `NgxFieldIdentity` on the host and drives the `@internal` writers itself — no writer becomes public. Auto-aria also stops reading a wrapper-published visibility flag and probes its own host element in the `earlyRead` phase it already runs.

**`91196b37` — the built-in wrapper composes it too.** So the public seam and the internal one are the same seam.

**`97674cae`, `a350b0c9`** — review fixes and documentation.

## Three verified deviations from the brief

**1. The input is `input<string | null | undefined>(undefined)`, not `input.required`.** A required host-directive input must be re-exposed (`NG2019`) and then bound in every consumer template (`NG8008`). A wrapper's own `fieldName` is normally optional — `NgxFormFieldWrapper`'s is, because the control's `id` is the usual source — so requiring it would break every field relying on that fallback. Note this is *not* about an extra binding: Angular feeds one `fieldName` attribute to both a component's own input and its exposed host-directive input.

**2. `isElementCssVisible()` fails open** on runtimes without `Element.checkVisibility()` instead of guessing from `offsetParent`. Browser specs prove the old fallback wrong in both directions — a false *positive* for collapsed `<details>` and `content-visibility: hidden` (so the staleness fix silently never worked on that branch) and a false *negative* for `position: fixed` and any environment with no layout engine.

**3. `opacityProperty` is deliberately not passed** to `checkVisibility()`. I added it, then a review caught that it reports the standard custom-checkbox pattern — a real input sitting transparently over a styled box — as hidden, stripping `aria-invalid` from a control the user is operating. A spec pins the case and asserts the control is still focusable.

## Behavior changes

- **Selection clusters**: the group element now tracks its own layout state instead of inheriting whichever single control the wrapper resolved. Hiding one radio used to strip `aria-invalid` from a visible group. Both halves asserted.
- **Test environments**: visibility is only assertable in a real browser now. jsdom implements neither `checkVisibility()` nor layout, so the jsdom specs pin the fail-open contract instead.

## Verification

`nx affected -t lint test test-browser build` green across 11 projects — 1527 jsdom + 112 browser tests. `tsconfig.lib.json` typechecks clean; the spec tsconfig sits at its unchanged 136-error baseline. `post-build` still publishes zero `set*` declarations, confirmed against the real emitted `.d.ts`, and `/core` stays out of the exports map. Every new behavioral test was confirmed to fail against the old code before being kept.

## Docs

ADR-0010 (per-channel resolution) and ADR-0011 (the host directive). `CUSTOM_WRAPPERS.md` gets a channel-oriented rewrite and loses the "Open design question (pre-v1)" block this issue resolves. Plus `docs/migrations/v1.0.0-rc.13.md`, `MIGRATING_BETA_TO_V1.md` §14–15, `CONTEXT.md`, the toolkit README, and the skill API reference.

## Demo coverage: none, deliberately — tracked in #405

Nothing in the demo catalog exercises this work, and nothing in it is broken by it either. `apps/demo` uses the built-in wrapper throughout; its only identity consumer reads `describedBy()`, whose type is unchanged. The three design-system demos hand-roll ARIA through the pure composition factories with their own field-name readers, so they never depended on auto-aria's DOM-`id` derivation and do not hit the gap this PR closes.

A demo page — a custom wrapper declaring a name that differs from its control's `id`, inside collapsible UI, showcasing both fixes at once — is #405. It is kept out of here because a new page pulls in the e2e visual-snapshot and a11y-baseline machinery, whose baselines are platform-scoped and need their own regeneration cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
