### PR TITLE
ci(release): run the non-atomized e2e target, and preflight the push credential

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,22 @@ jobs:
       # the environment while untrusted dependency code runs.
       - name: Verify release credential
         env:
+          # Resolved separately from the token itself: the `||` fallback below
+          # is indistinguishable from a real RELEASE_TOKEN once evaluated, so
+          # without this the preflight would happily green-light a run that
+          # has no push credential at all.
+          HAS_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN != '' }}
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          if [ "$HAS_RELEASE_TOKEN" != "true" ]; then
+            echo "::error::RELEASE_TOKEN is not set on the 'release' environment."
+            echo "The workflow would fall back to GITHUB_TOKEN, which cannot push to" >&2
+            echo "protected main, so the Release step would fail only after the full" >&2
+            echo "quality gate has already run. Add the secret in" >&2
+            echo "Settings > Environments > release." >&2
+            exit 1
+          fi
+
           BODY=$(mktemp)
           HEADERS=$(mktemp)
           CODE=$(curl -sS -o "$BODY" -D "$HEADERS" -w '%{http_code}' \
@@ -114,7 +128,7 @@ jobs:
 
           if [ "$CODE" != "200" ]; then
             echo "::error::RELEASE_TOKEN could not authenticate against $GITHUB_REPOSITORY (HTTP $CODE)."
-            echo "The token is most likely expired or revoked. Mint a new one and update" >&2
+            echo "The token is expired, revoked, or invalid. Mint a new one and update" >&2
             echo "the RELEASE_TOKEN secret in Settings > Environments > release." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,10 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # The quality gate runs every affected e2e suite in this one job, including
+    # demo-e2e unsharded (ci.yml splits it across a 4-way matrix). Matches the
+    # 35 min ci.yml allows its own main job.
+    timeout-minutes: 35
     # Gate the release behind a protected environment. Store RELEASE_TOKEN as an
     # *environment* secret (not a plain repo secret) with required reviewers, so
     # a `workflow_dispatch` on an untrusted ref cannot reach the admin push token
@@ -91,6 +94,52 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Fail fast if the release credential is missing, expired, or revoked.
+      # A release runs a ~15 min quality gate before it ever touches the push
+      # token; without this the only signal of an expired PAT is a failure at
+      # the very end. Deliberately placed BEFORE `pnpm install`: no
+      # third-party code has executed yet, so the token is never resident in
+      # the environment while untrusted dependency code runs.
+      - name: Verify release credential
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(mktemp)
+          HEADERS=$(mktemp)
+          CODE=$(curl -sS -o "$BODY" -D "$HEADERS" -w '%{http_code}' \
+            -H "Authorization: Bearer $RELEASE_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY")
+
+          if [ "$CODE" != "200" ]; then
+            echo "::error::RELEASE_TOKEN could not authenticate against $GITHUB_REPOSITORY (HTTP $CODE)."
+            echo "The token is most likely expired or revoked. Mint a new one and update" >&2
+            echo "the RELEASE_TOKEN secret in Settings > Environments > release." >&2
+            exit 1
+          fi
+
+          # GitHub returns this header for PATs that carry an expiry date.
+          EXPIRY=$(grep -i '^github-authentication-token-expiration:' "$HEADERS" \
+            | cut -d: -f2- | sed 's/^ *//' | tr -d '\r')
+
+          if [ -n "$EXPIRY" ]; then
+            echo "Release credential expires: $EXPIRY"
+            echo "- Release credential expires: \`$EXPIRY\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Release credential has no expiration date set."
+            echo "- Release credential: no expiry" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Warn (do not block) if push access is not visible: the permissions
+          # object is absent for some GitHub App installation tokens that can
+          # still push perfectly well.
+          PUSH=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); p=d.get('permissions'); print('' if p is None else str(p.get('push', False)).lower())" "$BODY")
+          if [ "$PUSH" = "false" ]; then
+            echo "::warning::RELEASE_TOKEN authenticated but reports no push permission on $GITHUB_REPOSITORY; the Release step may fail."
+          fi
+
+          echo "Release credential OK."
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -146,7 +195,14 @@ jobs:
         # Using affected ensures we only verify what changed, but caching handles the rest.
         # We target all projects to ensure workspace health before release.
         # nx-safe.sh falls back to local execution if Nx Cloud rejects our token.
-        run: bash .github/scripts/nx-safe.sh pnpm exec nx affected -t lint test test-browser build e2e-ci --outputStyle=static
+        #
+        # Use the non-atomized `e2e` target, never `e2e-ci`. The Playwright
+        # plugin's `ciTargetName: e2e-ci` (nx.json) splits each suite into
+        # per-spec tasks that Nx refuses to run without Nx Agents, and this
+        # workspace stopped distributing in #252. ci.yml was switched at the
+        # same time; this gate was missed and broke for any release whose
+        # affected set contains an e2e project.
+        run: bash .github/scripts/nx-safe.sh pnpm exec nx affected -t lint test test-browser build e2e --outputStyle=static
 
       - name: Validate release inputs
         env:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -87,9 +87,13 @@ jobs:
 
       - name: Update Playwright snapshots
         if: ${{ inputs.scope == 'all' || inputs.scope == 'playwright' }}
-        # --skip-nx-cache: e2e-ci is cacheable, but __screenshots__/ isn't in
+        # --skip-nx-cache: e2e is cacheable, but __screenshots__/ isn't in
         # the target's outputs, so a cache hit would silently skip regeneration.
-        run: bash .github/scripts/nx-safe.sh pnpm exec nx run demo-e2e:e2e-ci --updateSnapshots --skip-nx-cache
+        #
+        # `e2e`, not `e2e-ci`: the latter is the Playwright plugin's atomized
+        # target and Nx refuses to run it without Nx Agents, which this
+        # workspace stopped using in #252.
+        run: bash .github/scripts/nx-safe.sh pnpm exec nx run demo-e2e:e2e --updateSnapshots --skip-nx-cache
 
       - name: Update Vitest browser screenshots
         if: ${{ inputs.scope == 'all' || inputs.scope == 'vitest' }}


### PR DESCRIPTION
## Why

The rc.12 release run [failed at the quality gate](https://github.com/ngx-signal-forms/ngx-signal-forms/actions/runs/32743050359/job/97481852898):

```
NX  The following tasks should only be run with Nx Agents:
  - demo-e2e:e2e-ci
  - demo-material-e2e:e2e-ci
  - demo-primeng-e2e:e2e-ci
  - demo-spartan-e2e:e2e-ci
```

`e2e-ci` is the Playwright plugin's **atomized** target (`ciTargetName` in `nx.json`), which Nx will not run without Nx Agents. #252 removed the Agents coordinator and switched `ci.yml` to the non-atomized `e2e` target in the same commit — `release.yml` and `update-snapshots.yml` were missed.

Both have been latently broken since 2026-08-03. `release.yml` only fails when the affected set contains an e2e project, which is why rc.11 released fine and rc.12 is the first to hit it. `update-snapshots.yml` has not run since 2026-07-09 and would fail the same way on its next use.

## What

- `release.yml`: `e2e-ci` → `e2e` in the quality gate.
- `update-snapshots.yml`: `demo-e2e:e2e-ci` → `demo-e2e:e2e`.
- `release.yml`: `timeout-minutes` 20 → 35. `ci.yml` shards `demo-e2e` across a 4-way matrix (~2-3 min per shard); this gate runs it unsharded in a single job, which does not reliably fit in 20 minutes. 35 matches what `ci.yml` allows its own `main` job.
- `release.yml`: new **Verify release credential** preflight step.

## The credential preflight

A release spends ~15 minutes on lint/test/build/e2e before it ever binds `RELEASE_TOKEN`, so an expired PAT currently surfaces only at the very last step. The new step calls the repo API with the token and:

- fails loudly with a pointer to *Settings → Environments → release* when it cannot authenticate,
- prints the token's expiry date into the job summary, read from GitHub's `github-authentication-token-expiration` response header,
- warns (does not block) when push permission is not visible, since that field is absent for some GitHub App installation tokens that can still push.

It is placed **before `pnpm install`**, so the token is never resident in the environment while third-party dependency code runs. That preserves the late-binding property the `Release` step documents — the point of which is keeping the admin token away from untrusted code, not keeping it away from step 5.

## Verification

Task graph computed against the exact failing range (`1640a7c2..e05dd125`):

```
total tasks: 32
e2e tasks: ['demo-e2e:e2e', 'demo-material-e2e:e2e',
            'demo-primeng-e2e:e2e', 'demo-spartan-e2e:e2e']
atomized e2e-ci--* tasks: []
```

`pnpm run format:check` passes. Both workflow files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release reliability by validating publishing credentials before deployment.
  * Release jobs now provide clearer authentication and permission feedback.
  * Extended the release operation time limit to better support longer-running releases.
  * Updated automated end-to-end and visual snapshot checks for more consistent results.
  * Added safeguards to ensure snapshot updates run with the appropriate test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->