### PR TITLE
docs: say when NgxFieldIdentityProvider is needed, and when it is not

### DIFF
--- a/.agents/skills/ngx-signal-forms/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/SKILL.md
@@ -23,7 +23,7 @@ Routing loop:
 | `[formRoot]`, error strategy, ARIA, submission, config, or presets    | `@ngx-signal-forms/toolkit`            | [core/SKILL.md](core/SKILL.md)             |
 | Styled wrappers, fieldsets, floating labels, or custom-control layout | `@ngx-signal-forms/toolkit/form-field` | [form-field/SKILL.md](form-field/SKILL.md) |
 | Standalone errors, notifications, hints, counters, or summaries       | `@ngx-signal-forms/toolkit/assistive`  | [assistive/SKILL.md](assistive/SKILL.md)   |
-| Full DOM control or custom wrapper ARIA/identity composition          | `@ngx-signal-forms/toolkit/headless`   | [headless/SKILL.md](headless/SKILL.md)     |
+| Full DOM control or custom wrapper ARIA/identity composition          | `…/headless` (+ root for identity)     | [headless/SKILL.md](headless/SKILL.md)     |
 | Vest suites or custom Vest validation flows                           | `@ngx-signal-forms/toolkit/vest`       | [vest/SKILL.md](vest/SKILL.md)             |
 | axe-core WCAG assertions                                              | `@ngx-signal-forms/toolkit/testing`    | [testing/SKILL.md](testing/SKILL.md)       |
 | Dev-time form inspection                                              | `@ngx-signal-forms/debugger`           | [debugger/SKILL.md](debugger/SKILL.md)     |

--- a/.agents/skills/ngx-signal-forms/headless/SKILL.md
+++ b/.agents/skills/ngx-signal-forms/headless/SKILL.md
@@ -176,6 +176,31 @@ export class DsFormFieldComponent {
 }
 ```
 
+### Publishing the field name from a design-system host
+
+The pattern above projects the bound control via `<ng-content />`, so auto-ARIA
+runs on the **consumer's** element and resolves the field name from that
+element's `id`. When the control's `id` is not the field's name — a widget that
+generates its own inner `id`, or a `role="group"` cluster — declare the name on
+your host so every generated id agrees:
+
+```typescript
+import { NgxFieldIdentityProvider } from '@ngx-signal-forms/toolkit'; // root, not /headless
+
+hostDirectives: [
+  {
+    directive: NgxHeadlessErrorState,
+    inputs: ['field', 'fieldName', 'strategy'],
+  },
+  { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+];
+```
+
+One `fieldName` attribute feeds both. The provider publishes the **name**
+channel only — hints and display timing keep resolving through their
+registries. See `references/pitfalls.md` for the `[formField]` naming trap that
+comes with this, and `docs/CUSTOM_WRAPPERS.md` for the full contract.
+
 ## Field-Name Directive
 
 `NgxHeadlessFieldName` exposes the resolved field name plus the canonical

--- a/.agents/skills/ngx-signal-forms/references/pitfalls.md
+++ b/.agents/skills/ngx-signal-forms/references/pitfalls.md
@@ -348,6 +348,42 @@ When the actual bound control is nested inside a custom component or its `id` is
 resolved dynamically, pass `fieldName` explicitly on the wrapper to keep error
 IDs and described-by wiring deterministic.
 
+## Your Own Wrapper — Publish the Name, and Call the Input `field`
+
+`fieldName` is an input on `ngx-form-field-wrapper`. A wrapper **you** wrote has
+no such input: auto-ARIA on the projected control resolves the name from the
+control's `id` and never asks your component. A widget that mints its own inner
+`id` then gets `pn_id_42-error` while your wrapper renders `country-error`, and
+`aria-describedby` points at nothing. Nothing throws.
+
+```typescript
+// Correct — publish the field-NAME channel from your wrapper's host
+@Component({
+  selector: 'my-field',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+})
+export class MyField {
+  // Name it `field`, not `formField`.
+  readonly field = input.required<FieldTree<unknown>>();
+}
+```
+
+Two rules travel with this:
+
+- **Import `NgxFieldIdentityProvider` from the package root**, not `/headless`.
+- **Call the field input `field`.** `NgxSignalFormAutoAria` and Angular's own
+  `FormField` both select on `[formField]` _including on elements that are not
+  controls_, so `<my-field [formField]="...">` pulls both directives onto your
+  wrapper host and auto-ARIA fails to inject `FORM_FIELD`:
+  `NG0201: No provider found for InjectionToken FORM_FIELD`. Reusing the name
+  works only if every consumer template also has `FormField` in scope — which is
+  why `ngx-form-field-wrapper` gets away with it.
+
+The provider publishes the name channel only; hints and display timing keep
+resolving through their registries. Full contract: `docs/CUSTOM_WRAPPERS.md`.
+
 ## Error Strategy `'on-submit'` Without `[formRoot]`
 
 ```html

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The `model` signal stays your source of truth. Angular keeps it in sync with the
 - ✅ Warnings render as `role="status"` when present
 - ✅ Hints and character counts project below the input with proper ARIA association
 - ✅ First invalid field focused on failed submit (`createOnInvalidHandler()`)
+- ✅ `aria-invalid` removed while a control has no layout box — inside a collapsed `<details>`, an inactive tab, or a non-current wizard step — so it can't go stale
 
 > Default path: plain `[formRoot]` is enough (`'on-touch'`); add `ngxSignalForm` only for custom strategy or submitted-status context — see [Adding `ngxSignalForm`](#adding-form-level-context-with-ngxsignalform).
 
@@ -204,25 +205,25 @@ and why every "you can override this" later in the doc points back to this order
 Most projects only need the **form-field wrapper**. The other entry points exist for
 advanced and specialized cases — pull them in when you hit that specific need.
 
-| I want to…                                  | Use                                                              | Demo                                                                                                                                                       |
-| ------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add accessible, themed fields fast          | [`/form-field`](./packages/toolkit/form-field/README.md) wrapper | [`your-first-form`](./apps/demo/src/app/01-getting-started/your-first-form)                                                                                |
-| Control when errors appear                  | Core + `errorStrategy`                                           | [`error-display-modes`](./apps/demo/src/app/02-toolkit-core/error-display-modes)                                                                           |
-| Show non-blocking warnings                  | `warningError()` + wrapper                                       | [`warning-support`](./apps/demo/src/app/02-toolkit-core/warning-support)                                                                                   |
-| Build complex multi-section forms           | `/form-field` + `<ngx-form-fieldset>`                            | [`complex-forms`](./apps/demo/src/app/04-form-field-wrapper/complex-forms)                                                                                 |
-| Wrap custom / third-party controls          | `/form-field` + `ngxSignalFormControl`                           | [`custom-controls`](./apps/demo/src/app/04-form-field-wrapper/custom-controls)                                                                             |
-| Name a field that is not its control's `id` | `NgxFieldIdentityProvider` on your own wrapper                   | [`field-identity`](./apps/demo/src/app/04-form-field-wrapper/field-identity)                                                                               |
-| Bring my own markup / design system         | [`/headless`](./packages/toolkit/headless/README.md) primitives  | [`fieldset-utilities`](./apps/demo/src/app/03-headless/fieldset-utilities)                                                                                 |
-| Validate with Vest business rules           | [`/vest`](./packages/toolkit/vest/README.md) entry point         | [`vest-validation`](./apps/demo/src/app/05-advanced/vest-validation)                                                                                       |
-| Combine Zod + Vest                          | `/vest` + `validateStandardSchema`                               | [`zod-vest-validation`](./apps/demo/src/app/05-advanced/zod-vest-validation)                                                                               |
-| Async / cross-field validation              | Angular validators + core helpers                                | [`async-validation`](./apps/demo/src/app/05-advanced/async-validation), [`cross-field-validation`](./apps/demo/src/app/05-advanced/cross-field-validation) |
-| Multi-step / wizard forms                   | Core + `NgxFormFieldset`                                         | [`advanced-wizard`](./apps/demo/src/app/05-advanced/advanced-wizard)                                                                                       |
-| Customize submission handling               | `createOnInvalidHandler`, `focusFirstInvalid`                    | [`submission-patterns`](./apps/demo/src/app/05-advanced/submission-patterns)                                                                               |
-| Set app-wide defaults                       | `provideNgxSignalFormsConfig`                                    | [`global-configuration`](./apps/demo/src/app/05-advanced/global-configuration)                                                                             |
-| Use with Angular Material                   | Custom wrapper on `mat-form-field`                               | [`demo-material`](./apps/demo-material/README.md)                                                                                                          |
-| Use with Spartan Components                 | Custom wrapper on `BrnField` + `helm`                            | [`demo-spartan`](./apps/demo-spartan/README.md)                                                                                                            |
-| Use with PrimeNG                            | Projected-control wrapper (`pInputText`, …)                      | [`demo-primeng`](./apps/demo-primeng/README.md)                                                                                                            |
-| Assert WCAG 2.2 AA in my own specs          | [`/testing`](./packages/toolkit/testing/README.md) entry point   | [`form-field-wrapper.a11y.browser.spec.ts`](./packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts)                                         |
+| I want to…                           | Use                                                                                | Demo                                                                                                                                                       |
+| ------------------------------------ | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add accessible, themed fields fast   | [`/form-field`](./packages/toolkit/form-field/README.md) wrapper                   | [`your-first-form`](./apps/demo/src/app/01-getting-started/your-first-form)                                                                                |
+| Control when errors appear           | Core + `errorStrategy`                                                             | [`error-display-modes`](./apps/demo/src/app/02-toolkit-core/error-display-modes)                                                                           |
+| Show non-blocking warnings           | `warningError()` + wrapper                                                         | [`warning-support`](./apps/demo/src/app/02-toolkit-core/warning-support)                                                                                   |
+| Build complex multi-section forms    | `/form-field` + `<ngx-form-fieldset>`                                              | [`complex-forms`](./apps/demo/src/app/04-form-field-wrapper/complex-forms)                                                                                 |
+| Wrap custom / third-party controls   | `/form-field` + `ngxSignalFormControl`                                             | [`custom-controls`](./apps/demo/src/app/04-form-field-wrapper/custom-controls)                                                                             |
+| Build my own field wrapper component | [Custom wrapper contracts](./docs/CUSTOM_WRAPPERS.md) + `NgxFieldIdentityProvider` | [`field-identity`](./apps/demo/src/app/04-form-field-wrapper/field-identity)                                                                               |
+| Bring my own markup / design system  | [`/headless`](./packages/toolkit/headless/README.md) primitives                    | [`fieldset-utilities`](./apps/demo/src/app/03-headless/fieldset-utilities)                                                                                 |
+| Validate with Vest business rules    | [`/vest`](./packages/toolkit/vest/README.md) entry point                           | [`vest-validation`](./apps/demo/src/app/05-advanced/vest-validation)                                                                                       |
+| Combine Zod + Vest                   | `/vest` + `validateStandardSchema`                                                 | [`zod-vest-validation`](./apps/demo/src/app/05-advanced/zod-vest-validation)                                                                               |
+| Async / cross-field validation       | Angular validators + core helpers                                                  | [`async-validation`](./apps/demo/src/app/05-advanced/async-validation), [`cross-field-validation`](./apps/demo/src/app/05-advanced/cross-field-validation) |
+| Multi-step / wizard forms            | Core + `NgxFormFieldset`                                                           | [`advanced-wizard`](./apps/demo/src/app/05-advanced/advanced-wizard)                                                                                       |
+| Customize submission handling        | `createOnInvalidHandler`, `focusFirstInvalid`                                      | [`submission-patterns`](./apps/demo/src/app/05-advanced/submission-patterns)                                                                               |
+| Set app-wide defaults                | `provideNgxSignalFormsConfig`                                                      | [`global-configuration`](./apps/demo/src/app/05-advanced/global-configuration)                                                                             |
+| Use with Angular Material            | Custom wrapper on `mat-form-field`                                                 | [`demo-material`](./apps/demo-material/README.md)                                                                                                          |
+| Use with Spartan Components          | Custom wrapper on `BrnField` + `helm`                                              | [`demo-spartan`](./apps/demo-spartan/README.md)                                                                                                            |
+| Use with PrimeNG                     | Projected-control wrapper (`pInputText`, …)                                        | [`demo-primeng`](./apps/demo-primeng/README.md)                                                                                                            |
+| Assert WCAG 2.2 AA in my own specs   | [`/testing`](./packages/toolkit/testing/README.md) entry point                     | [`form-field-wrapper.a11y.browser.spec.ts`](./packages/toolkit/form-field/form-field-wrapper.a11y.browser.spec.ts)                                         |
 
 ---
 
@@ -560,7 +561,7 @@ The short version — each one is expanded with do/don't examples in the
 
 ## Troubleshooting quick checks
 
-- **No ARIA linkage?** Ensure the control has a stable `id` (or set `fieldName`).
+- **No ARIA linkage?** Ensure the control has a stable `id` (or set `fieldName` on the wrapper). If you wrote your own wrapper component, it needs [`NgxFieldIdentityProvider`](./docs/CUSTOM_WRAPPERS.md) — see the FAQ entry below.
 - **Errors show too early?** Check your strategy (`'on-touch'`, `'on-submit'`, `'immediate'`).
 - **`on-submit` not behaving as expected?** Use `ngxSignalForm` on the same host as `[formRoot]`.
 - **Warnings blocking submit?** Use warning helpers (`warningError`, `submitWithWarnings`, `canSubmitWithWarnings`).
@@ -633,6 +634,63 @@ ownership (`ngxSignalFormControlAria="manual"`), or preset-driven defaults for c
 families (sliders, composites). Native `<input>`, `<textarea>`, and `<select>` do not
 need it. See [`docs/CUSTOM_CONTROLS.md`](./docs/CUSTOM_CONTROLS.md) and
 [ADR-0001](./docs/decisions/0001-control-semantics-architecture.md).
+
+</details>
+
+<details>
+<summary><strong>When do I need <code>NgxFieldIdentityProvider</code>?</strong></summary>
+
+Only when you build **your own** form-field wrapper component. If you use
+`ngx-form-field-wrapper`, you never need it — even for a third-party widget
+that mints its own inner `id`.
+
+Every ARIA id the toolkit generates (`{fieldName}-error`,
+`{fieldName}-warning`) is built from the field's name, so the name has to
+resolve. Where it resolves from depends on your setup:
+
+| Your setup                                                   | Where the field name comes from                         |
+| ------------------------------------------------------------ | ------------------------------------------------------- |
+| `ngx-form-field-wrapper`, control has a stable `id`          | Automatic — derived from the `id`                       |
+| `ngx-form-field-wrapper`, generated or unusable control `id` | Set `fieldName` on the wrapper                          |
+| **Your own wrapper component**                               | Compose `NgxFieldIdentityProvider` via `hostDirectives` |
+| A bound control with no wrapper at all                       | The control's `id` — auto-ARIA has no `fieldName` input |
+
+The third row is the gap. A wrapper you wrote has no way to tell auto-ARIA
+what the field is called, so auto-ARIA falls back to the projected control's
+`id` and mints `pn_id_42-error` — an id that disagrees with the
+`emailAddress-error` element your wrapper actually rendered, leaving
+`aria-describedby` pointing at nothing. Screen readers announce the field
+without its error.
+
+Two shapes hit this:
+
+- **A widget library that generates its own inner input `id`** — PrimeNG's
+  `pn_id_n`, Material's `mat-mdc-input-n`. If the library lets you set that id
+  (PrimeNG's `[inputId]`, for example), you can use it instead.
+- **A `role="group"` cluster** — radios, checkboxes, or date parts, where the
+  name belongs to the group rather than to any one control.
+
+Compose it on your wrapper's host and expose its input:
+
+```typescript
+@Component({
+  selector: 'my-field',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+})
+export class MyField {}
+```
+
+It publishes the **field name only** — hints and error-display timing keep
+resolving through their own registries, so claiming the name leaves the rest
+of your wrapper working untouched.
+
+See [`docs/CUSTOM_WRAPPERS.md`](./docs/CUSTOM_WRAPPERS.md) for the full
+contract, and the
+[`field-identity` demo](https://ngx-signal-forms.github.io/ngx-signal-forms/form-field-wrapper/field-identity/)
+([code](./apps/demo/src/app/04-form-field-wrapper/field-identity)) for a
+runnable version.
 
 </details>
 

--- a/docs/CUSTOM_CONTROLS.md
+++ b/docs/CUSTOM_CONTROLS.md
@@ -499,6 +499,43 @@ on the wrapper or an `id` on the bound control:
 </ngx-form-field-wrapper>
 ```
 
+### If the wrapper is your own
+
+Both options above are inputs on `ngx-form-field-wrapper`. A wrapper **you**
+wrote has neither: auto-ARIA on the projected control resolves the name from
+the control's `id` and never asks your component, so a widget that generates
+its own inner `id` produces `pn_id_42-error` while your wrapper renders
+`country-error`. Nothing errors — `aria-describedby` simply points at an
+element that does not exist.
+
+Declare the name on your wrapper's host instead:
+
+```typescript
+import { NgxFieldIdentityProvider } from '@ngx-signal-forms/toolkit';
+
+@Component({
+  selector: 'my-field',
+  hostDirectives: [
+    { directive: NgxFieldIdentityProvider, inputs: ['fieldName'] },
+  ],
+})
+export class MyField {}
+```
+
+The directive provides `NgxFieldIdentity` on that host element, which is the
+element injector your projected control resolves through. It is selectorless
+on purpose — host placement is load-bearing, and a selector would invite
+putting it somewhere that silently does nothing.
+
+It publishes the **field name only**. Hint ids keep flowing through
+`NGX_SIGNAL_FORM_HINT_REGISTRY` and display timing through
+`NGX_SIGNAL_FORM_FIELD_VISIBILITY_REGISTRY`, so adopting it for the name does
+not disturb the rest of your wrapper.
+
+Full contract in [`CUSTOM_WRAPPERS.md`](./CUSTOM_WRAPPERS.md); runnable
+version in the
+[`field-identity` demo](https://ngx-signal-forms.github.io/ngx-signal-forms/form-field-wrapper/field-identity/).
+
 ## Custom Control Checklist
 
 When building custom controls that work with the toolkit:


### PR DESCRIPTION
Follow-up to #407. Docs only — no code, no API change.

## Why

The row #407 added to the README named a symptom — *"a field whose name is not its control's `id`"* — which reads as though `NgxFieldIdentityProvider` is the answer to that. For most readers it isn't.

`ngx-form-field-wrapper` already has a `fieldName` input, and it wins over the projected control's `id`. That is pinned by an existing spec, `form-field-wrapper.spec.ts:420`:

```html
<ngx-form-field-wrapper [formField]="field" fieldName="custom-email">
  <input id="email" type="email" />
</ngx-form-field-wrapper>
<!-- renders #custom-email-error, not #email-error -->
```

So the case people picture — a PrimeNG or Material widget that mints its own inner `id` — needs no new API at all. Pointing them at a host directive for it would be wrong.

The provider has exactly one audience: **people building their own wrapper component**, who have no such input and no way to tell auto-ARIA what the field is called.

## What changed

- **README table row** now targets that audience ("Build my own field wrapper component") instead of the symptom.
- **New FAQ entry**, in the same shape as the existing `ngxSignalForm` and `ngxSignalFormControl` ones: a table of where the field name resolves from per setup. Its top rows tell most readers *you don't need this*; the third row is the gap.
- **`docs/CUSTOM_CONTROLS.md`** — the biggest gap, and not in the README at all. This is where people land when integrating a third-party widget, and it did not mention the seam anywhere. Its "Field identity" section offered two escapes, both wrapper inputs, and then stopped — exactly where a custom-wrapper author needs a third. Added.
- **"What you get for free"** now lists the `aria-invalid`-on-a-hidden-control fix. That half of #387 needs no API, applies to every collapsed `<details>`, inactive tab, and non-current wizard step, and was invisible in the docs.
- **Troubleshooting** — "No ARIA linkage?" now forks on built-in vs. your own wrapper.

## Verification

Every factual claim checked against the code rather than the prose:

- `fieldName` beats control `id` — existing spec above.
- Auto-ARIA has **no** `fieldName` input, so a control with no wrapper genuinely has only its `id` as a name source — that FAQ row would otherwise have been a guess.
- All relative links in both changed files resolve.

The large README diff is the formatter re-padding the table's column widths after one cell changed; only that one row differs in content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
