### PR TITLE
fix(demo): probe layout before writing aria-invalid in the reference wrappers

### DIFF
--- a/.agents/skills/ngx-signal-forms/references/api.md
+++ b/.agents/skills/ngx-signal-forms/references/api.md
@@ -819,7 +819,7 @@ that own their DOM and ARIA. Use the factories as one composition unit instead
 of reproducing the wrapper's strategy, identity, hint, and renderer rules.
 
 ```typescript
-createAriaInvalidSignal(fieldState, visibility): Signal<'true' | null>
+createAriaInvalidSignal(fieldState, visibility, isControlVisible?): Signal<'true' | 'false' | null>
 createAriaRequiredSignal(fieldState): Signal<'true' | null>
 createAriaDescribedBySignal(options): Signal<string | null>
 createHintIdsSignal(options): Signal<readonly string[]>
@@ -829,6 +829,13 @@ createFieldNameResolver(options): Signal<string | null>
 
 - `createFieldNameResolver` resolves explicit input → optional label `for` →
   bound control `id`.
+- `createAriaInvalidSignal`'s third argument is optional in the type signature
+  only. A wrapper that composes the factory owns the layout probe itself —
+  without it `aria-invalid` goes stale on a control inside a collapsed
+  `<details>`, an inactive tab panel, or a non-current wizard step. Probe the
+  element that carries the attribute with `isElementCssVisible` in
+  `afterEveryRender`'s `earlyRead` phase. See `docs/CUSTOM_WRAPPERS.md`
+  call-out 5 under "Composing ARIA primitives".
 - `createAriaDescribedByBridge` coordinates the chain with a third-party host
   that owns `aria-describedby`; ordinary custom wrappers use
   `createAriaDescribedBySignal` directly.

--- a/apps/demo-material-e2e/src/collapsed-container-aria.spec.ts
+++ b/apps/demo-material-e2e/src/collapsed-container-aria.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Regression cover for #406 — `aria-invalid` going stale on a control that
+ * has lost its layout box.
+ *
+ * `MatFormFieldWrapper` opts every projected control into `ariaMode="manual"`
+ * (Material owns the real `aria-invalid` on `<input matInput>` /
+ * `<mat-select>` through its `ErrorStateMatcher`), so the toolkit-owned
+ * surface here is the wrapper's `data-ngx-mat-invalid` mirror — the attribute
+ * `createAriaInvalidSignal` actually drives in this reference. That mirror is
+ * what a consumer reads when they compose the primitive themselves, so it is
+ * what this spec asserts.
+ *
+ * The `<details>` is bound to Angular state on purpose: a bare `<details>`
+ * toggles in the browser without running change detection, so no layout probe
+ * would ever re-read and the test would pass for the wrong reason.
+ */
+test.describe('demo-material — aria state inside a collapsed container', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('drops the invalid mirror while collapsed and restores it on reopen', async ({
+    page,
+  }) => {
+    const details = page.getByTestId('topic-details');
+    const summary = details.locator('> summary');
+    const topicField = details.locator('mat-form-field');
+    const topic = page.getByRole('combobox', { name: 'Topic' });
+
+    await test.step('touch the required topic select so it reports invalid', async () => {
+      // Opening and dismissing the panel is what marks `mat-select` touched;
+      // the demo runs the on-touch strategy, so nothing is invalid before.
+      await expect(topicField).toHaveAttribute('data-ngx-mat-invalid', 'false');
+
+      await topic.click();
+      await page.keyboard.press('Escape');
+      await expect(topicField).toHaveAttribute('data-ngx-mat-invalid', 'true');
+    });
+
+    await test.step('collapsing removes the attribute rather than freezing it', async () => {
+      await summary.click();
+      await expect(details).not.toHaveJSProperty('open', true);
+
+      await expect(topicField).not.toHaveAttribute(
+        'data-ngx-mat-invalid',
+        /.*/u,
+      );
+    });
+
+    await test.step('reopening brings it back', async () => {
+      await summary.click();
+      await expect(details).toHaveJSProperty('open', true);
+
+      await expect(topicField).toHaveAttribute('data-ngx-mat-invalid', 'true');
+    });
+  });
+});

--- a/apps/demo-material/src/app/contact-form/contact-form.html
+++ b/apps/demo-material/src/app/contact-form/contact-form.html
@@ -52,31 +52,50 @@
     </mat-error>
   </mat-form-field>
 
-  <mat-form-field
-    class="demo-form__field"
-    [ngxMatFormField]="contactForm.topic"
-    fieldName="contact-topic"
+  <!-- Collapsible container — the `aria-invalid` staleness case.
+
+       `[open]` + `(toggle)` keeps `topicExpanded` authoritative: a bare
+       `<details>` toggles in the browser without going through Angular, so
+       nothing would re-run change detection and the wrapper's layout probe
+       would never re-read. With the binding in place, collapsing the section
+       takes the `<mat-select>`'s layout box away, the wrapper's
+       `createControlVisibilitySignal` probe reports `false` in the next
+       `earlyRead`, and `data-ngx-mat-invalid` drops off instead of freezing
+       at its last value. -->
+  <details
+    class="demo-form__collapsible"
+    [open]="topicExpanded()"
+    (toggle)="onTopicToggle($event)"
+    data-testid="topic-details"
   >
-    <mat-label>Topic</mat-label>
-    <mat-select
-      id="contact-topic"
-      [formField]="contactForm.topic"
-      ngxMatSelectControl
+    <summary class="demo-form__collapsible-summary">Topic details</summary>
+
+    <mat-form-field
+      class="demo-form__field"
+      [ngxMatFormField]="contactForm.topic"
+      fieldName="contact-topic"
     >
-      <mat-option value="">— Choose one —</mat-option>
-      <mat-option value="support">Product support</mat-option>
-      <mat-option value="sales">Sales question</mat-option>
-      <mat-option value="feedback">General feedback</mat-option>
-    </mat-select>
-    <mat-hint *ngxMatHintSlot="contactForm.topic; let warning">
-      @if (warning) {
-      <ngx-mat-feedback-outlet [message]="warning" severity="warning" />
-      } @else { Pick the closest match }
-    </mat-hint>
-    <mat-error *ngxMatErrorSlot="contactForm.topic; let message">
-      <ngx-mat-feedback-outlet [message]="message" severity="error" />
-    </mat-error>
-  </mat-form-field>
+      <mat-label>Topic</mat-label>
+      <mat-select
+        id="contact-topic"
+        [formField]="contactForm.topic"
+        ngxMatSelectControl
+      >
+        <mat-option value="">— Choose one —</mat-option>
+        <mat-option value="support">Product support</mat-option>
+        <mat-option value="sales">Sales question</mat-option>
+        <mat-option value="feedback">General feedback</mat-option>
+      </mat-select>
+      <mat-hint *ngxMatHintSlot="contactForm.topic; let warning">
+        @if (warning) {
+        <ngx-mat-feedback-outlet [message]="warning" severity="warning" />
+        } @else { Pick the closest match }
+      </mat-hint>
+      <mat-error *ngxMatErrorSlot="contactForm.topic; let message">
+        <ngx-mat-feedback-outlet [message]="message" severity="error" />
+      </mat-error>
+    </mat-form-field>
+  </details>
 
   <!-- `*ngxMatFeedback` is declared BEFORE `<mat-checkbox>` on purpose: the
        checkbox's `[aria-describedby]` binding (below) reads this directive's

--- a/apps/demo-material/src/app/contact-form/contact-form.html
+++ b/apps/demo-material/src/app/contact-form/contact-form.html
@@ -54,14 +54,12 @@
 
   <!-- Collapsible container — the `aria-invalid` staleness case.
 
-       `[open]` + `(toggle)` keeps `topicExpanded` authoritative: a bare
-       `<details>` toggles in the browser without going through Angular, so
-       nothing would re-run change detection and the wrapper's layout probe
-       would never re-read. With the binding in place, collapsing the section
-       takes the `<mat-select>`'s layout box away, the wrapper's
-       `createControlVisibilitySignal` probe reports `false` in the next
-       `earlyRead`, and `data-ngx-mat-invalid` drops off instead of freezing
-       at its last value. -->
+       `[open]` + `(toggle)` keeps `topicExpanded` authoritative. A bare
+       `<details>` toggles without going through Angular, so no change
+       detection runs and the layout probe never re-reads. Collapsing this
+       section takes the `<mat-select>`'s layout box away, and
+       `data-ngx-mat-invalid` drops off the wrapper. See
+       `createControlVisibilitySignal` in ../wrapper/control-visibility.ts. -->
   <details
     class="demo-form__collapsible"
     [open]="topicExpanded()"

--- a/apps/demo-material/src/app/contact-form/contact-form.ts
+++ b/apps/demo-material/src/app/contact-form/contact-form.ts
@@ -98,12 +98,9 @@ export class ContactFormComponent {
   protected readonly submitted = signal(false);
 
   /**
-   * Drives the `<details>` around the Topic field. The `<details>` binds
-   * `[open]` to this signal and pushes browser-initiated toggles back into
-   * it via `(toggle)` — a bare `<details>` would open and close without ever
-   * running change detection, so `MatFormFieldWrapper`'s layout probe would
-   * never re-read and `data-ngx-mat-invalid` would go stale on the hidden
-   * `<mat-select>`.
+   * Drives the `<details>` around the Topic field. Bound both ways so a
+   * browser-initiated toggle still runs change detection — see the template
+   * comment on the `<details>` for why that matters.
    */
   protected readonly topicExpanded = signal(true);
 

--- a/apps/demo-material/src/app/contact-form/contact-form.ts
+++ b/apps/demo-material/src/app/contact-form/contact-form.ts
@@ -98,6 +98,20 @@ export class ContactFormComponent {
   protected readonly submitted = signal(false);
 
   /**
+   * Drives the `<details>` around the Topic field. The `<details>` binds
+   * `[open]` to this signal and pushes browser-initiated toggles back into
+   * it via `(toggle)` — a bare `<details>` would open and close without ever
+   * running change detection, so `MatFormFieldWrapper`'s layout probe would
+   * never re-read and `data-ngx-mat-invalid` would go stale on the hidden
+   * `<mat-select>`.
+   */
+  protected readonly topicExpanded = signal(true);
+
+  protected onTopicToggle(event: Event): void {
+    this.topicExpanded.set((event.target as HTMLDetailsElement).open);
+  }
+
+  /**
    * Drives the consent checkbox's `[aria-describedby]` in the template —
    * `<mat-checkbox>` doesn't project into `<mat-form-field>`, so nothing
    * else associates its rendered `*ngxMatFeedback` block with the control.

--- a/apps/demo-material/src/app/wrapper/control-visibility.ts
+++ b/apps/demo-material/src/app/wrapper/control-visibility.ts
@@ -8,42 +8,33 @@ import { isElementCssVisible } from '@ngx-signal-forms/toolkit';
 
 /**
  * Tracks whether the element that carries `aria-invalid` still has a CSS
- * layout box, and publishes the answer as a signal fit for
+ * layout box, and publishes the answer as a signal for
  * `createAriaInvalidSignal`'s third parameter.
  *
- * **Why a wrapper needs this.** `NgxSignalFormAutoAria` probes its own host
- * element every read phase, so plain `[formField]` controls drop
- * `aria-invalid` for free when a collapsed `<details>`, an inactive tab
- * panel, or a non-current wizard step takes their layout box away. A
- * reference wrapper that opts out of auto-ARIA and composes the pure
- * factories instead inherits nothing — without this probe its
- * `aria-invalid` freezes at whatever it was when the container closed, and
- * is wrong the instant the container reopens with a different validation
- * state.
+ * A wrapper that composes the pure ARIA factories opts out of
+ * `NgxSignalFormAutoAria`, so it inherits no layout probe and must own one.
+ * `docs/CUSTOM_WRAPPERS.md` ("Composing ARIA primitives") explains why.
  *
- * **Why `afterEveryRender`'s `earlyRead` phase.** `checkVisibility()` is a
- * layout read. Effects flush strictly *before* render hooks in the same
- * change-detection cycle, so an effect-based probe would report pre-layout
- * geometry. `earlyRead` runs after layout and before any write phase, so
- * the write that sets the attribute sees a value settled for this render.
+ * The probe runs in `afterEveryRender`'s `earlyRead` phase because
+ * `checkVisibility()` is a layout read. Effects flush before render hooks,
+ * so an effect-based probe would report pre-layout geometry.
  * `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`)
  * is the reference for the phasing.
  *
- * The signal starts at `true` and stays `true` while `resolveElement`
- * returns `null`: an element that has not been through layout reports
- * `false`, and stripping `aria-invalid` on the strength of a pre-layout
- * probe would flicker the attribute off and back on every first render.
- * Fail open, then correct on the first real read phase.
+ * The probe fails open: the signal starts `true` and stays `true` while
+ * `resolveElement` returns `null`. An element that has not been through
+ * layout reports `false`, which would flicker the attribute off and back on
+ * during the first render.
  *
- * Each of the three design-system reference apps carries its own copy of
- * this helper on purpose — they are standalone references, and neither
- * depends on the others.
+ * Each design-system demo app carries its own copy. The repo has no shared
+ * Angular library for demo code — `packages/demo-shared` is framework-free
+ * Playwright metadata — so there is nowhere else to put it today.
  *
- * @param resolveElement Returns the element that carries `aria-invalid` —
- *   NOT necessarily the wrapper host. Shims that write onto an inner
- *   focusable element must probe that element.
- * @param injector Injector used to register the render hook, so the helper can
- *   be called from a field initializer rather than only inside a constructor.
+ * @param resolveElement Returns the element that carries `aria-invalid`,
+ *   which is not necessarily the wrapper host. A shim that writes onto an
+ *   inner focusable element must probe that element.
+ * @param injector Registers the render hook, so a field initializer can call
+ *   this helper instead of only a constructor.
  */
 export function createControlVisibilitySignal(
   resolveElement: () => HTMLElement | null,
@@ -59,9 +50,7 @@ export function createControlVisibilitySignal(
         return element === null ? true : isElementCssVisible(element);
       },
       write: (visible) => {
-        if (isControlVisible() !== visible) {
-          isControlVisible.set(visible);
-        }
+        isControlVisible.set(visible);
       },
     },
     { injector },

--- a/apps/demo-material/src/app/wrapper/control-visibility.ts
+++ b/apps/demo-material/src/app/wrapper/control-visibility.ts
@@ -1,0 +1,71 @@
+import {
+  afterEveryRender,
+  signal,
+  type Injector,
+  type Signal,
+} from '@angular/core';
+import { isElementCssVisible } from '@ngx-signal-forms/toolkit';
+
+/**
+ * Tracks whether the element that carries `aria-invalid` still has a CSS
+ * layout box, and publishes the answer as a signal fit for
+ * `createAriaInvalidSignal`'s third parameter.
+ *
+ * **Why a wrapper needs this.** `NgxSignalFormAutoAria` probes its own host
+ * element every read phase, so plain `[formField]` controls drop
+ * `aria-invalid` for free when a collapsed `<details>`, an inactive tab
+ * panel, or a non-current wizard step takes their layout box away. A
+ * reference wrapper that opts out of auto-ARIA and composes the pure
+ * factories instead inherits nothing — without this probe its
+ * `aria-invalid` freezes at whatever it was when the container closed, and
+ * is wrong the instant the container reopens with a different validation
+ * state.
+ *
+ * **Why `afterEveryRender`'s `earlyRead` phase.** `checkVisibility()` is a
+ * layout read. Effects flush strictly *before* render hooks in the same
+ * change-detection cycle, so an effect-based probe would report pre-layout
+ * geometry. `earlyRead` runs after layout and before any write phase, so
+ * the write that sets the attribute sees a value settled for this render.
+ * `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`)
+ * is the reference for the phasing.
+ *
+ * The signal starts at `true` and stays `true` while `resolveElement`
+ * returns `null`: an element that has not been through layout reports
+ * `false`, and stripping `aria-invalid` on the strength of a pre-layout
+ * probe would flicker the attribute off and back on every first render.
+ * Fail open, then correct on the first real read phase.
+ *
+ * Each of the three design-system reference apps carries its own copy of
+ * this helper on purpose — they are standalone references, and neither
+ * depends on the others.
+ *
+ * @param resolveElement Returns the element that carries `aria-invalid` —
+ *   NOT necessarily the wrapper host. Shims that write onto an inner
+ *   focusable element must probe that element.
+ * @param injector Injector used to register the render hook, so the helper can
+ *   be called from a field initializer rather than only inside a constructor.
+ */
+export function createControlVisibilitySignal(
+  resolveElement: () => HTMLElement | null,
+  injector: Injector,
+): Signal<boolean> {
+  const isControlVisible = signal(true);
+
+  afterEveryRender(
+    {
+      earlyRead: () => {
+        const element = resolveElement();
+
+        return element === null ? true : isElementCssVisible(element);
+      },
+      write: (visible) => {
+        if (isControlVisible() !== visible) {
+          isControlVisible.set(visible);
+        }
+      },
+    },
+    { injector },
+  );
+
+  return isControlVisible.asReadonly();
+}

--- a/apps/demo-material/src/app/wrapper/mat-form-field-wrapper.ts
+++ b/apps/demo-material/src/app/wrapper/mat-form-field-wrapper.ts
@@ -4,6 +4,7 @@ import {
   Directive,
   effect,
   inject,
+  Injector,
   input,
   isDevMode,
   signal,
@@ -37,6 +38,7 @@ import {
   NgxMatSlideToggleControl,
   NgxMatTextControl,
 } from './control-directives';
+import { createControlVisibilitySignal } from './control-visibility';
 import { NgxMatFeedback } from './feedback-directive';
 import { NgxMatFeedbackOutlet } from './material-error-renderer';
 import { NgxMatErrorSlot, NgxMatHintSlot } from './slot-directives';
@@ -152,6 +154,7 @@ export class MatFormFieldWrapper<TValue = unknown> {
 
   readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
   readonly #formContext = injectFormContext();
+  readonly #injector = inject(Injector);
 
   readonly effectiveStrategy = computed(() =>
     resolveErrorDisplayStrategy(
@@ -301,9 +304,22 @@ export class MatFormFieldWrapper<TValue = unknown> {
   // can verify the toolkit's identity model is wired even when Material
   // owns the actual DOM ARIA writes.
 
+  /**
+   * Layout probe for the element Material writes `aria-invalid` onto — the
+   * bound control, not the `<mat-form-field>` host. Threading it into
+   * `createAriaInvalidSignal` is what keeps `ariaInvalidValue` (and the
+   * `data-ngx-mat-invalid` mirror) from going stale while the control sits
+   * inside a collapsed container.
+   */
+  readonly #isControlVisible = createControlVisibilitySignal(
+    () => this.#boundControlElement(),
+    this.#injector,
+  );
+
   readonly ariaInvalidValue = createAriaInvalidSignal(
     this.#fieldStateSignal,
     this.#showByStrategy,
+    this.#isControlVisible,
   );
 
   readonly ariaRequiredValue = createAriaRequiredSignal(this.#fieldStateSignal);

--- a/apps/demo-material/src/styles.css
+++ b/apps/demo-material/src/styles.css
@@ -184,6 +184,23 @@ body {
   width: 100%;
 }
 
+/* Collapsible section around the Topic field. Its only job in this demo is
+   to take a bound control's layout box away on demand, so the wrapper's
+   visibility probe has something real to react to. */
+.demo-form__collapsible {
+  border: 1px solid rgba(15, 41, 74, 0.14);
+  border-radius: 20px;
+  padding: 0.85rem 1rem 1rem;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.demo-form__collapsible-summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
 .demo-form__field {
   --mat-form-field-container-height: 54px;
   --mat-form-field-container-vertical-padding: 13px;

--- a/apps/demo-primeng-e2e/src/collapsed-container-aria.spec.ts
+++ b/apps/demo-primeng-e2e/src/collapsed-container-aria.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Regression cover for #406 — `aria-invalid` going stale on a control that
+ * has lost its layout box.
+ *
+ * The PrimeNG reference is the one demo where all three composition shapes
+ * live inside a single collapsible container:
+ *
+ * - `<prime-form-field>` mirrors the toolkit's view of validity as
+ *   `data-invalid` on its own host,
+ * - `prime-select-control` writes the real `aria-invalid` onto the inner
+ *   `[role="combobox"]` element,
+ * - `prime-checkbox-control` writes it onto the native `<input
+ *   type="checkbox">` inside `p-checkbox`.
+ *
+ * Each probes the element it writes to, so all three must drop the attribute
+ * while the container is closed.
+ *
+ * The `<details>` is bound to Angular state on purpose: a bare `<details>`
+ * toggles in the browser without running change detection, so no layout probe
+ * would ever re-read and the test would pass for the wrong reason.
+ */
+test.describe('demo-primeng — aria state inside a collapsed container', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('drops aria-invalid on every surface while collapsed, and restores it', async ({
+    page,
+  }) => {
+    const details = page.getByTestId('preferences-details');
+    const summary = details.locator('> summary');
+
+    const roleWrapper = details.locator(
+      'prime-form-field[data-field-name="profile-role"]',
+    );
+    const combobox = details.locator('[role="combobox"]');
+    const checkbox = details.locator('input[type="checkbox"]');
+
+    await test.step('touch the required role select so it reports invalid', async () => {
+      await expect(combobox).toHaveAttribute('aria-invalid', 'false');
+
+      // `prime-select-control` emits `touch` from `p-select`'s `onBlur`, so
+      // the field only goes invalid once focus actually leaves the control.
+      await combobox.click();
+      await page.keyboard.press('Escape');
+      await page.locator('#profile-email').click();
+
+      await expect(roleWrapper).toHaveAttribute('data-invalid', 'true');
+      await expect(combobox).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    await test.step('collapsing removes the attributes rather than freezing them', async () => {
+      await summary.click();
+      await expect(details).not.toHaveJSProperty('open', true);
+
+      await expect(roleWrapper).not.toHaveAttribute('data-invalid', /.*/u);
+      await expect(combobox).not.toHaveAttribute('aria-invalid', /.*/u);
+      await expect(checkbox).not.toHaveAttribute('aria-invalid', /.*/u);
+    });
+
+    await test.step('reopening brings them back', async () => {
+      await summary.click();
+      await expect(details).toHaveJSProperty('open', true);
+
+      await expect(roleWrapper).toHaveAttribute('data-invalid', 'true');
+      await expect(combobox).toHaveAttribute('aria-invalid', 'true');
+      // The checkbox is optional, so it comes back as an explicit "valid"
+      // rather than being left off — the distinction the third
+      // `createAriaInvalidSignal` argument exists to preserve.
+      await expect(checkbox).toHaveAttribute('aria-invalid', 'false');
+    });
+  });
+});

--- a/apps/demo-primeng-e2e/src/profile-form.spec.ts
+++ b/apps/demo-primeng-e2e/src/profile-form.spec.ts
@@ -236,6 +236,14 @@ test.describe('demo-primeng — profile form', () => {
 
     await test.step('Tab onto the combobox and open it with the keyboard', async () => {
       await page.locator('#profile-email').focus();
+
+      // The role select lives inside a collapsible `<details>` (the #406
+      // layout-box case), so its `<summary>` is the intervening tab stop.
+      await page.keyboard.press('Tab');
+      await expect(
+        page.getByTestId('preferences-details').locator('> summary'),
+      ).toBeFocused();
+
       await page.keyboard.press('Tab');
       await expect(roleCombobox).toBeFocused();
 

--- a/apps/demo-primeng/src/app/a11y/control-visibility.ts
+++ b/apps/demo-primeng/src/app/a11y/control-visibility.ts
@@ -8,42 +8,33 @@ import { isElementCssVisible } from '@ngx-signal-forms/toolkit';
 
 /**
  * Tracks whether the element that carries `aria-invalid` still has a CSS
- * layout box, and publishes the answer as a signal fit for
+ * layout box, and publishes the answer as a signal for
  * `createAriaInvalidSignal`'s third parameter.
  *
- * **Why a wrapper needs this.** `NgxSignalFormAutoAria` probes its own host
- * element every read phase, so plain `[formField]` controls drop
- * `aria-invalid` for free when a collapsed `<details>`, an inactive tab
- * panel, or a non-current wizard step takes their layout box away. A
- * reference wrapper that opts out of auto-ARIA and composes the pure
- * factories instead inherits nothing — without this probe its
- * `aria-invalid` freezes at whatever it was when the container closed, and
- * is wrong the instant the container reopens with a different validation
- * state.
+ * A wrapper that composes the pure ARIA factories opts out of
+ * `NgxSignalFormAutoAria`, so it inherits no layout probe and must own one.
+ * `docs/CUSTOM_WRAPPERS.md` ("Composing ARIA primitives") explains why.
  *
- * **Why `afterEveryRender`'s `earlyRead` phase.** `checkVisibility()` is a
- * layout read. Effects flush strictly *before* render hooks in the same
- * change-detection cycle, so an effect-based probe would report pre-layout
- * geometry. `earlyRead` runs after layout and before any write phase, so
- * the write that sets the attribute sees a value settled for this render.
+ * The probe runs in `afterEveryRender`'s `earlyRead` phase because
+ * `checkVisibility()` is a layout read. Effects flush before render hooks,
+ * so an effect-based probe would report pre-layout geometry.
  * `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`)
  * is the reference for the phasing.
  *
- * The signal starts at `true` and stays `true` while `resolveElement`
- * returns `null`: an element that has not been through layout reports
- * `false`, and stripping `aria-invalid` on the strength of a pre-layout
- * probe would flicker the attribute off and back on every first render.
- * Fail open, then correct on the first real read phase.
+ * The probe fails open: the signal starts `true` and stays `true` while
+ * `resolveElement` returns `null`. An element that has not been through
+ * layout reports `false`, which would flicker the attribute off and back on
+ * during the first render.
  *
- * Each of the three design-system reference apps carries its own copy of
- * this helper on purpose — they are standalone references, and neither
- * depends on the others.
+ * Each design-system demo app carries its own copy. The repo has no shared
+ * Angular library for demo code — `packages/demo-shared` is framework-free
+ * Playwright metadata — so there is nowhere else to put it today.
  *
- * @param resolveElement Returns the element that carries `aria-invalid` —
- *   NOT necessarily the wrapper host. Shims that write onto an inner
- *   focusable element must probe that element.
- * @param injector Injector used to register the render hook, so the helper can
- *   be called from a field initializer rather than only inside a constructor.
+ * @param resolveElement Returns the element that carries `aria-invalid`,
+ *   which is not necessarily the wrapper host. A shim that writes onto an
+ *   inner focusable element must probe that element.
+ * @param injector Registers the render hook, so a field initializer can call
+ *   this helper instead of only a constructor.
  */
 export function createControlVisibilitySignal(
   resolveElement: () => HTMLElement | null,
@@ -59,9 +50,7 @@ export function createControlVisibilitySignal(
         return element === null ? true : isElementCssVisible(element);
       },
       write: (visible) => {
-        if (isControlVisible() !== visible) {
-          isControlVisible.set(visible);
-        }
+        isControlVisible.set(visible);
       },
     },
     { injector },

--- a/apps/demo-primeng/src/app/a11y/control-visibility.ts
+++ b/apps/demo-primeng/src/app/a11y/control-visibility.ts
@@ -1,0 +1,71 @@
+import {
+  afterEveryRender,
+  signal,
+  type Injector,
+  type Signal,
+} from '@angular/core';
+import { isElementCssVisible } from '@ngx-signal-forms/toolkit';
+
+/**
+ * Tracks whether the element that carries `aria-invalid` still has a CSS
+ * layout box, and publishes the answer as a signal fit for
+ * `createAriaInvalidSignal`'s third parameter.
+ *
+ * **Why a wrapper needs this.** `NgxSignalFormAutoAria` probes its own host
+ * element every read phase, so plain `[formField]` controls drop
+ * `aria-invalid` for free when a collapsed `<details>`, an inactive tab
+ * panel, or a non-current wizard step takes their layout box away. A
+ * reference wrapper that opts out of auto-ARIA and composes the pure
+ * factories instead inherits nothing — without this probe its
+ * `aria-invalid` freezes at whatever it was when the container closed, and
+ * is wrong the instant the container reopens with a different validation
+ * state.
+ *
+ * **Why `afterEveryRender`'s `earlyRead` phase.** `checkVisibility()` is a
+ * layout read. Effects flush strictly *before* render hooks in the same
+ * change-detection cycle, so an effect-based probe would report pre-layout
+ * geometry. `earlyRead` runs after layout and before any write phase, so
+ * the write that sets the attribute sees a value settled for this render.
+ * `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`)
+ * is the reference for the phasing.
+ *
+ * The signal starts at `true` and stays `true` while `resolveElement`
+ * returns `null`: an element that has not been through layout reports
+ * `false`, and stripping `aria-invalid` on the strength of a pre-layout
+ * probe would flicker the attribute off and back on every first render.
+ * Fail open, then correct on the first real read phase.
+ *
+ * Each of the three design-system reference apps carries its own copy of
+ * this helper on purpose — they are standalone references, and neither
+ * depends on the others.
+ *
+ * @param resolveElement Returns the element that carries `aria-invalid` —
+ *   NOT necessarily the wrapper host. Shims that write onto an inner
+ *   focusable element must probe that element.
+ * @param injector Injector used to register the render hook, so the helper can
+ *   be called from a field initializer rather than only inside a constructor.
+ */
+export function createControlVisibilitySignal(
+  resolveElement: () => HTMLElement | null,
+  injector: Injector,
+): Signal<boolean> {
+  const isControlVisible = signal(true);
+
+  afterEveryRender(
+    {
+      earlyRead: () => {
+        const element = resolveElement();
+
+        return element === null ? true : isElementCssVisible(element);
+      },
+      write: (visible) => {
+        if (isControlVisible() !== visible) {
+          isControlVisible.set(visible);
+        }
+      },
+    },
+    { injector },
+  );
+
+  return isControlVisible.asReadonly();
+}

--- a/apps/demo-primeng/src/app/controls/prime-checkbox-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-checkbox-control.ts
@@ -30,6 +30,7 @@ import {
   createAriaRequiredSignal,
   createHintIdsSignal,
 } from '@ngx-signal-forms/toolkit/headless';
+import { createControlVisibilitySignal } from '../a11y/control-visibility';
 import { Checkbox, CheckboxModule } from 'primeng/checkbox';
 
 /**
@@ -126,9 +127,20 @@ export class PrimeCheckboxControlComponent implements FormValueControl<boolean> 
     fieldName: () => this.#fieldContext?.fieldName() ?? null,
   });
 
+  /**
+   * Layout probe for the element this shim writes `aria-invalid` onto — the
+   * native `<input type="checkbox">` PrimeNG renders inside `p-checkbox`,
+   * not the component host. Same element the write phase below resolves.
+   */
+  readonly #isControlVisible = createControlVisibilitySignal(
+    () => this.#nativeInput(),
+    this.#injector,
+  );
+
   protected readonly ariaInvalid = createAriaInvalidSignal(
     this.#fieldState,
     this.#visibility,
+    this.#isControlVisible,
   );
 
   protected readonly ariaRequired = createAriaRequiredSignal(this.#fieldState);
@@ -141,16 +153,26 @@ export class PrimeCheckboxControlComponent implements FormValueControl<boolean> 
     fieldName: () => this.#fieldContext?.fieldName() ?? null,
   });
 
+  /**
+   * The native `<input>` inside `p-checkbox`. PrimeNG exposes it as
+   * `inputViewChild`, which is a signal on newer versions and a plain
+   * `ElementRef` on older ones — hence the shape check. Shared by the
+   * layout probe and the write phase so both address the same element.
+   */
+  #nativeInput(): HTMLInputElement | null {
+    const inputViewChild = this.checkboxControl().inputViewChild;
+
+    return (
+      (typeof inputViewChild === 'function' ? inputViewChild() : inputViewChild)
+        ?.nativeElement ?? null
+    );
+  }
+
   constructor() {
     afterEveryRender(
       {
         write: () => {
-          const inputViewChild = this.checkboxControl().inputViewChild;
-          const nativeInput =
-            (typeof inputViewChild === 'function'
-              ? inputViewChild()
-              : inputViewChild
-            )?.nativeElement ?? null;
+          const nativeInput = this.#nativeInput();
 
           if (!nativeInput) {
             return;

--- a/apps/demo-primeng/src/app/controls/prime-checkbox-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-checkbox-control.ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/forms/signals';
 import {
   createErrorVisibility,
+  isElementCssVisible,
   NGX_SIGNAL_FORM_ARIA_MODE,
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
   NGX_SIGNAL_FORM_HINT_REGISTRY,
@@ -30,7 +31,6 @@ import {
   createAriaRequiredSignal,
   createHintIdsSignal,
 } from '@ngx-signal-forms/toolkit/headless';
-import { createControlVisibilitySignal } from '../a11y/control-visibility';
 import { Checkbox, CheckboxModule } from 'primeng/checkbox';
 
 /**
@@ -128,19 +128,17 @@ export class PrimeCheckboxControlComponent implements FormValueControl<boolean> 
   });
 
   /**
-   * Layout probe for the element this shim writes `aria-invalid` onto — the
-   * native `<input type="checkbox">` PrimeNG renders inside `p-checkbox`,
-   * not the component host. Same element the write phase below resolves.
+   * Whether the element this shim writes `aria-invalid` onto still has a
+   * layout box. The single render hook below owns it: `earlyRead` probes the
+   * native input, `write` publishes the result and then writes the
+   * attributes, so one DOM lookup serves both phases.
    */
-  readonly #isControlVisible = createControlVisibilitySignal(
-    () => this.#nativeInput(),
-    this.#injector,
-  );
+  readonly #isControlVisible = signal(true);
 
   protected readonly ariaInvalid = createAriaInvalidSignal(
     this.#fieldState,
     this.#visibility,
-    this.#isControlVisible,
+    this.#isControlVisible.asReadonly(),
   );
 
   protected readonly ariaRequired = createAriaRequiredSignal(this.#fieldState);
@@ -171,8 +169,23 @@ export class PrimeCheckboxControlComponent implements FormValueControl<boolean> 
   constructor() {
     afterEveryRender(
       {
-        write: () => {
+        // `checkVisibility()` is a layout read, so it belongs in `earlyRead`:
+        // effects flush before render hooks and would report pre-layout
+        // geometry. Resolving the input here also hands `write` the same
+        // element, so `inputViewChild` is walked once per render.
+        earlyRead: () => {
           const nativeInput = this.#nativeInput();
+
+          return {
+            nativeInput,
+            visible: nativeInput === null || isElementCssVisible(nativeInput),
+          };
+        },
+        write: ({ nativeInput, visible }) => {
+          // Publish before reading `ariaInvalid()`: the computed re-runs on
+          // read, so the attribute reflects this render's layout rather than
+          // the previous one's.
+          this.#isControlVisible.set(visible);
 
           if (!nativeInput) {
             return;

--- a/apps/demo-primeng/src/app/controls/prime-select-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-select-control.ts
@@ -31,6 +31,7 @@ import {
   createAriaRequiredSignal,
   createHintIdsSignal,
 } from '@ngx-signal-forms/toolkit/headless';
+import { createControlVisibilitySignal } from '../a11y/control-visibility';
 import { Select, SelectModule } from 'primeng/select';
 import type { RoleOption } from '../profile-form/profile-form.model';
 
@@ -166,9 +167,21 @@ export class PrimeSelectControlComponent implements FormValueControl<string> {
     fieldName: () => this.#fieldContext?.fieldName() ?? null,
   });
 
+  /**
+   * Layout probe for the element this shim writes `aria-invalid` onto — the
+   * inner `[role="combobox"]`, not the component host. Same element the
+   * write phase below resolves, so the attribute is never set on a control
+   * that has no layout box (collapsed `<details>`, inactive tab panel, …).
+   */
+  readonly #isControlVisible = createControlVisibilitySignal(
+    () => this.#comboboxElement(),
+    this.#injector,
+  );
+
   protected readonly ariaInvalid = createAriaInvalidSignal(
     this.#fieldState,
     this.#visibility,
+    this.#isControlVisible,
   );
 
   protected readonly ariaRequired = createAriaRequiredSignal(this.#fieldState);
@@ -181,14 +194,23 @@ export class PrimeSelectControlComponent implements FormValueControl<string> {
     fieldName: () => this.#fieldContext?.fieldName() ?? null,
   });
 
+  /**
+   * The inner element PrimeNG gives the combobox role to. `p-select` renders
+   * it, so there is no `viewChild` handle for it — a scoped DOM query is the
+   * only way in, and it is shared by the layout probe and the write phase so
+   * both address the same element.
+   */
+  #comboboxElement(): HTMLElement | null {
+    return this.#host.nativeElement.querySelector<HTMLElement>(
+      '[role="combobox"]',
+    );
+  }
+
   constructor() {
     afterEveryRender(
       {
         write: () => {
-          const combobox =
-            this.#host.nativeElement.querySelector<HTMLElement>(
-              '[role="combobox"]',
-            );
+          const combobox = this.#comboboxElement();
 
           if (!combobox) {
             return;

--- a/apps/demo-primeng/src/app/controls/prime-select-control.ts
+++ b/apps/demo-primeng/src/app/controls/prime-select-control.ts
@@ -20,6 +20,7 @@ import {
 } from '@angular/forms/signals';
 import {
   createErrorVisibility,
+  isElementCssVisible,
   NGX_SIGNAL_FORM_ARIA_MODE,
   NGX_SIGNAL_FORM_FIELD_CONTEXT,
   NGX_SIGNAL_FORM_HINT_REGISTRY,
@@ -31,7 +32,6 @@ import {
   createAriaRequiredSignal,
   createHintIdsSignal,
 } from '@ngx-signal-forms/toolkit/headless';
-import { createControlVisibilitySignal } from '../a11y/control-visibility';
 import { Select, SelectModule } from 'primeng/select';
 import type { RoleOption } from '../profile-form/profile-form.model';
 
@@ -168,20 +168,19 @@ export class PrimeSelectControlComponent implements FormValueControl<string> {
   });
 
   /**
-   * Layout probe for the element this shim writes `aria-invalid` onto — the
-   * inner `[role="combobox"]`, not the component host. Same element the
-   * write phase below resolves, so the attribute is never set on a control
-   * that has no layout box (collapsed `<details>`, inactive tab panel, …).
+   * Whether the element this shim writes `aria-invalid` onto still has a
+   * layout box. The single render hook below owns it: `earlyRead` probes the
+   * combobox, `write` publishes the result and then writes the attributes,
+   * so one DOM query serves both phases and the attribute never lands on a
+   * control that has no layout box (collapsed `<details>`, inactive tab
+   * panel, and so on).
    */
-  readonly #isControlVisible = createControlVisibilitySignal(
-    () => this.#comboboxElement(),
-    this.#injector,
-  );
+  readonly #isControlVisible = signal(true);
 
   protected readonly ariaInvalid = createAriaInvalidSignal(
     this.#fieldState,
     this.#visibility,
-    this.#isControlVisible,
+    this.#isControlVisible.asReadonly(),
   );
 
   protected readonly ariaRequired = createAriaRequiredSignal(this.#fieldState);
@@ -209,8 +208,23 @@ export class PrimeSelectControlComponent implements FormValueControl<string> {
   constructor() {
     afterEveryRender(
       {
-        write: () => {
+        // `checkVisibility()` is a layout read, so it belongs in `earlyRead`:
+        // effects flush before render hooks and would report pre-layout
+        // geometry. Resolving the combobox here also hands `write` the same
+        // element, so the DOM is queried once per render.
+        earlyRead: () => {
           const combobox = this.#comboboxElement();
+
+          return {
+            combobox,
+            visible: combobox === null || isElementCssVisible(combobox),
+          };
+        },
+        write: ({ combobox, visible }) => {
+          // Publish before reading `ariaInvalid()`: the computed re-runs on
+          // read, so the attribute reflects this render's layout rather than
+          // the previous one's.
+          this.#isControlVisible.set(visible);
 
           if (!combobox) {
             return;

--- a/apps/demo-primeng/src/app/form-field/prime-form-field.ts
+++ b/apps/demo-primeng/src/app/form-field/prime-form-field.ts
@@ -6,6 +6,7 @@ import {
   contentChildren,
   effect,
   inject,
+  Injector,
   input,
   isDevMode,
   signal,
@@ -31,6 +32,7 @@ import {
   createAriaRequiredSignal,
   createFieldNameResolver,
 } from '@ngx-signal-forms/toolkit/headless';
+import { createControlVisibilitySignal } from '../a11y/control-visibility';
 
 /**
  * PrimeNG-flavoured form-field wrapper.
@@ -289,6 +291,7 @@ export class PrimeFormFieldComponent<TValue = unknown> {
 
   readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
   readonly #formContext = injectFormContext();
+  readonly #injector = inject(Injector);
 
   /**
    * Strategy resolved against the global config and any form-level
@@ -342,9 +345,22 @@ export class PrimeFormFieldComponent<TValue = unknown> {
     this.submittedStatus,
   );
 
+  /**
+   * Layout probe for the bound control — the element `aria-invalid` actually
+   * lands on (auto-ARIA writes it there for `input-like` controls, and the
+   * `p-select` / `p-checkbox` shims write it onto their inner focusable
+   * element). Probing the wrapper host instead would miss a control hidden
+   * inside a still-laid-out wrapper.
+   */
+  readonly #isControlVisible = createControlVisibilitySignal(
+    () => this.#boundControlElement(),
+    this.#injector,
+  );
+
   readonly ariaInvalidValue = createAriaInvalidSignal(
     this.#fieldStateSignal,
     this.#showByStrategy,
+    this.#isControlVisible,
   );
 
   readonly ariaRequiredValue = createAriaRequiredSignal(this.#fieldStateSignal);

--- a/apps/demo-primeng/src/app/form-field/prime-form-field.ts
+++ b/apps/demo-primeng/src/app/form-field/prime-form-field.ts
@@ -162,7 +162,11 @@ import { createControlVisibilitySignal } from '../a11y/control-visibility';
   host: {
     style:
       '--prime-form-field-invalid-border-color: var(--p-form-field-invalid-border-color, #ef4444);',
-    '[attr.data-invalid]': 'ariaInvalidValue() === "true" ? "true" : null',
+    // Mirrors `ariaInvalidValue()` verbatim, so 'false' (valid, laid out) and
+    // absent (no layout box) stay distinguishable — matching the Material and
+    // Spartan wrappers. The styles.css seam keys off [data-invalid='true'],
+    // so only that value drives the invalid border.
+    '[attr.data-invalid]': 'ariaInvalidValue()',
     '[attr.data-field-name]': 'resolvedFieldName()',
     '[attr.data-prime-required]': 'ariaRequiredValue()',
     '[class.prime-form-field--checkbox]': 'isCheckboxControl()',

--- a/apps/demo-primeng/src/app/profile-form/profile-form.ts
+++ b/apps/demo-primeng/src/app/profile-form/profile-form.ts
@@ -116,10 +116,9 @@ import { profileFormSchema } from './profile-form.schema';
         Collapsible section — the \`aria-invalid\` staleness case.
 
         \`[open]\` + \`(toggle)\` keeps \`preferencesExpanded\` authoritative. A
-        bare \`<details>\` toggles in the browser without going through
-        Angular, so nothing would re-run change detection and no layout probe
-        would re-read. With the binding in place, collapsing the section takes
-        the layout box away from three surfaces at once:
+        bare \`<details>\` toggles without going through Angular, so no change
+        detection runs and no layout probe re-reads. Collapsing the section
+        takes the layout box away from three surfaces at once:
 
         - \`<prime-form-field>\`'s own \`data-invalid\` mirror,
         - the \`[role="combobox"]\` element \`prime-select-control\` writes
@@ -277,10 +276,8 @@ export class ProfileFormComponent {
 
   /**
    * Drives the `<details>` around the role select and newsletter checkbox.
-   * Bound both ways (`[open]` out, `(toggle)` back in) so a browser-initiated
-   * toggle still runs change detection — otherwise the wrapper's and the two
-   * shims' layout probes would never re-read and `aria-invalid` would go
-   * stale on the hidden controls.
+   * Bound both ways so a browser-initiated toggle still runs change
+   * detection — see the template comment on the `<details>` for why.
    */
   protected readonly preferencesExpanded = signal(true);
 

--- a/apps/demo-primeng/src/app/profile-form/profile-form.ts
+++ b/apps/demo-primeng/src/app/profile-form/profile-form.ts
@@ -110,43 +110,77 @@ import { profileFormSchema } from './profile-form.schema';
             Work addresses are best for recovery and team handoff.
           </ngx-form-field-hint>
         </prime-form-field>
-
-        <!-- Select (PrimeNG compatibility shim; toolkit wiring still lives in the wrapper layer) -->
-        <prime-form-field
-          [ngxPrimeFormField]="roleField"
-          fieldName="profile-role"
-          showRequiredMarker
-        >
-          <label id="profile-role-label" for="profile-role">Role</label>
-          <prime-select-control
-            inputId="profile-role"
-            ariaLabelledBy="profile-role-label"
-            [options]="roleOptions"
-            placeholder="Pick a role"
-            ngxSignalFormControl="standalone-field-like"
-            [formField]="roleField"
-          />
-          <ngx-form-field-hint>
-            We use this to tailor examples and sensible defaults.
-          </ngx-form-field-hint>
-        </prime-form-field>
       </div>
 
-      <!-- Checkbox -->
-      <prime-form-field
-        [ngxPrimeFormField]="newsletterField"
-        fieldName="profile-newsletter"
+      <!--
+        Collapsible section — the \`aria-invalid\` staleness case.
+
+        \`[open]\` + \`(toggle)\` keeps \`preferencesExpanded\` authoritative. A
+        bare \`<details>\` toggles in the browser without going through
+        Angular, so nothing would re-run change detection and no layout probe
+        would re-read. With the binding in place, collapsing the section takes
+        the layout box away from three surfaces at once:
+
+        - \`<prime-form-field>\`'s own \`data-invalid\` mirror,
+        - the \`[role="combobox"]\` element \`prime-select-control\` writes
+          \`aria-invalid\` onto,
+        - the native \`<input type="checkbox">\` \`prime-checkbox-control\`
+          writes \`aria-invalid\` onto.
+
+        All three probe the element they write to, so all three drop the
+        attribute instead of freezing at its last value.
+      -->
+      <details
+        class="profile-form__collapsible"
+        [open]="preferencesExpanded()"
+        (toggle)="onPreferencesToggle($event)"
+        data-testid="preferences-details"
       >
-        <label for="profile-newsletter">Subscribe to the release notes</label>
-        <prime-checkbox-control
-          inputId="profile-newsletter"
-          ngxSignalFormControl="checkbox"
-          [formField]="newsletterField"
-        />
-        <ngx-form-field-hint>
-          One concise digest when new toolkit features ship — no inbox confetti.
-        </ngx-form-field-hint>
-      </prime-form-field>
+        <summary class="profile-form__collapsible-summary">
+          Role and subscription preferences
+        </summary>
+
+        <div class="profile-form__collapsible-body field-stack">
+          <!-- Select (PrimeNG compatibility shim; toolkit wiring still lives in the wrapper layer) -->
+          <prime-form-field
+            [ngxPrimeFormField]="roleField"
+            fieldName="profile-role"
+            showRequiredMarker
+          >
+            <label id="profile-role-label" for="profile-role">Role</label>
+            <prime-select-control
+              inputId="profile-role"
+              ariaLabelledBy="profile-role-label"
+              [options]="roleOptions"
+              placeholder="Pick a role"
+              ngxSignalFormControl="standalone-field-like"
+              [formField]="roleField"
+            />
+            <ngx-form-field-hint>
+              We use this to tailor examples and sensible defaults.
+            </ngx-form-field-hint>
+          </prime-form-field>
+
+          <!-- Checkbox -->
+          <prime-form-field
+            [ngxPrimeFormField]="newsletterField"
+            fieldName="profile-newsletter"
+          >
+            <label for="profile-newsletter"
+              >Subscribe to the release notes</label
+            >
+            <prime-checkbox-control
+              inputId="profile-newsletter"
+              ngxSignalFormControl="checkbox"
+              [formField]="newsletterField"
+            />
+            <ngx-form-field-hint>
+              One concise digest when new toolkit features ship — no inbox
+              confetti.
+            </ngx-form-field-hint>
+          </prime-form-field>
+        </div>
+      </details>
 
       <aside class="profile-form__status" aria-live="polite">
         <p class="profile-form__status-label">Validation rhythm</p>
@@ -240,6 +274,19 @@ export class ProfileFormComponent {
   );
 
   protected readonly lastSubmission = signal<string | null>(null);
+
+  /**
+   * Drives the `<details>` around the role select and newsletter checkbox.
+   * Bound both ways (`[open]` out, `(toggle)` back in) so a browser-initiated
+   * toggle still runs change detection — otherwise the wrapper's and the two
+   * shims' layout probes would never re-read and `aria-invalid` would go
+   * stale on the hidden controls.
+   */
+  protected readonly preferencesExpanded = signal(true);
+
+  protected onPreferencesToggle(event: Event): void {
+    this.preferencesExpanded.set((event.target as HTMLDetailsElement).open);
+  }
 
   protected reset(): void {
     // Reset model first so the form derives its baseline from the cleared

--- a/apps/demo-primeng/src/styles.css
+++ b/apps/demo-primeng/src/styles.css
@@ -161,6 +161,26 @@ main.shell {
   gap: 1.2rem;
 }
 
+/* Collapsible section around the role select and newsletter checkbox. Its
+   only job in this demo is to take those controls' layout boxes away on
+   demand, so each surface's visibility probe has something real to react
+   to. */
+.profile-form__collapsible {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--demo-border);
+  border-radius: 1rem;
+  background: rgb(255 255 255 / 0.55);
+}
+
+.profile-form__collapsible-summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.profile-form__collapsible-body {
+  margin-top: 1.2rem;
+}
+
 .profile-form__status {
   padding: 1rem 1.1rem;
   border: 1px solid var(--demo-border);

--- a/apps/demo-spartan-e2e/src/collapsed-container-aria.spec.ts
+++ b/apps/demo-spartan-e2e/src/collapsed-container-aria.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Regression cover for #406 — `aria-invalid` going stale on a control that
+ * has lost its layout box.
+ *
+ * `NgxSpartanFormField` does not write `aria-invalid` itself: Brain's
+ * `BrnSelectTrigger` / `HlmSelectTrigger` own that attribute on the real
+ * `role="combobox"` button. The toolkit-owned surface here is the wrapper's
+ * `data-spartan-invalid` mirror — the attribute `createAriaInvalidSignal`
+ * actually drives in this reference, and the one a consumer reads when they
+ * compose the primitive themselves.
+ *
+ * The `<details>` is bound to Angular state on purpose: a bare `<details>`
+ * toggles in the browser without running change detection, so the wrapper's
+ * layout probe would never re-read and the test would pass for the wrong
+ * reason.
+ */
+test.describe('demo-spartan — aria state inside a collapsed container', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('drops the invalid mirror while collapsed and restores it on reopen', async ({
+    page,
+  }) => {
+    const details = page.getByTestId('plan-details');
+    const summary = details.locator('> summary');
+    const planField = details.locator('spartan-form-field');
+    const trigger = page.locator('#plan-trigger');
+
+    await test.step('touch the required plan select so it reports invalid', async () => {
+      await expect(planField).toHaveAttribute('data-spartan-invalid', 'false');
+
+      await trigger.click();
+      await page.keyboard.press('Escape');
+      await page.locator('#display-name').click();
+
+      await expect(planField).toHaveAttribute('data-spartan-invalid', 'true');
+    });
+
+    await test.step('collapsing removes the attribute rather than freezing it', async () => {
+      await summary.click();
+      await expect(details).not.toHaveJSProperty('open', true);
+
+      await expect(planField).not.toHaveAttribute(
+        'data-spartan-invalid',
+        /.*/u,
+      );
+    });
+
+    await test.step('reopening brings it back', async () => {
+      await summary.click();
+      await expect(details).toHaveJSProperty('open', true);
+
+      await expect(planField).toHaveAttribute('data-spartan-invalid', 'true');
+    });
+  });
+});

--- a/apps/demo-spartan/src/app/form/account-preferences-form.ts
+++ b/apps/demo-spartan/src/app/form/account-preferences-form.ts
@@ -125,23 +125,46 @@ const accountSchema = schema<AccountPreferences>((path) => {
         falling through to the hlm-select host id, which is invisible to
         the label and easy to forget when refactoring).
       -->
-      <spartan-form-field [ngxSpartanFormField]="form.plan" fieldName="plan">
-        <label hlmLabel for="plan-trigger">Plan</label>
-        <hlm-select
-          id="plan"
-          ngxSignalFormControl="input-like"
-          [formField]="form.plan"
-        >
-          <hlm-select-trigger buttonId="plan-trigger" class="w-full">
-            <hlm-select-value placeholder="Select a plan" />
-          </hlm-select-trigger>
-          <hlm-select-content *hlmSelectPortal>
-            <hlm-select-item value="starter">Starter</hlm-select-item>
-            <hlm-select-item value="pro">Pro</hlm-select-item>
-            <hlm-select-item value="enterprise">Enterprise</hlm-select-item>
-          </hlm-select-content>
-        </hlm-select>
-      </spartan-form-field>
+      <!--
+        The plan field lives inside a collapsible container so the demo can
+        take a bound control's layout box away on demand.
+
+        \`[open]\` + \`(toggle)\` keeps \`planExpanded\` authoritative: a bare
+        \`<details>\` toggles in the browser without going through Angular, so
+        nothing would re-run change detection and the wrapper's layout probe
+        would never re-read. With the binding in place, collapsing the section
+        makes \`NgxSpartanFormField\`'s probe report \`false\` in the next
+        \`earlyRead\`, and \`data-spartan-invalid\` drops off the wrapper
+        instead of freezing at its last value.
+      -->
+      <details
+        class="mt-5 rounded-md border p-4"
+        [open]="planExpanded()"
+        (toggle)="onPlanToggle($event)"
+        data-testid="plan-details"
+      >
+        <summary class="cursor-pointer text-sm font-medium">
+          Plan selection
+        </summary>
+
+        <spartan-form-field [ngxSpartanFormField]="form.plan" fieldName="plan">
+          <label hlmLabel for="plan-trigger">Plan</label>
+          <hlm-select
+            id="plan"
+            ngxSignalFormControl="input-like"
+            [formField]="form.plan"
+          >
+            <hlm-select-trigger buttonId="plan-trigger" class="w-full">
+              <hlm-select-value placeholder="Select a plan" />
+            </hlm-select-trigger>
+            <hlm-select-content *hlmSelectPortal>
+              <hlm-select-item value="starter">Starter</hlm-select-item>
+              <hlm-select-item value="pro">Pro</hlm-select-item>
+              <hlm-select-item value="enterprise">Enterprise</hlm-select-item>
+            </hlm-select-content>
+          </hlm-select>
+        </spartan-form-field>
+      </details>
 
       <!--
         Checkbox. hlm-checkbox's host is display:contents (invisible to
@@ -217,4 +240,17 @@ export class AccountPreferencesForm {
   );
 
   protected readonly lastSubmission = signal<string | null>(null);
+
+  /**
+   * Drives the `<details>` around the plan select. Bound both ways
+   * (`[open]` out, `(toggle)` back in) so a browser-initiated toggle still
+   * runs change detection — otherwise `NgxSpartanFormField`'s layout probe
+   * would never re-read and `aria-invalid` would go stale on the hidden
+   * control.
+   */
+  protected readonly planExpanded = signal(true);
+
+  protected onPlanToggle(event: Event): void {
+    this.planExpanded.set((event.target as HTMLDetailsElement).open);
+  }
 }

--- a/apps/demo-spartan/src/app/form/account-preferences-form.ts
+++ b/apps/demo-spartan/src/app/form/account-preferences-form.ts
@@ -129,13 +129,11 @@ const accountSchema = schema<AccountPreferences>((path) => {
         The plan field lives inside a collapsible container so the demo can
         take a bound control's layout box away on demand.
 
-        \`[open]\` + \`(toggle)\` keeps \`planExpanded\` authoritative: a bare
-        \`<details>\` toggles in the browser without going through Angular, so
-        nothing would re-run change detection and the wrapper's layout probe
-        would never re-read. With the binding in place, collapsing the section
-        makes \`NgxSpartanFormField\`'s probe report \`false\` in the next
-        \`earlyRead\`, and \`data-spartan-invalid\` drops off the wrapper
-        instead of freezing at its last value.
+        \`[open]\` + \`(toggle)\` keeps \`planExpanded\` authoritative. A bare
+        \`<details>\` toggles without going through Angular, so no change
+        detection runs and the layout probe never re-reads. Collapsing the
+        section makes \`NgxSpartanFormField\`'s probe report \`false\`, and
+        \`data-spartan-invalid\` drops off the wrapper.
       -->
       <details
         class="mt-5 rounded-md border p-4"
@@ -242,11 +240,9 @@ export class AccountPreferencesForm {
   protected readonly lastSubmission = signal<string | null>(null);
 
   /**
-   * Drives the `<details>` around the plan select. Bound both ways
-   * (`[open]` out, `(toggle)` back in) so a browser-initiated toggle still
-   * runs change detection — otherwise `NgxSpartanFormField`'s layout probe
-   * would never re-read and `aria-invalid` would go stale on the hidden
-   * control.
+   * Drives the `<details>` around the plan select. Bound both ways so a
+   * browser-initiated toggle still runs change detection — see the template
+   * comment on the `<details>` for why.
    */
   protected readonly planExpanded = signal(true);
 

--- a/apps/demo-spartan/src/app/wrapper/control-visibility.ts
+++ b/apps/demo-spartan/src/app/wrapper/control-visibility.ts
@@ -8,42 +8,33 @@ import { isElementCssVisible } from '@ngx-signal-forms/toolkit';
 
 /**
  * Tracks whether the element that carries `aria-invalid` still has a CSS
- * layout box, and publishes the answer as a signal fit for
+ * layout box, and publishes the answer as a signal for
  * `createAriaInvalidSignal`'s third parameter.
  *
- * **Why a wrapper needs this.** `NgxSignalFormAutoAria` probes its own host
- * element every read phase, so plain `[formField]` controls drop
- * `aria-invalid` for free when a collapsed `<details>`, an inactive tab
- * panel, or a non-current wizard step takes their layout box away. A
- * reference wrapper that opts out of auto-ARIA and composes the pure
- * factories instead inherits nothing — without this probe its
- * `aria-invalid` freezes at whatever it was when the container closed, and
- * is wrong the instant the container reopens with a different validation
- * state.
+ * A wrapper that composes the pure ARIA factories opts out of
+ * `NgxSignalFormAutoAria`, so it inherits no layout probe and must own one.
+ * `docs/CUSTOM_WRAPPERS.md` ("Composing ARIA primitives") explains why.
  *
- * **Why `afterEveryRender`'s `earlyRead` phase.** `checkVisibility()` is a
- * layout read. Effects flush strictly *before* render hooks in the same
- * change-detection cycle, so an effect-based probe would report pre-layout
- * geometry. `earlyRead` runs after layout and before any write phase, so
- * the write that sets the attribute sees a value settled for this render.
+ * The probe runs in `afterEveryRender`'s `earlyRead` phase because
+ * `checkVisibility()` is a layout read. Effects flush before render hooks,
+ * so an effect-based probe would report pre-layout geometry.
  * `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`)
  * is the reference for the phasing.
  *
- * The signal starts at `true` and stays `true` while `resolveElement`
- * returns `null`: an element that has not been through layout reports
- * `false`, and stripping `aria-invalid` on the strength of a pre-layout
- * probe would flicker the attribute off and back on every first render.
- * Fail open, then correct on the first real read phase.
+ * The probe fails open: the signal starts `true` and stays `true` while
+ * `resolveElement` returns `null`. An element that has not been through
+ * layout reports `false`, which would flicker the attribute off and back on
+ * during the first render.
  *
- * Each of the three design-system reference apps carries its own copy of
- * this helper on purpose — they are standalone references, and neither
- * depends on the others.
+ * Each design-system demo app carries its own copy. The repo has no shared
+ * Angular library for demo code — `packages/demo-shared` is framework-free
+ * Playwright metadata — so there is nowhere else to put it today.
  *
- * @param resolveElement Returns the element that carries `aria-invalid` —
- *   NOT necessarily the wrapper host. Shims that write onto an inner
- *   focusable element must probe that element.
- * @param injector Injector used to register the render hook, so the helper can
- *   be called from a field initializer rather than only inside a constructor.
+ * @param resolveElement Returns the element that carries `aria-invalid`,
+ *   which is not necessarily the wrapper host. A shim that writes onto an
+ *   inner focusable element must probe that element.
+ * @param injector Registers the render hook, so a field initializer can call
+ *   this helper instead of only a constructor.
  */
 export function createControlVisibilitySignal(
   resolveElement: () => HTMLElement | null,
@@ -59,9 +50,7 @@ export function createControlVisibilitySignal(
         return element === null ? true : isElementCssVisible(element);
       },
       write: (visible) => {
-        if (isControlVisible() !== visible) {
-          isControlVisible.set(visible);
-        }
+        isControlVisible.set(visible);
       },
     },
     { injector },

--- a/apps/demo-spartan/src/app/wrapper/control-visibility.ts
+++ b/apps/demo-spartan/src/app/wrapper/control-visibility.ts
@@ -1,0 +1,71 @@
+import {
+  afterEveryRender,
+  signal,
+  type Injector,
+  type Signal,
+} from '@angular/core';
+import { isElementCssVisible } from '@ngx-signal-forms/toolkit';
+
+/**
+ * Tracks whether the element that carries `aria-invalid` still has a CSS
+ * layout box, and publishes the answer as a signal fit for
+ * `createAriaInvalidSignal`'s third parameter.
+ *
+ * **Why a wrapper needs this.** `NgxSignalFormAutoAria` probes its own host
+ * element every read phase, so plain `[formField]` controls drop
+ * `aria-invalid` for free when a collapsed `<details>`, an inactive tab
+ * panel, or a non-current wizard step takes their layout box away. A
+ * reference wrapper that opts out of auto-ARIA and composes the pure
+ * factories instead inherits nothing — without this probe its
+ * `aria-invalid` freezes at whatever it was when the container closed, and
+ * is wrong the instant the container reopens with a different validation
+ * state.
+ *
+ * **Why `afterEveryRender`'s `earlyRead` phase.** `checkVisibility()` is a
+ * layout read. Effects flush strictly *before* render hooks in the same
+ * change-detection cycle, so an effect-based probe would report pre-layout
+ * geometry. `earlyRead` runs after layout and before any write phase, so
+ * the write that sets the attribute sees a value settled for this render.
+ * `NgxSignalFormAutoAria` (`packages/toolkit/core/directives/auto-aria.ts`)
+ * is the reference for the phasing.
+ *
+ * The signal starts at `true` and stays `true` while `resolveElement`
+ * returns `null`: an element that has not been through layout reports
+ * `false`, and stripping `aria-invalid` on the strength of a pre-layout
+ * probe would flicker the attribute off and back on every first render.
+ * Fail open, then correct on the first real read phase.
+ *
+ * Each of the three design-system reference apps carries its own copy of
+ * this helper on purpose — they are standalone references, and neither
+ * depends on the others.
+ *
+ * @param resolveElement Returns the element that carries `aria-invalid` —
+ *   NOT necessarily the wrapper host. Shims that write onto an inner
+ *   focusable element must probe that element.
+ * @param injector Injector used to register the render hook, so the helper can
+ *   be called from a field initializer rather than only inside a constructor.
+ */
+export function createControlVisibilitySignal(
+  resolveElement: () => HTMLElement | null,
+  injector: Injector,
+): Signal<boolean> {
+  const isControlVisible = signal(true);
+
+  afterEveryRender(
+    {
+      earlyRead: () => {
+        const element = resolveElement();
+
+        return element === null ? true : isElementCssVisible(element);
+      },
+      write: (visible) => {
+        if (isControlVisible() !== visible) {
+          isControlVisible.set(visible);
+        }
+      },
+    },
+    { injector },
+  );
+
+  return isControlVisible.asReadonly();
+}

--- a/apps/demo-spartan/src/app/wrapper/spartan-form-field.ts
+++ b/apps/demo-spartan/src/app/wrapper/spartan-form-field.ts
@@ -5,6 +5,7 @@ import {
   contentChildren,
   effect,
   inject,
+  Injector,
   input,
   isDevMode,
   type Type,
@@ -32,6 +33,7 @@ import {
   createFieldNameResolver,
   createHintIdsSignal,
 } from '@ngx-signal-forms/toolkit/headless';
+import { createControlVisibilitySignal } from './control-visibility';
 import { NgxSpartanFormFieldError } from './spartan-form-field-error';
 
 /**
@@ -384,6 +386,7 @@ export class NgxSpartanFormField<TValue = unknown> {
    */
   readonly #config = inject(NGX_SIGNAL_FORMS_CONFIG);
   readonly #formContext = injectFormContext();
+  readonly #injector = inject(Injector);
 
   protected readonly effectiveStrategy = computed(() =>
     resolveErrorDisplayStrategy(
@@ -438,9 +441,22 @@ export class NgxSpartanFormField<TValue = unknown> {
   // verify the toolkit's identity model is wired even though Brain owns
   // the host binding on the bound control (and the bridge feeds it).
 
+  /**
+   * Layout probe for the bound helm control — the element Brain host-binds
+   * `aria-invalid` onto, not the wrapper host. Threading it into
+   * `createAriaInvalidSignal` keeps `ariaInvalidValue` (and the
+   * `data-spartan-invalid` mirror) from freezing while the control sits in
+   * a collapsed container.
+   */
+  readonly #isControlVisible = createControlVisibilitySignal(
+    () => this.#boundControlElement(),
+    this.#injector,
+  );
+
   readonly ariaInvalidValue = createAriaInvalidSignal(
     this.#fieldStateSignal,
     this.#showByStrategy,
+    this.#isControlVisible,
   );
 
   readonly ariaRequiredValue = createAriaRequiredSignal(this.#fieldStateSignal);

--- a/docs/CUSTOM_WRAPPERS.md
+++ b/docs/CUSTOM_WRAPPERS.md
@@ -317,6 +317,7 @@ import {
   createErrorVisibility,
   generateErrorId,
   generateWarningId,
+  isElementCssVisible,
   resolveFieldName,
 } from '@ngx-signal-forms/toolkit';
 import {
@@ -330,11 +331,17 @@ import {
 interface MyAriaDomSnapshot {
   readonly fieldName: string | null;
   readonly describedBy: string | null;
+  /** Whether the element that carries `aria-invalid` still has a layout box. */
+  readonly isControlVisible: boolean;
 }
 
 const INITIAL_DOM_SNAPSHOT: MyAriaDomSnapshot = {
   fieldName: null,
   describedBy: null,
+  // Assume laid out until a real read phase says otherwise: an element that
+  // has not been through layout reports `false`, and stripping `aria-invalid`
+  // on the strength of a pre-layout probe would flicker it off and back on.
+  isControlVisible: true,
 };
 
 @Directive({
@@ -381,9 +388,17 @@ export class MyDesignSystemAriaDirective {
     fieldName: () => this.#domSnapshot().fieldName,
   });
 
+  // The visibility probe is the wrapper's own responsibility (see call-out 5
+  // below): nothing in the factory reads the DOM, so `aria-invalid` would go
+  // stale on a control inside a collapsed container without this.
+  readonly #isControlVisible = computed(
+    () => this.#domSnapshot().isControlVisible,
+  );
+
   readonly #ariaInvalid = createAriaInvalidSignal(
     this.#fieldState,
     this.#visibility,
+    this.#isControlVisible,
   );
 
   readonly #ariaRequired = createAriaRequiredSignal(this.#fieldState);
@@ -402,13 +417,20 @@ export class MyDesignSystemAriaDirective {
     //    thrashing — never mix `read` and `write` work in the same callback.
     afterEveryRender(
       {
-        earlyRead: () => this.#readDomSnapshot(),
+        earlyRead: () =>
+          // `checkVisibility()` is a layout read, so it belongs here rather
+          // than in an `effect()` — effects flush before render hooks in the
+          // same cycle and would report pre-layout geometry.
+          this.#readDomSnapshot(
+            isElementCssVisible(this.#element.nativeElement),
+          ),
         write: (snapshot) => {
           // Commit the snapshot read in `earlyRead`. Doing it here (not in
           // `earlyRead`) keeps the write phase the single mutation point.
           if (
             snapshot.fieldName !== this.#domSnapshot().fieldName ||
-            snapshot.describedBy !== this.#domSnapshot().describedBy
+            snapshot.describedBy !== this.#domSnapshot().describedBy ||
+            snapshot.isControlVisible !== this.#domSnapshot().isControlVisible
           ) {
             this.#domSnapshot.set(snapshot);
           }
@@ -422,7 +444,7 @@ export class MyDesignSystemAriaDirective {
     );
   }
 
-  #readDomSnapshot(): MyAriaDomSnapshot {
+  #readDomSnapshot(isControlVisible: boolean): MyAriaDomSnapshot {
     const el = this.#element.nativeElement;
     const fieldName = resolveFieldName(el);
     const raw = el.getAttribute('aria-describedby');
@@ -431,7 +453,7 @@ export class MyDesignSystemAriaDirective {
     // get re-counted as "preserved". A production directive caches the managed
     // ID set in a signal; this example recomputes inline for clarity.
     if (!raw || !fieldName) {
-      return { fieldName, describedBy: raw };
+      return { fieldName, describedBy: raw, isControlVisible };
     }
 
     const managed = new Set<string>([
@@ -447,6 +469,7 @@ export class MyDesignSystemAriaDirective {
     return {
       fieldName,
       describedBy: preserved.length > 0 ? preserved : null,
+      isControlVisible,
     };
   }
 
@@ -483,12 +506,33 @@ A few things to call out:
    pre-existing `aria-describedby` IDs to preserve) never race with the
    attribute writes that follow. Mixing reads and writes in the same callback
    triggers layout thrash on every change-detection cycle.
-5. **`isControlVisible` is optional.** `createAriaInvalidSignal` accepts an
-   optional third argument — a `Signal<boolean>` that suppresses
-   `aria-invalid` when the host is collapsed (e.g. inside a closed
-   `<details>`). `NgxSignalFormAutoAria` wires this from `NgxFieldIdentity`'s
-   shared visibility flag; consumers can pass any `Signal<boolean>` they
-   already maintain.
+5. **A wrapper composing `createAriaInvalidSignal` owns the visibility probe
+   itself.** The factory's third argument is a `Signal<boolean>` that resolves
+   the attribute to `null` while the control has no layout box — a collapsed
+   `<details>`, an inactive tab panel, a non-current wizard step. It is
+   optional in the type signature only; omitting it means `aria-invalid`
+   freezes at whatever it was when the container closed, and is wrong the
+   instant the container reopens with a different validation state.
+
+   Nothing supplies this for you. `NgxSignalFormAutoAria` probes its own host
+   element every read phase, so plain `[formField]` controls get the
+   behaviour for free — but a wrapper that opts out of the directive and
+   composes the factories instead inherits none of it. Probe with
+   `isElementCssVisible(el)` (the same public helper auto-aria uses; it fails
+   open on runtimes without `Element.checkVisibility()`) inside
+   `afterEveryRender`'s `earlyRead` phase, publish the result into a signal,
+   and thread that signal in — exactly as the example above does.
+
+   Probe **the element you write `aria-invalid` onto**, which is not always
+   the wrapper host. A shim that writes onto an inner focusable element (a
+   rendered `[role="combobox"]`, the native `<input>` inside a design-system
+   checkbox) must probe that inner element, or a control hidden inside a
+   still-laid-out wrapper goes unnoticed. The three design-system reference
+   apps under `apps/demo-material`, `apps/demo-primeng`, and
+   `apps/demo-spartan` each carry a `createControlVisibilitySignal` helper
+   that packages this phasing, and a collapsible-container case in their
+   e2e suites that proves it.
+
 6. **The consumer never inherits `NgxSignalFormAutoAria`.** That's the whole
    point — your directive owns the host, owns the writes, and owns the
    render phasing. The factories are reactive transforms over `FieldState`,
@@ -760,6 +804,10 @@ above). See `NgxFormFieldError` for the reference implementation.
 - [ ] Wrapper does **not** write `aria-invalid`, `aria-required`, or
       `aria-describedby` on its host element — those belong on the bound
       control and are owned by `NgxSignalFormAutoAria`.
+- [ ] If the wrapper composes `createAriaInvalidSignal` instead of inheriting
+      `NgxSignalFormAutoAria`, it passes the third `isControlVisible`
+      argument, probed from the element that carries the attribute — see
+      call-out 5 under [Composing ARIA primitives](#composing-aria-primitives).
 - [ ] Optional: register `NGX_FORM_FIELD_HINT_RENDERER` via
       `provideFormFieldHintRenderer(...)` if you want projected
       `<ngx-form-field-hint>` instances to render with design-system chrome.


### PR DESCRIPTION
The three design-system reference wrappers opt out of `NgxSignalFormAutoAria` and compose `createAriaInvalidSignal` from the pure factories instead. All five call sites passed only two arguments, so nothing ever told the factory the control had lost its layout box — a control inside a collapsed `<details>`, an inactive tab panel, or a non-current wizard step kept whatever `aria-invalid` it had, and the value was wrong the instant the container reopened with a different validation state. Plain `[formField]` controls were never affected: auto-ARIA probes its own host element each read phase.

Each call site now threads an `isControlVisible` signal probed from **the element that carries the attribute**, which is not the wrapper host for the PrimeNG shims — they write onto the inner focusable element:

| Call site | Probed element |
| --- | --- |
| `MatFormFieldWrapper` | bound control |
| `PrimeFormFieldComponent` | bound control |
| `NgxSpartanFormField` | bound control |
| `PrimeSelectControlComponent` | rendered `[role="combobox"]` |
| `PrimeCheckboxControlComponent` | native `<input>` inside `p-checkbox` |

The layout read belongs in `afterEveryRender`'s `earlyRead` phase, not an effect — effects flush strictly before render hooks in the same change-detection cycle and would report pre-layout geometry. It fails open until a real read phase runs, so the attribute never flickers off on first paint.

The three wrappers get that phasing from a `createControlVisibilitySignal` helper. The two PrimeNG shims already ran a render hook to write their ARIA attributes, so they probe inside it instead of registering a second one: `earlyRead` resolves the element and probes it, `write` reuses the same element. That also keeps the attribute in step with the current render — publishing the visibility signal before reading `ariaInvalid()` makes the computed re-run on read, where a separate hook would lag one render behind.

Each app carries its own copy of the helper. The repo has no shared Angular library for demo code (`packages/demo-shared` is framework-free Playwright metadata), and the issue put toolkit API changes out of scope — so promoting it is a follow-up, not part of this PR. Filed as #411.

One small contract change came out of review: `prime-form-field`'s `data-invalid` mirror now passes `ariaInvalidValue()` through verbatim rather than collapsing everything but `'true'` to `null`. Absence previously meant both "valid" and "no layout box", which made the collapsed assertion weaker than it read. Material and Spartan already mirrored faithfully, and the styling seam keys off `[data-invalid='true']`, so nothing visual changes.

Each demo grows a collapsible section holding a bound control, bound to Angular state with `[open]` + `(toggle)`. That binding is load-bearing — a bare `<details>` toggles in the browser without running change detection, so no probe would ever re-read and the new specs would pass for the wrong reason.

### Scope: only PrimeNG's `aria-invalid` was actually stale

Worth knowing before reading the specs. In the Material and Spartan references the wrapper's factory does not drive a real `aria-invalid` at all — Material's `ErrorStateMatcher` and Brain's `HlmSelectTrigger` own that attribute on the bound control, and the wrapper only mirrors it as `data-ngx-mat-invalid` / `data-spartan-invalid`. Those two e2e specs therefore assert the mirror, which is the only surface the listed call sites drive.

The consequence: the real `aria-invalid` still goes stale on the `mat-select` and the plan trigger while collapsed. Correcting the design systems' own writes means touching Material's matcher wiring and the vendored `HlmSelectTrigger` — well outside the five call sites this issue named. Filed as #409 with a sketch for both halves.

### Review notes

`docs/CUSTOM_WRAPPERS.md` call-out 5 is rewritten: the third argument is optional in the type signature only, and a wrapper composing the factory owns the probe itself. The skill's `references/api.md` carried a stale two-argument signature (and a wrong return type) that would have kept agents writing the same bug; both are corrected.

Verified by driving all three apps in a real browser, and each new spec was confirmed to fail with the stale `"true"` when the third argument is removed — the failure mode this PR exists to prevent is one where the specs pass while the bug is live. a11y scans report no new baseline entries under CI parity.

One pre-existing spec needed updating: `profile-form.spec.ts` tabbed straight from the email field to the role combobox, and the new `<summary>` is now an intervening tab stop.

Fixes #406
Refs #387, #404, #405, #409, #411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invalid-state accessibility attributes now update correctly when form controls are collapsed or expanded.
  * Added collapsible form sections across the demo applications, with synchronized validation behavior and styling.

* **Bug Fixes**
  * Prevented stale `aria-invalid` and related invalid-state indicators on hidden controls.

* **Documentation**
  * Updated custom wrapper guidance with visibility-handling recommendations.

* **Tests**
  * Added regression coverage for collapsed-container accessibility behavior across supported demos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

